### PR TITLE
refactor: move response cycling state into per-stub StubState wrapper

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -117,13 +117,7 @@ pub async fn handle_replace_all(
         Err(e) => return e.into(),
     };
 
-    {
-        let mut stubs = imposter.stubs.write();
-        stubs.clear();
-        for stub in replace_req.stubs {
-            stubs.push(stub);
-        }
-    }
+    imposter.replace_stubs(replace_req.stubs);
 
     handle_get_imposter(port, None, base_url, manager).await
 }

--- a/crates/rift-http-proxy/src/behaviors/mod.rs
+++ b/crates/rift-http-proxy/src/behaviors/mod.rs
@@ -27,7 +27,7 @@ mod wait;
 // Re-export main types for library consumers
 #[allow(unused_imports)]
 pub use copy::{apply_copy_behaviors, CopyBehavior, CopySource};
-pub use cycler::{HasRepeatBehavior, ResponseCycler};
+pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
 #[allow(unused_imports)]
 pub use extraction::{extract_jsonpath, extract_xpath, ExtractionMethod};
 #[allow(unused_imports)]

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -7,6 +7,7 @@
 //! - ImposterManager lifecycle
 
 use super::*;
+use crate::imposter::core::StubState;
 use std::collections::HashMap;
 
 #[test]
@@ -135,7 +136,7 @@ fn test_execute_stub() {
         scenario_name: None,
     };
 
-    let result = imposter.execute_stub(&stub, 0);
+    let result = imposter.execute_stub(&StubState::new(stub));
     assert!(result.is_some());
     let (status, _headers, body, _behaviors, is_fault) = result.unwrap();
     assert_eq!(status, 201);


### PR DESCRIPTION
Replace the impostor-global ResponseCycler with per-stub cycling state by introducing two new types:

- RuleCycler: A lock-free atomic cycler that packs response index and repeat index into a single AtomicU64, enabling efficient concurrent access without any locking
- StubState: Wraps each Stub with its own RuleCycler, eliminating both the global lock and string-based rule ID lookups

Changes:
- Imposter.stubs now holds Vec<StubState> instead of Vec<Stub>
- Removed Imposter.response_cycler field entirely
- Methods like execute_stub, get_proxy_response, get_inject_response now take &StubState instead of (&Stub, stub_index) pairs
- Added Imposter::replace_stubs() helper to encapsulate stub replacement logic
- Updated all call sites in handler, admin API, and tests
- Update the implementation of ResponseCycler (still used in the rift proxy code) to be based on RuleCycler: almost always only needing a read lock.

This should remove lock contention between concurrent requests—previously all cycling operations acquired the same RwLock<HashMap>, now each stub cycles independently via its own atomic.