### PR TITLE
ci: integrate Docker publishing into release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to use for Docker images (e.g., v0.1.0)'
+        required: true
+        type: string
 
 env:
   REGISTRY_DOCKERHUB: docker.io
@@ -54,17 +60,21 @@ jobs:
           images: |
             ${{ env.REGISTRY_DOCKERHUB }}/${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy
             ${{ env.REGISTRY_GHCR }}/${{ github.repository_owner }}/rift-proxy
+          # Override ref when called via workflow_call to enable semver tag extraction
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }}
             type=raw,value=latest
 
       - name: Determine version and build date
         id: vars
         shell: bash
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            # Called via workflow_call with explicit tag
+            echo "VERSION=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "VERSION=edge" >> $GITHUB_OUTPUT
@@ -140,17 +150,21 @@ jobs:
           images: |
             ${{ env.REGISTRY_DOCKERHUB }}/${{ secrets.DOCKERHUB_USERNAME }}/rift-lint
             ${{ env.REGISTRY_GHCR }}/${{ github.repository_owner }}/rift-lint
+          # Override ref when called via workflow_call to enable semver tag extraction
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}},value=${{ inputs.tag }}
             type=raw,value=latest
 
       - name: Determine version and build date
         id: vars
         shell: bash
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            # Called via workflow_call with explicit tag
+            echo "VERSION=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "VERSION=edge" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,3 +530,15 @@ jobs:
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "npm install @rift-vs/rift" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  # =============================================================================
+  # Publish Docker images
+  # =============================================================================
+  publish-docker:
+    name: Publish Docker Images
+    needs: release
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
- Add workflow_call trigger to docker-publish.yml with tag input
- Update docker-publish.yml to use explicit tag when called via workflow_call
- Add publish-docker job to release.yml that calls docker-publish.yml
- Use secrets: inherit to pass required secrets to the called workflow

This ensures Docker images are automatically published as part of the release workflow, working around GitHub Actions' limitation where GITHUB_TOKEN-created tags don't trigger other workflows.