### PR TITLE
fix(ci): add required permissions for Docker publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,6 +538,11 @@ jobs:
     name: Publish Docker Images
     needs: release
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}


### PR DESCRIPTION
The publish-docker job needs packages:write, id-token:write, and attestations:write permissions for the called docker-publish workflow to push images and generate attestations.