### PR TITLE
fix: exists predicate matches inside JSON objects (Issue #75)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -624,8 +624,77 @@ fn check_predicate_fields_regex(
     true
 }
 
+/// Convert a JSON value to its string representation for predicate comparison.
+/// Strings are unwrapped (no quotes), other primitives use their natural representation.
+fn json_value_to_string(val: &serde_json::Value) -> String {
+    match val {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => String::new(),
+        _ => val.to_string(),
+    }
+}
+
+/// Recursively check field existence within a JSON object.
+/// When the exists value is an object, parse the actual string as JSON
+/// and check each field's existence recursively (Mountebank compatible).
+fn check_exists_json_recursive(expected: &serde_json::Value, actual_str: &str) -> bool {
+    match expected {
+        serde_json::Value::Bool(should_exist) => {
+            let exists = !actual_str.is_empty();
+            exists == *should_exist
+        }
+        serde_json::Value::Object(expected_obj) => {
+            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
+                Ok(v) => v,
+                Err(_) => {
+                    // If we can't parse as JSON, check if any field expects non-existence
+                    return expected_obj
+                        .values()
+                        .all(|v| v == &serde_json::Value::Bool(false));
+                }
+            };
+
+            for (key, expected_val) in expected_obj {
+                match expected_val {
+                    serde_json::Value::Bool(should_exist) => {
+                        let exists = actual_json.get(key).is_some();
+                        if exists != *should_exist {
+                            return false;
+                        }
+                    }
+                    serde_json::Value::Object(_) => {
+                        // Recurse into nested object
+                        let nested_str = match actual_json.get(key) {
+                            Some(v) => json_value_to_string(v),
+                            None => return false,
+                        };
+                        if !check_exists_json_recursive(expected_val, &nested_str) {
+                            return false;
+                        }
+                    }
+                    _ => {
+                        // Non-boolean, non-object values are treated as true (field should exist)
+                        if actual_json.get(key).is_none() {
+                            return false;
+                        }
+                    }
+                }
+            }
+            true
+        }
+        _ => {
+            // Non-boolean, non-object exists values: treat as "should exist" = true
+            !actual_str.is_empty()
+        }
+    }
+}
+
 /// Check exists predicate - verifies field presence or absence
 /// Supports: body, query, headers, form
+/// When a field's value is an object (not a boolean), parse the actual value as JSON
+/// and recursively check field existence within it (Mountebank compatible).
 fn check_exists_predicate(
     obj: &HashMap<String, serde_json::Value>,
     query: &HashMap<String, String>,
@@ -633,10 +702,9 @@ fn check_exists_predicate(
     body: &str,
     form: Option<&HashMap<String, String>>,
 ) -> bool {
-    // Check body exists
-    if let Some(should_exist) = obj.get("body").and_then(|v| v.as_bool()) {
-        let exists = !body.is_empty();
-        if exists != should_exist {
+    // Check body exists - supports both boolean and object values
+    if let Some(expected) = obj.get("body") {
+        if !check_exists_json_recursive(expected, body) {
             return false;
         }
     }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1047,3 +1047,149 @@ fn test_predicate_matches_body_regex() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #75: exists predicate doesn't match inside objects
+// =============================================================================
+
+#[test]
+fn test_exists_predicate_body_object_field_present() {
+    // {"exists": {"body": {"blah": true}}} should check that JSON body contains "blah" field
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "body": {
+                "blah": true
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body has "blah" field → should match
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "hello", "other": "stuff"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body does NOT have "blah" field → should not match
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"other": "stuff"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_exists_predicate_body_object_field_absent() {
+    // {"exists": {"body": {"blah": false}}} checks that body does NOT contain "blah"
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "body": {
+                "blah": false
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body has "blah" field → should NOT match (we want it absent)
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "hello"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body does NOT have "blah" field → should match
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"other": "stuff"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_exists_predicate_body_object_non_json_body() {
+    // When body is not valid JSON, object exists predicate should not match for true fields
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "body": {
+                "blah": true
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some("not json at all"),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_exists_predicate_body_boolean_still_works() {
+    // Original boolean behavior should still work
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "body": true
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some("any body content"),
+        None,
+        None,
+        None
+    ));
+
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- When the `exists` predicate value is an object (e.g. `{"exists": {"body": {"blah": true}}}`), parse the body as JSON and recursively check field existence
- Previously, non-boolean exists values were silently ignored, causing the predicate to always match
- Adds `check_exists_json_recursive` helper for recursive field existence checking

Fixes #75

## Test plan
- [x] Added 4 new tests: field present, field absent, non-JSON body, boolean backward compat
- [x] All 459 existing tests still pass