### PR TITLE
fix: parse body as JSON when predicate value is an object (Issue #76)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -325,15 +325,27 @@ where
         }
     }
 
-    // Check body
+    // Check body - when expected is an object, parse actual body as JSON
+    // and compare field-by-field recursively (Mountebank compatible)
     if let Some(expected) = obj.get("body") {
-        let expected_str = match expected {
-            serde_json::Value::String(s) => s.clone(),
-            _ => expected.to_string(),
-        };
         let actual = apply_except(body);
-        if !compare(&expected_str, &actual) {
-            return false;
+        match expected {
+            serde_json::Value::Object(_) => {
+                if !compare_json_recursive(expected, &actual, &compare) {
+                    return false;
+                }
+            }
+            serde_json::Value::String(s) => {
+                if !compare(s, &actual) {
+                    return false;
+                }
+            }
+            _ => {
+                let expected_str = expected.to_string();
+                if !compare(&expected_str, &actual) {
+                    return false;
+                }
+            }
         }
     }
 
@@ -676,6 +688,52 @@ fn check_exists_predicate(
     }
 
     true
+}
+
+/// Convert a JSON value to its string representation for predicate comparison.
+/// Strings are unwrapped (no quotes), other primitives use their natural representation.
+fn json_value_to_string(val: &serde_json::Value) -> String {
+    match val {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => String::new(),
+        _ => val.to_string(),
+    }
+}
+
+/// Recursively apply a comparison function when the expected value is a JSON object.
+/// Parses the actual string as JSON and compares each field recursively.
+/// For leaf values, converts both to strings and applies the comparison function.
+fn compare_json_recursive<F>(expected: &serde_json::Value, actual_str: &str, compare: &F) -> bool
+where
+    F: Fn(&str, &str) -> bool,
+{
+    match expected {
+        serde_json::Value::Object(expected_obj) => {
+            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+
+            for (key, expected_val) in expected_obj {
+                let actual_val = match actual_json.get(key) {
+                    Some(v) => v,
+                    None => return false,
+                };
+
+                let actual_val_str = json_value_to_string(actual_val);
+                if !compare_json_recursive(expected_val, &actual_val_str, compare) {
+                    return false;
+                }
+            }
+            true
+        }
+        _ => {
+            let expected_str = json_value_to_string(expected);
+            compare(&expected_str, actual_str)
+        }
+    }
 }
 
 /// Parse query string into HashMap (public helper)

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1047,3 +1047,187 @@ fn test_predicate_matches_body_regex() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #76: Body isn't parsed as JSON when predicate is an object
+// =============================================================================
+
+#[test]
+fn test_equals_body_as_json_object() {
+    // {"equals": {"body": {"blah": "123"}}} should parse body as JSON and compare fields
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "body": {
+                "blah": "123"
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body with matching field (extra fields ignored for equals)
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "123", "other": "ignored"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body with matching field, no extra fields
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "123"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body with wrong value
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "456"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body missing the field
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"other": "123"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_equals_body_string_still_works() {
+    // String body comparison should still work as before
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "body": "hello world"
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some("hello world"),
+        None,
+        None,
+        None
+    ));
+
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some("other"),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_contains_body_as_json_object() {
+    // {"contains": {"body": {"name": "ali"}}} should parse body as JSON and check contains
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "contains": {
+            "body": {
+                "name": "ali"
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body field contains the substring
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"name": "alice", "age": 30}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body field does NOT contain the substring
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"name": "bob"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_ends_with_body_as_json_object_with_numeric_value() {
+    // When expected value is a number in an object, convert to string for comparison
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "body": {"abc": 123}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body has field "abc" with value ending in "123"
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"abc": "other123"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body has field "abc" with value NOT ending in "123"
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"abc": "other456"}"#),
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- When predicates (equals, contains, startsWith, endsWith) have an object value for `body`, parse the actual body as JSON and compare field-by-field recursively
- Previously the expected object was serialized to a string and compared directly, so spacing mattered and extra fields caused mismatches
- Adds `compare_json_recursive` helper for recursive JSON field comparison

Fixes #76

## Test plan
- [x] Added 4 new tests: equals with JSON object, string backward compat, contains with object, endsWith with numeric value
- [x] All 459 existing tests still pass