### PR TITLE
fix: unexpected types in predicate no longer always match (Issue #77)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -310,47 +310,55 @@ where
         }
     };
 
+    // Helper: check a string field against expected value.
+    // When expected is an object, parse actual as JSON and compare recursively (Mountebank compat).
+    // When expected is a string/primitive, compare directly.
+    // Previously, non-string expected values were silently ignored, causing always-match.
+    let check_string_field = |expected: &serde_json::Value, actual: &str| -> bool {
+        let actual = apply_except(actual);
+        match expected {
+            serde_json::Value::Object(_) => compare_json_recursive(expected, &actual, &compare),
+            serde_json::Value::String(s) => compare(s, &actual),
+            _ => {
+                let expected_str = expected.to_string();
+                compare(&expected_str, &actual)
+            }
+        }
+    };
+
     // Check method
-    if let Some(expected) = obj.get("method").and_then(|v| v.as_str()) {
-        if !compare(expected, method) {
+    if let Some(expected) = obj.get("method") {
+        if !check_string_field(expected, method) {
             return false;
         }
     }
 
     // Check path
-    if let Some(expected) = obj.get("path").and_then(|v| v.as_str()) {
-        let actual = apply_except(path);
-        if !compare(expected, &actual) {
+    if let Some(expected) = obj.get("path") {
+        if !check_string_field(expected, path) {
             return false;
         }
     }
 
     // Check body
     if let Some(expected) = obj.get("body") {
-        let expected_str = match expected {
-            serde_json::Value::String(s) => s.clone(),
-            _ => expected.to_string(),
-        };
-        let actual = apply_except(body);
-        if !compare(&expected_str, &actual) {
+        if !check_string_field(expected, body) {
             return false;
         }
     }
 
     // Check requestFrom (IP:port) - Mountebank compatible
-    if let Some(expected) = obj.get("requestFrom").and_then(|v| v.as_str()) {
+    if let Some(expected) = obj.get("requestFrom") {
         let actual = request_from.unwrap_or("");
-        let actual = apply_except(actual);
-        if !compare(expected, &actual) {
+        if !check_string_field(expected, actual) {
             return false;
         }
     }
 
     // Check ip (just the IP address) - Mountebank compatible
-    if let Some(expected) = obj.get("ip").and_then(|v| v.as_str()) {
+    if let Some(expected) = obj.get("ip") {
         let actual = client_ip.unwrap_or("");
-        let actual = apply_except(actual);
-        if !compare(expected, &actual) {
+        if !check_string_field(expected, actual) {
             return false;
         }
     }
@@ -744,6 +752,40 @@ fn check_exists_predicate(
     }
 
     true
+}
+
+/// Recursively apply a comparison function when the expected value is a JSON object.
+/// Parses the actual string as JSON and compares each field recursively.
+/// For leaf values, converts both to strings and applies the comparison function.
+fn compare_json_recursive<F>(expected: &serde_json::Value, actual_str: &str, compare: &F) -> bool
+where
+    F: Fn(&str, &str) -> bool,
+{
+    match expected {
+        serde_json::Value::Object(expected_obj) => {
+            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+
+            for (key, expected_val) in expected_obj {
+                let actual_val = match actual_json.get(key) {
+                    Some(v) => v,
+                    None => return false,
+                };
+
+                let actual_val_str = json_value_to_string(actual_val);
+                if !compare_json_recursive(expected_val, &actual_val_str, compare) {
+                    return false;
+                }
+            }
+            true
+        }
+        _ => {
+            let expected_str = json_value_to_string(expected);
+            compare(&expected_str, actual_str)
+        }
+    }
 }
 
 /// Parse query string into HashMap (public helper)

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1193,3 +1193,183 @@ fn test_exists_predicate_body_boolean_still_works() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #77: Unexpected types in predicate lead to always matching
+// =============================================================================
+
+#[test]
+fn test_ends_with_object_value_does_not_always_match() {
+    // {"endsWith": {"path": {"abc": "123"}}} should NOT match a plain string path
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "path": {"abc": "123"}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Path is a plain string, not JSON → should NOT match (was incorrectly always matching)
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/blah",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_ends_with_path_as_json_object() {
+    // When path is a JSON string, object predicate should parse it and match recursively
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "path": {"abc": "123"}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Path is a JSON string with a field whose value ends with "123"
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        r#"{"abc": "other123", "other": "ignored"}"#,
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // Path is a JSON string but field doesn't end with "123"
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        r#"{"abc": "other456"}"#,
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_starts_with_object_value_does_not_always_match() {
+    // {"startsWith": {"path": {"x": "y"}}} should NOT match a plain string path
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "startsWith": {
+            "path": {"x": "y"}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/something",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_equals_body_as_json_object() {
+    // {"equals": {"body": {"blah": "123"}}} should parse body as JSON and compare fields
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "body": {
+                "blah": "123"
+            }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Body with matching field (extra fields ignored for equals)
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "123", "other": "ignored"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body with wrong value
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"blah": "456"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Body missing the field
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"other": "123"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_ends_with_body_object_with_numeric_value() {
+    // When expected value is a number in an object, convert to string for comparison
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "body": {"abc": 123}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"abc": "other123"}"#),
+        None,
+        None,
+        None
+    ));
+
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"abc": "other456"}"#),
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- When predicate values are objects (e.g. `{"endsWith": {"path": {"abc": "123"}}}`), parse the actual value as JSON and apply the matcher recursively
- Previously, non-string expected values for `path`, `method`, `requestFrom`, and `ip` were silently skipped via `.and_then(|v| v.as_str())`, causing the predicate to always match
- Introduces a unified `check_string_field` closure that handles string, object, and other value types consistently

Fixes #77

## Test plan
- [x] Added 5 new tests: endsWith with object on path (plain string fails, JSON string matches), startsWith with object, equals body object, endsWith body with numeric value
- [x] All 459 existing tests still pass