### PR TITLE
test: add Mountebank compatibility test suite

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -693,3 +693,1041 @@ pub fn parse_query_string(query: &str) -> HashMap<String, String> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imposter::types::{Predicate, PredicateOperation, PredicateParameters};
+    use serde_json::json;
+
+    /// Helper to build a Predicate from operation with default parameters
+    fn make_predicate(op: PredicateOperation) -> Predicate {
+        Predicate {
+            parameters: PredicateParameters::default(),
+            operation: op,
+        }
+    }
+
+    /// Helper to build a Predicate with custom parameters
+    fn make_predicate_with_params(
+        op: PredicateOperation,
+        params: PredicateParameters,
+    ) -> Predicate {
+        Predicate {
+            parameters: params,
+            operation: op,
+        }
+    }
+
+    fn empty_headers() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    // =========================================================================
+    // Bug 1: Multi-valued query parameters lost
+    // Mountebank preserves all values for ?key=first&key=second
+    // Current code: HashMap overwrites, keeping only one value
+    // =========================================================================
+
+    #[test]
+    fn test_parse_query_string_multi_valued_first_value_preserved() {
+        // In Mountebank, ?key=first&key=second results in key having value ["first","second"]
+        // In Rift, HashMap<String, String> can only hold one value per key.
+        // This test documents the bug: the first value "first" should be accessible
+        // but depending on iteration order, it may be overwritten by "second".
+        let result = parse_query_string("key=first&key=second");
+
+        // The bug: HashMap can only store one value. We can't verify WHICH value
+        // survives, but we know one is lost.
+        assert_eq!(
+            result.len(),
+            1,
+            "HashMap collapses multi-valued params to 1 entry"
+        );
+
+        // For Mountebank compatibility, we'd need both values accessible.
+        // This test should eventually assert that both "first" and "second" are available.
+        let value = result.get("key").unwrap();
+        // The value will be either "first" or "second" - either way, one is lost
+        assert!(
+            value == "first" || value == "second",
+            "Got unexpected value: {value}"
+        );
+    }
+
+    #[test]
+    fn test_equals_query_multi_valued_param() {
+        // Mountebank: equals { query: { key: "first" } } should match ?key=first&key=second
+        // because "first" is one of the values for "key"
+        // Rift bug: only one value is kept, so if "second" overwrites "first", this fails
+        let fields: HashMap<String, serde_json::Value> =
+            [("query".to_string(), json!({"key": "first"}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            Some("key=first&key=second"),
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // Bug: This may fail if "second" overwrites "first" in the HashMap
+        // Mountebank would match because "first" is among the values
+        // We document this as a known failure for the bug report
+        if !result {
+            eprintln!(
+                "BUG CONFIRMED: Multi-valued query param 'first' lost when 'second' overwrites"
+            );
+        }
+        // Note: we don't assert true/false here because behavior depends on HashMap ordering
+        // The real fix would use HashMap<String, Vec<String>>
+    }
+
+    // =========================================================================
+    // Bug 2: Query parameters without '=' sign filtered out
+    // Mountebank treats ?flag as flag=""
+    // Current code: split_once('=') returns None, filter_map drops it
+    // =========================================================================
+
+    #[test]
+    fn test_parse_query_string_bare_param() {
+        // Mountebank: ?flag is treated as flag=""
+        // Current code: split_once('=') returns None for "flag", so it's dropped
+        let result = parse_query_string("flag");
+
+        // BUG: bare param "flag" is dropped entirely
+        assert!(
+            !result.contains_key("flag"),
+            "BUG CONFIRMED: bare query param 'flag' should be present with empty value, \
+             but it was dropped because split_once('=') returned None"
+        );
+        // After fix, this should be:
+        // assert_eq!(result.get("flag"), Some(&String::new()));
+    }
+
+    #[test]
+    fn test_parse_query_string_mixed_bare_and_valued() {
+        // ?a=1&flag&b=2 - Mountebank keeps all three
+        let result = parse_query_string("a=1&flag&b=2");
+
+        assert_eq!(result.get("a"), Some(&"1".to_string()));
+        assert_eq!(result.get("b"), Some(&"2".to_string()));
+        // BUG: "flag" is missing
+        assert!(
+            !result.contains_key("flag"),
+            "BUG CONFIRMED: bare param 'flag' dropped from mixed query string"
+        );
+    }
+
+    #[test]
+    fn test_exists_query_bare_param() {
+        // exists: { query: { flag: true } } should match ?flag
+        // But parse_query_string drops "flag", so exists check returns false
+        let fields: HashMap<String, serde_json::Value> =
+            [("query".to_string(), json!({"flag": true}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            Some("flag"),
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns false because parse_query_string drops "flag"
+        assert!(
+            !result,
+            "BUG CONFIRMED: exists predicate fails for bare query param '?flag'"
+        );
+    }
+
+    // =========================================================================
+    // Bug 3: deepEquals body comparison is string-based, not structural
+    // Mountebank does recursive structural comparison for JSON bodies
+    // Current code: serializes to string and does string comparison
+    // =========================================================================
+
+    #[test]
+    fn test_deep_equals_body_json_key_order_independence() {
+        // Mountebank: deepEquals { body: { "a": 1, "b": 2 } } should match body {"b":2,"a":1}
+        // because JSON objects are unordered. Mountebank does structural comparison.
+        // Rift bug: serializes expected to string via serde_json (which uses BTreeMap,
+        // producing alphabetically-sorted keys like '{"a":1,"b":2}'), then does string
+        // comparison against the actual body. If the body has non-alphabetical key order,
+        // the string comparison fails.
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"a": 1, "b": 2}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::DeepEquals(fields));
+
+        // Body with keys in non-alphabetical order (as a real HTTP client might send)
+        // serde_json serializes the predicate value to '{"a":1,"b":2}' (BTreeMap sorts keys)
+        // but the actual body has keys in different order
+        let body = r#"{"b":2,"a":1}"#;
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            Some(body),
+            None,
+            None,
+            None,
+        );
+
+        // BUG: expected.to_string() produces '{"a":1,"b":2}' which doesn't match '{"b":2,"a":1}'
+        assert!(
+            !result,
+            "BUG CONFIRMED: deepEquals body comparison is string-based, not structural. \
+             JSON key order difference causes mismatch."
+        );
+        // After fix, this should assert true (structural equality)
+    }
+
+    #[test]
+    fn test_deep_equals_body_string_match() {
+        // deepEquals with matching string body should still work
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!("hello world"))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::DeepEquals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            Some("hello world"),
+            None,
+            None,
+            None,
+        );
+
+        assert!(result, "deepEquals should match identical string bodies");
+    }
+
+    // =========================================================================
+    // Bug 4: keyCaseSensitive not passed to check_exists_predicate
+    // The exists predicate ignores the keyCaseSensitive parameter entirely
+    // =========================================================================
+
+    #[test]
+    fn test_exists_query_key_case_sensitive_false() {
+        // With keyCaseSensitive: false (default), exists { query: { Key: true } }
+        // should match if query has "key" (case-insensitive key lookup)
+        let fields: HashMap<String, serde_json::Value> =
+            [("query".to_string(), json!({"Key": true}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            Some("key=value"),
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: check_exists_predicate uses query.contains_key(key) which is exact match
+        // "Key" != "key", so this returns false even though keyCaseSensitive defaults to false
+        assert!(
+            !result,
+            "BUG CONFIRMED: exists predicate query check ignores keyCaseSensitive, \
+             uses exact key match instead of case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_exists_header_key_case_sensitive_true() {
+        // With keyCaseSensitive: true, exists { headers: { "content-type": true } }
+        // should NOT match header "Content-Type" because keys must match exactly
+        // But currently, check_exists_predicate ALWAYS uses eq_ignore_ascii_case for headers
+        let fields: HashMap<String, serde_json::Value> =
+            [("headers".to_string(), json!({"content-type": true}))]
+                .into_iter()
+                .collect();
+
+        let params = PredicateParameters {
+            key_case_sensitive: Some(true),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Exists(fields), params);
+
+        // Headers have uppercase "Content-Type" key (but hyper lowercases, so use lowercase)
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        let result = predicate_matches(
+            &pred, "GET", "/test", None, &headers, None, None, None, None,
+        );
+
+        // This matches because both are lowercase, but the point is keyCaseSensitive
+        // is completely ignored - check_exists_predicate doesn't receive it
+        assert!(
+            result,
+            "This case happens to work because both keys are lowercase, \
+             but keyCaseSensitive is not actually being respected"
+        );
+    }
+
+    #[test]
+    fn test_exists_form_key_case_sensitive() {
+        // exists { form: { Name: true } } with keyCaseSensitive: false
+        // should match form with key "name"
+        // BUG: check_exists_predicate uses actual_form.contains_key(key) - exact match
+        let fields: HashMap<String, serde_json::Value> =
+            [("form".to_string(), json!({"Name": true}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let mut form = HashMap::new();
+        form.insert("name".to_string(), "John".to_string());
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some("name=John"),
+            None,
+            None,
+            Some(&form),
+        );
+
+        // BUG: "Name" != "name", returns false despite keyCaseSensitive defaulting to false
+        assert!(
+            !result,
+            "BUG CONFIRMED: exists predicate form check ignores keyCaseSensitive"
+        );
+    }
+
+    // =========================================================================
+    // Bug 5: Header keys always lowercase breaks keyCaseSensitive=true
+    // hyper lowercases all header keys, so keyCaseSensitive=true with
+    // Title-Case headers in predicates will never match
+    // =========================================================================
+
+    #[test]
+    fn test_header_key_case_sensitive_true_with_title_case() {
+        // With keyCaseSensitive: true, equals { headers: { "Content-Type": "application/json" } }
+        // should match header "Content-Type: application/json"
+        // But hyper lowercases keys to "content-type", so exact match fails
+        let fields: HashMap<String, serde_json::Value> = [(
+            "headers".to_string(),
+            json!({"Content-Type": "application/json"}),
+        )]
+        .into_iter()
+        .collect();
+
+        let params = PredicateParameters {
+            case_sensitive: Some(true),
+            key_case_sensitive: Some(true),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Equals(fields), params);
+
+        // Simulate hyper header map - keys are always lowercase
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        let result = predicate_matches(
+            &pred, "GET", "/test", None, &headers, None, None, None, None,
+        );
+
+        // BUG: "Content-Type" != "content-type" when keyCaseSensitive=true
+        // The predicate specifies Title-Case but hyper always lowercases
+        assert!(
+            !result,
+            "BUG CONFIRMED: keyCaseSensitive=true with Title-Case header key never matches \
+             because hyper lowercases all header keys to 'content-type'"
+        );
+    }
+
+    #[test]
+    fn test_header_key_case_sensitive_false_default() {
+        // Default: keyCaseSensitive=false, header key matching should be case-insensitive
+        // This should work correctly (not a bug, just verifying the default works)
+        let fields: HashMap<String, serde_json::Value> = [(
+            "headers".to_string(),
+            json!({"Content-Type": "application/json"}),
+        )]
+        .into_iter()
+        .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            Some(""),
+            None,
+            None,
+            None,
+        );
+
+        assert!(
+            result,
+            "Default keyCaseSensitive=false should match case-insensitively"
+        );
+    }
+
+    // =========================================================================
+    // Additional predicate tests (non-bug, for coverage)
+    // =========================================================================
+
+    #[test]
+    fn test_equals_method() {
+        let fields: HashMap<String, serde_json::Value> = [("method".to_string(), json!("POST"))]
+            .into_iter()
+            .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        // Default is case-insensitive
+        assert!(predicate_matches(
+            &pred,
+            "post",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_equals_path() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!("/api/users"))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/api/users",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/api/other",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_contains_body() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!("hello"))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::Contains(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            Some("say hello world"),
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            Some("goodbye"),
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_starts_with_path() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!("/api/"))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::StartsWith(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/api/users",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/web/page",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_ends_with_path() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!(".json"))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::EndsWith(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/data/file.json",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/data/file.xml",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_matches_regex() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!("^/api/users/\\d+$"))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Matches(fields));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/api/users/123",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/api/users/abc",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_not_predicate() {
+        let inner_fields: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!("GET"))].into_iter().collect();
+
+        let inner = make_predicate(PredicateOperation::Equals(inner_fields));
+        let pred = make_predicate(PredicateOperation::Not(Box::new(inner)));
+
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_or_predicate() {
+        let eq_get: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!("GET"))].into_iter().collect();
+        let eq_post: HashMap<String, serde_json::Value> = [("method".to_string(), json!("POST"))]
+            .into_iter()
+            .collect();
+
+        let pred = make_predicate(PredicateOperation::Or(vec![
+            make_predicate(PredicateOperation::Equals(eq_get)),
+            make_predicate(PredicateOperation::Equals(eq_post)),
+        ]));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "DELETE",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_and_predicate() {
+        let eq_get: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!("GET"))].into_iter().collect();
+        let eq_path: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!("/api"))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::And(vec![
+            make_predicate(PredicateOperation::Equals(eq_get)),
+            make_predicate(PredicateOperation::Equals(eq_path)),
+        ]));
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "POST",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/other",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_case_sensitive_equals() {
+        let fields: HashMap<String, serde_json::Value> = [("method".to_string(), json!("POST"))]
+            .into_iter()
+            .collect();
+
+        let params = PredicateParameters {
+            case_sensitive: Some(true),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Equals(fields), params);
+
+        assert!(predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        // With caseSensitive: true, "post" should NOT match "POST"
+        assert!(!predicate_matches(
+            &pred,
+            "post",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_except_pattern() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!("/api/users"))]
+                .into_iter()
+                .collect();
+
+        let params = PredicateParameters {
+            except: "/api".to_string(),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Equals(fields), params);
+
+        // except removes "/api" from actual path, so "/api/users" becomes "/users"
+        // which doesn't match "/api/users"
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/api/users",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_exists_body() {
+        let fields_true: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!(true))].into_iter().collect();
+
+        let fields_false: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!(false))].into_iter().collect();
+
+        let pred_true = make_predicate(PredicateOperation::Exists(fields_true));
+        let pred_false = make_predicate(PredicateOperation::Exists(fields_false));
+
+        // Body exists
+        assert!(predicate_matches(
+            &pred_true,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            Some("content"),
+            None,
+            None,
+            None,
+        ));
+        // Body does not exist
+        assert!(!predicate_matches(
+            &pred_true,
+            "GET",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        // Body should NOT exist (false) - empty body
+        assert!(predicate_matches(
+            &pred_false,
+            "GET",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_exists_header() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("headers".to_string(), json!({"content-type": true}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        assert!(predicate_matches(
+            &pred, "GET", "/", None, &headers, None, None, None, None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_deep_equals_query_extra_params_mismatch() {
+        // deepEquals on query should fail if actual has extra params
+        let fields: HashMap<String, serde_json::Value> = [("query".to_string(), json!({"a": "1"}))]
+            .into_iter()
+            .collect();
+
+        let pred = make_predicate(PredicateOperation::DeepEquals(fields));
+
+        // Exact match - should pass
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            Some("a=1"),
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        // Extra param - should fail for deepEquals
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            Some("a=1&b=2"),
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_deep_equals_headers_extra_mismatch() {
+        // deepEquals on headers should fail if actual has extra headers
+        let fields: HashMap<String, serde_json::Value> =
+            [("headers".to_string(), json!({"x-custom": "value"}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::DeepEquals(fields));
+
+        let mut exact_headers = HashMap::new();
+        exact_headers.insert("x-custom".to_string(), "value".to_string());
+
+        let mut extra_headers = HashMap::new();
+        extra_headers.insert("x-custom".to_string(), "value".to_string());
+        extra_headers.insert("x-other".to_string(), "other".to_string());
+
+        assert!(predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            None,
+            &exact_headers,
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!predicate_matches(
+            &pred,
+            "GET",
+            "/",
+            None,
+            &extra_headers,
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_stub_matches_empty_predicates() {
+        // Empty predicates should match everything
+        assert!(stub_matches(
+            &[],
+            "GET",
+            "/anything",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_stub_matches_all_must_match() {
+        // All predicates must match (implicit AND)
+        let predicates = vec![
+            make_predicate(PredicateOperation::Equals(
+                [("method".to_string(), json!("GET"))].into_iter().collect(),
+            )),
+            make_predicate(PredicateOperation::Equals(
+                [("path".to_string(), json!("/api"))].into_iter().collect(),
+            )),
+        ];
+
+        assert!(stub_matches(
+            &predicates,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+        assert!(!stub_matches(
+            &predicates,
+            "POST",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_parse_query_string_url_encoded() {
+        // Already fixed in #70 - verify URL decoding works
+        let result = parse_query_string("key=hello%20world&name=caf%C3%A9");
+        assert_eq!(result.get("key"), Some(&"hello world".to_string()));
+        assert_eq!(result.get("name"), Some(&"café".to_string()));
+    }
+
+    #[test]
+    fn test_parse_query_string_empty() {
+        let result = parse_query_string("");
+        assert!(result.is_empty());
+    }
+}

--- a/crates/rift-http-proxy/tests/mountebank_compatibility.rs
+++ b/crates/rift-http-proxy/tests/mountebank_compatibility.rs
@@ -1,0 +1,1953 @@
+//! Mountebank compatibility integration tests.
+//!
+//! These tests verify that Rift behaves compatibly with Mountebank's HTTP imposter API.
+//! Tests are organized by feature category and include tests for known bugs
+//! (marked with `#[should_panic]` or documented assertions).
+
+use reqwest::Client;
+use serde_json::json;
+use std::time::Duration;
+use tokio::time::sleep;
+
+const ADMIN_URL: &str = "http://127.0.0.1";
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Helper to get unique test ports (avoids conflicts between parallel tests)
+fn get_test_ports() -> (u16, u16) {
+    use std::sync::atomic::{AtomicU16, Ordering};
+    static PORT_COUNTER: AtomicU16 = AtomicU16::new(19000);
+    let admin = PORT_COUNTER.fetch_add(2, Ordering::SeqCst);
+    let imposter = admin + 1;
+    (admin, imposter)
+}
+
+/// Start a Rift server for testing
+async fn start_rift_server(admin_port: u16) -> tokio::process::Child {
+    let child = tokio::process::Command::new("cargo")
+        .args([
+            "run",
+            "--package",
+            "rift-http-proxy",
+            "--",
+            "--port",
+            &admin_port.to_string(),
+            "--allow-injection",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("Failed to start Rift server");
+
+    let client = Client::new();
+    for _ in 0..50 {
+        if client
+            .get(format!("{ADMIN_URL}:{admin_port}/"))
+            .timeout(Duration::from_millis(200))
+            .send()
+            .await
+            .is_ok()
+        {
+            return child;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("Rift server failed to start within timeout");
+}
+
+/// Create an imposter via the admin API
+async fn create_imposter(client: &Client, admin_port: u16, config: serde_json::Value) -> u16 {
+    let response = client
+        .post(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .json(&config)
+        .send()
+        .await
+        .expect("Failed to create imposter");
+
+    assert!(
+        response.status().is_success(),
+        "Failed to create imposter: {}",
+        response.text().await.unwrap_or_default()
+    );
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    body["port"].as_u64().expect("Missing port in response") as u16
+}
+
+/// Delete all imposters
+async fn clear_imposters(client: &Client, admin_port: u16) {
+    let _ = client
+        .delete(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .send()
+        .await;
+}
+
+// =============================================================================
+// 1. Basic Predicates
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_equals_method_path() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"equals": {"method": "POST", "path": "/api/data"}}],
+                "responses": [{"is": {"statusCode": 201, "body": "created"}}]
+            },
+            {
+                "predicates": [{"equals": {"method": "GET", "path": "/api/data"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "data"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // GET should match second stub
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/data"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "data");
+
+    // POST should match first stub
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/api/data"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    assert_eq!(resp.text().await.unwrap(), "created");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_equals_query_parameter() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"query": {"status": "active"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "active users"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/users?status=active"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "active users");
+
+    // Non-matching query
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/users?status=inactive"))
+        .send()
+        .await
+        .unwrap();
+    // Should not match, get default response
+    assert_ne!(resp.text().await.unwrap(), "active users");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_equals_header_default_case_insensitive() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"headers": {"X-Custom": "test-value"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "header matched"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Headers are case-insensitive by default
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .header("x-custom", "test-value")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "header matched");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_contains_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"contains": {"body": "search-term"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "found"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/search"))
+        .body("this contains search-term in it")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "found");
+
+    // Non-matching body
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/search"))
+        .body("this does not contain it")
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "found");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_starts_with_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"startsWith": {"path": "/api/"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "api response"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/users"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "api response");
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/web/page"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "api response");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_ends_with_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"endsWith": {"path": ".json"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "json endpoint"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/data/file.json"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "json endpoint");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_matches_regex_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"matches": {"path": "^/api/users/\\d+$"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "user found"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/users/123"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "user found");
+
+    // Non-numeric ID - should not match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/users/abc"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "user found");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_case_sensitive_true() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"body": "Hello World"},
+                "caseSensitive": true
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "matched"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Exact case match
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/"))
+        .body("Hello World")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "matched");
+
+    // Different case - should NOT match with caseSensitive: true
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/"))
+        .body("hello world")
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "matched");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_except_regex_exclusion() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"path": "/users"},
+                "except": "^/api"
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "matched with except"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // /api/users -> except removes "/api" -> "/users" matches "/users"
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/users"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "matched with except");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 2. deepEquals Semantics
+// =============================================================================
+
+/// Bug 3: deepEquals body comparison is string-based, not structural
+/// Mountebank does recursive structural comparison for JSON bodies
+#[tokio::test]
+#[ignore = "requires running server - known bug: deepEquals body is string-based"]
+async fn test_deep_equals_body_json_key_order() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "deepEquals": {"body": {"b": 2, "a": 1}}
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "deep match"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Body with keys in different order - Mountebank matches, Rift may not (Bug 3)
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/"))
+        .header("content-type", "application/json")
+        .body(r#"{"a":1,"b":2}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // BUG 3: This may fail because deepEquals does string comparison, not structural
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 3: deepEquals body should match regardless of JSON key order"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_deep_equals_query_extra_params() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"deepEquals": {"query": {"a": "1"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "exact query"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Exact match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/?a=1"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "exact query");
+
+    // Extra param - deepEquals should fail
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/?a=1&b=2"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.text().await.unwrap(),
+        "exact query",
+        "deepEquals query should fail when extra params present"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_deep_equals_headers_extra() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    // Note: deepEquals on headers is tricky because HTTP clients add default headers
+    // This test verifies the concept but may need adjustment for real header counts
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"deepEquals": {"query": {"only": "this"}}}],
+                "responses": [{"is": {"statusCode": 200, "body": "deep match"}}]
+            },
+            {
+                "predicates": [],
+                "responses": [{"is": {"statusCode": 404, "body": "no match"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Extra query param should cause deepEquals to fail
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{imposter_port}/?only=this&extra=param"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.text().await.unwrap(), "no match");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 3. Query String Edge Cases
+// =============================================================================
+
+/// Bug 1: Multi-valued query parameters lost
+/// Mountebank preserves all values as array
+#[tokio::test]
+#[ignore = "requires running server - known bug: multi-valued query params"]
+async fn test_query_multi_valued_params() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"query": {"key": "first"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "found first"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Bug 1: ?key=first&key=second - "second" may overwrite "first" in HashMap
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{imposter_port}/search?key=first&key=second"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // In Mountebank, this matches because "first" is one of the values
+    // In Rift, HashMap keeps only one value, so this may fail
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 1: Multi-valued query param should preserve all values"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+/// Bug 2: Query parameters without '=' sign filtered out
+/// Mountebank treats ?flag as flag=""
+#[tokio::test]
+#[ignore = "requires running server - known bug: bare query params"]
+async fn test_query_bare_param_no_equals() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"exists": {"query": {"flag": true}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "flag exists"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Bug 2: ?flag (no = sign) should be treated as flag=""
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/search?flag"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 2: Bare query param '?flag' should be treated as flag='' and exist"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server - known bug: bare query params"]
+async fn test_query_mixed_bare_and_valued() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"query": {"a": "1"}},
+            }, {
+                "exists": {"query": {"flag": true}}
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "mixed match"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Bug 2: ?a=1&flag&b=2 - "flag" is dropped by parse_query_string
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/?a=1&flag&b=2"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 2: Mixed query string with bare param should work"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_query_url_encoded_params() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    // Already fixed in #70 - verify through integration test
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"query": {"name": "hello world"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "decoded match"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{imposter_port}/test?name=hello%20world"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "decoded match");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_query_empty_string() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"query": {"key": ""}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "empty value"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test?key="))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "empty value");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 4. Header Edge Cases
+// =============================================================================
+
+/// Bug 5: Header keys always lowercase breaks keyCaseSensitive=true
+#[tokio::test]
+#[ignore = "requires running server - known bug: header keys always lowercase"]
+async fn test_header_key_case_sensitive_true() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"headers": {"Content-Type": "application/json"}},
+                "keyCaseSensitive": true
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "key sensitive match"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Bug 5: hyper lowercases headers to "content-type", but predicate has "Content-Type"
+    // With keyCaseSensitive=true, exact match fails
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 5: keyCaseSensitive=true with Title-Case header should match, \
+         but fails because hyper lowercases all keys"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_header_value_case_sensitivity() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"headers": {"x-custom": "TestValue"}},
+                "caseSensitive": true
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "case match"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Exact case match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .header("x-custom", "TestValue")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Different case - should NOT match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .header("x-custom", "testvalue")
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "case match");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 5. exists Predicate
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_exists_body() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"exists": {"body": true}}],
+                "responses": [{"is": {"statusCode": 200, "body": "has body"}}]
+            },
+            {
+                "predicates": [{"exists": {"body": false}}],
+                "responses": [{"is": {"statusCode": 200, "body": "no body"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Request with body
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .body("some content")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "has body");
+
+    // Request without body (GET typically has no body)
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "no body");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_exists_query_param() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"exists": {"query": {"token": true}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "has token"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test?token=abc123"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "has token");
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "has token");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_exists_header() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"exists": {"headers": {"authorization": true}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "authorized"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .header("Authorization", "Bearer token123")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "authorized");
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "authorized");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+/// Bug 4: keyCaseSensitive not passed to check_exists_predicate
+#[tokio::test]
+#[ignore = "requires running server - known bug: exists ignores keyCaseSensitive"]
+async fn test_exists_key_case_sensitive() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "exists": {"query": {"Token": true}},
+                "keyCaseSensitive": false
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "token found"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Bug 4: keyCaseSensitive=false, predicate has "Token", query has "token"
+    // Should match case-insensitively, but check_exists_predicate uses exact match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test?token=abc"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "Bug 4: exists predicate should respect keyCaseSensitive=false for query keys"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 6. Logical Combinators
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_not_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"not": {"equals": {"method": "GET"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "not GET"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // POST should match (not GET)
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "not GET");
+
+    // GET should NOT match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "not GET");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_or_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "or": [
+                    {"equals": {"path": "/api/v1"}},
+                    {"equals": {"path": "/api/v2"}}
+                ]
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "api version"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/v1"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "api version");
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/v2"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "api version");
+
+    // v3 should not match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/v3"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "api version");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_and_predicate() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "and": [
+                    {"equals": {"method": "POST"}},
+                    {"startsWith": {"path": "/api/"}}
+                ]
+            }],
+            "responses": [{"is": {"statusCode": 201, "body": "created"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Both conditions met
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/api/users"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+
+    // Only one condition met
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/api/users"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), 201);
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_nested_not_and_or() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    // not(or(GET, DELETE)) => matches POST, PUT, PATCH, etc.
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "not": {
+                    "or": [
+                        {"equals": {"method": "GET"}},
+                        {"equals": {"method": "DELETE"}}
+                    ]
+                }
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "not get or delete"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // POST should match (not GET and not DELETE)
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "not get or delete");
+
+    // GET should NOT match
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "not get or delete");
+
+    // DELETE should NOT match
+    let resp = client
+        .delete(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "not get or delete");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 7. Response Types
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_is_response_with_headers() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [],
+            "responses": [{
+                "is": {
+                    "statusCode": 201,
+                    "headers": {
+                        "Content-Type": "application/json",
+                        "X-Custom-Header": "custom-value"
+                    },
+                    "body": "{\"id\": 1}"
+                }
+            }]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/json"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-custom-header")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "custom-value"
+    );
+    assert_eq!(resp.text().await.unwrap(), "{\"id\": 1}");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_multiple_responses_round_robin() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [],
+            "responses": [
+                {"is": {"statusCode": 200, "body": "first"}},
+                {"is": {"statusCode": 200, "body": "second"}},
+                {"is": {"statusCode": 200, "body": "third"}}
+            ]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let expected = ["first", "second", "third", "first", "second", "third"];
+    for expected_body in &expected {
+        let resp = client
+            .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.text().await.unwrap(), *expected_body);
+    }
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_fault_connection_reset() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [],
+            "responses": [{"fault": "CONNECTION_RESET_BY_PEER"}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // The connection should be reset, causing an error
+    let result = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Fault response should cause connection error"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_default_response_empty_stubs() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "defaultResponse": {
+            "statusCode": 418,
+            "body": "I'm a teapot"
+        },
+        "stubs": []
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/anything"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 418);
+    assert_eq!(resp.text().await.unwrap(), "I'm a teapot");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 8. Behaviors
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_behavior_wait() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [],
+            "responses": [{
+                "is": {"statusCode": 200, "body": "waited"},
+                "_behaviors": {"wait": 200}
+            }]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let start = std::time::Instant::now();
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(resp.status(), 200);
+    assert!(
+        elapsed >= Duration::from_millis(180),
+        "Wait behavior should delay at least 180ms, got {elapsed:?}"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_behavior_repeat() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [],
+            "responses": [
+                {
+                    "is": {"statusCode": 200, "body": "repeated"},
+                    "_behaviors": {"repeat": 3}
+                },
+                {"is": {"statusCode": 200, "body": "after repeat"}}
+            ]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // First 3 should return "repeated"
+    for _ in 0..3 {
+        let resp = client
+            .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.text().await.unwrap(), "repeated");
+    }
+
+    // 4th should return "after repeat"
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "after repeat");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 9. Admin API CRUD
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_create_and_get_imposter() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "name": "Test Imposter",
+        "stubs": [{
+            "predicates": [],
+            "responses": [{"is": {"statusCode": 200, "body": "hello"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // GET /imposters/:port
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{admin_port}/imposters/{imposter_port}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["port"], imposter_port);
+    assert_eq!(body["protocol"], "http");
+    assert_eq!(body["name"], "Test Imposter");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_list_imposters() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    // Create two imposters
+    let config1 = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": []
+    });
+    let config2 = json!({
+        "port": imposter_port + 10,
+        "protocol": "http",
+        "stubs": []
+    });
+
+    create_imposter(&client, admin_port, config1).await;
+    create_imposter(&client, admin_port, config2).await;
+
+    // GET /imposters
+    let resp = client
+        .get(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let imposters = body["imposters"]
+        .as_array()
+        .expect("Expected imposters array");
+    assert!(imposters.len() >= 2);
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_delete_single_imposter() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": []
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // DELETE /imposters/:port
+    let resp = client
+        .delete(format!(
+            "{ADMIN_URL}:{admin_port}/imposters/{imposter_port}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // Verify it's gone
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{admin_port}/imposters/{imposter_port}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_delete_all_imposters() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": []
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // DELETE /imposters
+    let resp = client
+        .delete(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // Verify all gone
+    let resp = client
+        .get(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let imposters = body["imposters"].as_array().unwrap();
+    assert_eq!(imposters.len(), 0);
+
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_put_overwrite_all_imposters() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    // Create initial imposter
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "old"}}]}]
+    });
+    create_imposter(&client, admin_port, config).await;
+
+    // PUT /imposters to overwrite all
+    let new_config = json!({
+        "imposters": [{
+            "port": imposter_port + 10,
+            "protocol": "http",
+            "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "new"}}]}]
+        }]
+    });
+
+    let resp = client
+        .put(format!("{ADMIN_URL}:{admin_port}/imposters"))
+        .json(&new_config)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // Old imposter should be gone
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{admin_port}/imposters/{imposter_port}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // New imposter should exist
+    let new_port = imposter_port + 10;
+    let resp = client
+        .get(format!("{ADMIN_URL}:{new_port}/anything"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "new");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_admin_recorded_requests() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "recordRequests": true,
+        "stubs": [{
+            "predicates": [],
+            "responses": [{"is": {"statusCode": 200, "body": "ok"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Make some requests
+    client
+        .get(format!("{ADMIN_URL}:{imposter_port}/path1"))
+        .send()
+        .await
+        .unwrap();
+    client
+        .post(format!("{ADMIN_URL}:{imposter_port}/path2"))
+        .body("test body")
+        .send()
+        .await
+        .unwrap();
+
+    // Retrieve recorded requests
+    let resp = client
+        .get(format!(
+            "{ADMIN_URL}:{admin_port}/imposters/{imposter_port}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let requests = body["requests"].as_array();
+    assert!(
+        requests.is_some(),
+        "Recorded requests should be present when recordRequests is true"
+    );
+    let requests = requests.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0]["method"], "GET");
+    assert_eq!(requests[0]["path"], "/path1");
+    assert_eq!(requests[1]["method"], "POST");
+    assert_eq!(requests[1]["path"], "/path2");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 10. Stub Ordering & Matching
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_first_matching_stub_wins() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"equals": {"path": "/test"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "first stub"}}]
+            },
+            {
+                "predicates": [{"equals": {"path": "/test"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "second stub"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // First matching stub should win
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "first stub");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_catch_all_stub() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"equals": {"path": "/specific"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "specific"}}]
+            },
+            {
+                "predicates": [],
+                "responses": [{"is": {"statusCode": 200, "body": "catch all"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/specific"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "specific");
+
+    let resp = client
+        .get(format!("{ADMIN_URL}:{imposter_port}/anything-else"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "catch all");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 11. Form Data
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_form_urlencoded_matching() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{"equals": {"form": {"username": "admin"}}}],
+            "responses": [{"is": {"statusCode": 200, "body": "form matched"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("username=admin&password=secret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "form matched");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_deep_equals_form_exact_fields() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [
+            {
+                "predicates": [{"deepEquals": {"form": {"username": "admin"}}}],
+                "responses": [{"is": {"statusCode": 200, "body": "exact form"}}]
+            },
+            {
+                "predicates": [],
+                "responses": [{"is": {"statusCode": 404, "body": "no match"}}]
+            }
+        ]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    // Exact match (only username)
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("username=admin")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.text().await.unwrap(), "exact form");
+
+    // Extra field - deepEquals should fail
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("username=admin&password=secret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.text().await.unwrap(),
+        "no match",
+        "deepEquals form should fail with extra fields"
+    );
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+// =============================================================================
+// 12. Predicate Selectors (jsonpath, xpath)
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_jsonpath_selector() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"body": "admin"},
+                "jsonpath": {"selector": "$.user.role"}
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "admin user"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/check"))
+        .header("content-type", "application/json")
+        .body(r#"{"user": {"name": "John", "role": "admin"}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "admin user");
+
+    // Non-admin role
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/check"))
+        .header("content-type", "application/json")
+        .body(r#"{"user": {"name": "Jane", "role": "viewer"}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.text().await.unwrap(), "admin user");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}
+
+#[tokio::test]
+#[ignore = "requires running server"]
+async fn test_xpath_selector() {
+    let (admin_port, imposter_port) = get_test_ports();
+    let mut server = start_rift_server(admin_port).await;
+    let client = Client::builder().timeout(TEST_TIMEOUT).build().unwrap();
+
+    let config = json!({
+        "port": imposter_port,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{
+                "equals": {"body": "John"},
+                "xpath": {"selector": "//user/name"}
+            }],
+            "responses": [{"is": {"statusCode": 200, "body": "xml matched"}}]
+        }]
+    });
+
+    create_imposter(&client, admin_port, config).await;
+
+    let resp = client
+        .post(format!("{ADMIN_URL}:{imposter_port}/check"))
+        .header("content-type", "application/xml")
+        .body("<root><user><name>John</name></user></root>")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "xml matched");
+
+    clear_imposters(&client, admin_port).await;
+    server.kill().await.ok();
+}


### PR DESCRIPTION
## Summary

- Add 31 unit tests to `predicates.rs` covering all predicate types, logical combinators, and edge cases
- Add 45 integration tests in new `mountebank_compatibility.rs` covering 12 feature categories
- Bug-confirming tests document current buggy behavior for 5 confirmed Mountebank incompatibilities

### Bugs confirmed by tests

| Issue | Bug | Unit Test |
|-------|-----|-----------|
| #83 | Multi-valued query params lost (HashMap) | `test_parse_query_string_multi_valued_first_value_preserved` |
| #84 | Bare query params `?flag` dropped | `test_parse_query_string_bare_param`, `test_exists_query_bare_param` |
| #85 | `deepEquals` body is string-based, not structural JSON | `test_deep_equals_body_json_key_order_independence` |
| #86 | `exists` predicate ignores `keyCaseSensitive` | `test_exists_query_key_case_sensitive_false`, `test_exists_form_key_case_sensitive` |
| #87 | Header keys always lowercase breaks `keyCaseSensitive=true` | `test_header_key_case_sensitive_true_with_title_case` |

### Integration test categories (all `#[ignore]`, require running server)

1. Basic predicates (equals, deepEquals, contains, startsWith, endsWith, matches)
2. deepEquals semantics (key order, extra params/headers)
3. Query string edge cases (multi-valued, bare params, URL-encoded, empty)
4. Header edge cases (keyCaseSensitive, value case sensitivity)
5. exists predicate (body, query, header, keyCaseSensitive)
6. Logical combinators (not, or, and, nested)
7. Response types (is with headers, round-robin, fault, default response)
8. Behaviors (wait, repeat)
9. Admin API CRUD (create, list, get, delete single/all, PUT overwrite, recorded requests)
10. Stub ordering (first match wins, catch-all)
11. Form data (urlencoded matching, deepEquals exact fields)
12. Predicate selectors (jsonpath, xpath)

## Test plan

- [x] `cargo test --package rift-http-proxy -- imposter::predicates::tests` — 31 unit tests pass (bug tests assert buggy behavior)
- [x] `cargo test --package rift-http-proxy --test mountebank_compatibility --no-run` — integration tests compile
- [x] `cargo fmt` and `cargo clippy` pass