### PR TITLE
fix: handle bare query params without = sign (Issue #84)

### DIFF
--- a/crates/rift-http-proxy/src/behaviors/request.rs
+++ b/crates/rift-http-proxy/src/behaviors/request.rs
@@ -37,13 +37,15 @@ impl RequestContext {
     ) -> Self {
         let mut query_map = HashMap::new();
         if let Some(query) = uri.query() {
-            for pair in query.split('&') {
-                if let Some((key, value)) = pair.split_once('=') {
-                    query_map.insert(
-                        key.to_string(),
-                        urlencoding::decode(value).unwrap_or_default().to_string(),
-                    );
-                }
+            for pair in query.split('&').filter(|s| !s.is_empty()) {
+                let (key, value) = match pair.split_once('=') {
+                    Some((k, v)) => (k, v),
+                    None => (pair, ""),
+                };
+                query_map.insert(
+                    key.to_string(),
+                    urlencoding::decode(value).unwrap_or_default().to_string(),
+                );
             }
         }
 

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -846,17 +846,20 @@ where
 }
 
 /// Parse query string into HashMap (public helper)
-/// URL-decodes both keys and values to properly handle encoded characters
+/// URL-decodes both keys and values to properly handle encoded characters.
+/// Bare params without `=` (e.g. `?flag`) are treated as key with empty value.
 pub fn parse_query_string(query: &str) -> HashMap<String, String> {
     query
         .split('&')
         .filter(|s| !s.is_empty())
-        .filter_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            // URL-decode both key and value to handle encoded characters like %2C -> ,
+        .map(|pair| {
+            let (key, value) = match pair.split_once('=') {
+                Some((k, v)) => (k, v),
+                None => (pair, ""),
+            };
             let decoded_key = urlencoding::decode(key).unwrap_or_default().into_owned();
             let decoded_value = urlencoding::decode(value).unwrap_or_default().into_owned();
-            Some((decoded_key, decoded_value))
+            (decoded_key, decoded_value)
         })
         .collect()
 }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1697,3 +1697,66 @@ fn test_header_predicate_matches_title_case() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #84: Bare query params (?flag) dropped
+// =============================================================================
+
+#[test]
+fn test_parse_query_string_bare_param() {
+    let result = parse_query_string("flag");
+    assert_eq!(result.get("flag").unwrap(), "");
+}
+
+#[test]
+fn test_parse_query_string_bare_and_valued() {
+    let result = parse_query_string("flag&key=value");
+    assert_eq!(result.get("flag").unwrap(), "");
+    assert_eq!(result.get("key").unwrap(), "value");
+}
+
+#[test]
+fn test_bare_query_param_exists_predicate() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "query": { "flag": true }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some("flag"),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_bare_query_param_equals_empty_string() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "query": { "flag": "" }
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some("flag"),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- Bare query parameters like `?flag` were silently dropped because `split_once('=')` returned `None`
- Now treats bare params as key with empty value, matching Mountebank's behavior
- Fixed in both `parse_query_string()` (predicates.rs) and `RequestContext::from_request` (request.rs)

## Test plan
- [x] New test: `test_parse_query_string_bare_param` — verifies bare param parsed as empty value
- [x] New test: `test_bare_query_param_exists_predicate` — verifies exists predicate detects bare params
- [x] New test: `test_bare_query_param_equals_empty_string` — verifies equals matches bare param to ""
- [x] All 480 existing + new tests pass
- [x] `cargo clippy` clean, `cargo fmt --check` clean

Closes #84