### PR TITLE
fix: deepEquals body rejects extra keys in JSON objects (Issue #85)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -311,13 +311,15 @@ where
     };
 
     // Helper: check a string field against expected value.
-    // When expected is an object, parse actual as JSON and compare recursively (Mountebank compat).
+    // When expected is an object/array, parse actual as JSON and compare recursively (Mountebank compat).
     // When expected is a string/primitive, compare directly.
     // Previously, non-string expected values were silently ignored, causing always-match.
     let check_string_field = |expected: &serde_json::Value, actual: &str| -> bool {
         let actual = apply_except(actual);
         match expected {
-            serde_json::Value::Object(_) => compare_json_recursive(expected, &actual, &compare),
+            serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                compare_json_recursive(expected, &actual, &compare, deep_equals)
+            }
             serde_json::Value::String(s) => compare(s, &actual),
             _ => {
                 let expected_str = expected.to_string();
@@ -757,7 +759,14 @@ fn check_exists_predicate(
 /// Recursively apply a comparison function when the expected value is a JSON object.
 /// Parses the actual string as JSON and compares each field recursively.
 /// For leaf values, converts both to strings and applies the comparison function.
-fn compare_json_recursive<F>(expected: &serde_json::Value, actual_str: &str, compare: &F) -> bool
+/// When `deep_equals` is true, also verifies no extra keys exist in actual objects
+/// and arrays are compared structurally (same length, element-wise).
+fn compare_json_recursive<F>(
+    expected: &serde_json::Value,
+    actual_str: &str,
+    compare: &F,
+    deep_equals: bool,
+) -> bool
 where
     F: Fn(&str, &str) -> bool,
 {
@@ -768,14 +777,47 @@ where
                 Err(_) => return false,
             };
 
+            let actual_obj = match actual_json.as_object() {
+                Some(obj) => obj,
+                None => return false,
+            };
+
+            // For deepEquals, actual must have exactly the same keys
+            if deep_equals && expected_obj.len() != actual_obj.len() {
+                return false;
+            }
+
             for (key, expected_val) in expected_obj {
-                let actual_val = match actual_json.get(key) {
+                let actual_val = match actual_obj.get(key) {
                     Some(v) => v,
                     None => return false,
                 };
 
                 let actual_val_str = json_value_to_string(actual_val);
-                if !compare_json_recursive(expected_val, &actual_val_str, compare) {
+                if !compare_json_recursive(expected_val, &actual_val_str, compare, deep_equals) {
+                    return false;
+                }
+            }
+            true
+        }
+        serde_json::Value::Array(expected_arr) => {
+            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+
+            let actual_arr = match actual_json.as_array() {
+                Some(arr) => arr,
+                None => return false,
+            };
+
+            if deep_equals && expected_arr.len() != actual_arr.len() {
+                return false;
+            }
+
+            for (expected_elem, actual_elem) in expected_arr.iter().zip(actual_arr.iter()) {
+                let actual_elem_str = json_value_to_string(actual_elem);
+                if !compare_json_recursive(expected_elem, &actual_elem_str, compare, deep_equals) {
                     return false;
                 }
             }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1373,3 +1373,155 @@ fn test_ends_with_body_object_with_numeric_value() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #85: deepEquals body missing extra-key check
+// =============================================================================
+
+#[test]
+fn test_deep_equals_body_extra_keys_rejected() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "deepEquals": {
+            "body": {"a": "1"}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Exact match should pass
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"a": "1"}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Extra key should be rejected by deepEquals
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"a": "1", "b": "2"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_equals_body_extra_keys_allowed() {
+    // Regular equals should still allow extra keys
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "body": {"a": "1"}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"a": "1", "b": "2"}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_deep_equals_body_nested_extra_keys_rejected() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "deepEquals": {
+            "body": {"outer": {"inner": "val"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Exact nested match
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"outer": {"inner": "val"}}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Extra key in nested object
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"outer": {"inner": "val", "extra": "x"}}"#),
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_deep_equals_body_array_comparison() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "deepEquals": {
+            "body": {"items": [1, 2, 3]}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // Exact array match
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"items": [1, 2, 3]}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Different length array
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"items": [1, 2, 3, 4]}"#),
+        None,
+        None,
+        None
+    ));
+
+    // Different values
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        Some(r#"{"items": [1, 2, 99]}"#),
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- `deepEquals` on body was only checking expected keys existed in actual, never verifying no extra keys
- `{"deepEquals": {"body": {"a":"1"}}}` incorrectly matched `{"a":"1", "b":"2"}`
- Added `deep_equals` parameter to `compare_json_recursive()` that enforces key count equality at every nesting level
- Also handles structural array comparison (same length, element-wise)

## Test plan
- [x] New test: `test_deep_equals_body_extra_keys_rejected` — extra keys fail deepEquals
- [x] New test: `test_equals_body_extra_keys_allowed` — regular equals still allows extra keys
- [x] New test: `test_deep_equals_body_nested_extra_keys_rejected` — nested objects checked too
- [x] New test: `test_deep_equals_body_array_comparison` — arrays compared structurally
- [x] All 481 existing + new tests pass
- [x] `cargo clippy` clean, `cargo fmt --check` clean

Closes #85