### PR TITLE
fix: exists predicate respects keyCaseSensitive option (Issue #86)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -237,9 +237,14 @@ pub fn predicate_matches(
             form,
             key_case_sensitive,
         ),
-        PredicateOperation::Exists(fields) => {
-            check_exists_predicate(fields, &query_map, headers, effective_body, form)
-        }
+        PredicateOperation::Exists(fields) => check_exists_predicate(
+            fields,
+            &query_map,
+            headers,
+            effective_body,
+            form,
+            key_case_sensitive,
+        ),
         PredicateOperation::Not(inner) => !predicate_matches(
             inner,
             method,
@@ -711,7 +716,17 @@ fn check_exists_predicate(
     headers: &HashMap<String, String>,
     body: &str,
     form: Option<&HashMap<String, String>>,
+    key_case_sensitive: bool,
 ) -> bool {
+    // Helper for key comparison based on keyCaseSensitive
+    let key_matches = |expected_key: &str, actual_key: &str| -> bool {
+        if key_case_sensitive {
+            expected_key == actual_key
+        } else {
+            expected_key.eq_ignore_ascii_case(actual_key)
+        }
+    };
+
     // Check body exists - supports both boolean and object values
     if let Some(expected) = obj.get("body") {
         if !check_exists_json_recursive(expected, body) {
@@ -723,7 +738,7 @@ fn check_exists_predicate(
     if let Some(expected_query) = obj.get("query").and_then(|v| v.as_object()) {
         for (key, should_exist_val) in expected_query {
             let should_exist = should_exist_val.as_bool().unwrap_or(true);
-            let exists = query.contains_key(key);
+            let exists = query.iter().any(|(k, _)| key_matches(key, k));
             if exists != should_exist {
                 return false;
             }
@@ -734,7 +749,7 @@ fn check_exists_predicate(
     if let Some(expected_headers) = obj.get("headers").and_then(|v| v.as_object()) {
         for (key, should_exist_val) in expected_headers {
             let should_exist = should_exist_val.as_bool().unwrap_or(true);
-            let exists = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case(key));
+            let exists = headers.iter().any(|(k, _)| key_matches(key, k));
             if exists != should_exist {
                 return false;
             }
@@ -746,7 +761,7 @@ fn check_exists_predicate(
         let actual_form = form.cloned().unwrap_or_default();
         for (key, should_exist_val) in expected_form {
             let should_exist = should_exist_val.as_bool().unwrap_or(true);
-            let exists = actual_form.contains_key(key);
+            let exists = actual_form.iter().any(|(k, _)| key_matches(key, k));
             if exists != should_exist {
                 return false;
             }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1525,3 +1525,131 @@ fn test_deep_equals_body_array_comparison() {
         None
     ));
 }
+
+// =============================================================================
+// Issue #86: keyCaseSensitive missing from check_exists_predicate
+// =============================================================================
+
+#[test]
+fn test_exists_predicate_query_key_case_insensitive() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "query": {"Token": true}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some("token=abc"),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_exists_predicate_query_key_case_sensitive() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "query": {"Token": true}
+        },
+        "caseSensitive": true
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some("token=abc"),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some("Token=abc"),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_exists_predicate_form_key_case_insensitive() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "form": {"Username": true}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+    let mut form = HashMap::new();
+    form.insert("username".to_string(), "alice".to_string());
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/test",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        Some(&form)
+    ));
+}
+
+#[test]
+fn test_exists_predicate_headers_key_case_sensitive() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "exists": {
+            "headers": {"X-Custom": true}
+        },
+        "caseSensitive": true
+    })]);
+
+    let mut headers = HashMap::new();
+    headers.insert("x-custom".to_string(), "value".to_string());
+
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    let mut headers_exact = HashMap::new();
+    headers_exact.insert("X-Custom".to_string(), "value".to_string());
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers_exact,
+        None,
+        None,
+        None,
+        None
+    ));
+}


### PR DESCRIPTION
## Summary
- `check_exists_predicate()` was ignoring the `keyCaseSensitive` parameter entirely
- Headers used hardcoded `eq_ignore_ascii_case`, query/form used `contains_key` (exact match)
- Now all key lookups use the same `key_matches` closure pattern as other predicates

## Test plan
- [x] New test: `test_exists_predicate_query_key_case_insensitive` — default case-insensitive works
- [x] New test: `test_exists_predicate_query_key_case_sensitive` — caseSensitive=true enforces exact match
- [x] New test: `test_exists_predicate_form_key_case_insensitive` — form keys case-insensitive by default
- [x] New test: `test_exists_predicate_headers_key_case_sensitive` — headers respect caseSensitive flag
- [x] All 481 existing + new tests pass
- [x] `cargo clippy` clean, `cargo fmt --check` clean

Closes #86