### PR TITLE
test: bug-confirming tests for 7 discovered bugs (#95-#101)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -921,3 +921,40 @@ impl Imposter {
         self.enabled.load(Ordering::SeqCst)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // Bug A: Multi-valued form fields silently overwritten (same pattern as #83)
+    // parse_form_data uses .collect() on an iterator of (key, value) pairs,
+    // which means duplicate keys get silently overwritten by the last value.
+    // This is the same bug pattern fixed for query params in Issue #83.
+    // =========================================================================
+
+    #[test]
+    fn test_parse_form_data_multi_valued_fields() {
+        // Form body: checkbox=A&checkbox=B
+        // CORRECT: should produce {"checkbox": "A,B"} (comma-joined, like query params)
+        // BUG: .collect() at line ~298 overwrites to {"checkbox": "B"}
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            "content-type",
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+
+        let body = "checkbox=A&checkbox=B";
+        let result = Imposter::parse_form_data(&headers, Some(body)).unwrap();
+
+        // BUG: The value is "B" (last wins) instead of "A,B" (comma-joined).
+        // Expected: "A,B" (multi-valued form fields should be comma-joined,
+        // matching the query param fix from Issue #83)
+        assert_eq!(
+            result.get("checkbox"),
+            Some(&"B".to_string()),
+            "BUG(A): Multi-valued form fields are overwritten by last value; \
+             expected 'A,B' (comma-joined like query params in #83), got 'B'"
+        );
+    }
+}

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -1841,4 +1841,153 @@ mod tests {
         let result = parse_query_string("");
         assert!(result.is_empty());
     }
+
+    // =========================================================================
+    // Bug E: `except` not applied to `method` in `matches` predicate
+    // In check_predicate_fields_regex (line ~511-518), the method field is
+    // matched against the regex directly without applying the `except` pattern
+    // first, unlike path, body, requestFrom, and ip which all call apply_except().
+    // =========================================================================
+
+    #[test]
+    fn test_matches_method_with_except_applied() {
+        // With except="P" and regex="^OST$", matching against method "POST":
+        // CORRECT: apply except first → "POST" minus "P" → "OST", then regex "^OST$" matches → true
+        // BUG: except is NOT applied, regex "^OST$" tested against raw "POST" → false
+        let fields: HashMap<String, serde_json::Value> = [("method".to_string(), json!("^OST$"))]
+            .into_iter()
+            .collect();
+
+        let params = PredicateParameters {
+            except: "P".to_string(),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Matches(fields), params);
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns false because except="P" is not applied to method before regex matching.
+        // Expected: true (except strips "P" from "POST" → "OST", regex "^OST$" matches)
+        assert!(
+            !result,
+            "BUG(E): matches predicate does not apply except to method field; \
+             expected true (except 'P' from 'POST' → 'OST' matches '^OST$'), got false"
+        );
+    }
+
+    // =========================================================================
+    // Bug F: `equals` array matching ignores extra elements via `.zip()`
+    // In compare_json_recursive (line ~833), arrays are compared with .zip()
+    // which silently stops at the shorter array. When deep_equals=false (the
+    // `equals` predicate), there's no length check, so [1,2] matches [1,2,3].
+    // =========================================================================
+
+    #[test]
+    fn test_equals_body_array_should_not_match_longer_array() {
+        // equals { body: [1, 2] } should NOT match body [1, 2, 3]
+        // because the actual array has extra elements not in the predicate.
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!([1, 2]))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some("[1, 2, 3]"),
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns true because .zip() only compares up to the shorter array length,
+        // so [1,2].zip([1,2,3]) compares (1,1) and (2,2), ignoring the extra 3.
+        // Expected: false (Mountebank's equals requires all elements to match;
+        // extra elements in actual mean the arrays are not equal)
+        assert!(
+            result,
+            "BUG(F): equals array matching ignores extra elements via .zip(); \
+             expected false ([1,2] should not match [1,2,3]), got true"
+        );
+    }
+
+    // =========================================================================
+    // Bug G: `exists` predicate ignores `method`, `path`, `requestFrom`, `ip`
+    // check_exists_predicate (line ~713-772) only handles body, query, headers,
+    // and form — it silently ignores method, path, requestFrom, and ip fields.
+    // =========================================================================
+
+    #[test]
+    fn test_exists_method_false_should_fail_when_present() {
+        // exists { method: false } should NOT match when method is "GET"
+        // (method exists, but predicate says it should not exist)
+        let fields: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!(false))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns true because check_exists_predicate doesn't handle the "method" field.
+        // Expected: false (method "GET" exists, but predicate requires method to NOT exist)
+        assert!(
+            result,
+            "BUG(G): exists predicate ignores 'method' field; \
+             expected false (method exists but predicate says false), got true"
+        );
+    }
+
+    #[test]
+    fn test_exists_path_false_should_fail_when_present() {
+        // exists { path: false } should NOT match when path is "/test"
+        // (path exists, but predicate says it should not exist)
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!(false))].into_iter().collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns true because check_exists_predicate doesn't handle the "path" field.
+        // Expected: false (path "/test" exists, but predicate requires path to NOT exist)
+        assert!(
+            result,
+            "BUG(G): exists predicate ignores 'path' field; \
+             expected false (path exists but predicate says false), got true"
+        );
+    }
 }

--- a/crates/rift-http-proxy/src/recording/stub_generator.rs
+++ b/crates/rift-http-proxy/src/recording/stub_generator.rs
@@ -83,3 +83,105 @@ pub fn generate_stub(
         "responses": [{ "is": response_obj }]
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recording::types::{RecordedResponse, RequestSignature};
+
+    fn make_response() -> RecordedResponse {
+        RecordedResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: b"OK".to_vec(),
+            latency_ms: None,
+            timestamp_secs: 0,
+        }
+    }
+
+    // =========================================================================
+    // Bug B: Query params not URL-decoded in generated predicates
+    // generate_stub parses query params by splitting on '&' and '=' but does
+    // NOT URL-decode the values. The predicate matcher (parse_query_string)
+    // DOES URL-decode, so encoded values like "John%20Doe" will never match
+    // the decoded "John Doe" in the matcher.
+    // =========================================================================
+
+    #[test]
+    fn test_stub_generator_url_decodes_query_params() {
+        // Query: name=John%20Doe
+        // CORRECT: generated predicate should have "John Doe" (decoded)
+        // BUG: generated predicate has "John%20Doe" (raw/encoded)
+        let sig = RequestSignature::new("GET", "/search", Some("name=John%20Doe"), &[]);
+        let resp = make_response();
+
+        let stub = generate_stub(&sig, &resp, false, false, true, &[]);
+        let query_equals = &stub["predicates"][0]["and"]["query"]["equals"];
+
+        // BUG: Value is "John%20Doe" (not decoded) instead of "John Doe".
+        // When this predicate is later matched, parse_query_string decodes
+        // the incoming query to "John Doe", which won't match "John%20Doe".
+        assert_eq!(
+            query_equals["name"].as_str().unwrap(),
+            "John%20Doe",
+            "BUG(B): Query param values are not URL-decoded in generated predicates; \
+             expected 'John Doe' (decoded), got 'John%20Doe'"
+        );
+    }
+
+    // =========================================================================
+    // Bug C: Bare query params (`?flag`) silently dropped (same as #84)
+    // generate_stub uses `parts.next()?` for the value part, which returns
+    // None for bare params (no '=' sign), causing filter_map to drop them.
+    // This is the same bug pattern fixed for predicate matching in Issue #84.
+    // =========================================================================
+
+    #[test]
+    fn test_stub_generator_preserves_bare_query_params() {
+        // Query: flag&key=value
+        // CORRECT: generated predicate should have {"flag": "", "key": "value"}
+        // BUG: "flag" is silently dropped because parts.next()? returns None
+        let sig = RequestSignature::new("GET", "/test", Some("flag&key=value"), &[]);
+        let resp = make_response();
+
+        let stub = generate_stub(&sig, &resp, false, false, true, &[]);
+        let query_equals = &stub["predicates"][0]["and"]["query"]["equals"];
+
+        // BUG: "flag" is missing from the generated predicate.
+        // Only "key" is present because bare params without '=' are dropped.
+        assert!(
+            query_equals.get("flag").is_none(),
+            "BUG(C): Bare query params are silently dropped in stub generation; \
+             expected 'flag' to be present with empty value, but it is missing"
+        );
+    }
+
+    // =========================================================================
+    // Bug D: Multi-valued query params overwritten (same as #83)
+    // generate_stub uses .collect() into HashMap, which overwrites duplicate
+    // keys with the last value. This is the same bug pattern fixed for
+    // predicate matching in Issue #83.
+    // =========================================================================
+
+    #[test]
+    fn test_stub_generator_comma_joins_multi_valued_params() {
+        // Query: color=red&color=blue
+        // CORRECT: generated predicate should have {"color": "red,blue"} (comma-joined)
+        // BUG: .collect() overwrites to {"color": "blue"} (last wins)
+        let sig = RequestSignature::new("GET", "/test", Some("color=red&color=blue"), &[]);
+        let resp = make_response();
+
+        let stub = generate_stub(&sig, &resp, false, false, true, &[]);
+        let query_equals = &stub["predicates"][0]["and"]["query"]["equals"];
+
+        // BUG: Value is "blue" (last wins) instead of "red,blue" (comma-joined).
+        // The predicate matcher (parse_query_string) comma-joins duplicate keys,
+        // producing "red,blue", which won't match the generated "blue".
+        assert_eq!(
+            query_equals["color"].as_str().unwrap(),
+            "blue",
+            "BUG(D): Multi-valued query params are overwritten in stub generation; \
+             expected 'red,blue' (comma-joined like predicate matcher), got 'blue'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add 8 targeted tests confirming 7 bugs discovered during code audit of the predicate matching system
- Tests assert **current (buggy) behavior** with `// BUG:` comments documenting expected correct behavior
- All tests pass green — they document the bugs, not fix them
- Created GitHub issues #95–#101 for each bug

## Bugs Confirmed

| Issue | Severity | Component | Bug |
|-------|----------|-----------|-----|
| #95 | MEDIUM | `core.rs` | Multi-valued form fields silently overwritten (same as #83) |
| #96 | HIGH | `stub_generator.rs` | Query params not URL-decoded in generated predicates |
| #97 | MEDIUM | `stub_generator.rs` | Bare query params silently dropped (same as #84) |
| #98 | MEDIUM | `stub_generator.rs` | Multi-valued query params overwritten (same as #83) |
| #99 | LOW | `predicates.rs` | `except` not applied to `method` in `matches` predicate |
| #100 | LOW-MED | `predicates.rs` | `equals` array matching ignores extra elements via `.zip()` |
| #101 | LOW | `predicates.rs` | `exists` predicate missing `method`/`path`/`requestFrom`/`ip` |

## Files Changed

| File | Tests Added |
|------|-------------|
| `crates/rift-http-proxy/src/imposter/predicates.rs` | 4 tests (bugs E, F, G) |
| `crates/rift-http-proxy/src/imposter/core.rs` | 1 test (bug A) |
| `crates/rift-http-proxy/src/recording/stub_generator.rs` | 3 tests (bugs B, C, D) |

## Test plan

- [x] `cargo test -p rift-http-proxy --lib` — all 534 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean