### PR TITLE
test: bug-confirming tests for 7 more discovered bugs (#103-#109)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -921,3 +921,159 @@ impl Imposter {
         self.enabled.load(Ordering::SeqCst)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imposter::types::ImposterConfig;
+    use serde_json::json;
+
+    fn make_test_imposter() -> Imposter {
+        let config = ImposterConfig {
+            port: Some(0),
+            protocol: "http".to_string(),
+            ..Default::default()
+        };
+        Imposter::new(config)
+    }
+
+    // =========================================================================
+    // Bug H: caseSensitive default mismatch between generator and matcher
+    // The predicate generator defaults caseSensitive to true (core.rs line 482)
+    // and only writes it to the predicate JSON when false (line 571).
+    // But the predicate matcher defaults caseSensitive to false when absent
+    // (predicates.rs line 69). This means generated predicates are evaluated
+    // case-insensitively when they should be case-sensitive.
+    // =========================================================================
+
+    #[test]
+    fn test_generator_case_sensitive_default_mismatch() {
+        // A predicateGenerator with default caseSensitive (true) generates a
+        // predicate without a caseSensitive field. When the matcher evaluates
+        // it, it defaults to false — the opposite of what was intended.
+        let imposter = make_test_imposter();
+
+        let generators = vec![json!({
+            "matches": { "method": true, "path": true }
+            // no caseSensitive field → generator defaults to true
+        })];
+
+        let headers = HashMap::new();
+        let predicates = imposter.generate_predicates_from_request(
+            &generators,
+            "GET",
+            "/API/Users",
+            &headers,
+            None,
+        );
+
+        assert_eq!(predicates.len(), 1);
+        let pred_json = &predicates[0];
+
+        // The generator defaults caseSensitive to true, but since true is the
+        // "default", it doesn't write the field to the predicate JSON.
+        assert!(
+            pred_json.get("caseSensitive").is_none(),
+            "Generator should not write caseSensitive when it's the 'default' (true)"
+        );
+
+        // Now deserialize as a Predicate and check what the matcher sees
+        let pred: crate::imposter::types::Predicate = serde_json::from_value(pred_json.clone())
+            .expect("Generated predicate should deserialize");
+
+        // BUG: The matcher defaults caseSensitive to false when absent.
+        // Generator intended true, matcher sees false.
+        assert_eq!(
+            pred.parameters.case_sensitive, None,
+            "caseSensitive should be None (absent from JSON)"
+        );
+        // When None, matcher uses unwrap_or(false) — so case-INSENSITIVE matching
+        let effective_case_sensitive = pred.parameters.case_sensitive.unwrap_or(false);
+        assert!(
+            !effective_case_sensitive,
+            "BUG(H): Generator defaults caseSensitive=true but doesn't write it; \
+             matcher defaults to false when absent. Generated predicates intended to be \
+             case-sensitive are evaluated case-insensitively."
+        );
+    }
+
+    // =========================================================================
+    // Bug M: `except` not applied to method in generate_predicates_from_request
+    // The generator applies except to path (line 500-503) and body (line 550-553)
+    // but NOT to method (line 514-516). The method value is stored raw.
+    // =========================================================================
+
+    #[test]
+    fn test_generator_except_not_applied_to_method() {
+        // A predicateGenerator with except="^(POST|DELETE)$" that matches method.
+        // For method "POST": except should strip "POST" → empty string.
+        // BUG: Method value "POST" is stored as-is, except is not applied.
+        let imposter = make_test_imposter();
+
+        let generators = vec![json!({
+            "matches": { "method": true },
+            "except": "^POST$"
+        })];
+
+        let headers = HashMap::new();
+        let predicates =
+            imposter.generate_predicates_from_request(&generators, "POST", "/test", &headers, None);
+
+        assert_eq!(predicates.len(), 1);
+        let pred_json = &predicates[0];
+        let method_val = pred_json["equals"]["method"].as_str().unwrap();
+
+        // BUG: Method is "POST" (raw) instead of "" (with except applied).
+        // Compare with path handling which correctly applies except.
+        assert_eq!(
+            method_val, "POST",
+            "BUG(M): except pattern not applied to method in predicate generator; \
+             expected '' (except strips 'POST'), got 'POST'"
+        );
+    }
+
+    // =========================================================================
+    // Bug N: generate_predicates_from_request ignores query parameters
+    // The function only handles method, path, headers, and body.
+    // If a predicateGenerator has "matches": { "query": true }, the query
+    // field is silently ignored — no query constraint is generated.
+    // =========================================================================
+
+    #[test]
+    fn test_generator_ignores_query_parameters() {
+        // A predicateGenerator that matches query should generate a query predicate.
+        // BUG: The function doesn't accept or process query parameters at all.
+        let imposter = make_test_imposter();
+
+        let generators = vec![json!({
+            "matches": { "path": true, "query": true }
+        })];
+
+        let headers = HashMap::new();
+        let predicates = imposter.generate_predicates_from_request(
+            &generators,
+            "GET",
+            "/search",
+            &headers,
+            None,
+        );
+
+        assert_eq!(predicates.len(), 1);
+        let pred_json = &predicates[0];
+        let equals_obj = pred_json["equals"].as_object().unwrap();
+
+        // Path should be present
+        assert!(
+            equals_obj.contains_key("path"),
+            "Path should be in generated predicate"
+        );
+
+        // BUG: Query is NOT present because the function doesn't handle it.
+        // Expected: query parameters should be included in the generated predicate.
+        assert!(
+            !equals_obj.contains_key("query"),
+            "BUG(N): generate_predicates_from_request ignores query parameters; \
+             expected query field in generated predicate, but it is missing"
+        );
+    }
+}

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -1841,4 +1841,137 @@ mod tests {
         let result = parse_query_string("");
         assert!(result.is_empty());
     }
+
+    // =========================================================================
+    // Bug I: JSON body key matching ignores keyCaseSensitive
+    // compare_json_recursive uses exact `actual_obj.get(key)` for JSON body
+    // key lookup, ignoring keyCaseSensitive (and caseSensitive). In Mountebank,
+    // when caseSensitive is false (the default), JSON body keys are matched
+    // case-insensitively.
+    // =========================================================================
+
+    #[test]
+    fn test_equals_json_body_key_case_insensitive_by_default() {
+        // equals { body: { "Name": "John" } } should match body {"name": "John"}
+        // because caseSensitive defaults to false, which affects JSON body keys too.
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"Name": "John"}))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some(r#"{"name": "John"}"#),
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns false because compare_json_recursive uses exact
+        // actual_obj.get("Name") which fails to find "name" (lowercase).
+        // Expected: true (caseSensitive=false means keys should match case-insensitively)
+        assert!(
+            !result,
+            "BUG(I): JSON body key matching ignores keyCaseSensitive; \
+             expected true (default caseSensitive=false should match 'Name' to 'name'), got false"
+        );
+    }
+
+    // =========================================================================
+    // Bug J: `except` applied to raw JSON string before parsing, breaking
+    // structured body matching.
+    // In check_string_field (line ~322-326), apply_except is called on the
+    // raw body string BEFORE compare_json_recursive tries to parse it as JSON.
+    // If the except regex removes JSON structural characters, parsing fails.
+    // =========================================================================
+
+    #[test]
+    fn test_except_breaks_json_body_matching() {
+        // equals { body: { "greeting": "hello" } } with except="\\d+"
+        // Body: {"greeting": "hello", "count": 42}
+        // BUG: except="\\d+" strips digits from raw JSON → {"greeting": "hello", "count": }
+        //      which is invalid JSON → parse fails → predicate returns false.
+        // CORRECT: except should be applied to individual leaf values AFTER parsing,
+        //          not to the raw JSON string before parsing.
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"greeting": "hello"}))]
+                .into_iter()
+                .collect();
+
+        let params = PredicateParameters {
+            except: "\\d+".to_string(),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Equals(fields), params);
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some(r#"{"greeting": "hello", "count": 42}"#),
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns false because except strips "42" from the raw JSON
+        // leaving invalid JSON that fails to parse.
+        // Expected: true (equals should match "greeting"="hello" with except
+        // only stripping digits from leaf values, not breaking JSON structure)
+        assert!(
+            !result,
+            "BUG(J): except applied to raw JSON body before parsing breaks structure; \
+             expected true (except should apply to leaf values, not raw JSON), got false"
+        );
+    }
+
+    // =========================================================================
+    // Bug K: Invalid regex patterns silently match everything
+    // build_regex uses .ok() to discard regex compilation errors. When the
+    // regex is invalid, build_regex returns None, the if-let body is skipped,
+    // and the field check passes successfully — meaning an invalid regex
+    // matches all requests instead of matching none.
+    // =========================================================================
+
+    #[test]
+    fn test_matches_invalid_regex_silently_matches_everything() {
+        // matches { path: "[unclosed" } — this is an invalid regex.
+        // CORRECT: An invalid regex should cause the predicate to NOT match.
+        // BUG: build_regex returns None, the check is skipped, predicate matches.
+        let fields: HashMap<String, serde_json::Value> = [("path".to_string(), json!("[unclosed"))]
+            .into_iter()
+            .collect();
+
+        let pred = make_predicate(PredicateOperation::Matches(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/any/path/at/all",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // BUG: Returns true because the invalid regex is silently discarded
+        // and the path check is skipped entirely.
+        // Expected: false (an invalid regex should fail to match)
+        assert!(
+            result,
+            "BUG(K): Invalid regex pattern silently matches everything; \
+             expected false (invalid regex should not match), got true"
+        );
+    }
 }

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -873,3 +873,35 @@ pub enum ImposterError {
     #[error("Stub index {0} out of bounds")]
     StubIndexOutOfBounds(usize),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // =========================================================================
+    // Bug L: Stub.responses missing #[serde(default)]
+    // The predicates field has #[serde(default)] but responses does not.
+    // A stub JSON without a "responses" field fails to deserialize, even
+    // though Mountebank allows stubs with no responses.
+    // =========================================================================
+
+    #[test]
+    fn test_stub_deserialize_without_responses_field() {
+        // A stub with predicates but no responses field should deserialize.
+        // Mountebank allows this — the stub matches but returns the default response.
+        let stub_json = json!({
+            "predicates": [{ "equals": { "path": "/test" } }]
+        });
+
+        let result: Result<Stub, _> = serde_json::from_value(stub_json);
+
+        // BUG: Deserialization fails because `responses` has no #[serde(default)].
+        // Expected: Ok with empty responses vec
+        assert!(
+            result.is_err(),
+            "BUG(L): Stub.responses missing #[serde(default)] causes deserialization failure; \
+             expected Ok with empty responses, got Err"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Round 2 of deep code audit: 7 more targeted tests confirming bugs across predicates, types, and core modules
- Tests assert **current (buggy) behavior** with `// BUG:` comments documenting expected correct behavior
- All tests pass green
- Created GitHub issues #103–#109 for each bug

## Bugs Confirmed

| Issue | Severity | Component | Bug |
|-------|----------|-----------|-----|
| #103 | HIGH | `core.rs` | caseSensitive default mismatch: generator=true, matcher=false |
| #104 | HIGH | `predicates.rs` | JSON body key matching ignores keyCaseSensitive |
| #105 | HIGH | `predicates.rs` | `except` applied to raw JSON body breaks structured matching |
| #106 | MEDIUM | `predicates.rs` | Invalid regex silently matches everything |
| #107 | MEDIUM | `types.rs` | `Stub.responses` missing `#[serde(default)]` |
| #108 | MEDIUM | `core.rs` | `except` not applied to method in generator |
| #109 | HIGH | `core.rs` | `generate_predicates_from_request` ignores query params |

## Files Changed

| File | Tests Added |
|------|-------------|
| `crates/rift-http-proxy/src/imposter/predicates.rs` | 3 tests (bugs I, J, K) |
| `crates/rift-http-proxy/src/imposter/types.rs` | 1 test (bug L) |
| `crates/rift-http-proxy/src/imposter/core.rs` | 3 tests (bugs H, M, N) |

## Test plan

- [x] `cargo test -p rift-http-proxy --lib` — all 533 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean