### PR TITLE
fix: apply except to method field in matches predicate (#99)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -2003,10 +2003,9 @@ mod tests {
     fn test_matches_method_with_except_applied() {
         // matches { method: "^OST$" } with except="P" and method "POST"
         // After applying except: "POST" → "OST", regex "^OST$" matches "OST" → true
-        let fields: HashMap<String, serde_json::Value> =
-            [("method".to_string(), json!("^OST$"))]
-                .into_iter()
-                .collect();
+        let fields: HashMap<String, serde_json::Value> = [("method".to_string(), json!("^OST$"))]
+            .into_iter()
+            .collect();
 
         let params = PredicateParameters {
             except: "P".to_string(),

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -520,7 +520,8 @@ fn check_predicate_fields_regex(
     if let Some(pattern) = obj.get("method").and_then(|v| v.as_str()) {
         match build_regex(pattern) {
             Ok(re) => {
-                if !re.is_match(method) {
+                let actual = apply_except(method);
+                if !re.is_match(&actual) {
                     return false;
                 }
             }
@@ -1994,6 +1995,41 @@ mod tests {
         assert!(
             !result,
             "Invalid regex pattern should cause the predicate to not match"
+        );
+    }
+
+    // Fix #99: except is now applied to method in matches predicate
+    #[test]
+    fn test_matches_method_with_except_applied() {
+        // matches { method: "^OST$" } with except="P" and method "POST"
+        // After applying except: "POST" → "OST", regex "^OST$" matches "OST" → true
+        let fields: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!("^OST$"))]
+                .into_iter()
+                .collect();
+
+        let params = PredicateParameters {
+            except: "P".to_string(),
+            ..Default::default()
+        };
+
+        let pred = make_predicate_with_params(PredicateOperation::Matches(fields), params);
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert!(
+            result,
+            "except should be applied to method before regex matching"
         );
     }
 }


### PR DESCRIPTION
## Summary\n- Add `apply_except(method)` before regex matching in the `matches` predicate\n- Previously, `except` was applied to `path`, `body`, `requestFrom`, `ip` but not `method`\n- Now consistent across all fields\n\n## Test plan\n- [x] `cargo test -p rift-http-proxy --lib` — 537 tests pass\n- [x] New test: `test_matches_method_with_except_applied`\n\nFixes #99