### PR TITLE
fix: check array length in equals predicate matching (#100)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -2036,9 +2036,7 @@ mod tests {
     #[test]
     fn test_equals_body_array_rejects_longer_actual() {
         let fields: HashMap<String, serde_json::Value> =
-            [("body".to_string(), json!([1, 2]))]
-                .into_iter()
-                .collect();
+            [("body".to_string(), json!([1, 2]))].into_iter().collect();
 
         let pred = make_predicate(PredicateOperation::Equals(fields));
 
@@ -2062,10 +2060,9 @@ mod tests {
 
     #[test]
     fn test_equals_body_array_rejects_shorter_actual() {
-        let fields: HashMap<String, serde_json::Value> =
-            [("body".to_string(), json!([1, 2, 3]))]
-                .into_iter()
-                .collect();
+        let fields: HashMap<String, serde_json::Value> = [("body".to_string(), json!([1, 2, 3]))]
+            .into_iter()
+            .collect();
 
         let pred = make_predicate(PredicateOperation::Equals(fields));
 

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -880,7 +880,7 @@ where
                 None => return false,
             };
 
-            if deep_equals && expected_arr.len() != actual_arr.len() {
+            if expected_arr.len() != actual_arr.len() {
                 return false;
             }
 
@@ -2029,6 +2029,61 @@ mod tests {
         assert!(
             result,
             "except should be applied to method before regex matching"
+        );
+    }
+
+    // Fix #100: equals array matching now checks array length
+    #[test]
+    fn test_equals_body_array_rejects_longer_actual() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!([1, 2]))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some("[1, 2, 3]"),
+            None,
+            None,
+            None,
+        );
+
+        assert!(
+            !result,
+            "equals [1, 2] should not match [1, 2, 3] — arrays have different lengths"
+        );
+    }
+
+    #[test]
+    fn test_equals_body_array_rejects_shorter_actual() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!([1, 2, 3]))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Equals(fields));
+
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/test",
+            None,
+            &empty_headers(),
+            Some("[1, 2]"),
+            None,
+            None,
+            None,
+        );
+
+        assert!(
+            !result,
+            "equals [1, 2, 3] should not match [1, 2] — arrays have different lengths"
         );
     }
 }


### PR DESCRIPTION
## Summary\n- Remove the `deep_equals` guard on the array length check in `compare_json_recursive`\n- Both `equals` and `deepEquals` now reject arrays with different lengths\n- Previously `.zip()` silently ignored extra elements in either array\n\n## Test plan\n- [x] `cargo test -p rift-http-proxy --lib` — 538 tests pass\n- [x] New tests: `test_equals_body_array_rejects_longer_actual`, `test_equals_body_array_rejects_shorter_actual`\n\nFixes #100