### PR TITLE
fix: add method/path/requestFrom/ip to exists predicate (#101)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -747,6 +747,7 @@ fn check_exists_json_recursive(expected: &serde_json::Value, actual_str: &str) -
 /// Supports: method, path, body, query, headers, form, requestFrom, ip
 /// When a field's value is an object (not a boolean), parse the actual value as JSON
 /// and recursively check field existence within it (Mountebank compatible).
+#[allow(clippy::too_many_arguments)]
 fn check_exists_predicate(
     obj: &HashMap<String, serde_json::Value>,
     method: &str,
@@ -789,7 +790,7 @@ fn check_exists_predicate(
     // Check requestFrom exists
     if let Some(expected) = obj.get("requestFrom") {
         let should_exist = expected.as_bool().unwrap_or(true);
-        let exists = request_from.map_or(false, |v| !v.is_empty());
+        let exists = request_from.is_some_and(|v| !v.is_empty());
         if exists != should_exist {
             return false;
         }
@@ -798,7 +799,7 @@ fn check_exists_predicate(
     // Check ip exists
     if let Some(expected) = obj.get("ip") {
         let should_exist = expected.as_bool().unwrap_or(true);
-        let exists = client_ip.map_or(false, |v| !v.is_empty());
+        let exists = client_ip.is_some_and(|v| !v.is_empty());
         if exists != should_exist {
             return false;
         }
@@ -2132,14 +2133,20 @@ mod tests {
     #[test]
     fn test_exists_method_false_fails_when_present() {
         let fields: HashMap<String, serde_json::Value> =
-            [("method".to_string(), json!(false))]
-                .into_iter()
-                .collect();
+            [("method".to_string(), json!(false))].into_iter().collect();
 
         let pred = make_predicate(PredicateOperation::Exists(fields));
 
         let result = predicate_matches(
-            &pred, "GET", "/test", None, &empty_headers(), None, None, None, None,
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(
@@ -2151,14 +2158,20 @@ mod tests {
     #[test]
     fn test_exists_path_false_fails_when_present() {
         let fields: HashMap<String, serde_json::Value> =
-            [("path".to_string(), json!(false))]
-                .into_iter()
-                .collect();
+            [("path".to_string(), json!(false))].into_iter().collect();
 
         let pred = make_predicate(PredicateOperation::Exists(fields));
 
         let result = predicate_matches(
-            &pred, "GET", "/test", None, &empty_headers(), None, None, None, None,
+            &pred,
+            "GET",
+            "/test",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
         );
 
         assert!(

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -239,9 +239,13 @@ pub fn predicate_matches(
         ),
         PredicateOperation::Exists(fields) => check_exists_predicate(
             fields,
+            method,
+            path,
             &query_map,
             headers,
             effective_body,
+            request_from,
+            client_ip,
             form,
             key_case_sensitive,
         ),
@@ -740,14 +744,18 @@ fn check_exists_json_recursive(expected: &serde_json::Value, actual_str: &str) -
 }
 
 /// Check exists predicate - verifies field presence or absence
-/// Supports: body, query, headers, form
+/// Supports: method, path, body, query, headers, form, requestFrom, ip
 /// When a field's value is an object (not a boolean), parse the actual value as JSON
 /// and recursively check field existence within it (Mountebank compatible).
 fn check_exists_predicate(
     obj: &HashMap<String, serde_json::Value>,
+    method: &str,
+    path: &str,
     query: &HashMap<String, String>,
     headers: &HashMap<String, String>,
     body: &str,
+    request_from: Option<&str>,
+    client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     key_case_sensitive: bool,
 ) -> bool {
@@ -759,6 +767,42 @@ fn check_exists_predicate(
             expected_key.eq_ignore_ascii_case(actual_key)
         }
     };
+
+    // Check method exists (always present in HTTP requests)
+    if let Some(expected) = obj.get("method") {
+        let should_exist = expected.as_bool().unwrap_or(true);
+        let exists = !method.is_empty();
+        if exists != should_exist {
+            return false;
+        }
+    }
+
+    // Check path exists (always present in HTTP requests)
+    if let Some(expected) = obj.get("path") {
+        let should_exist = expected.as_bool().unwrap_or(true);
+        let exists = !path.is_empty();
+        if exists != should_exist {
+            return false;
+        }
+    }
+
+    // Check requestFrom exists
+    if let Some(expected) = obj.get("requestFrom") {
+        let should_exist = expected.as_bool().unwrap_or(true);
+        let exists = request_from.map_or(false, |v| !v.is_empty());
+        if exists != should_exist {
+            return false;
+        }
+    }
+
+    // Check ip exists
+    if let Some(expected) = obj.get("ip") {
+        let should_exist = expected.as_bool().unwrap_or(true);
+        let exists = client_ip.map_or(false, |v| !v.is_empty());
+        if exists != should_exist {
+            return false;
+        }
+    }
 
     // Check body exists - supports both boolean and object values
     if let Some(expected) = obj.get("body") {
@@ -2081,6 +2125,45 @@ mod tests {
         assert!(
             !result,
             "equals [1, 2, 3] should not match [1, 2] — arrays have different lengths"
+        );
+    }
+
+    // Fix #101: exists predicate now handles method, path, requestFrom, ip
+    #[test]
+    fn test_exists_method_false_fails_when_present() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("method".to_string(), json!(false))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred, "GET", "/test", None, &empty_headers(), None, None, None, None,
+        );
+
+        assert!(
+            !result,
+            "exists method=false should fail when method is present"
+        );
+    }
+
+    #[test]
+    fn test_exists_path_false_fails_when_present() {
+        let fields: HashMap<String, serde_json::Value> =
+            [("path".to_string(), json!(false))]
+                .into_iter()
+                .collect();
+
+        let pred = make_predicate(PredicateOperation::Exists(fields));
+
+        let result = predicate_matches(
+            &pred, "GET", "/test", None, &empty_headers(), None, None, None, None,
+        );
+
+        assert!(
+            !result,
+            "exists path=false should fail when path is present"
         );
     }
 }


### PR DESCRIPTION
## Summary\n- Add handling for `method`, `path`, `requestFrom`, and `ip` fields in `check_exists_predicate`\n- Previously these fields were silently ignored, causing predicates like `exists { method: false }` to always return true\n\n## Test plan\n- [x] `cargo test -p rift-http-proxy --lib` — 538 tests pass\n- [x] New tests: `test_exists_method_false_fails_when_present`, `test_exists_path_false_fails_when_present`\n\nFixes #101