### PR TITLE
fix: apply recursive JSON matching to form/query/headers predicates (#77)

### DIFF
--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -394,10 +394,6 @@ where
             }
 
             for (key, expected_val) in expected_obj {
-                let expected_str = match expected_val {
-                    serde_json::Value::String(s) => s.clone(),
-                    _ => expected_val.to_string(),
-                };
                 // Find key using keyCaseSensitive option
                 let actual = actual_form
                     .iter()
@@ -406,8 +402,7 @@ where
 
                 match actual {
                     Some(actual) => {
-                        let actual = apply_except(actual);
-                        if !compare(&expected_str, &actual) {
+                        if !check_string_field(expected_val, actual) {
                             return false;
                         }
                     }
@@ -426,10 +421,6 @@ where
             }
 
             for (key, expected_val) in expected_obj {
-                let expected_str = match expected_val {
-                    serde_json::Value::String(s) => s.clone(),
-                    _ => expected_val.to_string(),
-                };
                 // Find key using keyCaseSensitive option
                 let actual = query
                     .iter()
@@ -438,8 +429,7 @@ where
 
                 match actual {
                     Some(actual) => {
-                        let actual = apply_except(actual);
-                        if !compare(&expected_str, &actual) {
+                        if !check_string_field(expected_val, actual) {
                             return false;
                         }
                     }
@@ -458,10 +448,6 @@ where
             }
 
             for (key, expected_val) in expected_obj {
-                let expected_str = match expected_val {
-                    serde_json::Value::String(s) => s.clone(),
-                    _ => expected_val.to_string(),
-                };
                 // Headers use keyCaseSensitive option
                 let actual = headers
                     .iter()
@@ -470,8 +456,7 @@ where
 
                 match actual {
                     Some(actual) => {
-                        let actual = apply_except(actual);
-                        if !compare(&expected_str, &actual) {
+                        if !check_string_field(expected_val, actual) {
                             return false;
                         }
                     }

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -505,68 +505,75 @@ fn check_predicate_fields_regex(
         }
     };
 
-    // Check method
-    if let Some(pattern) = obj.get("method").and_then(|v| v.as_str()) {
-        match build_regex(pattern) {
-            Ok(re) => {
-                let actual = apply_except(method);
-                if !re.is_match(&actual) {
-                    return false;
+    // Helper: check a field against expected value for regex matching.
+    // When expected is an object/array, recurse via compare_json_recursive with regex comparator.
+    // When expected is a string, build regex and match directly.
+    let check_regex_field = |expected: &serde_json::Value, actual: &str| -> bool {
+        match expected {
+            serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                let regex_compare = |pattern: &str, actual: &str| -> bool {
+                    match build_regex(pattern) {
+                        Ok(re) => re.is_match(actual),
+                        Err(_) => false,
+                    }
+                };
+                compare_json_recursive(
+                    expected,
+                    actual,
+                    &regex_compare,
+                    false,
+                    key_case_sensitive,
+                    &apply_except,
+                )
+            }
+            _ => {
+                let pattern = match expected {
+                    serde_json::Value::String(s) => s.as_str().to_string(),
+                    _ => expected.to_string(),
+                };
+                match build_regex(&pattern) {
+                    Ok(re) => {
+                        let actual = apply_except(actual);
+                        re.is_match(&actual)
+                    }
+                    Err(_) => false,
                 }
             }
-            Err(_) => return false,
+        }
+    };
+
+    // Check method
+    if let Some(expected) = obj.get("method") {
+        if !check_regex_field(expected, method) {
+            return false;
         }
     }
 
     // Check path
-    if let Some(pattern) = obj.get("path").and_then(|v| v.as_str()) {
-        match build_regex(pattern) {
-            Ok(re) => {
-                let actual = apply_except(path);
-                if !re.is_match(&actual) {
-                    return false;
-                }
-            }
-            Err(_) => return false,
+    if let Some(expected) = obj.get("path") {
+        if !check_regex_field(expected, path) {
+            return false;
         }
     }
 
     // Check body
-    if let Some(pattern) = obj.get("body").and_then(|v| v.as_str()) {
-        match build_regex(pattern) {
-            Ok(re) => {
-                let actual = apply_except(body);
-                if !re.is_match(&actual) {
-                    return false;
-                }
-            }
-            Err(_) => return false,
+    if let Some(expected) = obj.get("body") {
+        if !check_regex_field(expected, body) {
+            return false;
         }
     }
 
     // Check requestFrom
-    if let Some(pattern) = obj.get("requestFrom").and_then(|v| v.as_str()) {
-        match build_regex(pattern) {
-            Ok(re) => {
-                let actual = apply_except(request_from.unwrap_or(""));
-                if !re.is_match(&actual) {
-                    return false;
-                }
-            }
-            Err(_) => return false,
+    if let Some(expected) = obj.get("requestFrom") {
+        if !check_regex_field(expected, request_from.unwrap_or("")) {
+            return false;
         }
     }
 
     // Check ip
-    if let Some(pattern) = obj.get("ip").and_then(|v| v.as_str()) {
-        match build_regex(pattern) {
-            Ok(re) => {
-                let actual = apply_except(client_ip.unwrap_or(""));
-                if !re.is_match(&actual) {
-                    return false;
-                }
-            }
-            Err(_) => return false,
+    if let Some(expected) = obj.get("ip") {
+        if !check_regex_field(expected, client_ip.unwrap_or("")) {
+            return false;
         }
     }
 
@@ -574,28 +581,18 @@ fn check_predicate_fields_regex(
     if let Some(expected_form) = obj.get("form").and_then(|v| v.as_object()) {
         let actual_form = form.cloned().unwrap_or_default();
         for (key, pattern_val) in expected_form {
-            let pattern = match pattern_val {
-                serde_json::Value::String(s) => s.as_str(),
-                _ => continue,
-            };
-            match build_regex(pattern) {
-                Ok(re) => {
-                    let actual = actual_form
-                        .iter()
-                        .find(|(k, _)| key_matches(key, k))
-                        .map(|(_, v)| v.as_str());
+            let actual = actual_form
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                    match actual {
-                        Some(actual) => {
-                            let actual = apply_except(actual);
-                            if !re.is_match(&actual) {
-                                return false;
-                            }
-                        }
-                        None => return false,
+            match actual {
+                Some(actual) => {
+                    if !check_regex_field(pattern_val, actual) {
+                        return false;
                     }
                 }
-                Err(_) => return false,
+                None => return false,
             }
         }
     }
@@ -603,28 +600,18 @@ fn check_predicate_fields_regex(
     // Check query parameters
     if let Some(expected_query) = obj.get("query").and_then(|v| v.as_object()) {
         for (key, pattern_val) in expected_query {
-            let pattern = match pattern_val {
-                serde_json::Value::String(s) => s.as_str(),
-                _ => continue,
-            };
-            match build_regex(pattern) {
-                Ok(re) => {
-                    let actual = query
-                        .iter()
-                        .find(|(k, _)| key_matches(key, k))
-                        .map(|(_, v)| v.as_str());
+            let actual = query
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                    match actual {
-                        Some(actual) => {
-                            let actual = apply_except(actual);
-                            if !re.is_match(&actual) {
-                                return false;
-                            }
-                        }
-                        None => return false,
+            match actual {
+                Some(actual) => {
+                    if !check_regex_field(pattern_val, actual) {
+                        return false;
                     }
                 }
-                Err(_) => return false,
+                None => return false,
             }
         }
     }
@@ -632,28 +619,18 @@ fn check_predicate_fields_regex(
     // Check headers
     if let Some(expected_headers) = obj.get("headers").and_then(|v| v.as_object()) {
         for (key, pattern_val) in expected_headers {
-            let pattern = match pattern_val {
-                serde_json::Value::String(s) => s.as_str(),
-                _ => continue,
-            };
-            match build_regex(pattern) {
-                Ok(re) => {
-                    let actual = headers
-                        .iter()
-                        .find(|(k, _)| key_matches(key, k))
-                        .map(|(_, v)| v.as_str());
+            let actual = headers
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                    match actual {
-                        Some(actual) => {
-                            let actual = apply_except(actual);
-                            if !re.is_match(&actual) {
-                                return false;
-                            }
-                        }
-                        None => return false,
+            match actual {
+                Some(actual) => {
+                    if !check_regex_field(pattern_val, actual) {
+                        return false;
                     }
                 }
-                Err(_) => return false,
+                None => return false,
             }
         }
     }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1670,6 +1670,160 @@ fn test_equals_header_object_value() {
     ));
 }
 
+// Issue #77: matches predicate with object expected values in query/headers/form
+// The regex function had the same bug — object values were silently skipped via `continue`.
+
+#[test]
+fn test_matches_query_object_value_does_not_always_match() {
+    // {"matches": {"query": {"q": {"nested": "^abc"}}}} should NOT match
+    // when the actual query param is a plain string
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "matches": {
+            "query": {"q": {"nested": "^abc"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/search",
+            Some("q=hello"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None
+        ),
+        "Object expected value in matches/query should not match a plain string"
+    );
+}
+
+#[test]
+fn test_matches_query_object_value_recursive_regex() {
+    // When query param value IS a JSON string, object predicate should recurse with regex
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "matches": {
+            "query": {"data": {"name": "^J.*n$"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // query param 'data' is JSON with a "name" field matching regex ^J.*n$
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"name": "John", "age": "30"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // "Jane" does NOT match ^J.*n$ (ends with 'e')
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"name": "Jane"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_matches_header_object_value_recursive_regex() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "matches": {
+            "headers": {"X-Data": {"id": "^\\d+$"}}
+        }
+    })]);
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        "X-Data".to_string(),
+        r#"{"id": "12345", "extra": "abc"}"#.to_string(),
+    );
+
+    // "12345" matches ^\d+$
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // "abc" does NOT match ^\d+$
+    headers.insert("X-Data".to_string(), r#"{"id": "abc"}"#.to_string());
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_matches_form_object_value_recursive_regex() {
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "matches": {
+            "form": {"payload": {"code": "^[A-Z]{3}$"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+    let mut form = HashMap::new();
+    form.insert(
+        "payload".to_string(),
+        r#"{"code": "ABC", "extra": "123"}"#.to_string(),
+    );
+
+    // "ABC" matches ^[A-Z]{3}$
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/submit",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        Some(&form)
+    ));
+
+    // "abcd" does NOT match ^[A-Z]{3}$
+    form.insert("payload".to_string(), r#"{"code": "abcd"}"#.to_string());
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/submit",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        Some(&form)
+    ));
+}
+
 // =============================================================================
 // Issue #85: deepEquals body missing extra-key check
 // =============================================================================

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -1374,6 +1374,302 @@ fn test_ends_with_body_object_with_numeric_value() {
     ));
 }
 
+// Issue #77 (reopened): Object predicates in query, headers, and form
+// The original fix only applied check_string_field to method/path/body.
+// Query, headers, and form still used inline to_string() which broke
+// recursive JSON matching when the expected value is an object.
+
+#[test]
+fn test_ends_with_query_object_value_does_not_always_match() {
+    // {"endsWith": {"query": {"q": {"nested": "val"}}}} should NOT match
+    // when the actual query param value is a plain string
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "query": {"q": {"nested": "val"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/search",
+            Some("q=hello"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None
+        ),
+        "Object expected value in query should not match a plain string"
+    );
+}
+
+#[test]
+fn test_ends_with_query_object_value_recursive_match() {
+    // When query param value IS a JSON string, object predicate should recurse
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "query": {"data": {"key": "123"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // query param 'data' is a JSON string with a field ending in "123"
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"key": "other123", "extra": "ignored"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // query param 'data' has a field NOT ending in "123"
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"key": "other456"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_ends_with_header_object_value_does_not_always_match() {
+    // {"endsWith": {"headers": {"X-Custom": {"nested": "val"}}}} should NOT match
+    // when the actual header value is a plain string
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "headers": {"X-Custom": {"nested": "val"}}
+        }
+    })]);
+
+    let mut headers = HashMap::new();
+    headers.insert("X-Custom".to_string(), "plaintext".to_string());
+
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None
+        ),
+        "Object expected value in headers should not match a plain string"
+    );
+}
+
+#[test]
+fn test_ends_with_header_object_value_recursive_match() {
+    // When header value IS a JSON string, object predicate should recurse
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "headers": {"X-Data": {"abc": "123"}}
+        }
+    })]);
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        "X-Data".to_string(),
+        r#"{"abc": "other123", "extra": "ignored"}"#.to_string(),
+    );
+
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // Header value with field NOT ending in "123"
+    headers.insert("X-Data".to_string(), r#"{"abc": "other456"}"#.to_string());
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_ends_with_form_object_value_does_not_always_match() {
+    // {"endsWith": {"form": {"field": {"nested": "val"}}}} should NOT match
+    // when the actual form field value is a plain string
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "form": {"field": {"nested": "val"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+    let mut form = HashMap::new();
+    form.insert("field".to_string(), "plaintext".to_string());
+
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/submit",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form)
+        ),
+        "Object expected value in form should not match a plain string"
+    );
+}
+
+#[test]
+fn test_ends_with_form_object_value_recursive_match() {
+    // When form field value IS a JSON string, object predicate should recurse
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "endsWith": {
+            "form": {"payload": {"key": "123"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+    let mut form = HashMap::new();
+    form.insert(
+        "payload".to_string(),
+        r#"{"key": "other123", "extra": "ignored"}"#.to_string(),
+    );
+
+    assert!(stub_matches(
+        &predicates,
+        "POST",
+        "/submit",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        Some(&form)
+    ));
+
+    // Form field with value NOT ending in "123"
+    form.insert("payload".to_string(), r#"{"key": "other456"}"#.to_string());
+    assert!(!stub_matches(
+        &predicates,
+        "POST",
+        "/submit",
+        None,
+        &empty_headers,
+        None,
+        None,
+        None,
+        Some(&form)
+    ));
+}
+
+#[test]
+fn test_contains_query_object_value() {
+    // Also verify 'contains' operator works for query with object expected values
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "contains": {
+            "query": {"data": {"name": "ohn"}}
+        }
+    })]);
+
+    let empty_headers = HashMap::new();
+
+    // query param 'data' is a JSON string with a field containing "ohn"
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"name": "John", "age": "30"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // query param 'data' does NOT contain "ohn"
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        Some(r#"data={"name": "Jane"}"#),
+        &empty_headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
+#[test]
+fn test_equals_header_object_value() {
+    // 'equals' operator should also recurse for headers with object expected values
+    let predicates = predicates_from_jsons(vec![serde_json::json!({
+        "equals": {
+            "headers": {"X-Config": {"mode": "test"}}
+        }
+    })]);
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        "X-Config".to_string(),
+        r#"{"mode": "test", "extra": "ignored"}"#.to_string(),
+    );
+
+    // equals with object does recursive field match (extra fields OK)
+    assert!(stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+
+    // Mismatched value
+    headers.insert("X-Config".to_string(), r#"{"mode": "prod"}"#.to_string());
+    assert!(!stub_matches(
+        &predicates,
+        "GET",
+        "/test",
+        None,
+        &headers,
+        None,
+        None,
+        None,
+        None
+    ));
+}
+
 // =============================================================================
 // Issue #85: deepEquals body missing extra-key check
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #77 (reopened). The original fix applied `check_string_field` to method/path/body but missed **form**, **query**, and **headers** — these still used inline `to_string()` which broke recursive JSON matching when the expected value is an object.

Additionally, `check_predicate_fields_regex` (the `matches` predicate) had the **same class of bug**: object expected values were silently skipped via `_ => continue`, causing the predicate to always match.

### Changes

**`check_predicate_fields`** (equals, deepEquals, contains, startsWith, endsWith):
- Form, query, and headers sections now delegate to `check_string_field` instead of inline `to_string()` + `compare()`
- This enables recursive JSON matching when the expected value is an object (Mountebank-compatible)

**`check_predicate_fields_regex`** (matches):
- Added `check_regex_field` helper that mirrors `check_string_field` but uses `compare_json_recursive` with a regex comparator for object/array expected values
- All field checks (method, path, body, requestFrom, ip, form, query, headers) now use this helper
- Object expected values now recurse into the parsed JSON and apply regex matching at leaf level

### What was broken

```json
{"endsWith": {"query": {"q": {"nested": "val"}}}}
```
This would **always match** because `{"nested": "val"}.to_string()` produced `"{\"nested\":\"val\"}"` which was compared as a literal string. Now it correctly parses the actual query value as JSON and checks recursively.

Same issue for `matches`:
```json
{"matches": {"query": {"q": {"nested": "^abc"}}}}
```
This would silently skip the field and match everything.

## Test plan

- [x] 12 new tests covering all affected predicates and field types
- [x] All 554 tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy -D warnings` clean