### PR TITLE
test: add verification tests for recent fixes #116-#120

### DIFF
--- a/crates/rift-http-proxy/src/imposter/response.rs
+++ b/crates/rift-http-proxy/src/imposter/response.rs
@@ -324,6 +324,165 @@ pub fn apply_js_or_rhai_decorate(
 mod tests {
     use super::*;
 
+    // =========================================================================
+    // Issue #116: Multi-valued headers preserved via create_stub_from_proxy_response
+    // =========================================================================
+
+    #[test]
+    fn test_create_stub_multi_valued_headers_comma_joined() {
+        // Multiple Set-Cookie headers should be comma-joined in the stub
+        let headers = vec![
+            ("Set-Cookie".to_string(), "session=abc".to_string()),
+            ("Set-Cookie".to_string(), "theme=dark".to_string()),
+            ("Content-Type".to_string(), "text/html".to_string()),
+        ];
+
+        let stub = create_stub_from_proxy_response(vec![], 200, &headers, b"OK", None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert_eq!(
+                    is.headers.get("Set-Cookie").unwrap(),
+                    "session=abc, theme=dark",
+                    "Multi-valued Set-Cookie headers should be comma-joined"
+                );
+                assert_eq!(is.headers.get("Content-Type").unwrap(), "text/html");
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    #[test]
+    fn test_create_stub_hop_by_hop_headers_filtered() {
+        let headers = vec![
+            ("Content-Type".to_string(), "text/html".to_string()),
+            ("Transfer-Encoding".to_string(), "chunked".to_string()),
+            ("Connection".to_string(), "keep-alive".to_string()),
+            ("Keep-Alive".to_string(), "timeout=5".to_string()),
+        ];
+
+        let stub = create_stub_from_proxy_response(vec![], 200, &headers, b"OK", None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert!(is.headers.contains_key("Content-Type"));
+                assert!(
+                    !is.headers.contains_key("Transfer-Encoding"),
+                    "Transfer-Encoding should be filtered"
+                );
+                assert!(
+                    !is.headers.contains_key("Connection"),
+                    "Connection should be filtered"
+                );
+                assert!(
+                    !is.headers.contains_key("Keep-Alive"),
+                    "Keep-Alive should be filtered"
+                );
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    // =========================================================================
+    // Issue #117: Binary response bodies correctly base64-encoded
+    // =========================================================================
+
+    #[test]
+    fn test_create_stub_binary_body_base64_encoded() {
+        // Non-UTF-8 bytes should be base64-encoded with binary mode
+        let binary_body: Vec<u8> = vec![0x00, 0xFF, 0xFE, 0xFD, 0x89, 0x50, 0x4E, 0x47];
+
+        let stub = create_stub_from_proxy_response(vec![], 200, &[], &binary_body, None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert_eq!(is.mode, ResponseMode::Binary, "Binary body should set mode");
+
+                // Verify the body is base64
+                use base64::Engine;
+                let expected_b64 = base64::engine::general_purpose::STANDARD.encode(&binary_body);
+                assert_eq!(
+                    is.body.as_ref().unwrap().as_str().unwrap(),
+                    expected_b64,
+                    "Binary body should be base64-encoded"
+                );
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    #[test]
+    fn test_create_stub_text_body_not_base64() {
+        let stub = create_stub_from_proxy_response(vec![], 200, &[], b"Hello, World!", None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert_eq!(
+                    is.mode,
+                    ResponseMode::Text,
+                    "Text body should use text mode"
+                );
+                assert_eq!(is.body.as_ref().unwrap().as_str().unwrap(), "Hello, World!");
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    #[test]
+    fn test_create_stub_json_body_parsed() {
+        let stub =
+            create_stub_from_proxy_response(vec![], 200, &[], br#"{"key": "value"}"#, None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert_eq!(is.mode, ResponseMode::Text);
+                // JSON bodies are parsed into serde_json::Value, not stored as strings
+                let body = is.body.as_ref().unwrap();
+                assert!(body.is_object(), "JSON body should be parsed as object");
+                assert_eq!(body["key"], "value");
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    #[test]
+    fn test_create_stub_empty_body() {
+        let stub = create_stub_from_proxy_response(vec![], 204, &[], b"", None, None);
+
+        match &stub.responses[0] {
+            StubResponse::Is { is, .. } => {
+                assert_eq!(is.mode, ResponseMode::Text);
+                assert!(is.body.is_none(), "Empty body should be None");
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    #[test]
+    fn test_create_stub_with_latency_and_decorate() {
+        let stub = create_stub_from_proxy_response(
+            vec![],
+            200,
+            &[],
+            b"OK",
+            Some(150),
+            Some("function(request, response) {}".to_string()),
+        );
+
+        match &stub.responses[0] {
+            StubResponse::Is { behaviors, .. } => {
+                let b = behaviors.as_ref().unwrap();
+                assert_eq!(b["wait"], 150);
+                assert_eq!(b["decorate"], "function(request, response) {}");
+            }
+            _ => panic!("Expected StubResponse::Is"),
+        }
+    }
+
+    // =========================================================================
+    // Truncation tests
+    // =========================================================================
+
     #[test]
     fn test_truncate_with_ellipsis_short_string() {
         assert_eq!(truncate_with_ellipsis("hello", 10), "hello");
@@ -373,5 +532,41 @@ mod tests {
     #[test]
     fn test_truncate_with_ellipsis_zero_max_len() {
         assert_eq!(truncate_with_ellipsis("hello", 0), "...");
+    }
+
+    // Issue #119: Malformed predicates are skipped instead of panicking
+    #[test]
+    fn test_create_stub_malformed_predicate_skipped() {
+        // A valid predicate alongside a completely invalid one
+        let valid_predicate = serde_json::json!({
+            "equals": { "method": "GET" }
+        });
+        // This is not a valid Predicate shape — should be skipped via filter_map
+        let malformed_predicate = serde_json::json!({
+            "notARealPredicate": { "foo": "bar" }
+        });
+
+        let stub = create_stub_from_proxy_response(
+            vec![valid_predicate, malformed_predicate],
+            200,
+            &[],
+            b"OK",
+            None,
+            None,
+        );
+
+        // The malformed predicate should be silently skipped
+        assert_eq!(stub.predicates.len(), 1);
+    }
+
+    #[test]
+    fn test_create_stub_all_predicates_malformed() {
+        // All predicates are invalid — stub should have zero predicates
+        let bad1 = serde_json::json!({"garbage": 123});
+        let bad2 = serde_json::json!("just a string");
+
+        let stub = create_stub_from_proxy_response(vec![bad1, bad2], 200, &[], b"OK", None, None);
+
+        assert!(stub.predicates.is_empty());
     }
 }

--- a/crates/rift-http-proxy/src/recording/store.rs
+++ b/crates/rift-http-proxy/src/recording/store.rs
@@ -423,4 +423,163 @@ mod tests {
         let transparent = RecordingStore::new(ProxyMode::ProxyTransparent);
         assert_eq!(transparent.mode(), ProxyMode::ProxyTransparent);
     }
+
+    // =========================================================================
+    // Issue #118: Race conditions — concurrent should_proxy in proxyOnce mode
+    // =========================================================================
+
+    #[test]
+    fn test_proxy_once_concurrent_should_proxy_only_one_wins() {
+        // In proxyOnce mode, only the first caller to should_proxy for a given
+        // signature should get true. All subsequent callers should get false
+        // until the response is recorded and the pending flag is cleared.
+        use std::sync::Arc;
+        use std::thread;
+
+        let store = Arc::new(RecordingStore::new(ProxyMode::ProxyOnce));
+        let sig = RequestSignature::new("GET", "/concurrent-test", None, &[]);
+
+        let num_threads = 10;
+        let wins = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let sig = sig.clone();
+                let wins = Arc::clone(&wins);
+                thread::spawn(move || {
+                    if store.should_proxy(&sig) {
+                        wins.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            wins.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "Only one thread should win should_proxy in proxyOnce mode"
+        );
+    }
+
+    #[test]
+    fn test_proxy_once_should_proxy_false_after_recording() {
+        // After recording, both should_proxy and pending should be cleared
+        let store = RecordingStore::new(ProxyMode::ProxyOnce);
+        let sig = RequestSignature::new("GET", "/test", None, &[]);
+
+        assert!(store.should_proxy(&sig), "First call should return true");
+        assert!(
+            !store.should_proxy(&sig),
+            "Second call should return false (pending)"
+        );
+
+        // Record the response — clears pending
+        store.record(
+            sig.clone(),
+            RecordedResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"ok".to_vec(),
+                latency_ms: Some(10),
+                timestamp_secs: unix_timestamp(),
+            },
+        );
+
+        // Now it should still return false (recorded)
+        assert!(
+            !store.should_proxy(&sig),
+            "After recording, should return false"
+        );
+    }
+
+    // =========================================================================
+    // Issue #120: Recording store enforces size limits
+    // =========================================================================
+
+    #[test]
+    fn test_proxy_always_evicts_oldest_when_limit_reached() {
+        let store = RecordingStore::new(ProxyMode::ProxyAlways);
+        let sig = RequestSignature::new("GET", "/evict-test", None, &[]);
+
+        // Record MAX_RECORDINGS_PER_SIGNATURE + 1 responses
+        for i in 0..=MAX_RECORDINGS_PER_SIGNATURE {
+            store.record(
+                sig.clone(),
+                RecordedResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: format!("response-{i}").into_bytes(),
+                    latency_ms: Some(10),
+                    timestamp_secs: unix_timestamp(),
+                },
+            );
+        }
+
+        let all = store.get_all();
+        let recordings = all.get(&sig).unwrap();
+        assert_eq!(
+            recordings.len(),
+            MAX_RECORDINGS_PER_SIGNATURE,
+            "Should not exceed MAX_RECORDINGS_PER_SIGNATURE"
+        );
+
+        // The oldest (response-0) should have been evicted
+        assert_eq!(
+            recordings[0].body, b"response-1",
+            "Oldest recording should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_recording_store_drops_new_signatures_when_full() {
+        let store = RecordingStore::new(ProxyMode::ProxyOnce);
+
+        // Fill up to MAX_TOTAL_SIGNATURES
+        for i in 0..MAX_TOTAL_SIGNATURES {
+            let sig = RequestSignature::new("GET", &format!("/path-{i}"), None, &[]);
+            // Claim the signature first so record() succeeds
+            store.should_proxy(&sig);
+            store.record(
+                sig,
+                RecordedResponse {
+                    status: 200,
+                    headers: Vec::new(),
+                    body: b"ok".to_vec(),
+                    latency_ms: Some(10),
+                    timestamp_secs: unix_timestamp(),
+                },
+            );
+        }
+
+        assert_eq!(store.len(), MAX_TOTAL_SIGNATURES);
+
+        // Adding a new signature should be silently dropped
+        let new_sig = RequestSignature::new("GET", "/overflow", None, &[]);
+        store.should_proxy(&new_sig);
+        store.record(
+            new_sig.clone(),
+            RecordedResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"dropped".to_vec(),
+                latency_ms: Some(10),
+                timestamp_secs: unix_timestamp(),
+            },
+        );
+
+        assert_eq!(
+            store.len(),
+            MAX_TOTAL_SIGNATURES,
+            "Store should not grow beyond MAX_TOTAL_SIGNATURES"
+        );
+        assert!(
+            store.get_recorded(&new_sig).is_none(),
+            "Overflow signature should not be recorded"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds targeted unit tests to verify the correctness of recent bug fixes:

- **#116** (multi-valued headers): Tests that `create_stub_from_proxy_response` comma-joins duplicate headers and filters hop-by-hop headers (transfer-encoding, connection, keep-alive)
- **#117** (binary response bodies): Tests that binary bodies are base64-encoded with binary mode, while text and JSON bodies are preserved correctly
- **#118** (race conditions in recording): Tests that concurrent `should_proxy` calls in proxyOnce mode allow exactly one thread to proxy, using a 10-thread race
- **#119** (dangerous expect/unwrap): Tests that malformed predicate JSON values are skipped via `filter_map` instead of panicking
- **#120** (body size limits): Tests that the recording store evicts oldest recordings when the per-signature limit is reached and drops new signatures when the global limit is full

## Test plan

- [x] All 555 existing tests pass
- [x] 13 new tests added (7 in `response.rs`, 4 in `store.rs`, 2 for #119 in `response.rs`)
- [x] `cargo fmt` clean
- [x] `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)