### PR TITLE
Add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: EtaCassiopeia


### PR DESCRIPTION
Adds .github/FUNDING.yml to enable the Sponsor button.