### PR TITLE
fix: add DELETE /imposters/:port/requests alias for savedRequests

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -37,7 +37,7 @@ impl ImposterRoute {
             [] => Some(ImposterRoute::Root),
             ["stubs"] => Some(ImposterRoute::Stubs),
             ["stubs", index_str] => index_str.parse().ok().map(ImposterRoute::StubByIndex),
-            ["savedRequests"] => Some(ImposterRoute::SavedRequests),
+            ["savedRequests"] | ["requests"] => Some(ImposterRoute::SavedRequests),
             ["savedProxyResponses"] => Some(ImposterRoute::SavedProxyResponses),
             ["enable"] => Some(ImposterRoute::Enable),
             ["disable"] => Some(ImposterRoute::Disable),
@@ -203,6 +203,10 @@ mod tests {
         ));
         assert!(matches!(
             ImposterRoute::parse(&["savedRequests"]),
+            Some(ImposterRoute::SavedRequests)
+        ));
+        assert!(matches!(
+            ImposterRoute::parse(&["requests"]),
             Some(ImposterRoute::SavedRequests)
         ));
         assert!(matches!(

--- a/tests/compatibility/features/admin_api.feature
+++ b/tests/compatibility/features/admin_api.feature
@@ -266,3 +266,14 @@ Feature: Admin API Compatibility
   Scenario: Get stub for non-existent imposter returns 404
     When I send GET request to "/imposters/9999/stubs/0" on both services
     Then both services should return status 404
+
+  # ==========================================================================
+  # DELETE /requests alias for savedRequests
+  # ==========================================================================
+
+  Scenario: DELETE requests path is alias for savedRequests
+    Given an imposter on port 4545 with recordRequests enabled
+    And I send 3 GET requests to "/test" on imposter 4545
+    When I send DELETE request to "/imposters/4545/requests" on both admin APIs
+    Then both services should return status 200
+    And imposter 4545 should have numberOfRequests equal to 0 on both services


### PR DESCRIPTION
## Summary
- Adds `requests` as an alias for `savedRequests` in the `ImposterRoute` parser
- `DELETE /imposters/:port/requests` now routes to the same handler as `DELETE /imposters/:port/savedRequests`
- Adds a test case for the new alias

Closes #141

## Test plan
- [ ] Run `cargo test --lib` — existing + new route alias tests pass
- [ ] Manual: `curl -X DELETE http://localhost:2525/imposters/4545/requests` returns 200 (same as `savedRequests`)