### PR TITLE
fix: accept 'rules' alias, delayRange, and recordedFrom in stubs

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -354,6 +354,7 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
                     predicates: stub.predicates,
                     responses: non_proxy_responses,
                     scenario_name: stub.scenario_name,
+                    recorded_from: stub.recorded_from,
                 })
             }
         })

--- a/crates/rift-http-proxy/src/extensions/stub_analysis.rs
+++ b/crates/rift-http-proxy/src/extensions/stub_analysis.rs
@@ -417,6 +417,7 @@ mod tests {
             predicates,
             responses: vec![],
             scenario_name: None,
+            recorded_from: None,
         }
     }
 
@@ -427,6 +428,7 @@ mod tests {
             predicates,
             responses: vec![],
             scenario_name: None,
+            recorded_from: None,
         }
     }
 

--- a/crates/rift-http-proxy/src/imposter/response.rs
+++ b/crates/rift-http-proxy/src/imposter/response.rs
@@ -260,6 +260,7 @@ pub fn create_stub_from_proxy_response(
             rift: None,
         }],
         scenario_name: None,
+        recorded_from: None,
     }
 }
 

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -57,6 +57,7 @@ fn test_predicate_matching() {
             rift: None,
         }],
         scenario_name: None,
+        recorded_from: None,
     };
 
     let empty_headers = HashMap::new();
@@ -141,6 +142,7 @@ fn test_execute_stub() {
             rift: None,
         }],
         scenario_name: None,
+        recorded_from: None,
     };
 
     let result = imposter.execute_stub_with_rift(&StubState::new(stub));

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -115,7 +115,7 @@ pub struct DebugStubInfo {
 /// Stub definition (Mountebank-compatible with Rift extensions)
 /// Field ordering matches Mountebank output: scenarioName, predicates, responses, _links
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", from = "StubRaw")]
 pub struct Stub {
     /// Optional scenario name for documentation/organization (Mountebank compatible)
     /// Placed first to match Mountebank output ordering
@@ -129,6 +129,126 @@ pub struct Stub {
     pub predicates: Vec<Predicate>,
     #[serde(default)]
     pub responses: Vec<StubResponse>,
+    /// Upstream URL recorded from during proxy recording (Mountebank compatible)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recorded_from: Option<String>,
+}
+
+/// Raw deserialization type for Stub — handles alternative field names and format conversions:
+/// - `rules` as Mimeo Solo alias for `predicates`
+/// - `delayRange` array (Mimeo Solo stub-level latency) converted to per-response `wait` behavior
+/// - `recordedFrom` URL from Mountebank proxy recording
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StubRaw {
+    #[serde(default)]
+    scenario_name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    predicates: Vec<Predicate>,
+    /// Mimeo Solo recorded format uses "rules" instead of "predicates"
+    #[serde(default)]
+    rules: Vec<Predicate>,
+    #[serde(default)]
+    responses: Vec<StubResponse>,
+    #[serde(default)]
+    recorded_from: Option<String>,
+    /// Mimeo Solo stub-level latency: `[{ "min": "50", "max": "100" }]`
+    #[serde(default)]
+    delay_range: Vec<DelayRange>,
+}
+
+/// A `delayRange` entry as emitted by the Mimeo Solo recorder.
+/// Both `min` and `max` may be numbers or numeric strings.
+#[derive(Debug, Clone, Deserialize)]
+struct DelayRange {
+    #[serde(deserialize_with = "de_u64_or_string")]
+    min: u64,
+    #[serde(deserialize_with = "de_u64_or_string")]
+    max: u64,
+}
+
+fn de_u64_or_string<'de, D: serde::Deserializer<'de>>(d: D) -> Result<u64, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| D::Error::custom("expected non-negative integer")),
+        serde_json::Value::String(s) => s
+            .parse::<u64>()
+            .map_err(|_| D::Error::custom(format!("cannot parse '{s}' as integer"))),
+        _ => Err(D::Error::custom("expected number or numeric string")),
+    }
+}
+
+impl From<StubRaw> for Stub {
+    fn from(raw: StubRaw) -> Self {
+        // "rules" is the Mimeo Solo alias for "predicates"; prefer "predicates" when both present
+        let predicates = if !raw.predicates.is_empty() {
+            raw.predicates
+        } else {
+            raw.rules
+        };
+
+        // Convert stub-level delayRange to a wait behavior injected into each response
+        let responses = if raw.delay_range.is_empty() {
+            raw.responses
+        } else {
+            let wait_val = build_wait_from_delay_range(&raw.delay_range);
+            raw.responses
+                .into_iter()
+                .map(|r| inject_wait_behavior(r, wait_val.clone()))
+                .collect()
+        };
+
+        Stub {
+            scenario_name: raw.scenario_name,
+            id: raw.id,
+            predicates,
+            responses,
+            recorded_from: raw.recorded_from,
+        }
+    }
+}
+
+/// Build a wait value from a delayRange array (uses first entry).
+/// Emits a fixed value when min == max, otherwise a range object.
+fn build_wait_from_delay_range(ranges: &[DelayRange]) -> serde_json::Value {
+    let first = &ranges[0];
+    if first.min == first.max {
+        serde_json::Value::Number(first.min.into())
+    } else {
+        serde_json::json!({ "min": first.min, "max": first.max })
+    }
+}
+
+/// Inject a `wait` value into a stub response's `_behaviors`, but only when
+/// the response does not already have an explicit wait configured.
+fn inject_wait_behavior(response: StubResponse, wait_val: serde_json::Value) -> StubResponse {
+    match response {
+        StubResponse::Is {
+            is,
+            behaviors,
+            rift,
+        } => {
+            let behaviors = Some(match behaviors {
+                Some(serde_json::Value::Object(mut obj)) => {
+                    obj.entry("wait").or_insert(wait_val);
+                    serde_json::Value::Object(obj)
+                }
+                Some(other) => other,
+                None => serde_json::json!({ "wait": wait_val }),
+            });
+            StubResponse::Is {
+                is,
+                behaviors,
+                rift,
+            }
+        }
+        other => other,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -894,5 +1014,74 @@ mod tests {
             "Stub without responses field should deserialize with empty responses vec"
         );
         assert!(result.unwrap().responses.is_empty());
+    }
+
+    #[test]
+    fn test_stub_rules_alias_for_predicates() {
+        let stub_json = json!({
+            "rules": [{ "equals": { "path": "/test" } }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        });
+        let stub: Stub = serde_json::from_value(stub_json).unwrap();
+        assert_eq!(stub.predicates.len(), 1);
+    }
+
+    #[test]
+    fn test_stub_predicates_takes_precedence_over_rules() {
+        let stub_json = json!({
+            "predicates": [{ "equals": { "path": "/a" } }],
+            "rules": [{ "equals": { "path": "/b" } }, { "equals": { "path": "/c" } }],
+            "responses": []
+        });
+        let stub: Stub = serde_json::from_value(stub_json).unwrap();
+        assert_eq!(stub.predicates.len(), 1);
+    }
+
+    #[test]
+    fn test_stub_delay_range_injected_as_wait() {
+        let stub_json = json!({
+            "predicates": [],
+            "delayRange": [{ "min": "50", "max": "100" }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        });
+        let stub: Stub = serde_json::from_value(stub_json).unwrap();
+        assert_eq!(stub.responses.len(), 1);
+        if let StubResponse::Is { behaviors, .. } = &stub.responses[0] {
+            let wait = behaviors.as_ref().unwrap().get("wait").unwrap();
+            // min != max → range object
+            assert_eq!(wait.get("min").unwrap(), &json!(50u64));
+            assert_eq!(wait.get("max").unwrap(), &json!(100u64));
+        } else {
+            panic!("expected Is response");
+        }
+    }
+
+    #[test]
+    fn test_stub_delay_range_fixed_when_min_equals_max() {
+        let stub_json = json!({
+            "predicates": [],
+            "delayRange": [{ "min": 0, "max": 0 }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        });
+        let stub: Stub = serde_json::from_value(stub_json).unwrap();
+        if let StubResponse::Is { behaviors, .. } = &stub.responses[0] {
+            let wait = behaviors.as_ref().unwrap().get("wait").unwrap();
+            assert_eq!(wait, &json!(0u64));
+        } else {
+            panic!("expected Is response");
+        }
+    }
+
+    #[test]
+    fn test_stub_recorded_from_roundtrip() {
+        let stub_json = json!({
+            "predicates": [],
+            "responses": [],
+            "recordedFrom": "http://upstream:8080"
+        });
+        let stub: Stub = serde_json::from_value(stub_json).unwrap();
+        assert_eq!(stub.recorded_from.as_deref(), Some("http://upstream:8080"));
+        let serialized = serde_json::to_value(&stub).unwrap();
+        assert_eq!(serialized["recordedFrom"], json!("http://upstream:8080"));
     }
 }

--- a/crates/rift-http-proxy/src/scripting/stub_validator.rs
+++ b/crates/rift-http-proxy/src/scripting/stub_validator.rs
@@ -271,6 +271,7 @@ mod tests {
                 },
             }],
             scenario_name: None,
+            recorded_from: None,
         }
     }
 
@@ -282,6 +283,7 @@ mod tests {
                 inject: code.to_string(),
             }],
             scenario_name: None,
+            recorded_from: None,
         }
     }
 
@@ -366,6 +368,7 @@ mod tests {
                     },
                 }],
                 scenario_name: None,
+                recorded_from: None,
             },
             Stub {
                 id: None, // No id, will use stub[1]
@@ -381,6 +384,7 @@ mod tests {
                     },
                 }],
                 scenario_name: None,
+                recorded_from: None,
             },
         ];
         let result = validate_stubs(&stubs);

--- a/tests/compatibility/features/alternative_formats.feature
+++ b/tests/compatibility/features/alternative_formats.feature
@@ -426,3 +426,85 @@ Feature: Alternative Mountebank Format Compatibility
     # Note: This will fail to connect but validates the format is accepted
     When I send GET request to "/proxy-redirect" on imposter 4545
     Then both services should return same error type
+
+  # ==========================================================================
+  # Mimeo Solo Compatibility: rules alias, delayRange, recordedFrom
+  # These formats are emitted by the Mimeo Solo recorder and are not part of
+  # Mountebank's own format — tests run against Rift only.
+  # ==========================================================================
+
+  @rift-only
+  Scenario: rules key is accepted as alias for predicates (Mimeo Solo format)
+    Given an imposter on port 4545 on Rift with:
+      """
+      {
+        "port": 4545,
+        "protocol": "http",
+        "stubs": [{
+          "rules": [{"equals": {"path": "/rules-alias"}}],
+          "responses": [{"is": {"statusCode": 200, "body": "rules alias matched"}}]
+        }]
+      }
+      """
+    When I send GET request to "/rules-alias" on Rift imposter 4545
+    Then Rift should return status 200
+    And Rift response body should be "rules alias matched"
+
+  @rift-only
+  Scenario: predicates wins over rules when both present
+    Given an imposter on port 4545 on Rift with:
+      """
+      {
+        "port": 4545,
+        "protocol": "http",
+        "stubs": [{
+          "predicates": [{"equals": {"path": "/pred-wins"}}],
+          "rules": [{"equals": {"path": "/rules-loses"}}],
+          "responses": [{"is": {"statusCode": 200, "body": "predicates won"}}]
+        }]
+      }
+      """
+    When I send GET request to "/pred-wins" on Rift imposter 4545
+    Then Rift should return status 200
+    When I send GET request to "/rules-loses" on Rift imposter 4545
+    Then Rift should return status 404
+
+  @rift-only
+  Scenario: delayRange array is converted to wait behavior (Mimeo Solo format)
+    Given an imposter on port 4545 on Rift with:
+      """
+      {
+        "port": 4545,
+        "protocol": "http",
+        "stubs": [{
+          "predicates": [{"equals": {"path": "/delay-range"}}],
+          "delayRange": [{"min": "100", "max": "200"}],
+          "responses": [{"is": {"statusCode": 200, "body": "delayed"}}]
+        }]
+      }
+      """
+    When I send GET request to "/delay-range" on Rift imposter 4545 and measure time
+    Then Rift should return status 200
+    And Rift response should take at least 100ms
+
+  @rift-only
+  Scenario: recordedFrom field is preserved on stubs
+    Given an imposter on port 4545 on Rift with:
+      """
+      {
+        "port": 4545,
+        "protocol": "http",
+        "stubs": [{
+          "predicates": [{"equals": {"path": "/recorded"}}],
+          "recordedFrom": "http://upstream:9090",
+          "responses": [{"is": {"statusCode": 200, "body": "recorded stub"}}]
+        }]
+      }
+      """
+    When I send GET request to "/recorded" on Rift imposter 4545
+    Then Rift should return status 200
+    And Rift response body should be "recorded stub"
+    When I query "/imposters/4545" on Rift admin API
+    Then Rift should return status 200
+    And Rift response body should contain "recordedFrom"
+    And Rift response body should contain "http://upstream:9090"

--- a/tests/compatibility/src/steps/rift_only.rs
+++ b/tests/compatibility/src/steps/rift_only.rs
@@ -333,6 +333,35 @@ async fn check_rift_header_same_as_previous(world: &mut CompatibilityWorld, head
 }
 
 // ==========================================================================
+// Admin API Steps
+// ==========================================================================
+
+#[when(expr = "I query {string} on Rift admin API")]
+async fn query_rift_admin(world: &mut CompatibilityWorld, path: String) {
+    let url = format!("{}{}", world.config.rift_admin_url, path);
+
+    let response = world.client
+        .get(&url)
+        .send()
+        .await
+        .expect("Failed to send request to Rift admin API");
+
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+
+    world.last_response = Some(crate::world::DualResponse {
+        mb_status: 0,
+        mb_body: String::new(),
+        mb_headers: HashMap::new(),
+        mb_duration: std::time::Duration::ZERO,
+        rift_status: status,
+        rift_body: body,
+        rift_headers: HashMap::new(),
+        rift_duration: std::time::Duration::ZERO,
+    });
+}
+
+// ==========================================================================
 // Script Validation Steps
 // ==========================================================================
 


### PR DESCRIPTION
## Summary
- Introduces `StubRaw` intermediate deserializer: `Stub` now accepts `rules` as a legacy alias for `predicates` (when both present, `predicates` wins)
- Converts stub-level `delayRange: [{min, max}]` into a `wait` behavior injected into each response — both numeric and string values accepted
- Adds `recordedFrom: Option<String>` field preserved through serde round-trip for Mountebank proxy-record compatibility
- Adds 5 unit tests covering each new behaviour

Closes #137, #138, #139

## Test plan
- [ ] `cargo test --lib` — 572 tests pass
- [ ] Load a legacy recorder config with `rules` → stubs are matched correctly
- [ ] Load a config with `delayRange: [{"min": "50", "max": "100"}]` → responses include a wait behavior
- [ ] Load a Mountebank-recorded stub with `recordedFrom` → field is preserved in GET /imposters response
