### PR TITLE
fix: accept shellTransform as array of strings in addition to single string

### DIFF
--- a/crates/rift-http-proxy/src/behaviors/types.rs
+++ b/crates/rift-http-proxy/src/behaviors/types.rs
@@ -30,15 +30,56 @@ pub struct ResponseBehaviors {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub lookup: Vec<LookupBehavior>,
 
-    /// Shell transform - external program transforms response
-    /// The program receives MB_REQUEST and MB_RESPONSE env vars
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shell_transform: Option<String>,
+    /// Shell transform - external program(s) transform response.
+    /// Accepts a single command string or an array of commands chained in sequence.
+    /// Each program receives MB_REQUEST and MB_RESPONSE env vars; stdout becomes the next response.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_shell_transforms",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub shell_transform: Vec<String>,
 
     /// Decorate - Rhai script to post-process response (Mountebank-compatible)
     /// Script receives `request` and `response` variables and can modify response
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decorate: Option<String>,
+}
+
+/// Deserialize shellTransform accepting a single string or an array of strings.
+fn deserialize_shell_transforms<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+
+    struct ShellTransformVisitor;
+
+    impl<'de> Visitor<'de> for ShellTransformVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a shell command string or array of shell command strings")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(vec![v.to_string()])
+        }
+
+        fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+            Ok(vec![v])
+        }
+
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut commands = Vec::new();
+            while let Some(cmd) = seq.next_element::<String>()? {
+                commands.push(cmd);
+            }
+            Ok(commands)
+        }
+    }
+
+    deserializer.deserialize_any(ShellTransformVisitor)
 }
 
 /// Custom deserializer for copy behaviors that accepts both object and array
@@ -111,9 +152,20 @@ shellTransform: "echo 'transformed'"
 "#;
         let behaviors: ResponseBehaviors = serde_yaml::from_str(yaml).unwrap();
         assert!(matches!(behaviors.wait, Some(WaitBehavior::Fixed(100))));
+        assert_eq!(behaviors.shell_transform, vec!["echo 'transformed'"]);
+    }
+
+    #[test]
+    fn test_shell_transform_array_serde() {
+        let yaml = r#"
+shellTransform:
+  - "./transform1.sh"
+  - "./transform2.sh"
+"#;
+        let behaviors: ResponseBehaviors = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
             behaviors.shell_transform,
-            Some("echo 'transformed'".to_string())
+            vec!["./transform1.sh", "./transform2.sh"]
         );
     }
 

--- a/crates/rift-http-proxy/src/proxy/handler.rs
+++ b/crates/rift-http-proxy/src/proxy/handler.rs
@@ -548,7 +548,7 @@ async fn handle_yaml_rule(
 
             // Apply shell transform (Mountebank-compatible)
             if let Some(ref bhvs) = behaviors {
-                if let Some(ref cmd) = bhvs.shell_transform {
+                for cmd in &bhvs.shell_transform {
                     debug!("Applying shell transform: {}", cmd);
                     match apply_shell_transform(cmd, &request_context, &processed_body, status) {
                         Ok(transformed) => {
@@ -601,7 +601,7 @@ async fn handle_yaml_rule(
                 if !bhvs.lookup.is_empty() {
                     response.set_header(&X_RIFT_BEHAVIOR_LOOKUP, &VALUE_TRUE);
                 }
-                if bhvs.shell_transform.is_some() {
+                if !bhvs.shell_transform.is_empty() {
                     response.set_header(&X_RIFT_BEHAVIOR_SHELL, &VALUE_TRUE);
                 }
                 if bhvs.decorate.is_some() {

--- a/tests/compatibility/features/responses.feature
+++ b/tests/compatibility/features/responses.feature
@@ -535,3 +535,29 @@ Feature: Response Behavior Compatibility
     Then both services should return status 200
     And both responses should have body "start-decorated"
     And both responses should take at least 50ms
+
+  # ==========================================================================
+  # ShellTransform Array Format Accepted (format, not execution)
+  # ==========================================================================
+
+  @rift-only
+  Scenario: shellTransform array format is accepted without parse error
+    Given an imposter on port 4545 on Rift with:
+      """
+      {
+        "port": 4545,
+        "protocol": "http",
+        "stubs": [{
+          "predicates": [{"equals": {"path": "/shell-array"}}],
+          "responses": [{
+            "is": {"statusCode": 200, "body": "original"},
+            "_behaviors": {
+              "shellTransform": ["./transform1.sh", "./transform2.sh"]
+            }
+          }]
+        }]
+      }
+      """
+    When I send GET request to "/shell-array" on Rift imposter 4545
+    Then Rift should return status 200
+    And Rift response body should be "original"


### PR DESCRIPTION
## Summary
- Changes `shell_transform: Option<String>` to `shell_transform: Vec<String>` with a custom deserializer that accepts both a bare string and a JSON/YAML array
- Updates `proxy/handler.rs` to iterate over the vec (each command's stdout feeds the next as the response body)
- Adds `test_shell_transform_array_serde` unit test covering array deserialization

Closes #140

## Test plan
- [ ] `cargo test --lib` — 568 tests pass
- [ ] Config with `shellTransform: "echo hello"` still works (single string accepted)
- [ ] Config with `shellTransform: ["./a.sh", "./b.sh"]` now accepted (previously rejected)