### PR TITLE
fix: accept --noParse, --formatter, --protofile CLI flags for MB compatibility

### DIFF
--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -122,6 +122,19 @@ struct Cli {
     /// Metrics server port
     #[arg(long, default_value = "9090", env = "RIFT_METRICS_PORT")]
     metrics_port: u16,
+
+    // === Mountebank compatibility flags (accepted, no-op) ===
+    /// Disable EJS template rendering of --configfile (Rift doesn't use EJS; accepted for compatibility)
+    #[arg(long, visible_alias = "noParse")]
+    no_parse: bool,
+
+    /// Custom config formatter module name (Rift auto-detects JSON/YAML; accepted for compatibility)
+    #[arg(long)]
+    formatter: Option<String>,
+
+    /// Custom protocol definitions file (custom protocols not yet supported; accepted for compatibility)
+    #[arg(long, value_name = "FILE")]
+    protofile: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -272,6 +285,17 @@ fn run_mountebank_mode(cli: Cli) -> Result<(), anyhow::Error> {
             info!("JavaScript injection enabled");
         }
 
+        if cli.formatter.is_some() {
+            tracing::warn!(
+                "--formatter is not supported; Rift auto-detects JSON/YAML config formats"
+            );
+        }
+        if cli.protofile.is_some() {
+            tracing::warn!(
+                "--protofile is not supported; custom protocols are not yet implemented"
+            );
+        }
+
         let server = AdminApiServer::new(addr, manager);
         server.run().await?;
 
@@ -397,6 +421,42 @@ fn save_imposters(cli: &Cli, savefile: &PathBuf) -> Result<(), anyhow::Error> {
 
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn test_no_parse_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--noParse"]).expect("--noParse should be accepted");
+        assert!(cli.no_parse);
+    }
+
+    #[test]
+    fn test_no_parse_snake_case_accepted() {
+        let cli =
+            Cli::try_parse_from(["rift", "--no-parse"]).expect("--no-parse should be accepted");
+        assert!(cli.no_parse);
+    }
+
+    #[test]
+    fn test_formatter_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--formatter", "mountebank-formatters"])
+            .expect("--formatter should be accepted");
+        assert_eq!(cli.formatter.as_deref(), Some("mountebank-formatters"));
+    }
+
+    #[test]
+    fn test_protofile_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--protofile", "protocols.json"])
+            .expect("--protofile should be accepted");
+        assert_eq!(
+            cli.protofile.as_deref(),
+            Some(std::path::Path::new("protocols.json"))
+        );
+    }
 }
 
 /// Run the metrics server

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -423,42 +423,6 @@ fn save_imposters(cli: &Cli, savefile: &PathBuf) -> Result<(), anyhow::Error> {
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    #[test]
-    fn test_no_parse_flag_accepted() {
-        let cli = Cli::try_parse_from(["rift", "--noParse"]).expect("--noParse should be accepted");
-        assert!(cli.no_parse);
-    }
-
-    #[test]
-    fn test_no_parse_snake_case_accepted() {
-        let cli =
-            Cli::try_parse_from(["rift", "--no-parse"]).expect("--no-parse should be accepted");
-        assert!(cli.no_parse);
-    }
-
-    #[test]
-    fn test_formatter_flag_accepted() {
-        let cli = Cli::try_parse_from(["rift", "--formatter", "mountebank-formatters"])
-            .expect("--formatter should be accepted");
-        assert_eq!(cli.formatter.as_deref(), Some("mountebank-formatters"));
-    }
-
-    #[test]
-    fn test_protofile_flag_accepted() {
-        let cli = Cli::try_parse_from(["rift", "--protofile", "protocols.json"])
-            .expect("--protofile should be accepted");
-        assert_eq!(
-            cli.protofile.as_deref(),
-            Some(std::path::Path::new("protocols.json"))
-        );
-    }
-}
-
 /// Run the metrics server
 async fn run_metrics_server(port: u16) -> anyhow::Result<()> {
     use hyper::server::conn::http1;
@@ -495,5 +459,41 @@ async fn run_metrics_server(port: u16) -> anyhow::Result<()> {
                 error!("Metrics server connection error: {}", err);
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn test_no_parse_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--noParse"]).expect("--noParse should be accepted");
+        assert!(cli.no_parse);
+    }
+
+    #[test]
+    fn test_no_parse_snake_case_accepted() {
+        let cli =
+            Cli::try_parse_from(["rift", "--no-parse"]).expect("--no-parse should be accepted");
+        assert!(cli.no_parse);
+    }
+
+    #[test]
+    fn test_formatter_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--formatter", "mountebank-formatters"])
+            .expect("--formatter should be accepted");
+        assert_eq!(cli.formatter.as_deref(), Some("mountebank-formatters"));
+    }
+
+    #[test]
+    fn test_protofile_flag_accepted() {
+        let cli = Cli::try_parse_from(["rift", "--protofile", "protocols.json"])
+            .expect("--protofile should be accepted");
+        assert_eq!(
+            cli.protofile.as_deref(),
+            Some(std::path::Path::new("protocols.json"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `--noParse` / `--no-parse`: accepted as a no-op (Rift doesn't use EJS rendering, so this is already the default behavior)
- Adds `--formatter <module>`: accepted with a startup warning (Rift auto-detects JSON/YAML; pluggable formatters not supported)
- Adds `--protofile <FILE>`: accepted with a startup warning (custom protocols not yet implemented)

Mountebank startup scripts that pass these flags will no longer fail with "Unknown argument". This is a drop-in compatibility fix for users migrating from Mountebank.

Fixes #145

## Test plan

- [ ] `test_no_parse_flag_accepted`: `--noParse` is accepted and sets `no_parse = true`
- [ ] `test_no_parse_snake_case_accepted`: `--no-parse` (kebab-case) is also accepted
- [ ] `test_formatter_flag_accepted`: `--formatter mountebank-formatters` is accepted and the value is stored
- [ ] `test_protofile_flag_accepted`: `--protofile protocols.json` is accepted and the path is stored