### PR TITLE
fix: XPath namespace maps (ns) applied during predicate evaluation (#155)

### DIFF
--- a/crates/rift-http-proxy/src/behaviors/extraction.rs
+++ b/crates/rift-http-proxy/src/behaviors/extraction.rs
@@ -79,16 +79,36 @@ pub fn extract_jsonpath(json_str: &str, path: &str) -> Option<String> {
     }
 }
 
-/// Extract value using XPath
-/// Used by copy behaviors and predicate xpath parameter
+/// Extract value using XPath, optionally with namespace prefix bindings.
+/// Used by copy behaviors and predicate xpath parameter.
 pub fn extract_xpath(xml_str: &str, path: &str) -> Option<String> {
+    extract_xpath_with_ns(xml_str, path, None)
+}
+
+/// Extract value using XPath with optional namespace prefix→URI map.
+pub fn extract_xpath_with_ns(
+    xml_str: &str,
+    path: &str,
+    ns: Option<&std::collections::HashMap<String, String>>,
+) -> Option<String> {
     use sxd_document::parser;
-    use sxd_xpath::{evaluate_xpath, Value};
+    use sxd_xpath::{Context, Factory, Value};
 
     let package = parser::parse(xml_str).ok()?;
     let document = package.as_document();
 
-    match evaluate_xpath(&document, path) {
+    let factory = Factory::new();
+    let xpath = factory.build(path).ok()??;
+
+    let mut context = Context::new();
+    if let Some(namespaces) = ns {
+        for (prefix, uri) in namespaces {
+            context.set_namespace(prefix, uri);
+        }
+    }
+
+    let root = document.root();
+    match xpath.evaluate(&context, root) {
         Ok(Value::String(s)) => Some(s),
         Ok(Value::Number(n)) => Some(n.to_string()),
         Ok(Value::Boolean(b)) => Some(b.to_string()),
@@ -340,5 +360,30 @@ mod tests {
             }
             _ => panic!("Expected Regex with options"),
         }
+    }
+
+    #[test]
+    fn test_extract_xpath_without_namespaces() {
+        let xml = r#"<root><child>value</child></root>"#;
+        assert_eq!(extract_xpath(xml, "//child"), Some("value".to_string()));
+    }
+
+    #[test]
+    fn test_extract_xpath_with_ns_map() {
+        let xml = r#"<ns:root xmlns:ns="http://example.com/ns"><ns:item>hello</ns:item></ns:root>"#;
+        let mut ns = std::collections::HashMap::new();
+        ns.insert("ns".to_string(), "http://example.com/ns".to_string());
+        let result = extract_xpath_with_ns(xml, "//ns:item", Some(&ns));
+        assert_eq!(result, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_extract_xpath_with_multiple_ns_bindings() {
+        let xml = r#"<a:root xmlns:a="http://a.com" xmlns:b="http://b.com"><a:x><b:y>found</b:y></a:x></a:root>"#;
+        let mut ns = std::collections::HashMap::new();
+        ns.insert("a".to_string(), "http://a.com".to_string());
+        ns.insert("b".to_string(), "http://b.com".to_string());
+        let result = extract_xpath_with_ns(xml, "//a:x/b:y", Some(&ns));
+        assert_eq!(result, Some("found".to_string()));
     }
 }

--- a/crates/rift-http-proxy/src/behaviors/mod.rs
+++ b/crates/rift-http-proxy/src/behaviors/mod.rs
@@ -29,7 +29,7 @@ mod wait;
 pub use copy::{apply_copy_behaviors, CopyBehavior, CopySource};
 pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
 #[allow(unused_imports)]
-pub use extraction::{extract_jsonpath, extract_xpath, ExtractionMethod};
+pub use extraction::{extract_jsonpath, extract_xpath, extract_xpath_with_ns, ExtractionMethod};
 #[allow(unused_imports)]
 pub use lookup::{
     apply_lookup_behaviors, CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey,

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -3,10 +3,9 @@
 //! Supports: equals, deepEquals, contains, startsWith, endsWith, matches, exists, not, or, and
 //! Also supports requestFrom, ip, and form fields.
 
-use crate::behaviors::{extract_jsonpath, extract_xpath};
+use crate::behaviors::{extract_jsonpath, extract_xpath_with_ns};
 use crate::imposter::types::{Predicate, PredicateOperation, PredicateSelector};
 use std::collections::HashMap;
-use tracing::warn;
 
 /// Check if a stub matches a request based on its predicates
 #[allow(clippy::too_many_arguments)]
@@ -134,10 +133,8 @@ pub fn predicate_matches(
             selector,
             namespaces,
         }) => {
-            extracted_body = extract_xpath(body_str, selector).unwrap_or_default();
-            if namespaces.is_some() {
-                warn!("XPath namespaces are not supported yet");
-            }
+            extracted_body =
+                extract_xpath_with_ns(body_str, selector, namespaces.as_ref()).unwrap_or_default();
             &extracted_body
         }
         None => body_str,


### PR DESCRIPTION
## Summary
- `extract_xpath` now delegates to a new `extract_xpath_with_ns(xml, path, ns)` helper
- `extract_xpath_with_ns` builds an `sxd_xpath::Context` and registers each prefix→URI binding via `context.set_namespace()`
- Predicate matching in `predicates.rs` passes the `namespaces` map from `PredicateSelector::XPath` to the new function
- Removed the `warn!("XPath namespaces are not supported yet")` message — they are now supported

## Test plan
- `test_extract_xpath_without_namespaces` — existing no-ns XPaths still work
- `test_extract_xpath_with_ns_map` — single namespace prefix resolved correctly
- `test_extract_xpath_with_multiple_ns_bindings` — multiple namespace bindings work simultaneously

Closes #155