### PR TITLE
fix: wire --log flag to write logs to a file (#157)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
  "urlencoding",
@@ -4194,6 +4195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,6 +4658,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -48,6 +48,7 @@ r2d2 = { version = "0.8", optional = true }
 # Logging & Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 prometheus = "0.13"
 lazy_static = "1.4"
 

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -48,7 +48,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer};
 
 /// Rift - A Mountebank-compatible HTTP chaos engineering proxy
 ///
@@ -196,10 +196,27 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     let filter = if cli.debug { "debug" } else { log_level };
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(filter));
+
+    // Build optional file log layer when --log is set and --nologfile is not
+    let file_layer: Option<Box<dyn Layer<_> + Send + Sync>> = if !cli.nologfile {
+        cli.log.as_ref().and_then(|log_path| {
+            let dir = log_path.parent().unwrap_or(std::path::Path::new("."));
+            let filename = log_path.file_name()?.to_string_lossy().into_owned();
+            let file_appender = tracing_appender::rolling::never(dir, filename);
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            // Leak the guard so it lives for the process lifetime
+            Box::leak(Box::new(guard));
+            Some(fmt::layer().with_writer(non_blocking).boxed())
+        })
+    } else {
+        None
+    };
 
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(filter)))
+        .with(env_filter)
+        .with(file_layer)
         .init();
 
     // Write PID file if requested
@@ -499,5 +516,26 @@ mod tests {
             cli.protofile.as_deref(),
             Some(std::path::Path::new("protocols.json"))
         );
+    }
+
+    #[test]
+    fn test_log_flag_parsed() {
+        let cli = Cli::try_parse_from(["rift", "--log", "/tmp/test.log"])
+            .expect("--log should be accepted");
+        assert_eq!(cli.log, Some(std::path::PathBuf::from("/tmp/test.log")));
+    }
+
+    #[test]
+    fn test_nologfile_flag_parsed() {
+        let cli =
+            Cli::try_parse_from(["rift", "--nologfile"]).expect("--nologfile should be accepted");
+        assert!(cli.nologfile);
+    }
+
+    #[test]
+    fn test_nologfile_default_is_false() {
+        let cli = Cli::try_parse_from(["rift"]).expect("default parse");
+        assert!(!cli.nologfile);
+        assert!(cli.log.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Added `tracing-appender = "0.2"` dependency
- When `--log <FILE>` is set (and `--nologfile` is not), a second tracing layer writes all log output to the specified file using `tracing_appender::rolling::never` (no rotation, append mode)
- When `--nologfile` is set, only stdout logging occurs (unchanged behavior)
- Stdout logging is always active, regardless of file logging

## Test plan
- `test_log_flag_parsed` — `--log /tmp/test.log` is accepted and path is stored
- `test_nologfile_flag_parsed` — `--nologfile` flag is accepted
- `test_nologfile_default_is_false` — without flags, `nologfile=false` and `log=None`

Closes #157