### PR TITLE
feat: inject predicate - execute JavaScript predicate function

### DIFF
--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -250,6 +250,7 @@ impl Imposter {
         // Parse form data if Content-Type is application/x-www-form-urlencoded
         let form = Self::parse_form_data(headers, body);
 
+        let imposter_port = self.config.port.unwrap_or(0);
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
             if stub_matches(
@@ -262,6 +263,7 @@ impl Imposter {
                 request_from,
                 client_ip,
                 form.as_ref(),
+                imposter_port,
             ) {
                 // TODO(perf): It's unfortunate that we end up deep cloning the whole stub here
                 return Some((stub_state.clone(), index));

--- a/crates/rift-http-proxy/src/imposter/predicates.rs
+++ b/crates/rift-http-proxy/src/imposter/predicates.rs
@@ -19,6 +19,7 @@ pub fn stub_matches(
     request_from: Option<&str>,
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
+    imposter_port: u16,
 ) -> bool {
     // If no predicates, match everything
     if predicates.is_empty() {
@@ -37,6 +38,7 @@ pub fn stub_matches(
             request_from,
             client_ip,
             form,
+            imposter_port,
         ) {
             return false;
         }
@@ -63,6 +65,7 @@ pub fn predicate_matches(
     request_from: Option<&str>,
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
+    imposter_port: u16,
 ) -> bool {
     // Get predicate options
     let case_sensitive = predicate.parameters.case_sensitive.unwrap_or(false);
@@ -256,6 +259,7 @@ pub fn predicate_matches(
             request_from,
             client_ip,
             form,
+            imposter_port,
         ),
         PredicateOperation::Or(children) => children.iter().any(|p| {
             predicate_matches(
@@ -268,6 +272,7 @@ pub fn predicate_matches(
                 request_from,
                 client_ip,
                 form,
+                imposter_port,
             )
         }),
         PredicateOperation::And(children) => children.iter().all(|p| {
@@ -281,8 +286,32 @@ pub fn predicate_matches(
                 request_from,
                 client_ip,
                 form,
+                imposter_port,
             )
         }),
+        PredicateOperation::Inject(inject_fn) => {
+            #[cfg(feature = "javascript")]
+            {
+                use crate::scripting::{execute_predicate_inject, MountebankRequest};
+                let query_map = parse_query(query);
+                let mb_request = MountebankRequest {
+                    method: method.to_string(),
+                    path: path.to_string(),
+                    query: query_map,
+                    headers: headers.clone(),
+                    body: body.map(|b| b.to_string()),
+                };
+                execute_predicate_inject(inject_fn, &mb_request, imposter_port)
+            }
+            #[cfg(not(feature = "javascript"))]
+            {
+                tracing::warn!(
+                    "inject predicate requires the 'javascript' feature; predicate will not match"
+                );
+                let _ = inject_fn;
+                false
+            }
+        }
     }
 }
 
@@ -1000,6 +1029,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1055,6 +1085,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1089,6 +1120,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1117,6 +1149,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(result, "deepEquals should match identical string bodies");
@@ -1147,6 +1180,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1175,7 +1209,7 @@ mod tests {
         headers.insert("Content-Type".to_string(), "application/json".to_string());
 
         let result = predicate_matches(
-            &pred, "GET", "/test", None, &headers, None, None, None, None,
+            &pred, "GET", "/test", None, &headers, None, None, None, None, 0,
         );
 
         assert!(
@@ -1208,6 +1242,7 @@ mod tests {
             None,
             None,
             Some(&form),
+            0,
         );
 
         assert!(
@@ -1245,7 +1280,7 @@ mod tests {
         headers.insert("Content-Type".to_string(), "application/json".to_string());
 
         let result = predicate_matches(
-            &pred, "GET", "/test", None, &headers, None, None, None, None,
+            &pred, "GET", "/test", None, &headers, None, None, None, None, 0,
         );
 
         assert!(
@@ -1280,6 +1315,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1310,6 +1346,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         // Default is case-insensitive
         assert!(predicate_matches(
@@ -1322,6 +1359,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1333,6 +1371,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1355,6 +1394,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1366,6 +1406,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1386,6 +1427,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1397,6 +1439,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1417,6 +1460,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1428,6 +1472,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1448,6 +1493,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1459,6 +1505,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1481,6 +1528,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1492,6 +1540,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1513,6 +1562,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(predicate_matches(
             &pred,
@@ -1524,6 +1574,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1550,6 +1601,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(predicate_matches(
             &pred,
@@ -1561,6 +1613,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1572,6 +1625,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1597,6 +1651,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1608,6 +1663,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1619,6 +1675,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1645,6 +1702,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         // With caseSensitive: true, "post" should NOT match "POST"
         assert!(!predicate_matches(
@@ -1657,6 +1715,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1686,6 +1745,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1711,6 +1771,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         // Body does not exist
         assert!(!predicate_matches(
@@ -1723,6 +1784,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         // Body should NOT exist (false) - empty body
         assert!(predicate_matches(
@@ -1735,6 +1797,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1751,7 +1814,7 @@ mod tests {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         assert!(predicate_matches(
-            &pred, "GET", "/", None, &headers, None, None, None, None,
+            &pred, "GET", "/", None, &headers, None, None, None, None, 0
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1763,6 +1826,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1786,6 +1850,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         // Extra param - should fail for deepEquals
         assert!(!predicate_matches(
@@ -1798,6 +1863,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1828,6 +1894,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
         assert!(!predicate_matches(
             &pred,
@@ -1839,6 +1906,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         ));
     }
 
@@ -1855,6 +1923,7 @@ mod tests {
             None,
             None,
             None,
+            0
         ));
     }
 
@@ -1880,6 +1949,7 @@ mod tests {
             None,
             None,
             None,
+            0
         ));
         assert!(!stub_matches(
             &predicates,
@@ -1891,6 +1961,7 @@ mod tests {
             None,
             None,
             None,
+            0
         ));
     }
 
@@ -1930,6 +2001,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1967,6 +2039,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -1994,6 +2067,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -2028,6 +2102,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -2054,6 +2129,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -2080,6 +2156,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -2106,6 +2183,7 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
@@ -2131,11 +2209,103 @@ mod tests {
             None,
             None,
             None,
+            0,
         );
 
         assert!(
             !result,
             "exists path=false should fail when path is present"
         );
+    }
+
+    // =========================================================================
+    // inject predicate tests (require javascript feature)
+    // =========================================================================
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_matches_true() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            "function(request) { return request.path === '/api'; }".to_string(),
+        ));
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(result, "inject predicate returning true should match");
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_matches_false() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            "function(request) { return request.path === '/other'; }".to_string(),
+        ));
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(!result, "inject predicate returning false should not match");
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_checks_method() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            "function(request) { return request.method === 'POST'; }".to_string(),
+        ));
+        let headers = HashMap::new();
+        let post_result = predicate_matches(
+            &pred, "POST", "/", None, &headers, None, None, None, None, 0,
+        );
+        let get_result =
+            predicate_matches(&pred, "GET", "/", None, &headers, None, None, None, None, 0);
+        assert!(post_result, "inject predicate should match POST");
+        assert!(!get_result, "inject predicate should not match GET");
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_accesses_body() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            r#"function(request) { return request.body && request.body.indexOf('hello') >= 0; }"#
+                .to_string(),
+        ));
+        let result = predicate_matches(
+            &pred,
+            "POST",
+            "/",
+            None,
+            &empty_headers(),
+            Some("hello world"),
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(result, "inject predicate should access request body");
+    }
+
+    #[test]
+    fn test_inject_predicate_deserializes() {
+        let json = r#"{"inject": "function(request) { return true; }"}"#;
+        let op: PredicateOperation = serde_json::from_str(json).expect("should deserialize inject");
+        assert!(matches!(op, PredicateOperation::Inject(_)));
     }
 }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -72,7 +72,8 @@ fn test_predicate_matching() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &stub.predicates,
@@ -83,7 +84,8 @@ fn test_predicate_matching() {
         None,
         None,
         None,
-        None
+        None,
+        0
     )); // case-insensitive method
 
     // Should not match
@@ -96,7 +98,8 @@ fn test_predicate_matching() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &stub.predicates,
@@ -107,7 +110,8 @@ fn test_predicate_matching() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -486,7 +490,8 @@ fn test_predicate_ends_with() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -497,7 +502,8 @@ fn test_predicate_ends_with() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Should not match
@@ -510,7 +516,8 @@ fn test_predicate_ends_with() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -521,7 +528,8 @@ fn test_predicate_ends_with() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -543,7 +551,8 @@ fn test_predicate_deep_equals_method() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -554,7 +563,8 @@ fn test_predicate_deep_equals_method() {
         None,
         None,
         None,
-        None
+        None,
+        0
     )); // case-insensitive
     assert!(!stub_matches(
         &predicates,
@@ -565,7 +575,8 @@ fn test_predicate_deep_equals_method() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -588,7 +599,8 @@ fn test_predicate_deep_equals_body() {
         Some(""),
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -599,7 +611,8 @@ fn test_predicate_deep_equals_body() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Non-empty body should not match
@@ -612,7 +625,8 @@ fn test_predicate_deep_equals_body() {
         Some("content"),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -635,7 +649,8 @@ fn test_predicate_contains_query() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -646,7 +661,8 @@ fn test_predicate_contains_query() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -657,7 +673,8 @@ fn test_predicate_contains_query() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Should not match
@@ -670,7 +687,8 @@ fn test_predicate_contains_query() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -681,7 +699,8 @@ fn test_predicate_contains_query() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -704,7 +723,8 @@ fn test_predicate_equals_headers() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Header key lookup is case-insensitive
@@ -719,7 +739,8 @@ fn test_predicate_equals_headers() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Wrong value
@@ -734,7 +755,8 @@ fn test_predicate_equals_headers() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Missing header
@@ -748,7 +770,8 @@ fn test_predicate_equals_headers() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -776,7 +799,8 @@ fn test_predicate_exists() {
         Some("body content"),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Missing query param
@@ -789,7 +813,8 @@ fn test_predicate_exists() {
         Some("body content"),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Missing header
@@ -803,7 +828,8 @@ fn test_predicate_exists() {
         Some("body content"),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Missing body
@@ -816,7 +842,8 @@ fn test_predicate_exists() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -839,7 +866,8 @@ fn test_predicate_logical_not() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -850,7 +878,8 @@ fn test_predicate_logical_not() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -861,7 +890,8 @@ fn test_predicate_logical_not() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -886,7 +916,8 @@ fn test_predicate_logical_or() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -897,7 +928,8 @@ fn test_predicate_logical_or() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -908,7 +940,8 @@ fn test_predicate_logical_or() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -933,7 +966,8 @@ fn test_predicate_logical_and() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -944,7 +978,8 @@ fn test_predicate_logical_and() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -955,7 +990,8 @@ fn test_predicate_logical_and() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -980,7 +1016,8 @@ fn test_predicate_matches_regex_all_fields() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(stub_matches(
         &predicates,
@@ -991,7 +1028,8 @@ fn test_predicate_matches_regex_all_fields() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -1002,7 +1040,8 @@ fn test_predicate_matches_regex_all_fields() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -1013,7 +1052,8 @@ fn test_predicate_matches_regex_all_fields() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1035,7 +1075,8 @@ fn test_predicate_matches_body_regex() {
         Some(r#"{"userId": "abc-123-def"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
     assert!(!stub_matches(
         &predicates,
@@ -1046,7 +1087,8 @@ fn test_predicate_matches_body_regex() {
         Some(r#"{"userId": "invalid!"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1077,7 +1119,8 @@ fn test_exists_predicate_body_object_field_present() {
         Some(r#"{"blah": "hello", "other": "stuff"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Body does NOT have "blah" field → should not match
@@ -1090,7 +1133,8 @@ fn test_exists_predicate_body_object_field_present() {
         Some(r#"{"other": "stuff"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1117,7 +1161,8 @@ fn test_exists_predicate_body_object_field_absent() {
         Some(r#"{"blah": "hello"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Body does NOT have "blah" field → should match
@@ -1130,7 +1175,8 @@ fn test_exists_predicate_body_object_field_absent() {
         Some(r#"{"other": "stuff"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1156,7 +1202,8 @@ fn test_exists_predicate_body_object_non_json_body() {
         Some("not json at all"),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1180,7 +1227,8 @@ fn test_exists_predicate_body_boolean_still_works() {
         Some("any body content"),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     assert!(!stub_matches(
@@ -1192,7 +1240,8 @@ fn test_exists_predicate_body_boolean_still_works() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1221,7 +1270,8 @@ fn test_ends_with_object_value_does_not_always_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1246,7 +1296,8 @@ fn test_ends_with_path_as_json_object() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Path is a JSON string but field doesn't end with "123"
@@ -1259,7 +1310,8 @@ fn test_ends_with_path_as_json_object() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1283,7 +1335,8 @@ fn test_starts_with_object_value_does_not_always_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1310,7 +1363,8 @@ fn test_equals_body_as_json_object() {
         Some(r#"{"blah": "123", "other": "ignored"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Body with wrong value
@@ -1323,7 +1377,8 @@ fn test_equals_body_as_json_object() {
         Some(r#"{"blah": "456"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Body missing the field
@@ -1336,7 +1391,8 @@ fn test_equals_body_as_json_object() {
         Some(r#"{"other": "123"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1360,7 +1416,8 @@ fn test_ends_with_body_object_with_numeric_value() {
         Some(r#"{"abc": "other123"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     assert!(!stub_matches(
@@ -1372,7 +1429,8 @@ fn test_ends_with_body_object_with_numeric_value() {
         Some(r#"{"abc": "other456"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1403,7 +1461,8 @@ fn test_ends_with_query_object_value_does_not_always_match() {
             None,
             None,
             None,
-            None
+            None,
+            0
         ),
         "Object expected value in query should not match a plain string"
     );
@@ -1430,7 +1489,8 @@ fn test_ends_with_query_object_value_recursive_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // query param 'data' has a field NOT ending in "123"
@@ -1443,7 +1503,8 @@ fn test_ends_with_query_object_value_recursive_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1470,7 +1531,8 @@ fn test_ends_with_header_object_value_does_not_always_match() {
             None,
             None,
             None,
-            None
+            None,
+            0
         ),
         "Object expected value in headers should not match a plain string"
     );
@@ -1500,7 +1562,8 @@ fn test_ends_with_header_object_value_recursive_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Header value with field NOT ending in "123"
@@ -1514,7 +1577,8 @@ fn test_ends_with_header_object_value_recursive_match() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1542,7 +1606,8 @@ fn test_ends_with_form_object_value_does_not_always_match() {
             None,
             None,
             None,
-            Some(&form)
+            Some(&form),
+            0
         ),
         "Object expected value in form should not match a plain string"
     );
@@ -1573,7 +1638,8 @@ fn test_ends_with_form_object_value_recursive_match() {
         None,
         None,
         None,
-        Some(&form)
+        Some(&form),
+        0
     ));
 
     // Form field with value NOT ending in "123"
@@ -1587,7 +1653,8 @@ fn test_ends_with_form_object_value_recursive_match() {
         None,
         None,
         None,
-        Some(&form)
+        Some(&form),
+        0
     ));
 }
 
@@ -1612,7 +1679,8 @@ fn test_contains_query_object_value() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // query param 'data' does NOT contain "ohn"
@@ -1625,7 +1693,8 @@ fn test_contains_query_object_value() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1654,7 +1723,8 @@ fn test_equals_header_object_value() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Mismatched value
@@ -1668,7 +1738,8 @@ fn test_equals_header_object_value() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1697,7 +1768,8 @@ fn test_matches_query_object_value_does_not_always_match() {
             None,
             None,
             None,
-            None
+            None,
+            0
         ),
         "Object expected value in matches/query should not match a plain string"
     );
@@ -1724,7 +1796,8 @@ fn test_matches_query_object_value_recursive_regex() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // "Jane" does NOT match ^J.*n$ (ends with 'e')
@@ -1737,7 +1810,8 @@ fn test_matches_query_object_value_recursive_regex() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1765,7 +1839,8 @@ fn test_matches_header_object_value_recursive_regex() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // "abc" does NOT match ^\d+$
@@ -1779,7 +1854,8 @@ fn test_matches_header_object_value_recursive_regex() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1808,7 +1884,8 @@ fn test_matches_form_object_value_recursive_regex() {
         None,
         None,
         None,
-        Some(&form)
+        Some(&form),
+        0
     ));
 
     // "abcd" does NOT match ^[A-Z]{3}$
@@ -1822,7 +1899,8 @@ fn test_matches_form_object_value_recursive_regex() {
         None,
         None,
         None,
-        Some(&form)
+        Some(&form),
+        0
     ));
 }
 
@@ -1850,7 +1928,8 @@ fn test_deep_equals_body_extra_keys_rejected() {
         Some(r#"{"a": "1"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Extra key should be rejected by deepEquals
@@ -1863,7 +1942,8 @@ fn test_deep_equals_body_extra_keys_rejected() {
         Some(r#"{"a": "1", "b": "2"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1887,7 +1967,8 @@ fn test_equals_body_extra_keys_allowed() {
         Some(r#"{"a": "1", "b": "2"}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1911,7 +1992,8 @@ fn test_deep_equals_body_nested_extra_keys_rejected() {
         Some(r#"{"outer": {"inner": "val"}}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Extra key in nested object
@@ -1924,7 +2006,8 @@ fn test_deep_equals_body_nested_extra_keys_rejected() {
         Some(r#"{"outer": {"inner": "val", "extra": "x"}}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -1948,7 +2031,8 @@ fn test_deep_equals_body_array_comparison() {
         Some(r#"{"items": [1, 2, 3]}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Different length array
@@ -1961,7 +2045,8 @@ fn test_deep_equals_body_array_comparison() {
         Some(r#"{"items": [1, 2, 3, 4]}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 
     // Different values
@@ -1974,7 +2059,8 @@ fn test_deep_equals_body_array_comparison() {
         Some(r#"{"items": [1, 2, 99]}"#),
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2001,7 +2087,8 @@ fn test_exists_predicate_query_key_case_insensitive() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2025,7 +2112,8 @@ fn test_exists_predicate_query_key_case_sensitive() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     assert!(stub_matches(
@@ -2037,7 +2125,8 @@ fn test_exists_predicate_query_key_case_sensitive() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2062,7 +2151,8 @@ fn test_exists_predicate_form_key_case_insensitive() {
         None,
         None,
         None,
-        Some(&form)
+        Some(&form),
+        0
     ));
 }
 
@@ -2087,7 +2177,8 @@ fn test_exists_predicate_headers_key_case_sensitive() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 
     let mut headers_exact = HashMap::new();
@@ -2102,7 +2193,8 @@ fn test_exists_predicate_headers_key_case_sensitive() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2146,7 +2238,8 @@ fn test_header_predicate_matches_title_case() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2186,7 +2279,8 @@ fn test_bare_query_param_exists_predicate() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2209,7 +2303,8 @@ fn test_bare_query_param_equals_empty_string() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2247,7 +2342,8 @@ fn test_multi_valued_query_param_equals() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }
 
@@ -2269,6 +2365,7 @@ fn test_multi_valued_query_param_contains() {
         None,
         None,
         None,
-        None
+        None,
+        0
     ));
 }

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -273,7 +273,7 @@ pub enum PredicateOperation {
     Not(Box<Predicate>),
     Or(Vec<Predicate>),
     And(Vec<Predicate>),
-    // TODO: "inject" predicate operation is missing
+    Inject(String),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/rift-http-proxy/src/scripting/js_engine.rs
+++ b/crates/rift-http-proxy/src/scripting/js_engine.rs
@@ -811,6 +811,64 @@ pub fn execute_mountebank_inject(
     parse_mountebank_response(&mut context, result)
 }
 
+/// Execute a Mountebank-style predicate inject function.
+/// The function signature is: `function(request, logger, imposterState) { return bool; }`
+/// Returns `true` if the predicate matches, `false` otherwise.
+pub fn execute_predicate_inject(
+    inject_fn: &str,
+    request: &MountebankRequest,
+    imposter_port: u16,
+) -> bool {
+    let mut context = Context::default();
+
+    let request_obj = match create_mountebank_request_object(&mut context, request) {
+        Ok(obj) => obj,
+        Err(e) => {
+            tracing::warn!("inject predicate: failed to build request object: {e}");
+            return false;
+        }
+    };
+
+    let state_map = get_imposter_state(imposter_port);
+    let state_obj = match json_to_js(&mut context, &Value::Object(state_map)) {
+        Ok(obj) => obj,
+        Err(e) => {
+            tracing::warn!("inject predicate: failed to build state object: {e}");
+            return false;
+        }
+    };
+
+    let global = context.global_object();
+    let _ = global.set(js_string!("__request"), request_obj, false, &mut context);
+    let _ = global.set(js_string!("__state"), state_obj, false, &mut context);
+
+    let wrapper_script = format!(
+        r#"
+        var __injectFn = {inject_fn};
+        var __logger = {{ debug: function() {{}}, info: function() {{}}, warn: function() {{}}, error: function() {{}} }};
+        var __result = __injectFn(__request, __logger, __state);
+        Boolean(__result);
+        "#
+    );
+
+    let result = match context.eval(Source::from_bytes(wrapper_script.as_bytes())) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("inject predicate: script execution error: {e}");
+            return false;
+        }
+    };
+
+    // Update state
+    if let Ok(updated_state) = global.get(js_string!("__state"), &mut context) {
+        if let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state) {
+            save_imposter_state(imposter_port, map);
+        }
+    }
+
+    result.to_boolean()
+}
+
 /// Request structure for Mountebank inject functions
 #[derive(Debug, Clone)]
 pub struct MountebankRequest {

--- a/crates/rift-http-proxy/src/scripting/mod.rs
+++ b/crates/rift-http-proxy/src/scripting/mod.rs
@@ -27,7 +27,7 @@ mod js_engine;
 #[cfg(feature = "javascript")]
 pub use js_engine::{
     clear_imposter_state, compile_js_to_bytecode, execute_mountebank_decorate,
-    execute_mountebank_inject, JsEngine, MountebankRequest,
+    execute_mountebank_inject, execute_predicate_inject, JsEngine, MountebankRequest,
 };
 #[cfg(feature = "javascript")]
 #[expect(unused_imports, reason = "public API for library consumers")]


### PR DESCRIPTION
## Summary

Closes #159.

- Adds `PredicateOperation::Inject(String)` variant to the predicate enum, replacing the `// TODO` comment
- Adds `execute_predicate_inject` in `js_engine.rs` — evaluates a JS function `(request, logger, imposterState) -> bool` and returns the boolean result
- Exports `execute_predicate_inject` from `scripting/mod.rs`
- Handles the `Inject` arm in `predicates.rs` — calls the JS engine when the `javascript` feature is enabled; logs a warning and returns `false` otherwise
- Threads `imposter_port: u16` through `stub_matches` and `predicate_matches` so inject predicates use the correct per-imposter JS state bucket
- Updates all existing `predicate_matches` and `stub_matches` call sites (tests + production code) to pass `imposter_port`

## Test plan

- [ ] `test_inject_predicate_matches_true` — inject returning `true` matches the stub
- [ ] `test_inject_predicate_matches_false` — inject returning `false` does not match
- [ ] `test_inject_predicate_checks_method` — inject can inspect `request.method`
- [ ] `test_inject_predicate_accesses_body` — inject can inspect `request.body`
- [ ] `test_inject_predicate_deserializes` — `{"inject": "..."}` deserializes to `Inject` variant
- [ ] All 1174 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)