### PR TITLE
feat: support ?list=true query param on GET /imposters

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -2,7 +2,7 @@
 
 use crate::admin_api::types::{
     collect_body, error_response, json_response, make_imposter_links, make_stub_links,
-    ImposterDetail, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
+    ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
     RiftImposterExtensions, StubWithLinks,
 };
 use crate::extensions::stub_analysis::analyze_stubs;
@@ -85,6 +85,21 @@ pub async fn handle_list(
             .collect();
         let body = serde_json::json!({ "imposters": configs });
         json_response(StatusCode::OK, &body)
+    } else if params.list {
+        // Mountebank-compatible abbreviated listing: port, protocol, name, numberOfRequests, _links
+        let entries: Vec<ImposterListEntry> = imposters
+            .iter()
+            .filter_map(|i| {
+                i.config.port.map(|port| ImposterListEntry {
+                    protocol: i.config.protocol.clone(),
+                    port,
+                    name: i.config.name.clone(),
+                    number_of_requests: i.get_request_count(),
+                    links: make_imposter_links(base_url, port),
+                })
+            })
+            .collect();
+        json_response(StatusCode::OK, &serde_json::json!({ "imposters": entries }))
     } else {
         let summaries: Vec<ImposterSummary> = imposters
             .iter()

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -119,6 +119,7 @@ pub struct ReplaceStubsRequest {
 pub struct ImposterQueryParams {
     pub replayable: bool,
     pub remove_proxies: bool,
+    pub list: bool,
 }
 
 impl ImposterQueryParams {
@@ -128,9 +129,23 @@ impl ImposterQueryParams {
         if let Some(q) = query {
             params.replayable = q.contains("replayable=true");
             params.remove_proxies = q.contains("removeProxies=true");
+            params.list = q.contains("list=true");
         }
         params
     }
+}
+
+/// Minimal imposter listing entry (Mountebank ?list=true response shape)
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImposterListEntry {
+    pub protocol: String,
+    pub port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub number_of_requests: u64,
+    #[serde(rename = "_links")]
+    pub links: ImposterLinks,
 }
 
 // =============================================================================
@@ -284,14 +299,44 @@ mod tests {
         let params = ImposterQueryParams::parse(Some("replayable=true&removeProxies=true"));
         assert!(params.replayable);
         assert!(params.remove_proxies);
+        assert!(!params.list);
 
         let params = ImposterQueryParams::parse(Some("replayable=false"));
         assert!(!params.replayable);
         assert!(!params.remove_proxies);
+        assert!(!params.list);
 
         let params = ImposterQueryParams::parse(None);
         assert!(!params.replayable);
         assert!(!params.remove_proxies);
+        assert!(!params.list);
+
+        let params = ImposterQueryParams::parse(Some("list=true"));
+        assert!(!params.replayable);
+        assert!(!params.remove_proxies);
+        assert!(params.list);
+
+        let params = ImposterQueryParams::parse(Some("list=true&replayable=true"));
+        assert!(params.replayable);
+        assert!(params.list);
+    }
+
+    #[test]
+    fn test_imposter_list_entry_excludes_enabled() {
+        let entry = ImposterListEntry {
+            protocol: "http".to_string(),
+            port: 8080,
+            name: None,
+            number_of_requests: 0,
+            links: make_imposter_links("http://localhost:2525", 8080),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert!(
+            json.get("enabled").is_none(),
+            "list entry must not include 'enabled'"
+        );
+        assert!(json.get("numberOfRequests").is_some());
+        assert!(json.get("_links").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #161.

- Adds `list: bool` field to `ImposterQueryParams`, parsed from `?list=true`
- Adds `ImposterListEntry` type — same as `ImposterSummary` but without `enabled` (matches Mountebank's shape)
- When `?list=true` is set on `GET /imposters`, returns the abbreviated Mountebank-compatible format: `{ imposters: [{ port, protocol, name, numberOfRequests, _links }] }`
- Existing `?replayable=true` and `?removeProxies=true` behavior is unchanged

## Test plan

- [ ] `test_imposter_query_params_parse` — verifies `list=true` is parsed correctly
- [ ] `test_imposter_list_entry_excludes_enabled` — verifies the list entry shape matches Mountebank (no `enabled` field)
- [ ] All 36 admin_api tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)