### PR TITLE
fix: resolve deferred issues #171 #172 #173 — TOCTOU, script timeout, persistence mismatch

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -76,7 +76,7 @@ pub async fn handle_add(
         }
     }
 
-    match manager.add_stub(port, add_req.stub, add_req.index) {
+    match manager.add_stub(port, add_req.stub, add_req.index).await {
         Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
         Err(e) => e.into(),
     }
@@ -124,7 +124,7 @@ pub async fn handle_replace_all(
         );
     }
 
-    if let Err(e) = manager.replace_stubs(port, replace_req.stubs) {
+    if let Err(e) = manager.replace_stubs(port, replace_req.stubs).await {
         return e.into();
     }
 
@@ -208,7 +208,7 @@ pub async fn handle_replace(
         );
     }
 
-    match manager.replace_stub(port, index, stub) {
+    match manager.replace_stub(port, index, stub).await {
         Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
         Err(e) => e.into(),
     }
@@ -221,7 +221,7 @@ pub async fn handle_delete(
     base_url: &str,
     manager: Arc<ImposterManager>,
 ) -> Response<Full<Bytes>> {
-    match manager.delete_stub(port, index) {
+    match manager.delete_stub(port, index).await {
         Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
         Err(e) => e.into(),
     }

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -274,6 +274,10 @@ impl From<ImposterError> for Response<Full<Bytes>> {
             ImposterError::StubIndexOutOfBounds(i) => {
                 error_response(StatusCode::NOT_FOUND, &format!("Stub index {i} not found"))
             }
+            ImposterError::PersistError(msg) => error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                &format!("Persistence error: {msg}"),
+            ),
         }
     }
 }

--- a/crates/rift-http-proxy/src/imposter/manager.rs
+++ b/crates/rift-http-proxy/src/imposter/manager.rs
@@ -226,7 +226,7 @@ impl ImposterManager {
     }
 
     /// Add stub to an imposter
-    pub fn add_stub(
+    pub async fn add_stub(
         &self,
         port: u16,
         stub: Stub,
@@ -234,36 +234,37 @@ impl ImposterManager {
     ) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.add_stub(stub, index);
-        self.persist_imposter(&imposter);
-        Ok(())
+        self.persist_imposter_checked(&imposter).await
     }
 
     /// Replace a stub
-    pub fn replace_stub(&self, port: u16, index: usize, stub: Stub) -> Result<(), ImposterError> {
+    pub async fn replace_stub(
+        &self,
+        port: u16,
+        index: usize,
+        stub: Stub,
+    ) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter
             .replace_stub(index, stub)
             .map_err(|_| ImposterError::StubIndexOutOfBounds(index))?;
-        self.persist_imposter(&imposter);
-        Ok(())
+        self.persist_imposter_checked(&imposter).await
     }
 
     /// Delete a stub
-    pub fn delete_stub(&self, port: u16, index: usize) -> Result<(), ImposterError> {
+    pub async fn delete_stub(&self, port: u16, index: usize) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter
             .delete_stub(index)
             .map_err(|_| ImposterError::StubIndexOutOfBounds(index))?;
-        self.persist_imposter(&imposter);
-        Ok(())
+        self.persist_imposter_checked(&imposter).await
     }
 
     /// Replace all stubs for an imposter
-    pub fn replace_stubs(&self, port: u16, stubs: Vec<Stub>) -> Result<(), ImposterError> {
+    pub async fn replace_stubs(&self, port: u16, stubs: Vec<Stub>) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.replace_stubs(stubs);
-        self.persist_imposter(&imposter);
-        Ok(())
+        self.persist_imposter_checked(&imposter).await
     }
 
     /// Get a specific stub by index
@@ -281,7 +282,31 @@ impl ImposterManager {
     }
 
     /// Persist an imposter's current config to datadir (if configured).
-    /// Spawns a background task; write failures are logged, not propagated.
+    /// Awaits the write and returns an error if it fails, so the caller can
+    /// surface a 503 to the API client instead of silently losing the change.
+    async fn persist_imposter_checked(&self, imposter: &Imposter) -> Result<(), ImposterError> {
+        let Some(ref datadir) = self.datadir else {
+            return Ok(());
+        };
+        let port = match imposter.config.port {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let mut snapshot = imposter.config.clone();
+        snapshot.stubs = imposter.get_stubs();
+        let path = datadir.join(format!("{port}.json"));
+        let json = serde_json::to_string_pretty(&snapshot).map_err(|e| {
+            ImposterError::PersistError(format!("Failed to serialize imposter {port}: {e}"))
+        })?;
+        tokio::fs::write(&path, json).await.map_err(|e| {
+            ImposterError::PersistError(format!("Failed to write imposter {port} to {path:?}: {e}"))
+        })
+    }
+
+    /// Persist an imposter's current config to datadir (if configured).
+    /// Fire-and-forget: write failures are logged but not propagated.
+    /// Used by create_imposter where the imposter is already running and
+    /// a persistence failure should not roll back the in-memory state.
     fn persist_imposter(&self, imposter: &Imposter) {
         let Some(ref datadir) = self.datadir else {
             return;
@@ -400,8 +425,7 @@ mod tests {
         .unwrap();
 
         manager.create_imposter(config).await.expect("create");
-        // Wait for the initial write-through to complete before modifying stubs.
-        // Without this, the create and add_stub writes race and can corrupt the file.
+        // Wait for create_imposter's fire-and-forget persistence to land.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let stub: Stub = serde_json::from_value(serde_json::json!({
@@ -410,8 +434,7 @@ mod tests {
         }))
         .unwrap();
 
-        manager.add_stub(19503, stub, None).unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        manager.add_stub(19503, stub, None).await.unwrap();
 
         let file = dir.path().join("19503.json");
         let content = std::fs::read_to_string(&file).unwrap();
@@ -431,5 +454,45 @@ mod tests {
     fn test_with_datadir_sets_datadir() {
         let manager = ImposterManager::with_datadir(Some("/tmp/test".into()));
         assert!(manager.datadir.is_some());
+    }
+
+    // =========================================================================
+    // Issue #173: persistence failures must surface as errors, not silently drop
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_add_stub_returns_persist_error_on_write_failure() {
+        // Point the datadir at a path that cannot be written (a file, not a dir).
+        // The write will fail, and add_stub must propagate ImposterError::PersistError.
+        let fake_dir = tempfile::tempdir().expect("tempdir");
+        // Use a datadir sub-path that was never created, so fs::write fails.
+        let nonexistent_datadir = fake_dir.path().join("does_not_exist_subdir");
+
+        let manager = ImposterManager::with_datadir(Some(nonexistent_datadir));
+        let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "port": 19600,
+            "stubs": []
+        }))
+        .unwrap();
+
+        manager
+            .create_imposter(config)
+            .await
+            .expect("create should succeed in memory");
+
+        let stub: Stub = serde_json::from_value(serde_json::json!({
+            "predicates": [],
+            "responses": [{"is": {"statusCode": 200}}]
+        }))
+        .unwrap();
+
+        let result = manager.add_stub(19600, stub, None).await;
+        assert!(
+            matches!(result, Err(ImposterError::PersistError(_))),
+            "add_stub should return PersistError when datadir is not writable, got: {result:?}"
+        );
+
+        manager.delete_imposter(19600).await.unwrap();
     }
 }

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -993,6 +993,8 @@ pub enum ImposterError {
     InvalidProtocol(String),
     #[error("Stub index {0} out of bounds")]
     StubIndexOutOfBounds(usize),
+    #[error("Failed to persist imposter: {0}")]
+    PersistError(String),
 }
 
 #[cfg(test)]

--- a/crates/rift-http-proxy/src/recording/store.rs
+++ b/crates/rift-http-proxy/src/recording/store.rs
@@ -104,13 +104,18 @@ impl RecordingStore {
     pub fn should_proxy(&self, signature: &RequestSignature) -> bool {
         match self.mode {
             ProxyMode::ProxyOnce => {
-                // Check if already recorded
-                if self.responses.read().contains_key(signature) {
+                // Hold the read guard through the pending.insert() call so that
+                // record() (which needs responses.write()) cannot complete between
+                // the "not found" check and the pending claim, eliminating the TOCTOU.
+                let responses = self.responses.read();
+                if responses.contains_key(signature) {
                     return false;
                 }
-                // Atomically claim the signature for proxying.
-                // Only the first thread to insert succeeds; others see it as pending.
+                // pending.lock() is acquired while `responses` read guard is still held.
+                // record() cannot acquire responses.write() until we release the read
+                // guard, so the check-and-claim is atomic with respect to record().
                 self.pending.lock().insert(signature.clone())
+                // `responses` guard dropped here
             }
             ProxyMode::ProxyAlways => true,
             ProxyMode::ProxyTransparent => true,
@@ -580,6 +585,54 @@ mod tests {
         assert!(
             store.get_recorded(&new_sig).is_none(),
             "Overflow signature should not be recorded"
+        );
+    }
+
+    // =========================================================================
+    // Issue #171: TOCTOU fix — should_proxy must not race with record()
+    // =========================================================================
+
+    #[test]
+    fn test_proxy_once_no_toctou_after_concurrent_record() {
+        // Reproduce the TOCTOU: record() completes while should_proxy is between
+        // its two operations (check responses, insert pending). With the fix,
+        // should_proxy holds responses.read() across both operations, so record()
+        // cannot complete mid-check.  We verify the observable invariant: after
+        // record() has finished, should_proxy always returns false.
+        use std::sync::Arc;
+        use std::thread;
+
+        let store = Arc::new(RecordingStore::new(ProxyMode::ProxyOnce));
+        let sig = RequestSignature::new("GET", "/toctou-test", None, &[]);
+
+        // Pre-record the response so the store already has it.
+        store.should_proxy(&sig); // claim pending
+        store.record(
+            sig.clone(),
+            RecordedResponse {
+                status: 200,
+                headers: Vec::new(),
+                body: b"pre-recorded".to_vec(),
+                latency_ms: Some(10),
+                timestamp_secs: unix_timestamp(),
+            },
+        );
+
+        // Spin up concurrent threads — all must see false because the response exists.
+        let results: Vec<bool> = (0..20)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let sig = sig.clone();
+                thread::spawn(move || store.should_proxy(&sig))
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .collect();
+
+        assert!(
+            results.iter().all(|&r| !r),
+            "All concurrent should_proxy calls after record() must return false"
         );
     }
 }

--- a/crates/rift-http-proxy/src/scripting/script_pool.rs
+++ b/crates/rift-http-proxy/src/scripting/script_pool.rs
@@ -3,7 +3,7 @@ use crate::scripting::{FaultDecision, ScriptRequest};
 use anyhow::{anyhow, Result};
 use crossbeam::channel::{bounded, Receiver, Sender};
 use rhai::AST;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -80,8 +80,25 @@ impl ScriptWorker {
             .spawn(move || {
                 debug!("Script worker {} started", worker_id);
 
-                // Create reusable engine instances per worker with custom functions
-                let rhai_engine = crate::scripting::rhai_engine::RhaiEngine::create_engine();
+                // Per-worker abort flag: set to true by the watchdog when the task
+                // deadline is exceeded; checked by Rhai's on_progress callback.
+                let abort_flag = Arc::new(AtomicBool::new(false));
+
+                // Create reusable engine instances per worker with custom functions.
+                // `mut` is required to install the on_progress callback.
+                let mut rhai_engine = crate::scripting::rhai_engine::RhaiEngine::create_engine();
+
+                // Register the abort flag as a Rhai progress callback.
+                // Rhai calls this periodically during AST evaluation; returning Some(_)
+                // terminates execution with EvalAltResult::ErrorTerminated.
+                let progress_flag = Arc::clone(&abort_flag);
+                rhai_engine.on_progress(move |_ops| {
+                    if progress_flag.load(Ordering::Relaxed) {
+                        Some(rhai::Dynamic::TRUE)
+                    } else {
+                        None
+                    }
+                });
 
                 #[cfg(feature = "lua")]
                 let lua = Lua::new();
@@ -97,6 +114,28 @@ impl ScriptWorker {
                     match work_rx.recv_timeout(Duration::from_millis(100)) {
                         Ok(task) => {
                             let start = Instant::now();
+                            let timeout = task.timeout;
+
+                            // Reset the abort flag before each task.
+                            abort_flag.store(false, Ordering::Relaxed);
+
+                            // Start a watchdog thread: sets the abort flag after
+                            // `timeout`, causing Rhai to self-interrupt via on_progress.
+                            // Using a channel so the watchdog can be cancelled cleanly
+                            // when the script finishes before the deadline.
+                            let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
+                            let watchdog_flag = Arc::clone(&abort_flag);
+                            thread::Builder::new()
+                                .name(format!("script-watchdog-{worker_id}"))
+                                .spawn(move || {
+                                    match cancel_rx.recv_timeout(timeout) {
+                                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                                            watchdog_flag.store(true, Ordering::Relaxed);
+                                        }
+                                        _ => {} // cancelled or disconnected before timeout
+                                    }
+                                })
+                                .expect("Failed to spawn watchdog thread");
 
                             let result = match &task.engine {
                                 CompiledScript::Rhai { ast, rule_id } => Self::execute_rhai(
@@ -125,11 +164,24 @@ impl ScriptWorker {
                                 }
                             };
 
+                            // Cancel the watchdog — dropping the sender closes the
+                            // channel, which causes cancel_rx.recv_timeout to return
+                            // Disconnected before the timeout fires.
+                            drop(cancel_tx);
+                            // Safety-net reset so the next task starts clean even if
+                            // the watchdog fired right at the task boundary.
+                            abort_flag.store(false, Ordering::Relaxed);
+
                             let duration = start.elapsed();
-                            debug!(
-                                "Script execution completed in {:?} for worker {}",
-                                duration, worker_id
-                            );
+                            if duration >= timeout {
+                                warn!(
+                                    worker_id,
+                                    ?duration,
+                                    "Script execution exceeded timeout; Rhai was interrupted"
+                                );
+                            } else {
+                                debug!(worker_id, ?duration, "Script execution completed");
+                            }
 
                             // Send result back (ignore if receiver dropped)
                             let _ = task.result_tx.send(result);
@@ -602,6 +654,101 @@ mod tests {
         let pool = ScriptPool::new(config).unwrap();
         // Pool should be created even with very short timeout
         assert_eq!(pool.worker_count(), 2);
+    }
+
+    // =========================================================================
+    // Issue #172: script worker must not be permanently blocked by a runaway script
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_rhai_infinite_loop_is_interrupted_by_timeout() {
+        // An infinite-loop Rhai script must be interrupted when the timeout fires.
+        // After the timeout, the same worker must be able to handle a subsequent
+        // script — proving it was never permanently blocked.
+        use crate::extensions::flow_state::NoOpFlowStore;
+        use crate::scripting::ScriptRequest;
+        use std::collections::HashMap;
+
+        let config = ScriptPoolConfig {
+            workers: 1, // single worker so we can verify it's freed
+            queue_size: 10,
+            timeout_ms: 100, // very short; infinite loop fires timeout quickly
+        };
+
+        let pool = ScriptPool::new(config).unwrap();
+
+        let make_request = || ScriptRequest {
+            method: "GET".to_string(),
+            path: "/test".to_string(),
+            headers: HashMap::new(),
+            body: serde_json::json!(null),
+            query: HashMap::new(),
+            path_params: HashMap::new(),
+        };
+        let flow_store =
+            || -> Arc<dyn crate::extensions::flow_state::FlowStore> { Arc::new(NoOpFlowStore) };
+
+        // Compile an infinite loop script using a Rhai engine without custom functions
+        // (on_progress hooks are installed on the *worker* engine; the compile engine
+        //  only needs to produce a valid AST).
+        let compile_engine = rhai::Engine::new();
+        let ast = compile_engine
+            .compile(
+                r#"
+                fn should_inject(request, flow) {
+                    let i = 0;
+                    loop { i += 1; }
+                    #{ inject: false }
+                }
+            "#,
+            )
+            .expect("infinite loop script should compile");
+
+        let compiled = CompiledScript::Rhai {
+            ast: Arc::new(ast),
+            rule_id: "infinite-loop".to_string(),
+        };
+
+        let result = pool.execute(compiled, make_request(), flow_store()).await;
+
+        assert!(
+            result.is_err(),
+            "Infinite loop must return an error (either tokio timeout or Rhai interrupt)"
+        );
+
+        // Give the worker time to finish its internal cleanup after the interrupt.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // The worker must be free and able to run another script normally.
+        let compile_engine2 = rhai::Engine::new();
+        let ast2 = compile_engine2
+            .compile(
+                r#"
+                fn should_inject(request, flow) {
+                    #{ inject: false }
+                }
+            "#,
+            )
+            .expect("normal script should compile");
+
+        let compiled2 = CompiledScript::Rhai {
+            ast: Arc::new(ast2),
+            rule_id: "post-timeout".to_string(),
+        };
+
+        let pool2 = ScriptPool::new(ScriptPoolConfig {
+            workers: 1,
+            queue_size: 10,
+            timeout_ms: 5000,
+        })
+        .unwrap();
+
+        let result2 = pool2.execute(compiled2, make_request(), flow_store()).await;
+
+        assert!(
+            result2.is_ok(),
+            "Worker (or a fresh pool) must handle scripts normally after a timeout"
+        );
     }
 
     #[tokio::test]

--- a/crates/rift-http-proxy/src/scripting/script_pool.rs
+++ b/crates/rift-http-proxy/src/scripting/script_pool.rs
@@ -128,11 +128,14 @@ impl ScriptWorker {
                             thread::Builder::new()
                                 .name(format!("script-watchdog-{worker_id}"))
                                 .spawn(move || {
-                                    match cancel_rx.recv_timeout(timeout) {
-                                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                                            watchdog_flag.store(true, Ordering::Relaxed);
-                                        }
-                                        _ => {} // cancelled or disconnected before timeout
+                                    // Timeout fires: set the abort flag so Rhai's
+                                    // on_progress callback interrupts the script.
+                                    // Any other outcome (Ok or Disconnected) means the
+                                    // task completed or was cancelled — nothing to do.
+                                    if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) =
+                                        cancel_rx.recv_timeout(timeout)
+                                    {
+                                        watchdog_flag.store(true, Ordering::Relaxed);
                                     }
                                 })
                                 .expect("Failed to spawn watchdog thread");

--- a/crates/rift-http-proxy/src/scripting/script_pool.rs
+++ b/crates/rift-http-proxy/src/scripting/script_pool.rs
@@ -125,7 +125,7 @@ impl ScriptWorker {
                             // when the script finishes before the deadline.
                             let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
                             let watchdog_flag = Arc::clone(&abort_flag);
-                            thread::Builder::new()
+                            let watchdog_handle = thread::Builder::new()
                                 .name(format!("script-watchdog-{worker_id}"))
                                 .spawn(move || {
                                     // Timeout fires: set the abort flag so Rhai's
@@ -167,12 +167,15 @@ impl ScriptWorker {
                                 }
                             };
 
-                            // Cancel the watchdog — dropping the sender closes the
-                            // channel, which causes cancel_rx.recv_timeout to return
-                            // Disconnected before the timeout fires.
+                            // Cancel the watchdog by closing the channel, then join
+                            // it to ensure it has fully exited before resetting the
+                            // flag. Joining is cheap: the watchdog exits immediately
+                            // on Disconnected (normal path) or has already exited
+                            // after setting the flag (timeout path). Without the join,
+                            // a delayed store(true) from watchdog could corrupt the
+                            // next task's abort state.
                             drop(cancel_tx);
-                            // Safety-net reset so the next task starts clean even if
-                            // the watchdog fired right at the task boundary.
+                            let _ = watchdog_handle.join();
                             abort_flag.store(false, Ordering::Relaxed);
 
                             let duration = start.elapsed();
@@ -720,9 +723,12 @@ mod tests {
         );
 
         // Give the worker time to finish its internal cleanup after the interrupt.
+        // The worker joins the watchdog (cheap), resets the flag, then loops back
+        // to recv_timeout — all well within 300 ms.
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-        // The worker must be free and able to run another script normally.
+        // Re-use the *same* pool (same single worker) to prove the worker is free.
+        // A fresh pool would always pass; only the original pool verifies the fix.
         let compile_engine2 = rhai::Engine::new();
         let ast2 = compile_engine2
             .compile(
@@ -739,18 +745,18 @@ mod tests {
             rule_id: "post-timeout".to_string(),
         };
 
-        let pool2 = ScriptPool::new(ScriptPoolConfig {
-            workers: 1,
-            queue_size: 10,
-            timeout_ms: 5000,
-        })
-        .unwrap();
-
-        let result2 = pool2.execute(compiled2, make_request(), flow_store()).await;
+        // Raise the pool's timeout for this follow-up call so the normal script
+        // doesn't race against the 100 ms limit.
+        let result2 = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            pool.execute(compiled2, make_request(), flow_store()),
+        )
+        .await
+        .expect("second execute timed out — worker was not freed after interrupt");
 
         assert!(
             result2.is_ok(),
-            "Worker (or a fresh pool) must handle scripts normally after a timeout"
+            "Same worker must handle scripts normally after a timeout interrupt; got: {result2:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **#171 — TOCTOU race in `ProxyOnce` recording store**: `should_proxy()` now holds `responses.read()` through `pending.lock().insert()`, so `record()` cannot complete between the check and the claim. Lock ordering (responses → pending) is consistent with `record()`, preventing deadlock.
- **#172 — Script worker not interrupted on timeout**: Each worker installs a Rhai `on_progress` callback backed by an `Arc<AtomicBool>`. A per-task watchdog thread sets the flag after the task deadline; Rhai self-interrupts on the next operation. Watchdog is cancelled cleanly when the script finishes early.
- **#173 — Disk-full persistence leaves silent in-memory/disk mismatch**: Added `ImposterError::PersistError`. `add_stub`, `replace_stub`, `delete_stub`, `replace_stubs` are now `async` and await `persist_imposter_checked`, which propagates write failures as 503 Service Unavailable instead of silently discarding them.

## Test plan

- [ ] `test_proxy_once_no_toctou_after_concurrent_record` — 20 concurrent threads all see false after `record()` completes
- [ ] `test_rhai_infinite_loop_is_interrupted_by_timeout` — infinite loop returns an error; a fresh pool handles subsequent scripts normally
- [ ] `test_add_stub_returns_persist_error_on_write_failure` — `add_stub` returns `PersistError` when datadir is non-writable
- [ ] All 1384 existing tests pass

Closes #171, closes #172, closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)