### PR TITLE
fix: wire allowCORS to inject CORS headers and handle OPTIONS preflight

### DIFF
--- a/crates/rift-http-proxy/src/imposter/handler.rs
+++ b/crates/rift-http-proxy/src/imposter/handler.rs
@@ -36,6 +36,33 @@ pub async fn handle_imposter_request(
     imposter: Arc<Imposter>,
     client_addr: SocketAddr,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
+    let allow_cors = imposter.config.allow_cors;
+    let mut response = handle_request_inner(req, imposter, client_addr).await?;
+    if allow_cors {
+        inject_cors_headers(response.headers_mut());
+    }
+    Ok(response)
+}
+
+fn inject_cors_headers(headers: &mut hyper::HeaderMap) {
+    use hyper::header::{HeaderName, HeaderValue};
+    for (name, value) in [
+        ("access-control-allow-origin", "*"),
+        ("access-control-allow-headers", "*"),
+        ("access-control-allow-methods", "*"),
+    ] {
+        let header_name = HeaderName::from_static(name);
+        if !headers.contains_key(&header_name) {
+            headers.insert(header_name, HeaderValue::from_static(value));
+        }
+    }
+}
+
+async fn handle_request_inner(
+    req: Request<Incoming>,
+    imposter: Arc<Imposter>,
+    client_addr: SocketAddr,
+) -> Result<Response<Full<Bytes>>, Infallible> {
     // Check if enabled
     if !imposter.is_enabled() {
         return Ok(build_response_with_headers(
@@ -63,6 +90,14 @@ pub async fn handle_imposter_request(
         .collect();
     let path = uri.path().to_string();
     let query_str = uri.query().unwrap_or("").to_string();
+
+    if method.eq_ignore_ascii_case("OPTIONS") && imposter.config.allow_cors {
+        return Ok(build_response_with_headers(
+            StatusCode::OK,
+            [("x-rift-imposter", "true")],
+            Bytes::new(),
+        ));
+    }
 
     // Collect request body with size limit to prevent memory exhaustion
     let limited_body = Limited::new(req.into_body(), MAX_REQUEST_BODY_SIZE);

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -2369,3 +2369,123 @@ fn test_multi_valued_query_param_contains() {
         0
     ));
 }
+
+// =============================================================================
+// Issue #189: allowCORS — OPTIONS preflight and CORS header injection
+// =============================================================================
+
+/// Assert that a response header equals `expected` (`None` asserts absence).
+fn assert_cors_header(response: &reqwest::Response, name: &str, expected: Option<&str>) {
+    let actual = response.headers().get(name).map(|v| v.to_str().unwrap());
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn test_cors_options_preflight() {
+    let manager = ImposterManager::new();
+    let config = ImposterConfig {
+        port: None,
+        protocol: "http".to_string(),
+        allow_cors: true,
+        stubs: vec![],
+        ..Default::default()
+    };
+    let port = manager
+        .create_imposter(config)
+        .await
+        .expect("failed to create CORS imposter");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://127.0.0.1:{port}/any/path"),
+        )
+        .send()
+        .await
+        .expect("OPTIONS request failed");
+
+    assert_eq!(response.status(), 200);
+    assert_cors_header(&response, "access-control-allow-origin", Some("*"));
+    assert_cors_header(&response, "access-control-allow-headers", Some("*"));
+    assert_cors_header(&response, "access-control-allow-methods", Some("*"));
+
+    let _ = manager.delete_imposter(port).await;
+}
+
+#[tokio::test]
+async fn test_cors_headers_on_stub_response() {
+    let manager = ImposterManager::new();
+    let stub = Stub {
+        id: None,
+        predicates: predicates_from_jsons(vec![serde_json::json!({
+            "equals": {"method": "GET", "path": "/test"}
+        })]),
+        responses: vec![StubResponse::Is {
+            is: IsResponse {
+                status_code: 200,
+                headers: HashMap::new(),
+                body: Some(serde_json::json!("ok")),
+                ..Default::default()
+            },
+            behaviors: None,
+            rift: None,
+        }],
+        scenario_name: None,
+        recorded_from: None,
+    };
+    let config = ImposterConfig {
+        port: None,
+        protocol: "http".to_string(),
+        allow_cors: true,
+        stubs: vec![stub],
+        ..Default::default()
+    };
+    let port = manager
+        .create_imposter(config)
+        .await
+        .expect("failed to create CORS imposter with stub");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/test"))
+        .send()
+        .await
+        .expect("GET request failed");
+
+    assert_eq!(response.status(), 200);
+    assert_cors_header(&response, "access-control-allow-origin", Some("*"));
+    assert_cors_header(&response, "access-control-allow-headers", Some("*"));
+    assert_cors_header(&response, "access-control-allow-methods", Some("*"));
+
+    let _ = manager.delete_imposter(port).await;
+}
+
+#[tokio::test]
+async fn test_cors_disabled_no_cors_headers() {
+    let manager = ImposterManager::new();
+    let config = ImposterConfig {
+        port: None,
+        protocol: "http".to_string(),
+        allow_cors: false,
+        stubs: vec![],
+        ..Default::default()
+    };
+    let port = manager
+        .create_imposter(config)
+        .await
+        .expect("failed to create imposter without CORS");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/"))
+        .send()
+        .await
+        .expect("GET request failed");
+
+    assert_cors_header(&response, "access-control-allow-origin", None);
+    assert_cors_header(&response, "access-control-allow-headers", None);
+    assert_cors_header(&response, "access-control-allow-methods", None);
+
+    let _ = manager.delete_imposter(port).await;
+}


### PR DESCRIPTION
## Summary

Fixes #189. `allowCORS: true` was parsed and stored in `ImposterConfig` but never acted upon, causing silent CORS failures for all 32 repos in the `cof-primary/*-mimeo-solo*` fleet that set `"allowCORS": true`.

- Wrap `handle_imposter_request` with a thin public function that reads `allow_cors` and injects the three CORS headers on every response via `inject_cors_headers`
- Short-circuit `OPTIONS` preflight in the inner handler: returns `200 OK` immediately without stub matching when `allow_cors: true`
- `inject_cors_headers` only sets headers that are not already present, so stubs that set their own CORS headers are not overridden

## Test plan

- [ ] `test_cors_options_preflight` — `allowCORS: true` + `OPTIONS` → 200 with all three CORS headers, no stub matched
- [ ] `test_cors_headers_on_stub_response` — `allowCORS: true` + `GET` matching a stub → stub response (200) with CORS headers appended
- [ ] `test_cors_disabled_no_cors_headers` — `allowCORS: false` (default) → CORS headers absent
- [ ] Full suite: 1244 tests pass, 57 ignored (no regressions)