### PR TITLE
fix: stop docker-publish from firing on tag push before release assets exist

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,10 @@
 name: Build and Publish Docker Images
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # Note: intentionally NOT triggered by `push: tags`. This workflow downloads
+  # the release binaries from the GitHub Release, which do not exist at tag-push
+  # time. It is invoked by release.yml (workflow_call) after the release job has
+  # uploaded the assets, or manually via workflow_dispatch.
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Problem

Every tag push (and thus every release) produces a **guaranteed-failing** "Build and Publish Docker Images" run — both jobs (`rift-proxy`, `rift-lint`) die immediately at **Download linux-amd64 binary** (exit 2). Example: run 28326059752 on `v0.2.0`.

## Cause

`docker-publish.yml` was triggered two ways at once:
- `on: push: tags: ['v*']` — fires the instant the tag is pushed.
- `workflow_call` — invoked by `release.yml`'s `publish-docker` job (`needs: release`).

The workflow's first step downloads the release tarballs from the GitHub Release. At tag-push time those assets don't exist yet (the release job is still building binaries), so the standalone `push`-triggered run can **never** succeed — it always races ahead of the binaries.

## Fix

Remove the standalone `push: tags` trigger. Docker images are still built and pushed by `release.yml` via `workflow_call` **after** the release assets are uploaded, and `workflow_dispatch` remains for manual runs. This eliminates the always-red run on every release with no loss of functionality.