### PR TITLE
fix: apply lookup behavior on direct imposter responses

### DIFF
--- a/crates/rift-http-proxy/src/behaviors/lookup.rs
+++ b/crates/rift-http-proxy/src/behaviors/lookup.rs
@@ -85,8 +85,16 @@ impl CsvCache {
             }
         }
 
-        // Load from file
-        let data = CsvData::load(path, delimiter).ok()?;
+        // Load from file. A failure here means a misconfigured data source
+        // (missing/unreadable/malformed CSV); surface it instead of silently
+        // serving the response with the lookup tokens left unreplaced.
+        let data = match CsvData::load(path, delimiter) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::warn!("lookup behavior: failed to load CSV data source '{path}': {e}");
+                return None;
+            }
+        };
         let data = Arc::new(data);
 
         // Cache it

--- a/crates/rift-http-proxy/src/behaviors/types.rs
+++ b/crates/rift-http-proxy/src/behaviors/types.rs
@@ -27,7 +27,11 @@ pub struct ResponseBehaviors {
     pub copy: Vec<CopyBehavior>,
 
     /// Lookup from external data source
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_lookup_behaviors",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub lookup: Vec<LookupBehavior>,
 
     /// Shell transform - external program(s) transform response.
@@ -122,6 +126,46 @@ where
     deserializer.deserialize_any(CopyBehaviorsVisitor)
 }
 
+/// Accept either a single `lookup` object or an array, mirroring `copy`.
+/// Mountebank and the docs use the single-object form (`"lookup": { ... }`).
+fn deserialize_lookup_behaviors<'de, D>(deserializer: D) -> Result<Vec<LookupBehavior>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+
+    struct LookupBehaviorsVisitor;
+
+    impl<'de> Visitor<'de> for LookupBehaviorsVisitor {
+        type Value = Vec<LookupBehavior>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a lookup behavior object or array of lookup behaviors")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut behaviors = Vec::new();
+            while let Some(behavior) = seq.next_element()? {
+                behaviors.push(behavior);
+            }
+            Ok(behaviors)
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+        where
+            M: de::MapAccess<'de>,
+        {
+            let behavior = LookupBehavior::deserialize(de::value::MapAccessDeserializer::new(map))?;
+            Ok(vec![behavior])
+        }
+    }
+
+    deserializer.deserialize_any(LookupBehaviorsVisitor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,6 +186,30 @@ copy:
         assert!(matches!(behaviors.wait, Some(WaitBehavior::Fixed(500))));
         assert_eq!(behaviors.repeat, Some(3));
         assert_eq!(behaviors.copy.len(), 1);
+    }
+
+    // The `lookup` field accepts both a single object (Mountebank/docs form) and
+    // an array, mirroring `copy`.
+    #[test]
+    fn test_lookup_behaviors_single_object_and_array() {
+        let lookup = serde_json::json!({
+            "key": { "from": "path", "using": { "method": "regex", "selector": "/c/(\\d+)" } },
+            "fromDataSource": { "csv": { "path": "x.csv", "keyColumn": "id" } },
+            "into": "${row}"
+        });
+
+        let single: ResponseBehaviors =
+            serde_json::from_value(serde_json::json!({ "lookup": lookup.clone() })).unwrap();
+        assert_eq!(
+            single.lookup.len(),
+            1,
+            "single object should yield one behavior"
+        );
+
+        let array: ResponseBehaviors =
+            serde_json::from_value(serde_json::json!({ "lookup": [lookup.clone(), lookup] }))
+                .unwrap();
+        assert_eq!(array.lookup.len(), 2, "array should yield two behaviors");
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/imposter/handler.rs
+++ b/crates/rift-http-proxy/src/imposter/handler.rs
@@ -9,7 +9,8 @@ use super::response::apply_js_or_rhai_decorate;
 use super::types::{DebugMatchResult, DebugRequest, DebugResponse, RecordedRequest, ResponseMode};
 use crate::admin_api::types::{build_response, build_response_with_headers};
 use crate::behaviors::{
-    apply_copy_behaviors, header_to_title_case, RequestContext, ResponseBehaviors,
+    apply_copy_behaviors, apply_lookup_behaviors, header_to_title_case, CsvCache, RequestContext,
+    ResponseBehaviors,
 };
 #[cfg(feature = "javascript")]
 use crate::scripting::{execute_mountebank_inject, MountebankRequest};
@@ -20,8 +21,6 @@ use http_body_util::{BodyExt, Full, Limited};
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
 
-/// Maximum allowed request body size (10 MB)
-const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
 use rand::Rng;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -29,6 +28,16 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, warn};
+
+/// Maximum allowed request body size (10 MB)
+const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
+
+/// Process-wide cache for `lookup` behavior CSV data sources, shared across all
+/// imposters so a file is parsed once and reused on subsequent requests.
+fn csv_cache() -> &'static CsvCache {
+    static CSV_CACHE: std::sync::OnceLock<CsvCache> = std::sync::OnceLock::new();
+    CSV_CACHE.get_or_init(CsvCache::new)
+}
 
 /// Handle a request to an imposter
 pub async fn handle_imposter_request(
@@ -446,6 +455,17 @@ async fn handle_request_inner(
                             &mut headers,
                             &parsed_behaviors.copy,
                             &request_context,
+                        );
+                    }
+
+                    // Apply lookup behaviors (CSV-backed token replacement)
+                    if !parsed_behaviors.lookup.is_empty() {
+                        body = apply_lookup_behaviors(
+                            &body,
+                            &mut headers,
+                            &parsed_behaviors.lookup,
+                            &request_context,
+                            csv_cache(),
                         );
                     }
 

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -2489,3 +2489,73 @@ async fn test_cors_disabled_no_cors_headers() {
 
     let _ = manager.delete_imposter(port).await;
 }
+
+// Issue #213: the `lookup` behavior must apply to direct imposter `is` responses,
+// not only to proxied responses. Tokens `${into}[column]` should be replaced from
+// the CSV data source.
+#[tokio::test]
+async fn test_lookup_behavior_applied_on_is_response() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv_path = dir.path().join("products.csv");
+    std::fs::write(&csv_path, "id,name,price\n456,Gadget,19.99\n").expect("write csv");
+    let csv_path = csv_path.to_str().expect("csv path utf8");
+
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19710,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{ "matches": { "path": "^/catalog/\\d+$" } }],
+            "responses": [{
+                "is": {
+                    "statusCode": 200,
+                    "headers": { "Content-Type": "application/json", "X-Product": "${row}[name]" },
+                    "body": { "name": "${row}[name]", "price": "${row}[price]" }
+                },
+                "_behaviors": {
+                    "lookup": {
+                        "key": { "from": "path", "using": { "method": "regex", "selector": "/catalog/(\\d+)" } },
+                        "fromDataSource": { "csv": { "path": csv_path, "keyColumn": "id" } },
+                        "into": "${row}"
+                    }
+                }
+            }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+
+    let response = reqwest::Client::new()
+        .get("http://127.0.0.1:19710/catalog/456")
+        .send()
+        .await
+        .expect("GET failed");
+    let status = response.status();
+    let product_header = response
+        .headers()
+        .get("X-Product")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let body = response.text().await.expect("body");
+
+    let _ = manager.delete_imposter(19710).await;
+
+    assert_eq!(status, 200, "lookup response should be 200");
+    assert!(
+        body.contains("Gadget") && body.contains("19.99"),
+        "lookup must replace body tokens with CSV values, got: {body}"
+    );
+    assert!(
+        !body.contains("${row}"),
+        "no lookup tokens should remain after replacement, got: {body}"
+    );
+    assert_eq!(
+        product_header.as_deref(),
+        Some("Gadget"),
+        "lookup must replace tokens in response headers too"
+    );
+}


### PR DESCRIPTION
## Summary

The `lookup` response behavior (`_behaviors.lookup`, CSV-backed `${into}[column]` token replacement) was only applied on the **proxy** code path. A normal imposter `is` response with `_behaviors.lookup` silently did nothing — the tokens were left verbatim. (`copy` on an `is` response worked, which made the gap confusing.)

## Root cause (two parts)

1. `imposter/handler.rs` applied `copy` but **never** called `apply_lookup_behaviors` — only `proxy/handler.rs` did.
2. The `lookup` field lacked the single-or-array deserializer that `copy` has, so the Mountebank/docs single-object form (`"lookup": { ... }`) **failed to deserialize and silently dropped the entire `_behaviors` block** — the real reason the repro showed verbatim tokens.

## Fix

- Apply `apply_lookup_behaviors` on imposter `is` responses (after the copy block), using a process-global `CsvCache` (`OnceLock`, mirroring `get_http_client`).
- Add `deserialize_lookup_behaviors` so `lookup` accepts a single object **or** an array, mirroring `deserialize_copy_behaviors`.
- Surface CSV load failures with a `warn!` instead of discarding the error via `.ok()?`, so a misconfigured data source is diagnosable — benefits the proxy path too.

## Tests

- `test_lookup_behavior_applied_on_is_response` — real HTTP GET through an imposter with a single-object `lookup` + temp CSV; asserts body **and** response-header token replacement, status 200, and no residual `${row}` tokens.
- `test_lookup_behaviors_single_object_and_array` — unit test for the new deserializer (both forms).

## Verification
- `cargo fmt` / `cargo clippy -- -D warnings` clean; `cargo test --lib` → 616 pass (2 new).

Closes #213