### PR TITLE
fix: script request header access is case-sensitive

### DIFF
--- a/crates/rift-http-proxy/src/imposter/handler.rs
+++ b/crates/rift-http-proxy/src/imposter/handler.rs
@@ -313,11 +313,16 @@ async fn handle_request_inner(
                 script_config.engine
             );
 
-            // Build script request
+            // Build script request. Expose headers with lowercase keys so scripts can read
+            // them case-insensitively (e.g. `request.headers["x-flow-id"]`) regardless of the
+            // wire casing; this matches the engine docs and HTTP header semantics.
             let script_request = ScriptRequest {
                 method: method.clone(),
                 path: path.clone(),
-                headers: headers_clone.clone(),
+                headers: headers_clone
+                    .iter()
+                    .map(|(k, v)| (k.to_ascii_lowercase(), v.clone()))
+                    .collect(),
                 body: body_string
                     .as_ref()
                     .and_then(|s| serde_json::from_str(s).ok())

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -2559,3 +2559,46 @@ async fn test_lookup_behavior_applied_on_is_response() {
         "lookup must replace tokens in response headers too"
     );
 }
+
+// Issue #215: scripts must access request headers case-insensitively. A request sent
+// with `X-Flow-Id: demo` must be readable as `request.headers["x-flow-id"]` (lowercase),
+// matching the engine docs/tests and HTTP's case-insensitive header semantics.
+#[tokio::test]
+async fn test_script_header_access_is_case_insensitive() {
+    let script = "fn should_inject(request, flow_store) { \
+         let f = request.headers[\"x-flow-id\"]; if f == () { f = \"MISS\"; }; \
+         #{ inject: true, fault: \"error\", status: 200, body: f } }";
+
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19720,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/whoami" } }],
+            "responses": [{ "_rift": { "script": { "engine": "rhai", "code": script } } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19720/whoami")
+        .header("X-Flow-Id", "demo")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+
+    let _ = manager.delete_imposter(19720).await;
+
+    assert_eq!(
+        body, "demo",
+        "script must read the Title-Cased wire header via a lowercase key, got: {body}"
+    );
+}

--- a/docs/demo/imposters-retry-proxy.json
+++ b/docs/demo/imposters-retry-proxy.json
@@ -26,7 +26,7 @@
               "_rift": {
                 "script": {
                   "engine": "rhai",
-                  "code": "let flow_id = request.headers.get(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{ inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Service temporarily unavailable\",\"attempt\":${attempts},\"message\":\"Retry after a moment\"}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\", \"X-Attempt\": `${attempts}`} } } else { #{ inject: false } }"
+                  "code": "let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{ inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Service temporarily unavailable\",\"attempt\":${attempts},\"message\":\"Retry after a moment\"}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\", \"X-Attempt\": `${attempts}`} } } else { #{ inject: false } }"
                 }
               },
               "_behaviors": {
@@ -53,7 +53,7 @@
               "_rift": {
                 "script": {
                   "engine": "rhai",
-                  "code": "let flow_id = request.headers.get(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; flow_store.delete(flow_id, \"attempts\"); #{ inject: true, fault: \"error\", status: 200, body: `{\"message\":\"Counter reset for flow: ${flow_id}\"}`, headers: #{\"Content-Type\": \"application/json\"} }"
+                  "code": "let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; flow_store.delete(flow_id, \"attempts\"); #{ inject: true, fault: \"error\", status: 200, body: `{\"message\":\"Counter reset for flow: ${flow_id}\"}`, headers: #{\"Content-Type\": \"application/json\"} }"
                 }
               }
             }
@@ -74,7 +74,7 @@
               "_rift": {
                 "script": {
                   "engine": "rhai",
-                  "code": "let flow_id = request.headers.get(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; #{ inject: true, fault: \"error\", status: 200, body: `{\"flow_id\":\"${flow_id}\",\"attempts\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"} }"
+                  "code": "let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; #{ inject: true, fault: \"error\", status: 200, body: `{\"flow_id\":\"${flow_id}\",\"attempts\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"} }"
                 }
               }
             }

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -199,7 +199,7 @@ Fail the first 2 requests, pass through on the 3rd:
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "let flow_id = request.headers.get(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { #{inject: false} }"
+          "code": "let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { #{inject: false} }"
         }
       }
     }]
@@ -315,7 +315,7 @@ Use scripting to fail a specific number of requests before succeeding:
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "let flow_id = request.headers.get(\"x-request-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.increment(flow_id, \"attempts\"); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Retry later\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\"}} } else { #{inject: false} }"
+          "code": "let flow_id = request.headers[\"x-request-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.increment(flow_id, \"attempts\"); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Retry later\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\"}} } else { #{inject: false} }"
         }
       }
     }]

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -304,7 +304,7 @@ return {
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "fn should_inject(request, flow_store) { let flow_id = request.headers.get(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { #{inject: false} } }"
+          "code": "fn should_inject(request, flow_store) { let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { #{inject: false} } }"
         }
       }
     }]

--- a/docs/mountebank/responses.md
+++ b/docs/mountebank/responses.md
@@ -291,7 +291,7 @@ With standard cycling, if User A triggers the first failure, User B gets the sec
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "fn should_inject(request, flow_store) { let user_id = request.headers.get(\"x-user-id\"); if user_id == () { user_id = \"anonymous\"; }; let attempts = flow_store.increment(user_id, \"attempts\"); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts},\"user\":\"${user_id}\"}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\"}} } else { #{inject: false} } }"
+          "code": "fn should_inject(request, flow_store) { let user_id = request.headers[\"x-user-id\"]; if user_id == () { user_id = \"anonymous\"; }; let attempts = flow_store.increment(user_id, \"attempts\"); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts},\"user\":\"${user_id}\"}`, headers: #{\"Content-Type\": \"application/json\", \"Retry-After\": \"1\"}} } else { #{inject: false} } }"
         }
       },
       "is": { "statusCode": 200, "body": "{\"status\": \"success\"}" }
@@ -356,7 +356,7 @@ Features not possible with Mountebank:
         "_rift": {
           "script": {
             "engine": "rhai",
-            "code": "fn should_inject(request, flow_store) { let api_key = request.headers.get(\"x-api-key\"); if api_key == () { return #{inject: true, fault: \"error\", status: 401, body: \"{\\\"error\\\":\\\"API key required\\\"}\", headers: #{\"Content-Type\": \"application/json\"}}; }; let used = flow_store.get(api_key, \"quota_used\"); if used == () { used = 0; }; let limit = 1000; if used >= limit { #{inject: true, fault: \"error\", status: 402, body: `{\"error\":\"Quota exceeded\",\"used\":${used},\"limit\":${limit}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { flow_store.set(api_key, \"quota_used\", used + 1); #{inject: false} } }"
+            "code": "fn should_inject(request, flow_store) { let api_key = request.headers[\"x-api-key\"]; if api_key == () { return #{inject: true, fault: \"error\", status: 401, body: \"{\\\"error\\\":\\\"API key required\\\"}\", headers: #{\"Content-Type\": \"application/json\"}}; }; let used = flow_store.get(api_key, \"quota_used\"); if used == () { used = 0; }; let limit = 1000; if used >= limit { #{inject: true, fault: \"error\", status: 402, body: `{\"error\":\"Quota exceeded\",\"used\":${used},\"limit\":${limit}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { flow_store.set(api_key, \"quota_used\", used + 1); #{inject: false} } }"
           }
         },
         "is": { "statusCode": 200, "body": "{\"result\": \"expensive computation\"}" }
@@ -368,7 +368,7 @@ Features not possible with Mountebank:
         "_rift": {
           "script": {
             "engine": "rhai",
-            "code": "fn should_inject(request, flow_store) { let api_key = request.headers.get(\"x-api-key\"); if api_key == () { api_key = \"default\"; }; flow_store.delete(api_key, \"quota_used\"); #{inject: true, fault: \"error\", status: 200, body: \"{\\\"message\\\":\\\"Quota reset\\\"}\", headers: #{\"Content-Type\": \"application/json\"}} }"
+            "code": "fn should_inject(request, flow_store) { let api_key = request.headers[\"x-api-key\"]; if api_key == () { api_key = \"default\"; }; flow_store.delete(api_key, \"quota_used\"); #{inject: true, fault: \"error\", status: 200, body: \"{\\\"message\\\":\\\"Quota reset\\\"}\", headers: #{\"Content-Type\": \"application/json\"}} }"
           }
         }
       }]


### PR DESCRIPTION
## Summary

Inside `_rift.script` handlers, request headers were exposed **Title-Cased** (via `header_to_title_case`), so `request.headers["x-flow-id"]` — the lowercase form the engine docs and tests assume — silently missed, while only `request.headers["X-Flow-Id"]` worked. HTTP headers are case-insensitive, so script authors shouldn't have to guess the casing.

## Fix

- `imposter/handler.rs` — lowercase the header keys when building `ScriptRequest` (one site; all three engines — rhai/lua/js — read that field), so scripts read headers case-insensitively regardless of wire casing. Uses `to_ascii_lowercase` (header names are ASCII).
- Fixed the broken `request.headers.get("…")` rhai pattern (rhai maps have no `.get()`; it errors at runtime — the HTTP 500 the issue cites) → `request.headers["…"]` in `docs/demo/imposters-retry-proxy.json` and 5 more snippets across `docs/features/scripting.md`, `docs/features/fault-injection.md`, `docs/mountebank/responses.md`.

Scope note: the Mountebank `inject`/predicate paths are intentionally left Title-Cased (compat); only the Rift `_rift.script` view changes.

## Tests

- `test_script_header_access_is_case_insensitive` — real HTTP: a rhai `_rift.script` reads `request.headers["x-flow-id"]` for a request sent with `X-Flow-Id: demo`; asserts the body is `demo` (pre-fix returned `MISS`). lua/js consume the same `ScriptRequest.headers`, so they're covered by the shared construction.

## Verification
- `cargo fmt` / `cargo clippy -- -D warnings` clean; `cargo test --lib` → 617 pass (1 new).

Closes #215