### PR TITLE
fix(rift-lint): accept imposters-wrapper and bare-array config shapes

### DIFF
--- a/crates/rift-lint/src/lib.rs
+++ b/crates/rift-lint/src/lib.rs
@@ -35,6 +35,29 @@ pub use validator::{
     validate_predicate, validate_proxy_response, validate_response, validate_stub,
 };
 
+/// Validate a parsed config value, accepting the same shapes `rift --configfile` accepts:
+/// a single imposter object, a `{"imposters": [...]}` wrapper, or a bare `[...]` array.
+/// Each imposter is validated individually so the wrapper itself isn't mistaken for one.
+fn validate_config(
+    path: &Path,
+    value: &serde_json::Value,
+    result: &mut LintResult,
+    options: &LintOptions,
+) {
+    let imposters = value
+        .get("imposters")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| value.as_array());
+    match imposters {
+        Some(arr) => {
+            for imposter in arr {
+                validate_imposter(path, imposter, result, options);
+            }
+        }
+        None => validate_imposter(path, value, result, options),
+    }
+}
+
 /// Lint a single imposter configuration file.
 ///
 /// Returns a `LintResult` containing all issues found.
@@ -66,7 +89,7 @@ pub fn lint_file(path: &Path, options: &LintOptions) -> LintResult {
         }
     };
 
-    validate_imposter(path, &value, &mut result, options);
+    validate_config(path, &value, &mut result, options);
     result
 }
 
@@ -120,7 +143,7 @@ pub fn lint_json(json: &str, source_name: &str, options: &LintOptions) -> LintRe
         }
     };
 
-    validate_imposter(path, &value, &mut result, options);
+    validate_config(path, &value, &mut result, options);
     result
 }
 
@@ -136,6 +159,6 @@ pub fn lint_value(
     result.files_checked = 1;
 
     let path = Path::new(source_name);
-    validate_imposter(path, value, &mut result, options);
+    validate_config(path, value, &mut result, options);
     result
 }

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -816,3 +816,89 @@ fn lint_directory_reads_json_files() {
     assert_eq!(result.files_checked, 2, "should check 2 JSON files");
     assert!(result.has_errors(), "should find error in invalid.json");
 }
+
+// ─── Issue #217: config wrapper / multi-imposter formats ─────────────────────
+
+#[test]
+fn wrapper_object_validates_each_imposter() {
+    // `{"imposters":[...]}` — the form `rift --configfile` accepts — must not be
+    // treated as a single imposter (which would spuriously flag E003 on the wrapper).
+    let cfg = json!({ "imposters": [ make_imposter(json!([minimal_stub()])) ] }).to_string();
+    let r = lint_json(&cfg, "<wrap>", &opts());
+    assert!(
+        !has_code(&r, "E003"),
+        "wrapper object must not produce E003, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn bare_array_validates_each_imposter() {
+    let cfg = json!([make_imposter(json!([minimal_stub()]))]).to_string();
+    let r = lint_json(&cfg, "<arr>", &opts());
+    assert!(
+        !has_code(&r, "E003"),
+        "bare array must not produce E003, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn wrapper_reports_inner_imposter_errors() {
+    // The inner imposter has an INVALID protocol → E004. E004 can only come from an
+    // imposter that actually has a `protocol` field, so (unlike E003) it can't be
+    // produced by the old "validate the wrapper as one imposter" path — proving the
+    // array element itself is reached and validated.
+    let cfg =
+        json!({ "imposters": [ { "port": 3000, "protocol": "smtp", "stubs": [] } ] }).to_string();
+    let r = lint_json(&cfg, "<wrap>", &opts());
+    assert!(
+        has_code(&r, "E004"),
+        "invalid protocol inside the wrapper must surface E004, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn array_validates_every_element_not_just_first() {
+    // A bare array whose SECOND element has an invalid protocol must be flagged — guards
+    // the `for imposter in arr` loop (a first-element-only bug would pass everything else).
+    let cfg = json!([
+        make_imposter(json!([minimal_stub()])),
+        { "port": 3001, "protocol": "smtp", "stubs": [] }
+    ])
+    .to_string();
+    let r = lint_json(&cfg, "<arr>", &opts());
+    assert!(
+        has_code(&r, "E004"),
+        "invalid protocol on a non-first array element must surface E004, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn empty_imposters_set_is_clean() {
+    // An empty imposter set is valid (matches `rift --configfile`) — no spurious E003.
+    for cfg in [
+        json!({ "imposters": [] }).to_string(),
+        json!([]).to_string(),
+    ] {
+        let r = lint_json(&cfg, "<empty>", &opts());
+        assert!(
+            !has_code(&r, "E003"),
+            "empty imposter set must not produce E003, got {:?}",
+            codes(&r)
+        );
+    }
+}
+
+#[test]
+fn single_imposter_still_validates() {
+    let cfg = make_imposter(json!([minimal_stub()])).to_string();
+    let r = lint_json(&cfg, "<single>", &opts());
+    assert!(
+        !has_code(&r, "E003"),
+        "single imposter must still validate cleanly, got {:?}",
+        codes(&r)
+    );
+}


### PR DESCRIPTION
## Summary

`rift-lint` validated the top-level JSON as a **single imposter**, so the multi-imposter wrapper format — `{"imposters": [ ... ]}`, exactly what `rift --configfile` accepts — was flagged with spurious `E003` (`Missing required field: port/protocol/stubs`) on the wrapper object, and the actual imposters inside the array were never validated. The project's own `docs/demo/*.json` files failed lint for this reason.

## Fix

Add a `validate_config` dispatch (`crates/rift-lint/src/lib.rs`) that detects three shapes and validates each imposter individually:
- a single imposter object (unchanged),
- a `{"imposters": [ ... ]}` wrapper,
- a bare `[ ... ]` array.

All three entry points (`lint_file`, `lint_json`, `lint_value`) route through it, so the CLI (which uses `lint_file`) is covered.

```rust
let imposters = value
    .get("imposters")
    .and_then(serde_json::Value::as_array)
    .or_else(|| value.as_array());
```

## Tests

Six new tests in `validator_tests.rs`:
- wrapper and bare-array shapes lint with **no spurious E003**;
- `E004` (invalid protocol) surfaces on an inner imposter — and on a **non-first** array element — proving each element is actually validated (E004 can't come from the old wrapper-as-imposter path);
- empty imposter set (`{"imposters":[]}` / `[]`) is clean;
- single imposter still validates.

## Verification
- `cargo fmt` / `cargo clippy -- -D warnings` clean; `cargo test -p rift-lint` → 87 pass (6 new).
- CLI smoke: `rift-lint docs/demo/imposters-scripting-engines.json` (was `E003` ×3) → **"All checks passed!"**.

Closes #217