### PR TITLE
feat: filter recorded requests by header/flow_id (GET /imposters/:port/requests?match=...)

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1,12 +1,15 @@
 //! Imposter CRUD handlers.
 
+use crate::admin_api::request_filter::{parse_match_clauses, request_matches};
 use crate::admin_api::types::{
     collect_body, error_response, json_response, make_imposter_links, make_stub_links,
     ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
     RiftImposterExtensions, StubWithLinks,
 };
 use crate::extensions::stub_analysis::analyze_stubs;
-use crate::imposter::{ImposterConfig, ImposterError, ImposterManager, StubResponse};
+use crate::imposter::{
+    Imposter, ImposterConfig, ImposterError, ImposterManager, RecordedRequest, StubResponse,
+};
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
 use http_body_util::Full;
@@ -310,15 +313,64 @@ async fn handle_set_enabled(
     }
 }
 
-/// DELETE /imposters/:port/savedRequests - Clear recorded requests
+/// Resolve the imposter's `flow_id_source` (default `"imposter_port"`).
+fn flow_id_source(imposter: &Imposter) -> String {
+    imposter
+        .config
+        .rift
+        .as_ref()
+        .and_then(|r| r.flow_state.as_ref())
+        .and_then(|fs| fs.mountebank_state_mapping.as_ref())
+        .map(|m| m.flow_id_source.clone())
+        .unwrap_or_else(|| "imposter_port".to_string())
+}
+
+/// GET /imposters/:port/requests[?match=...] - recorded requests, optionally
+/// filtered by `header:<Name>=<Value>` / `flow_id=<Value>` clauses (AND'd).
+pub async fn handle_get_requests(
+    port: u16,
+    query: Option<&str>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let clauses = match parse_match_clauses(query) {
+        Ok(c) => c,
+        Err(msg) => return error_response(StatusCode::BAD_REQUEST, &msg),
+    };
+    match manager.get_imposter(port) {
+        Ok(imposter) => {
+            let source = flow_id_source(&imposter);
+            let filtered: Vec<RecordedRequest> = imposter
+                .get_recorded_requests()
+                .into_iter()
+                .filter(|r| request_matches(r, &clauses, &source, port))
+                .collect();
+            json_response(StatusCode::OK, &filtered)
+        }
+        Err(e) => e.into(),
+    }
+}
+
+/// DELETE /imposters/:port/savedRequests - Clear recorded requests.
+/// With `match=...` clauses, only the matching slice is removed (the rest are kept);
+/// without clauses, all recorded requests are cleared.
 pub async fn handle_clear_requests(
     port: u16,
+    query: Option<&str>,
     base_url: &str,
     manager: Arc<ImposterManager>,
 ) -> Response<Full<Bytes>> {
+    let clauses = match parse_match_clauses(query) {
+        Ok(c) => c,
+        Err(msg) => return error_response(StatusCode::BAD_REQUEST, &msg),
+    };
     match manager.get_imposter(port) {
         Ok(imposter) => {
-            imposter.clear_recorded_requests();
+            if clauses.is_empty() {
+                imposter.clear_recorded_requests();
+            } else {
+                let source = flow_id_source(&imposter);
+                imposter.retain_recorded_requests(|r| !request_matches(r, &clauses, &source, port));
+            }
             handle_get(port, None, base_url, manager).await
         }
         Err(e) => e.into(),
@@ -376,4 +428,209 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
             }
         })
         .collect()
+}
+
+// Issue #201: filter recorded requests by header / flow_id via
+// GET /imposters/:port/requests?match=...  (and targeted DELETE).
+#[cfg(test)]
+mod requests_filter_tests {
+    use super::*;
+    use http_body_util::BodyExt;
+    use std::collections::HashMap;
+
+    fn rec(space: &str, tenant: Option<&str>) -> RecordedRequest {
+        let mut headers = HashMap::new();
+        headers.insert("X-Mock-Space".to_string(), space.to_string());
+        if let Some(t) = tenant {
+            headers.insert("X-Tenant".to_string(), t.to_string());
+        }
+        RecordedRequest {
+            request_from: "127.0.0.1".to_string(),
+            method: "GET".to_string(),
+            path: "/p".to_string(),
+            query: HashMap::new(),
+            headers,
+            body: None,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    async fn manager_with(
+        port: u16,
+        flow_id_source: Option<&str>,
+        recorded: &[RecordedRequest],
+    ) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new());
+        let mut cfg = serde_json::json!({
+            "port": port, "protocol": "http", "recordRequests": true, "stubs": []
+        });
+        if let Some(src) = flow_id_source {
+            cfg["_rift"] = serde_json::json!({
+                "flowState": { "mountebankStateMapping": { "flowIdSource": src } }
+            });
+        }
+        let config = serde_json::from_value(cfg).expect("config");
+        manager.create_imposter(config).await.expect("create");
+        let imposter = manager.get_imposter(port).expect("imposter");
+        for r in recorded {
+            imposter.record_request(r);
+        }
+        manager
+    }
+
+    async fn requests(resp: Response<Full<Bytes>>) -> Vec<RecordedRequest> {
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        serde_json::from_slice(&bytes).expect("decode requests")
+    }
+
+    #[tokio::test]
+    async fn get_requests_returns_all_without_match() {
+        let m = manager_with(19731, None, &[rec("A", None), rec("B", None)]).await;
+        let resp = handle_get_requests(19731, None, m.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(requests(resp).await.len(), 2);
+        let _ = m.delete_imposter(19731).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_filters_by_header() {
+        let m = manager_with(
+            19732,
+            None,
+            &[rec("A", None), rec("B", None), rec("A", None)],
+        )
+        .await;
+        let resp = handle_get_requests(19732, Some("match=header:X-Mock-Space=A"), m.clone()).await;
+        let got = requests(resp).await;
+        assert_eq!(got.len(), 2, "only the two X-Mock-Space=A requests");
+        assert!(got
+            .iter()
+            .all(|r| r.headers.get("X-Mock-Space").unwrap() == "A"));
+        let _ = m.delete_imposter(19732).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_no_match_is_empty_200() {
+        let m = manager_with(19733, None, &[rec("A", None)]).await;
+        let resp =
+            handle_get_requests(19733, Some("match=header:X-Mock-Space=ZZZ"), m.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(requests(resp).await.is_empty());
+        let _ = m.delete_imposter(19733).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_flow_id_header_source_parity() {
+        let m = manager_with(
+            19734,
+            Some("header:X-Mock-Space"),
+            &[rec("A", None), rec("B", None)],
+        )
+        .await;
+        let by_flow_id =
+            requests(handle_get_requests(19734, Some("match=flow_id=A"), m.clone()).await).await;
+        let by_header = requests(
+            handle_get_requests(19734, Some("match=header:X-Mock-Space=A"), m.clone()).await,
+        )
+        .await;
+        assert_eq!(by_flow_id.len(), 1);
+        assert_eq!(by_flow_id[0].headers.get("X-Mock-Space").unwrap(), "A");
+        assert_eq!(
+            serde_json::to_value(&by_flow_id).unwrap(),
+            serde_json::to_value(&by_header).unwrap(),
+            "flow_id= and header: must return the identical slice when flow_id_source is that header"
+        );
+        let _ = m.delete_imposter(19734).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_flow_id_imposter_port() {
+        let m = manager_with(19735, None, &[rec("A", None), rec("B", None)]).await;
+        // default flow_id_source = imposter_port → every request shares flow_id = port
+        let all = handle_get_requests(19735, Some("match=flow_id=19735"), m.clone()).await;
+        assert_eq!(requests(all).await.len(), 2);
+        let none = handle_get_requests(19735, Some("match=flow_id=9999"), m.clone()).await;
+        assert!(requests(none).await.is_empty());
+        let _ = m.delete_imposter(19735).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_multiple_match_anded() {
+        let m = manager_with(
+            19736,
+            None,
+            &[
+                rec("A", Some("t1")),
+                rec("A", Some("t2")),
+                rec("B", Some("t1")),
+            ],
+        )
+        .await;
+        let resp = handle_get_requests(
+            19736,
+            Some("match=header:X-Mock-Space=A&match=header:X-Tenant=t1"),
+            m.clone(),
+        )
+        .await;
+        let got = requests(resp).await;
+        assert_eq!(got.len(), 1, "only the A+t1 request matches both clauses");
+        let _ = m.delete_imposter(19736).await;
+    }
+
+    #[tokio::test]
+    async fn get_requests_unknown_port_404() {
+        let m = Arc::new(ImposterManager::new());
+        let resp = handle_get_requests(19737, None, m).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_requests_malformed_match_400() {
+        let m = manager_with(19738, None, &[rec("A", None)]).await;
+        let resp = handle_get_requests(19738, Some("match=path=/foo"), m.clone()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let _ = m.delete_imposter(19738).await;
+    }
+
+    #[tokio::test]
+    async fn delete_requests_targeted_clear_removes_only_slice() {
+        let m = manager_with(
+            19739,
+            None,
+            &[rec("A", None), rec("B", None), rec("A", None)],
+        )
+        .await;
+        let base = "http://localhost:2525";
+        handle_clear_requests(19739, Some("match=header:X-Mock-Space=A"), base, m.clone()).await;
+        let remaining = requests(handle_get_requests(19739, None, m.clone()).await).await;
+        assert_eq!(remaining.len(), 1, "only the B request survives");
+        assert_eq!(remaining[0].headers.get("X-Mock-Space").unwrap(), "B");
+        let _ = m.delete_imposter(19739).await;
+    }
+
+    #[tokio::test]
+    async fn delete_requests_without_match_clears_all() {
+        let m = manager_with(19740, None, &[rec("A", None), rec("B", None)]).await;
+        let base = "http://localhost:2525";
+        handle_clear_requests(19740, None, base, m.clone()).await;
+        let remaining = requests(handle_get_requests(19740, None, m.clone()).await).await;
+        assert!(remaining.is_empty());
+        let _ = m.delete_imposter(19740).await;
+    }
+
+    #[tokio::test]
+    async fn delete_requests_malformed_match_400() {
+        let m = manager_with(19741, None, &[rec("A", None)]).await;
+        let base = "http://localhost:2525";
+        let resp = handle_clear_requests(19741, Some("match=path=/foo"), base, m.clone()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // a rejected clear must leave the buffer untouched
+        let remaining = requests(handle_get_requests(19741, None, m.clone()).await).await;
+        assert_eq!(
+            remaining.len(),
+            1,
+            "malformed DELETE must not clear anything"
+        );
+        let _ = m.delete_imposter(19741).await;
+    }
 }

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -9,6 +9,7 @@
 //! The API listens on a configurable port (default: 2525).
 
 mod handlers;
+mod request_filter;
 mod router;
 mod server;
 pub mod types;

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -1,0 +1,229 @@
+//! Server-side filtering of recorded requests by `match=` query clauses.
+//!
+//! Supports `header:<Name>=<Value>` and `flow_id=<Value>` (the latter resolved
+//! via the imposter's `flow_id_source`). Multiple clauses are AND'd together.
+
+use crate::imposter::RecordedRequest;
+
+/// A single parsed `match=` clause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MatchClause {
+    /// Match a request header by (case-insensitive) name and exact value.
+    Header { name: String, value: String },
+    /// Match the request's resolved `flow_id`.
+    FlowId(String),
+}
+
+/// Parse every `match=` query parameter into clauses.
+///
+/// Returns `Err` for a `match` value that is neither `header:<Name>=<Value>` nor
+/// `flow_id=<Value>`: a malformed filter must not silently fall back to returning
+/// every request, which would cross-contaminate correlated scenarios.
+pub(crate) fn parse_match_clauses(query: Option<&str>) -> Result<Vec<MatchClause>, String> {
+    let mut clauses = Vec::new();
+    let Some(q) = query else {
+        return Ok(clauses);
+    };
+    for pair in q.split('&') {
+        let Some((key, raw_value)) = pair.split_once('=') else {
+            continue;
+        };
+        if key != "match" {
+            continue;
+        }
+        let value = urlencoding::decode(raw_value)
+            .map(|v| v.into_owned())
+            .unwrap_or_else(|_| raw_value.to_string());
+        clauses.push(parse_one(&value)?);
+    }
+    Ok(clauses)
+}
+
+fn parse_one(value: &str) -> Result<MatchClause, String> {
+    if let Some(rest) = value.strip_prefix("header:") {
+        let (name, header_value) = rest.split_once('=').ok_or_else(|| {
+            format!("invalid match clause '{value}' (expected header:<Name>=<Value>)")
+        })?;
+        if name.is_empty() {
+            return Err(format!(
+                "invalid match clause '{value}' (empty header name)"
+            ));
+        }
+        Ok(MatchClause::Header {
+            name: name.to_string(),
+            value: header_value.to_string(),
+        })
+    } else if let Some(flow_id) = value.strip_prefix("flow_id=") {
+        Ok(MatchClause::FlowId(flow_id.to_string()))
+    } else {
+        Err(format!(
+            "unsupported match clause '{value}' (expected header:<Name>=<Value> or flow_id=<Value>)"
+        ))
+    }
+}
+
+/// Resolve a recorded request's `flow_id` from the imposter's `flow_id_source`:
+/// `"imposter_port"` → the port; `"header:<Name>"` → the header value if present.
+fn resolve_flow_id(req: &RecordedRequest, flow_id_source: &str, port: u16) -> Option<String> {
+    if flow_id_source == "imposter_port" {
+        Some(port.to_string())
+    } else if let Some(name) = flow_id_source.strip_prefix("header:") {
+        header_value(req, name)
+    } else {
+        None
+    }
+}
+
+/// Case-insensitive header lookup against a recorded request.
+fn header_value(req: &RecordedRequest, name: &str) -> Option<String> {
+    req.headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.clone())
+}
+
+/// Does `req` satisfy ALL clauses (AND)?
+pub(crate) fn request_matches(
+    req: &RecordedRequest,
+    clauses: &[MatchClause],
+    flow_id_source: &str,
+    port: u16,
+) -> bool {
+    clauses.iter().all(|clause| match clause {
+        MatchClause::Header { name, value } => {
+            header_value(req, name).as_deref() == Some(value.as_str())
+        }
+        MatchClause::FlowId(value) => {
+            resolve_flow_id(req, flow_id_source, port).as_deref() == Some(value.as_str())
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn req_with_header(name: &str, value: &str) -> RecordedRequest {
+        let mut headers = HashMap::new();
+        headers.insert(name.to_string(), value.to_string());
+        RecordedRequest {
+            request_from: "127.0.0.1".to_string(),
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            query: HashMap::new(),
+            headers,
+            body: None,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_header_and_flow_id_clauses() {
+        let clauses =
+            parse_match_clauses(Some("match=header:X-Mock-Space=abc&match=flow_id=xyz")).unwrap();
+        assert_eq!(
+            clauses,
+            vec![
+                MatchClause::Header {
+                    name: "X-Mock-Space".to_string(),
+                    value: "abc".to_string()
+                },
+                MatchClause::FlowId("xyz".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_url_encoded_clause() {
+        let clauses = parse_match_clauses(Some("match=header%3AX-Mock-Space%3Dabc")).unwrap();
+        assert_eq!(
+            clauses,
+            vec![MatchClause::Header {
+                name: "X-Mock-Space".to_string(),
+                value: "abc".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn no_match_param_is_empty_clause_set() {
+        assert!(parse_match_clauses(None).unwrap().is_empty());
+        assert!(parse_match_clauses(Some("foo=bar")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rejects_unsupported_clause() {
+        assert!(parse_match_clauses(Some("match=path=/foo")).is_err());
+        assert!(parse_match_clauses(Some("match=header:X-Name")).is_err());
+    }
+
+    #[test]
+    fn header_match_is_case_insensitive_on_name() {
+        let req = req_with_header("X-Mock-Space", "abc");
+        let clauses = vec![MatchClause::Header {
+            name: "x-mock-space".to_string(),
+            value: "abc".to_string(),
+        }];
+        assert!(request_matches(&req, &clauses, "imposter_port", 4545));
+    }
+
+    #[test]
+    fn flow_id_resolves_via_header_source() {
+        let req = req_with_header("X-Mock-Space", "abc");
+        let clauses = vec![MatchClause::FlowId("abc".to_string())];
+        assert!(request_matches(&req, &clauses, "header:X-Mock-Space", 4545));
+        let clauses = vec![MatchClause::FlowId("other".to_string())];
+        assert!(!request_matches(
+            &req,
+            &clauses,
+            "header:X-Mock-Space",
+            4545
+        ));
+    }
+
+    #[test]
+    fn flow_id_resolves_via_imposter_port() {
+        let req = req_with_header("X-Mock-Space", "abc");
+        assert!(request_matches(
+            &req,
+            &[MatchClause::FlowId("4545".to_string())],
+            "imposter_port",
+            4545
+        ));
+        assert!(!request_matches(
+            &req,
+            &[MatchClause::FlowId("9999".to_string())],
+            "imposter_port",
+            4545
+        ));
+    }
+
+    #[test]
+    fn multiple_clauses_are_anded() {
+        let mut req = req_with_header("X-Mock-Space", "abc");
+        req.headers.insert("X-Tenant".to_string(), "t1".to_string());
+        let clauses = vec![
+            MatchClause::Header {
+                name: "X-Mock-Space".to_string(),
+                value: "abc".to_string(),
+            },
+            MatchClause::Header {
+                name: "X-Tenant".to_string(),
+                value: "t1".to_string(),
+            },
+        ];
+        assert!(request_matches(&req, &clauses, "imposter_port", 4545));
+        let clauses = vec![
+            MatchClause::Header {
+                name: "X-Mock-Space".to_string(),
+                value: "abc".to_string(),
+            },
+            MatchClause::Header {
+                name: "X-Tenant".to_string(),
+                value: "WRONG".to_string(),
+            },
+        ];
+        assert!(!request_matches(&req, &clauses, "imposter_port", 4545));
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -161,9 +161,12 @@ async fn route_imposter(
             stubs::handle_delete(port, index, base_url, manager).await
         }
 
-        // /imposters/:port/savedRequests
+        // /imposters/:port/savedRequests (alias /requests)
+        (&Method::GET, ImposterRoute::SavedRequests) => {
+            imposters::handle_get_requests(port, query, manager).await
+        }
         (&Method::DELETE, ImposterRoute::SavedRequests) => {
-            imposters::handle_clear_requests(port, base_url, manager).await
+            imposters::handle_clear_requests(port, query, base_url, manager).await
         }
 
         // /imposters/:port/savedProxyResponses

--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -939,6 +939,14 @@ impl Imposter {
         self.request_count.store(0, Ordering::SeqCst);
     }
 
+    /// Retain only the recorded requests for which `keep` returns true.
+    /// Used for targeted clears (a single correlated slice); unlike
+    /// `clear_recorded_requests` it does not reset the total request count,
+    /// since other slices' requests remain.
+    pub fn retain_recorded_requests<F: Fn(&RecordedRequest) -> bool>(&self, keep: F) {
+        self.recorded_requests.write().retain(|r| keep(r));
+    }
+
     /// Clear saved proxy responses
     pub fn clear_proxy_responses(&self) {
         self.recording_store.clear();
@@ -1240,6 +1248,55 @@ mod tests {
             recorded.len(),
             MAX_RECORDED_REQUESTS,
             "Recorded requests must not exceed the cap"
+        );
+    }
+
+    // Issue #201: a targeted retain removes only the non-kept entries and, unlike a
+    // full clear, must NOT reset the total request count (other slices' requests remain).
+    #[test]
+    fn test_retain_recorded_requests_preserves_count() {
+        let config = ImposterConfig {
+            port: Some(0),
+            protocol: "http".to_string(),
+            record_requests: true,
+            ..Default::default()
+        };
+        let imposter = Imposter::new(config);
+
+        let req = |space: &str| {
+            let mut headers = std::collections::HashMap::new();
+            headers.insert("X-Mock-Space".to_string(), space.to_string());
+            RecordedRequest {
+                request_from: "127.0.0.1".to_string(),
+                method: "GET".to_string(),
+                path: "/".to_string(),
+                query: std::collections::HashMap::new(),
+                headers,
+                body: None,
+                timestamp: "2026-01-01T00:00:00Z".to_string(),
+            }
+        };
+        imposter.record_request(&req("A"));
+        imposter.record_request(&req("B"));
+        imposter.record_request(&req("A"));
+        for _ in 0..3 {
+            imposter.increment_request_count();
+        }
+
+        imposter.retain_recorded_requests(|r| r.headers.get("X-Mock-Space").unwrap() != "A");
+        assert_eq!(imposter.get_recorded_requests().len(), 1, "only B kept");
+        assert_eq!(
+            imposter.get_request_count(),
+            3,
+            "targeted retain must not reset the request count"
+        );
+
+        imposter.clear_recorded_requests();
+        assert_eq!(imposter.get_recorded_requests().len(), 0);
+        assert_eq!(
+            imposter.get_request_count(),
+            0,
+            "full clear resets the request count"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds server-side filtering of an imposter's recorded requests by a correlation header (or `flow_id`), so one shared imposter can serve many parallel test scenarios and verification returns only that scenario's traffic.

```
GET    /imposters/:port/requests?match=header:X-Mock-Space=<v>   → 200 [RecordedRequest…]
GET    /imposters/:port/requests?match=flow_id=<v>               → 200 [RecordedRequest…]
GET    /imposters/:port/requests                                 → 200 [all]   (back-compat)
DELETE /imposters/:port/requests?match=...                       → clear only the matching slice
DELETE /imposters/:port/requests                                 → clear all   (unchanged)
```

## Behaviour

- `match` clauses: `header:<Name>=<Value>` (case-insensitive name, exact value) and `flow_id=<Value>` (resolved via the imposter's `flow_id_source` — `imposter_port` or `header:<Name>`). Multiple `match` params are **AND'd**.
- `flow_id=` and the equivalent `header:` filter return the **identical** slice when `flow_id_source = header:<Name>`.
- Unknown port → `404`; empty result → `200 []`.
- A **malformed** `match` clause → `400` (never a silent fall-back to "all", which would cross-contaminate correlated scenarios).
- Targeted `DELETE` removes only the matching slice and does **not** reset the total request count (other slices remain).
- No change to the recording hot path.

## Implementation

- New `admin_api/request_filter.rs` — clause parsing (URL-decoded), `flow_id` resolution, matching.
- `handle_get_requests` + extended `handle_clear_requests` in `admin_api/handlers/imposters.rs`; route wired in `admin_api/router.rs` (the `/requests` alias already existed).
- New `Imposter::retain_recorded_requests` (targeted slice removal under the existing `RwLock`).

## Tests
20 new (8 unit in `request_filter`, 11 handler-level integration, 1 core contract test). Covers every acceptance criterion: header/flow_id filtering, both `flow_id_source` modes, AND, case-insensitive name, no-match `200 []`, unknown-port `404`, malformed `400`, targeted vs full DELETE, and the count-preservation contract.

## Verification
- `cargo fmt` / `cargo clippy -- -D warnings` clean; `cargo test --lib` → 637 pass (20 new).
- Live HTTP smoke (real router): header filter 2/1, no-match `[] 200`, malformed `400`, targeted DELETE leaves only the other slice, unknown port `404`.

Part of the portable MockControl SPI integration (zio-bdd#109) — provides the **Correlated** isolation mode.

Milestone: M2

Closes #201