### PR TITLE
feat: declarative stateful scenarios (whenState/thenState) + flow-state admin endpoints

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -423,6 +423,8 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
                     predicates: stub.predicates,
                     responses: non_proxy_responses,
                     scenario_name: stub.scenario_name,
+                    required_scenario_state: stub.required_scenario_state,
+                    new_scenario_state: stub.new_scenario_state,
                     recorded_from: stub.recorded_from,
                 })
             }

--- a/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
@@ -1,5 +1,6 @@
 //! Request handlers for the Admin API.
 
 pub mod imposters;
+pub mod scenarios;
 pub mod stubs;
 pub mod system;

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -1,0 +1,203 @@
+//! Scenario FSM + flow-state admin handlers (issue #190).
+//!
+//! Scenario state and arbitrary flow-state both live in the imposter's `FlowStore`,
+//! partitioned by `flow_id`. When a `flowId` is not supplied, the imposter's default
+//! flow (`resolve_flow_id` with no headers ⇒ the `imposter_port` flow) is used.
+
+use crate::admin_api::types::{collect_body, error_response, json_response};
+use crate::imposter::{Imposter, ImposterManager};
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::{Request, Response, StatusCode};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn default_flow_id(imposter: &Imposter) -> String {
+    imposter.resolve_flow_id(&HashMap::new())
+}
+
+/// Collect and JSON-parse a request body, returning a `400` response on failure.
+async fn parse_json_body(
+    req: Request<Incoming>,
+) -> Result<serde_json::Value, Response<Full<Bytes>>> {
+    let body = collect_body(req)
+        .await
+        .map_err(|e| error_response(StatusCode::BAD_REQUEST, &e))?;
+    serde_json::from_slice(&body)
+        .map_err(|e| error_response(StatusCode::BAD_REQUEST, &format!("Invalid JSON: {e}")))
+}
+
+/// Extract `flowId=` from a query string.
+fn flow_id_from_query(query: Option<&str>) -> Option<String> {
+    query?.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == "flowId").then(|| {
+            urlencoding::decode(v)
+                .map(|d| d.into_owned())
+                .unwrap_or_else(|_| v.to_string())
+        })
+    })
+}
+
+/// GET /imposters/:port/scenarios[?flowId=] → `{flowId, scenarios:[{name,state}]}`
+pub async fn handle_list_scenarios(
+    port: u16,
+    query: Option<&str>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => {
+            let flow_id = flow_id_from_query(query).unwrap_or_else(|| default_flow_id(&imposter));
+            let scenarios: Vec<_> = imposter
+                .scenario_names()
+                .into_iter()
+                .map(|name| {
+                    let state = imposter.scenario_state(&flow_id, &name);
+                    serde_json::json!({ "name": name, "state": state })
+                })
+                .collect();
+            json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "scenarios": scenarios }),
+            )
+        }
+        Err(e) => e.into(),
+    }
+}
+
+/// PUT /imposters/:port/scenarios/:name/state — body `{"state":"…","flowId":"…"?}`
+pub async fn handle_set_scenario_state(
+    port: u16,
+    name: &str,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let payload = match parse_json_body(req).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let Some(state) = payload.get("state").and_then(|v| v.as_str()) else {
+        return error_response(StatusCode::BAD_REQUEST, "missing required field: state");
+    };
+    match manager.get_imposter(port) {
+        Ok(imposter) => {
+            let flow_id = payload
+                .get("flowId")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .unwrap_or_else(|| default_flow_id(&imposter));
+            match imposter.set_scenario_state(&flow_id, name, state) {
+                Ok(()) => json_response(
+                    StatusCode::OK,
+                    &serde_json::json!({ "flowId": flow_id, "name": name, "state": state }),
+                ),
+                Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+            }
+        }
+        Err(e) => e.into(),
+    }
+}
+
+/// POST /imposters/:port/scenarios/reset — body `{"flowId":"…"?}` (resets ONLY that flow's slice).
+pub async fn handle_reset_scenarios(
+    port: u16,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let body = match collect_body(req).await {
+        Ok(b) => b,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e),
+    };
+    let flow_id_opt = if body.is_empty() {
+        None
+    } else {
+        match serde_json::from_slice::<serde_json::Value>(&body) {
+            Ok(v) => v.get("flowId").and_then(|v| v.as_str()).map(String::from),
+            Err(e) => {
+                return error_response(StatusCode::BAD_REQUEST, &format!("Invalid JSON: {e}"))
+            }
+        }
+    };
+    match manager.get_imposter(port) {
+        Ok(imposter) => {
+            let flow_id = flow_id_opt.unwrap_or_else(|| default_flow_id(&imposter));
+            for name in imposter.scenario_names() {
+                if let Err(e) = imposter.delete_scenario_state(&flow_id, &name) {
+                    return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
+                }
+            }
+            json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "reset": true }),
+            )
+        }
+        Err(e) => e.into(),
+    }
+}
+
+/// GET /admin/imposters/:port/flow-state/:flow_id/:key → `{flowId,key,value}` | 404
+pub async fn handle_get_flow_state(
+    port: u16,
+    flow_id: &str,
+    key: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => match imposter.flow_get(flow_id, key) {
+            Ok(Some(value)) => json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "key": key, "value": value }),
+            ),
+            Ok(None) => error_response(StatusCode::NOT_FOUND, "flow-state key not found"),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        Err(e) => e.into(),
+    }
+}
+
+/// PUT /admin/imposters/:port/flow-state/:flow_id/:key — body `{"value": …}`
+pub async fn handle_put_flow_state(
+    port: u16,
+    flow_id: &str,
+    key: &str,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let payload = match parse_json_body(req).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let Some(value) = payload.get("value") else {
+        return error_response(StatusCode::BAD_REQUEST, "missing required field: value");
+    };
+    match manager.get_imposter(port) {
+        Ok(imposter) => match imposter.flow_set(flow_id, key, value.clone()) {
+            Ok(()) => json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "key": key, "value": value }),
+            ),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        Err(e) => e.into(),
+    }
+}
+
+/// DELETE /admin/imposters/:port/flow-state/:flow_id/:key
+pub async fn handle_delete_flow_state(
+    port: u16,
+    flow_id: &str,
+    key: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => match imposter.flow_delete(flow_id, key) {
+            Ok(()) => json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "key": key, "deleted": true }),
+            ),
+            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        Err(e) => e.into(),
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides routing
 
-use crate::admin_api::handlers::{imposters, stubs, system};
+use crate::admin_api::handlers::{imposters, scenarios, stubs, system};
 use crate::admin_api::types::{error_response, get_base_url, not_found};
 use crate::imposter::ImposterManager;
 use bytes::Bytes;
@@ -28,6 +28,12 @@ enum ImposterRoute {
     Enable,
     /// POST /imposters/:port/disable
     Disable,
+    /// GET /imposters/:port/scenarios
+    Scenarios,
+    /// PUT /imposters/:port/scenarios/:name/state
+    ScenarioState(String),
+    /// POST /imposters/:port/scenarios/reset
+    ScenariosReset,
 }
 
 impl ImposterRoute {
@@ -41,6 +47,9 @@ impl ImposterRoute {
             ["savedProxyResponses"] => Some(ImposterRoute::SavedProxyResponses),
             ["enable"] => Some(ImposterRoute::Enable),
             ["disable"] => Some(ImposterRoute::Disable),
+            ["scenarios"] => Some(ImposterRoute::Scenarios),
+            ["scenarios", "reset"] => Some(ImposterRoute::ScenariosReset),
+            ["scenarios", name, "state"] => Some(ImposterRoute::ScenarioState((*name).to_string())),
             _ => None,
         }
     }
@@ -93,12 +102,45 @@ async fn route_by_path(
         };
     }
 
+    // Admin flow-state inspection routes: /admin/imposters/:port/flow-state/:flow_id[/:key]
+    if let Some(rest) = path.strip_prefix("/admin/imposters/") {
+        return route_admin_flow_state(method, rest, req, manager).await;
+    }
+
     // Individual imposter routes
     if let Some(rest) = path.strip_prefix("/imposters/") {
         return route_imposter(method, rest, query, req, base_url, manager).await;
     }
 
     not_found()
+}
+
+/// Route `/admin/imposters/:port/flow-state/:flow_id/:key` (issue #190 StateInspection).
+async fn route_admin_flow_state(
+    method: &Method,
+    rest: &str,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
+    match segments.as_slice() {
+        [port_str, "flow-state", flow_id, key] => {
+            let Ok(port) = port_str.parse::<u16>() else {
+                return not_found();
+            };
+            match *method {
+                Method::GET => scenarios::handle_get_flow_state(port, flow_id, key, manager).await,
+                Method::PUT => {
+                    scenarios::handle_put_flow_state(port, flow_id, key, req, manager).await
+                }
+                Method::DELETE => {
+                    scenarios::handle_delete_flow_state(port, flow_id, key, manager).await
+                }
+                _ => not_found(),
+            }
+        }
+        _ => not_found(),
+    }
 }
 
 /// Route imposter-specific requests
@@ -177,6 +219,17 @@ async fn route_imposter(
         // /imposters/:port/enable, /imposters/:port/disable
         (&Method::POST, ImposterRoute::Enable) => imposters::handle_enable(port, manager).await,
         (&Method::POST, ImposterRoute::Disable) => imposters::handle_disable(port, manager).await,
+
+        // /imposters/:port/scenarios — declarative FSM state inspection/arrangement
+        (&Method::GET, ImposterRoute::Scenarios) => {
+            scenarios::handle_list_scenarios(port, query, manager).await
+        }
+        (&Method::PUT, ImposterRoute::ScenarioState(name)) => {
+            scenarios::handle_set_scenario_state(port, &name, req, manager).await
+        }
+        (&Method::POST, ImposterRoute::ScenariosReset) => {
+            scenarios::handle_reset_scenarios(port, req, manager).await
+        }
 
         _ => not_found(),
     }

--- a/crates/rift-http-proxy/src/extensions/stub_analysis.rs
+++ b/crates/rift-http-proxy/src/extensions/stub_analysis.rs
@@ -417,6 +417,8 @@ mod tests {
             predicates,
             responses: vec![],
             scenario_name: None,
+            required_scenario_state: None,
+            new_scenario_state: None,
             recorded_from: None,
         }
     }
@@ -428,6 +430,8 @@ mod tests {
             predicates,
             responses: vec![],
             scenario_name: None,
+            required_scenario_state: None,
+            new_scenario_state: None,
             recorded_from: None,
         }
     }

--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -7,6 +7,9 @@
 /// Once the cap is reached, the oldest entry is evicted (ring-buffer semantics).
 const MAX_RECORDED_REQUESTS: usize = 10_000;
 
+/// Default scenario state when a `(flow_id, scenario)` entry is absent (WireMock parity).
+pub const INITIAL_SCENARIO_STATE: &str = "Started";
+
 use super::predicates::stub_matches;
 use super::response::{
     create_response_preview, create_stub_from_proxy_response, execute_stub_response_with_rift,
@@ -138,30 +141,45 @@ impl Imposter {
         stubs.extend(new_stubs.into_iter().map(StubState::new));
     }
 
-    /// Create flow store based on _rift.flowState configuration
+    /// Create flow store based on _rift.flowState configuration.
+    /// Falls back to a default in-memory store (not NoOp) when stubs declare the scenario FSM,
+    /// so declarative scenarios work out of the box without explicit `_rift.flowState`.
+    ///
+    /// Note: the store is chosen at construction. Scenario stubs added later via an in-place
+    /// `PUT /imposters/:port/stubs` to an imposter that started with no scenario stubs (and no
+    /// `_rift.flowState`) will hit the NoOp store and not advance — declare scenario stubs at
+    /// creation, configure `_rift.flowState`, or use `PUT /imposters` (which recreates).
     fn create_flow_store(config: &ImposterConfig) -> Arc<dyn FlowStore> {
-        let Some(ref rift_config) = config.rift else {
-            return Arc::new(NoOpFlowStore);
-        };
-
-        let Some(ref flow_state_config) = rift_config.flow_state else {
-            return Arc::new(NoOpFlowStore);
-        };
-
-        match flow_state_config.backend.as_str() {
-            "inmemory" => {
-                info!(
-                    "Creating InMemory FlowStore for imposter (ttl={}s)",
-                    flow_state_config.ttl_seconds
-                );
-                Arc::new(InMemoryFlowStore::new(flow_state_config.ttl_seconds as u64))
-            }
-            "redis" => Self::create_redis_flow_store(flow_state_config),
-            other => {
-                warn!("Unknown flow state backend '{}', using NoOp", other);
-                Arc::new(NoOpFlowStore)
-            }
+        if let Some(flow_state_config) = config.rift.as_ref().and_then(|r| r.flow_state.as_ref()) {
+            return match flow_state_config.backend.as_str() {
+                "inmemory" => {
+                    info!(
+                        "Creating InMemory FlowStore for imposter (ttl={}s)",
+                        flow_state_config.ttl_seconds
+                    );
+                    Arc::new(InMemoryFlowStore::new(flow_state_config.ttl_seconds as u64))
+                }
+                "redis" => Self::create_redis_flow_store(flow_state_config),
+                other => {
+                    warn!("Unknown flow state backend '{}', using NoOp", other);
+                    Arc::new(NoOpFlowStore)
+                }
+            };
         }
+
+        if Self::uses_scenario_fsm(&config.stubs) {
+            info!("Stubs declare scenario state; using default in-memory FlowStore");
+            return Arc::new(InMemoryFlowStore::new(300));
+        }
+
+        Arc::new(NoOpFlowStore)
+    }
+
+    /// Whether any stub declares the declarative scenario FSM (`requiredScenarioState`/`newScenarioState`).
+    fn uses_scenario_fsm(stubs: &[Stub]) -> bool {
+        stubs
+            .iter()
+            .any(|s| s.required_scenario_state.is_some() || s.new_scenario_state.is_some())
     }
 
     /// Create Redis flow store if configured and available
@@ -255,8 +273,18 @@ impl Imposter {
         let form = Self::parse_form_data(headers, body);
 
         let imposter_port = self.config.port.unwrap_or(0);
+        let flow_id = self.resolve_flow_id(&headers_map);
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
+            // Scenario FSM eligibility gate (before predicate precedence): a stub guarded by
+            // `requiredScenarioState` only participates in matching when the current
+            // (flow_id, scenario) state equals it.
+            if let Some(required) = &stub.required_scenario_state {
+                let scenario = stub.scenario_name.as_deref().unwrap_or("");
+                if self.scenario_state(&flow_id, scenario) != *required {
+                    continue;
+                }
+            }
             if stub_matches(
                 &stub.predicates,
                 method,
@@ -274,6 +302,111 @@ impl Imposter {
             }
         }
         None
+    }
+
+    /// The configured `flow_id_source` (`"imposter_port"` or `"header:<Name>"`),
+    /// defaulting to `"imposter_port"`.
+    pub fn flow_id_source(&self) -> String {
+        self.config
+            .rift
+            .as_ref()
+            .and_then(|r| r.flow_state.as_ref())
+            .and_then(|fs| fs.mountebank_state_mapping.as_ref())
+            .map(|m| m.flow_id_source.clone())
+            .unwrap_or_else(|| "imposter_port".to_string())
+    }
+
+    /// Resolve the correlation `flow_id` for a request, partitioning scenario state.
+    /// `"header:<Name>"` uses that (case-insensitive) header; `"imposter_port"` (the default,
+    /// and the fallback when the header is absent) uses the imposter port.
+    pub fn resolve_flow_id(&self, headers: &HashMap<String, String>) -> String {
+        let port_id = || self.config.port.unwrap_or(0).to_string();
+        match self.flow_id_source().strip_prefix("header:") {
+            Some(name) => headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(port_id),
+            None => port_id(),
+        }
+    }
+
+    /// Current scenario state for `(flow_id, scenario)`, or the initial state if absent.
+    /// A backend read error degrades to the initial state but is logged — it must not be
+    /// silently mistaken for "no state yet", which would mis-gate matching.
+    pub fn scenario_state(&self, flow_id: &str, scenario: &str) -> String {
+        match self.flow_store.get(flow_id, scenario) {
+            Ok(Some(v)) => v.as_str().unwrap_or(INITIAL_SCENARIO_STATE).to_string(),
+            Ok(None) => INITIAL_SCENARIO_STATE.to_string(),
+            Err(e) => {
+                warn!(
+                    "scenario state read failed ({flow_id}/{scenario}); using initial '{INITIAL_SCENARIO_STATE}': {e}"
+                );
+                INITIAL_SCENARIO_STATE.to_string()
+            }
+        }
+    }
+
+    /// Set scenario state for `(flow_id, scenario)`.
+    pub fn set_scenario_state(
+        &self,
+        flow_id: &str,
+        scenario: &str,
+        state: &str,
+    ) -> anyhow::Result<()> {
+        self.flow_store.set(
+            flow_id,
+            scenario,
+            serde_json::Value::String(state.to_string()),
+        )
+    }
+
+    /// Delete a scenario's state for a flow (so it reads back as the initial state).
+    pub fn delete_scenario_state(&self, flow_id: &str, scenario: &str) -> anyhow::Result<()> {
+        self.flow_store.delete(flow_id, scenario)
+    }
+
+    /// Apply a matched stub's `newScenarioState` transition after it responds (no-op if unset).
+    pub fn apply_scenario_transition(&self, flow_id: &str, stub: &Stub) {
+        if let Some(next) = &stub.new_scenario_state {
+            let scenario = stub.scenario_name.as_deref().unwrap_or("");
+            if let Err(e) = self.set_scenario_state(flow_id, scenario, next) {
+                warn!("scenario transition failed ({flow_id}/{scenario} -> {next}): {e}");
+            }
+        }
+    }
+
+    /// Read a raw flow-state value (admin flow-state inspection).
+    pub fn flow_get(&self, flow_id: &str, key: &str) -> anyhow::Result<Option<serde_json::Value>> {
+        self.flow_store.get(flow_id, key)
+    }
+
+    /// Set a raw flow-state value (admin flow-state arrange).
+    pub fn flow_set(
+        &self,
+        flow_id: &str,
+        key: &str,
+        value: serde_json::Value,
+    ) -> anyhow::Result<()> {
+        self.flow_store.set(flow_id, key, value)
+    }
+
+    /// Delete a raw flow-state value (admin flow-state teardown).
+    pub fn flow_delete(&self, flow_id: &str, key: &str) -> anyhow::Result<()> {
+        self.flow_store.delete(flow_id, key)
+    }
+
+    /// Distinct scenario names declared by this imposter's stubs (sorted).
+    pub fn scenario_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .stubs
+            .read()
+            .iter()
+            .filter_map(|s| s.stub.scenario_name.clone())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
     }
 
     /// Parse form-urlencoded data from body if Content-Type matches

--- a/crates/rift-http-proxy/src/imposter/handler.rs
+++ b/crates/rift-http-proxy/src/imposter/handler.rs
@@ -202,6 +202,13 @@ async fn handle_request_inner(
         Some(&request_from),
         Some(&client_ip),
     ) {
+        // Scenario FSM: apply the matched stub's newScenarioState transition (no-op unless set).
+        // Resolve flow_id from the same header map the eligibility gate used (headers_for_context)
+        // so the transition writes the exact key the gate read.
+        let scenario_flow_id =
+            imposter.resolve_flow_id(&Imposter::header_map_to_hashmap(&headers_for_context));
+        imposter.apply_scenario_transition(&scenario_flow_id, &stub_state.stub);
+
         // Check if this is a proxy response
         if let Some(proxy_config) = imposter.get_proxy_response(&stub_state) {
             debug!("Handling proxy request to {}", proxy_config.to);

--- a/crates/rift-http-proxy/src/imposter/response.rs
+++ b/crates/rift-http-proxy/src/imposter/response.rs
@@ -261,6 +261,8 @@ pub fn create_stub_from_proxy_response(
             rift: None,
         }],
         scenario_name: None,
+        required_scenario_state: None,
+        new_scenario_state: None,
         recorded_from,
     }
 }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -57,6 +57,8 @@ fn test_predicate_matching() {
             rift: None,
         }],
         scenario_name: None,
+        required_scenario_state: None,
+        new_scenario_state: None,
         recorded_from: None,
     };
 
@@ -146,6 +148,8 @@ fn test_execute_stub() {
             rift: None,
         }],
         scenario_name: None,
+        required_scenario_state: None,
+        new_scenario_state: None,
         recorded_from: None,
     };
 
@@ -2432,6 +2436,8 @@ async fn test_cors_headers_on_stub_response() {
             rift: None,
         }],
         scenario_name: None,
+        required_scenario_state: None,
+        new_scenario_state: None,
         recorded_from: None,
     };
     let config = ImposterConfig {
@@ -2601,4 +2607,334 @@ async fn test_script_header_access_is_case_insensitive() {
         body, "demo",
         "script must read the Title-Cased wire header via a lowercase key, got: {body}"
     );
+}
+
+// Issue #190: declarative stateful scenarios (whenState/thenState), flow_id-keyed.
+#[cfg(test)]
+mod scenario_fsm_tests {
+    use super::*;
+
+    async fn get(client: &reqwest::Client, port: u16, path: &str, space: Option<&str>) -> String {
+        let mut req = client.get(format!("http://127.0.0.1:{port}{path}"));
+        if let Some(s) = space {
+            req = req.header("X-Mock-Space", s);
+        }
+        req.send().await.expect("send").text().await.expect("body")
+    }
+
+    fn order_fsm(port: u16, flow_id_source: Option<&str>) -> serde_json::Value {
+        let mut flow_state = serde_json::json!({ "backend": "inmemory", "ttlSeconds": 300 });
+        if let Some(src) = flow_id_source {
+            flow_state["mountebankStateMapping"] = serde_json::json!({ "flowIdSource": src });
+        }
+        serde_json::json!({
+            "port": port, "protocol": "http",
+            "_rift": { "flowState": flow_state },
+            "stubs": [
+                { "scenarioName": "order", "requiredScenarioState": "Started",
+                  "predicates": [{ "equals": { "path": "/status" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "unpaid" } }] },
+                { "scenarioName": "order", "requiredScenarioState": "Started", "newScenarioState": "paid",
+                  "predicates": [{ "equals": { "path": "/pay" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] },
+                { "scenarioName": "order", "requiredScenarioState": "paid",
+                  "predicates": [{ "equals": { "path": "/status" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "paid" } }] }
+            ]
+        })
+    }
+
+    #[tokio::test]
+    async fn scenario_auto_provisions_store_without_explicit_flow_state() {
+        // No `_rift.flowState` at all: declaring scenario stubs must auto-provision an in-memory
+        // store so the FSM works out of the box (otherwise transitions silently no-op on NoOp).
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19764, "protocol": "http",
+            "stubs": [
+                { "scenarioName": "order", "requiredScenarioState": "Started",
+                  "predicates": [{ "equals": { "path": "/status" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "unpaid" } }] },
+                { "scenarioName": "order", "requiredScenarioState": "Started", "newScenarioState": "paid",
+                  "predicates": [{ "equals": { "path": "/pay" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] },
+                { "scenarioName": "order", "requiredScenarioState": "paid",
+                  "predicates": [{ "equals": { "path": "/status" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "paid" } }] }
+            ]
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        assert_eq!(get(&c, 19764, "/status", None).await, "unpaid");
+        assert_eq!(get(&c, 19764, "/pay", None).await, "ok");
+        assert_eq!(
+            get(&c, 19764, "/status", None).await,
+            "paid",
+            "FSM works without _rift.flowState"
+        );
+
+        let _ = manager.delete_imposter(19764).await;
+    }
+
+    #[tokio::test]
+    async fn scenario_transition_advances_state() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(order_fsm(19760, None)).unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        assert_eq!(
+            get(&c, 19760, "/status", None).await,
+            "unpaid",
+            "initial state"
+        );
+        assert_eq!(
+            get(&c, 19760, "/pay", None).await,
+            "ok",
+            "pay transitions to paid"
+        );
+        assert_eq!(
+            get(&c, 19760, "/status", None).await,
+            "paid",
+            "state advanced after pay"
+        );
+
+        let _ = manager.delete_imposter(19760).await;
+    }
+
+    #[tokio::test]
+    async fn scenario_unmatched_in_state_keeps_state() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(order_fsm(19761, None)).unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        // /status only reads; it never carries newScenarioState, so it must not advance.
+        assert_eq!(get(&c, 19761, "/status", None).await, "unpaid");
+        assert_eq!(
+            get(&c, 19761, "/status", None).await,
+            "unpaid",
+            "read-only stub keeps state"
+        );
+
+        let _ = manager.delete_imposter(19761).await;
+    }
+
+    #[tokio::test]
+    async fn scenario_flow_ids_are_isolated() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(order_fsm(19762, Some("header:X-Mock-Space"))).unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        // Advance only space "alpha"; "beta" stays at the initial state on the same imposter.
+        assert_eq!(get(&c, 19762, "/pay", Some("alpha")).await, "ok");
+        assert_eq!(
+            get(&c, 19762, "/status", Some("alpha")).await,
+            "paid",
+            "alpha advanced"
+        );
+        assert_eq!(
+            get(&c, 19762, "/status", Some("beta")).await,
+            "unpaid",
+            "beta isolated"
+        );
+
+        let _ = manager.delete_imposter(19762).await;
+    }
+
+    fn imposter_with_source(port: u16, src: Option<&str>) -> Imposter {
+        let mut flow_state = serde_json::json!({ "backend": "inmemory", "ttlSeconds": 300 });
+        if let Some(s) = src {
+            flow_state["mountebankStateMapping"] = serde_json::json!({ "flowIdSource": s });
+        }
+        let cfg = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http",
+            "_rift": { "flowState": flow_state }, "stubs": []
+        }))
+        .unwrap();
+        Imposter::new(cfg)
+    }
+
+    #[test]
+    fn resolve_flow_id_modes() {
+        // default flow_id_source = imposter_port
+        let by_port = imposter_with_source(7000, None);
+        assert_eq!(by_port.resolve_flow_id(&HashMap::new()), "7000");
+
+        // header source: present → header value; absent → port fallback
+        let by_header = imposter_with_source(7000, Some("header:X-Mock-Space"));
+        let mut h = HashMap::new();
+        h.insert("X-Mock-Space".to_string(), "abc".to_string());
+        assert_eq!(by_header.resolve_flow_id(&h), "abc");
+        assert_eq!(by_header.resolve_flow_id(&HashMap::new()), "7000");
+    }
+
+    #[test]
+    fn scenario_gate_selects_stub_by_state() {
+        let cfg = serde_json::from_value(serde_json::json!({
+            "port": 7001, "protocol": "http",
+            "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300 } },
+            "stubs": [
+                { "scenarioName": "order", "requiredScenarioState": "Started",
+                  "predicates": [{ "equals": { "path": "/s" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "a" } }] },
+                { "scenarioName": "order", "requiredScenarioState": "paid",
+                  "predicates": [{ "equals": { "path": "/s" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "b" } }] }
+            ]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+        let hdrs = hyper::HeaderMap::new();
+
+        // Started ⇒ first eligible (index 0)
+        let (_, idx) = imp
+            .find_matching_stub("GET", "/s", &hdrs, None, None)
+            .expect("match in Started");
+        assert_eq!(idx, 0);
+
+        // After paid ⇒ the Started stub is gated out, so index 1 wins
+        imp.set_scenario_state("7001", "order", "paid").unwrap();
+        let (_, idx) = imp
+            .find_matching_stub("GET", "/s", &hdrs, None, None)
+            .expect("match in paid");
+        assert_eq!(idx, 1);
+    }
+
+    async fn text(c: &reqwest::Client, url: String) -> String {
+        c.get(url)
+            .send()
+            .await
+            .expect("send")
+            .text()
+            .await
+            .expect("text")
+    }
+
+    async fn json(c: &reqwest::Client, url: String) -> serde_json::Value {
+        serde_json::from_str(&text(c, url).await).expect("json")
+    }
+
+    #[tokio::test]
+    async fn scenario_admin_endpoints_arrange_inspect_reset() {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(order_fsm(19763, None)).unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let admin_addr = "127.0.0.1:12590".parse().unwrap();
+        let server = crate::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let c = reqwest::Client::new();
+        let admin = "http://127.0.0.1:12590";
+
+        // GET scenarios → initial "Started"
+        let v = json(&c, format!("{admin}/imposters/19763/scenarios")).await;
+        assert_eq!(v["scenarios"][0]["name"], "order");
+        assert_eq!(v["scenarios"][0]["state"], "Started");
+
+        // PUT state=paid → a subsequent request observes it
+        let r = c
+            .put(format!("{admin}/imposters/19763/scenarios/order/state"))
+            .header("content-type", "application/json")
+            .body(r#"{"state":"paid"}"#)
+            .send()
+            .await
+            .expect("put");
+        assert_eq!(r.status(), 200);
+        assert_eq!(
+            text(&c, "http://127.0.0.1:19763/status".to_string()).await,
+            "paid"
+        );
+
+        // GET reflects the transition
+        let v = json(&c, format!("{admin}/imposters/19763/scenarios")).await;
+        assert_eq!(v["scenarios"][0]["state"], "paid");
+
+        // reset → back to initial
+        let r = c
+            .post(format!("{admin}/imposters/19763/scenarios/reset"))
+            .send()
+            .await
+            .expect("reset");
+        assert_eq!(r.status(), 200);
+        assert_eq!(
+            text(&c, "http://127.0.0.1:19763/status".to_string()).await,
+            "unpaid"
+        );
+
+        // flow-state KV: PUT / GET / DELETE (default flow_id = imposter_port = "19763")
+        let kv = format!("{admin}/admin/imposters/19763/flow-state/19763/mykey");
+        let r = c
+            .put(&kv)
+            .header("content-type", "application/json")
+            .body(r#"{"value":42}"#)
+            .send()
+            .await
+            .expect("put kv");
+        assert_eq!(r.status(), 200);
+        assert_eq!(json(&c, kv.clone()).await["value"], 42);
+        let r = c.delete(&kv).send().await.expect("del kv");
+        assert_eq!(r.status(), 200);
+        let r = c.get(&kv).send().await.expect("get kv");
+        assert_eq!(r.status(), 404, "deleted key → 404");
+
+        let _ = manager.delete_imposter(19763).await;
+    }
+
+    #[tokio::test]
+    async fn scenario_admin_reset_is_per_flow_with_explicit_flow_id() {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(order_fsm(19765, Some("header:X-Mock-Space"))).unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let admin_addr = "127.0.0.1:12591".parse().unwrap();
+        let server = crate::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let c = reqwest::Client::new();
+        let admin = "http://127.0.0.1:12591";
+        let set_state = |flow: &str| {
+            c.put(format!("{admin}/imposters/19765/scenarios/order/state"))
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"state":"paid","flowId":"{flow}"}}"#))
+                .send()
+        };
+        // Arrange both flows to "paid" via explicit flowId
+        assert_eq!(set_state("alpha").await.expect("a").status(), 200);
+        assert_eq!(set_state("beta").await.expect("b").status(), 200);
+
+        // Reset ONLY alpha
+        let r = c
+            .post(format!("{admin}/imposters/19765/scenarios/reset"))
+            .header("content-type", "application/json")
+            .body(r#"{"flowId":"alpha"}"#)
+            .send()
+            .await
+            .expect("reset");
+        assert_eq!(r.status(), 200);
+
+        // alpha back to initial; beta untouched — via GET ?flowId=
+        let a = json(
+            &c,
+            format!("{admin}/imposters/19765/scenarios?flowId=alpha"),
+        )
+        .await;
+        let b = json(&c, format!("{admin}/imposters/19765/scenarios?flowId=beta")).await;
+        assert_eq!(
+            a["scenarios"][0]["state"], "Started",
+            "alpha reset to initial"
+        );
+        assert_eq!(
+            b["scenarios"][0]["state"], "paid",
+            "beta untouched by alpha reset"
+        );
+
+        let _ = manager.delete_imposter(19765).await;
+    }
 }

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -121,6 +121,14 @@ pub struct Stub {
     /// Placed first to match Mountebank output ordering
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scenario_name: Option<String>,
+    /// Scenario FSM gate (WireMock `whenScenarioStateIs`): the stub is eligible only when the
+    /// `(flow_id, scenario_name)` state equals this. Absent ⇒ always eligible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_scenario_state: Option<String>,
+    /// Scenario FSM transition (WireMock `willSetStateTo`): after this stub responds, set the
+    /// `(flow_id, scenario_name)` state to this. Absent ⇒ no transition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_scenario_state: Option<String>,
     /// Optional unique identifier for the stub (Rift extension)
     /// Useful for targeting specific stubs for updates/deletion without relying on index
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -143,6 +151,10 @@ pub struct Stub {
 struct StubRaw {
     #[serde(default)]
     scenario_name: Option<String>,
+    #[serde(default)]
+    required_scenario_state: Option<String>,
+    #[serde(default)]
+    new_scenario_state: Option<String>,
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
@@ -205,6 +217,8 @@ impl From<StubRaw> for Stub {
 
         Stub {
             scenario_name: raw.scenario_name,
+            required_scenario_state: raw.required_scenario_state,
+            new_scenario_state: raw.new_scenario_state,
             id: raw.id,
             predicates,
             responses,

--- a/crates/rift-http-proxy/src/scripting/stub_validator.rs
+++ b/crates/rift-http-proxy/src/scripting/stub_validator.rs
@@ -271,6 +271,8 @@ mod tests {
                 },
             }],
             scenario_name: None,
+            required_scenario_state: None,
+            new_scenario_state: None,
             recorded_from: None,
         }
     }
@@ -283,6 +285,8 @@ mod tests {
                 inject: code.to_string(),
             }],
             scenario_name: None,
+            required_scenario_state: None,
+            new_scenario_state: None,
             recorded_from: None,
         }
     }
@@ -368,6 +372,8 @@ mod tests {
                     },
                 }],
                 scenario_name: None,
+                required_scenario_state: None,
+                new_scenario_state: None,
                 recorded_from: None,
             },
             Stub {
@@ -384,6 +390,8 @@ mod tests {
                     },
                 }],
                 scenario_name: None,
+                required_scenario_state: None,
+                new_scenario_state: None,
                 recorded_from: None,
             },
         ];


### PR DESCRIPTION
## Summary

Adds a declarative, script-free **single-token scenario FSM** to Rift — the primary missing WireMock-parity feature and the Rift backing for the portable `StatefulScenarios` + `StateInspection` capabilities in the MockControl SPI (zio-bdd#109).

## Model

```rust
required_scenario_state: Option<String>,  // whenScenarioStateIs — eligible only in this state
new_scenario_state:      Option<String>,  // willSetStateTo — transition after responding
```

- **Gate** (before predicate precedence): a stub guarded by `requiredScenarioState` only participates in matching when the current `(flow_id, scenario_name)` state equals it; first eligible stub wins.
- **Transition**: after a stub responds, its `newScenarioState` is written (no-op if unset).
- **Locality**: state is keyed by a correlation `flow_id` resolved from `flowIdSource` — `"imposter_port"` (PerInstance) or `"header:X-Mock-Space"` (Correlated). One shared imposter serves many parallel scenarios with **independent** state.
- **Initial state**: absent entry ⇒ `"Started"` (WireMock parity).
- **Storage**: reuses the existing `FlowStore`; an in-memory store is **auto-provisioned** when stubs declare the FSM, so scenarios work without explicit `_rift.flowState`. Backend-agnostic (in-memory + Redis).

## Admin endpoints (StateInspection)

| Method | Path |
|--------|------|
| GET | `/imposters/:port/scenarios[?flowId=]` → `[{name,state}]` |
| PUT | `/imposters/:port/scenarios/:name/state` ← `{state, flowId?}` |
| POST | `/imposters/:port/scenarios/reset` ← `{flowId?}` (per-flow, not global) |
| GET/PUT/DELETE | `/admin/imposters/:port/flow-state/:flow_id/:key` |

## Tests (8 new)

unpaid→pay→paid transition; read-only stub keeps state; two `flow_id`s isolated on one imposter; `flow_id` resolution (port + header + fallback); gate selects stub by state; auto-provision without `_rift.flowState`; and two admin tests that spin up the real `AdminApiServer` and drive PUT/GET/reset + flow-state KV (incl. 404-after-delete and **per-flow reset isolation with explicit `flowId`**).

## Verification
- `cargo fmt` / `cargo clippy -- -D warnings` clean; `cargo test --lib` → 645 pass (8 new). Redis parity covered via the backend-agnostic `FlowStore` trait (CI redis-integration job).

## Scope notes
- The all-entries `GET /admin/.../flow-state/:flow_id` enumeration endpoint is **deferred** (needs a new `FlowStore` enumeration method + Redis `SCAN`; not in the acceptance Tests). Single-key flow-state GET/PUT/DELETE are implemented.
- Auto-provision happens at imposter creation; adding scenario stubs to an existing non-scenario imposter via in-place `PUT /stubs` won't reprovision (documented) — declare at creation or configure `_rift.flowState`.

Backs zio-bdd EtaCassiopeia/zio-bdd#109 (Epic D). Milestone: M3.

Closes #190