### PR TITLE
refactor: create rift-types crate for shared types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,6 +3428,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rhai",
+ "rift-types",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -3485,6 +3486,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tui-popup",
+]
+
+[[package]]
+name = "rift-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/rift-types",
     "crates/rift-http-proxy",
     "crates/rift-lint",
     "crates/rift-tui",

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -39,6 +39,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 
+# Shared workspace types
+rift-types = { path = "../rift-types" }
+
 # Scripting engines
 rhai = { version = "=1.21.0", features = ["sync", "serde"] }
 mlua = { version = "0.10", features = ["luajit", "serialize"], optional = true }

--- a/crates/rift-http-proxy/src/imposter/mod.rs
+++ b/crates/rift-http-proxy/src/imposter/mod.rs
@@ -31,10 +31,11 @@ mod tests;
 pub use types::{
     DebugImposter, DebugMatchResult, DebugRequest, DebugResponse, DebugResponsePreview,
     DebugStubInfo, ImposterConfig, ImposterError, IsResponse, MountebankStateMapping, PathRewrite,
-    Predicate, PredicateOperation, ProxyResponse, RecordedRequest, ResponseMode, RiftConfig,
-    RiftConnectionPoolConfig, RiftErrorFault, RiftFaultConfig, RiftFlowStateConfig,
-    RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig, RiftRedisConfig, RiftResponseExtension,
-    RiftScriptConfig, RiftScriptEngineConfig, RiftUpstreamConfig, Stub, StubResponse,
+    Predicate, PredicateOperation, PredicateParameters, PredicateSelector, ProxyResponse,
+    RecordedRequest, ResponseMode, RiftConfig, RiftConnectionPoolConfig, RiftErrorFault,
+    RiftFaultConfig, RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig,
+    RiftRedisConfig, RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig,
+    RiftUpstreamConfig, Stub, StubResponse,
 };
 
 // Re-export core imposter

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -265,56 +265,10 @@ fn inject_wait_behavior(response: StubResponse, wait_val: serde_json::Value) -> 
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Predicate {
-    #[serde(flatten)]
-    pub parameters: PredicateParameters,
-    #[serde(flatten)]
-    pub operation: PredicateOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum PredicateOperation {
-    Equals(HashMap<String, serde_json::Value>),
-    DeepEquals(HashMap<String, serde_json::Value>),
-    Contains(HashMap<String, serde_json::Value>),
-    StartsWith(HashMap<String, serde_json::Value>),
-    EndsWith(HashMap<String, serde_json::Value>),
-    Matches(HashMap<String, serde_json::Value>),
-    Exists(HashMap<String, serde_json::Value>),
-    Not(Box<Predicate>),
-    Or(Vec<Predicate>),
-    And(Vec<Predicate>),
-    Inject(String),
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PredicateParameters {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub case_sensitive: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub key_case_sensitive: Option<bool>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub except: String,
-    #[serde(flatten)]
-    pub selector: Option<PredicateSelector>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum PredicateSelector {
-    XPath {
-        selector: String,
-        #[serde(rename = "ns", default, skip_serializing_if = "Option::is_none")]
-        namespaces: Option<HashMap<String, String>>,
-    },
-    JsonPath {
-        selector: String,
-    },
-}
+// Predicate types live in the shared `rift-types` crate (issue #36) so the proxy and the
+// linter share one definition. Re-exported here so existing `crate::imposter::types::*`
+// paths keep resolving unchanged.
+pub use rift_types::{Predicate, PredicateOperation, PredicateParameters, PredicateSelector};
 
 /// Response within a stub - wrapper type that handles various formats
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/rift-types/Cargo.toml
+++ b/crates/rift-types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rift-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Shared core types for the Rift workspace (imposters, stubs, predicates)."
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/rift-types/src/lib.rs
+++ b/crates/rift-types/src/lib.rs
@@ -1,0 +1,8 @@
+//! Shared core types for the Rift workspace.
+//!
+//! Pure, serde-friendly data types with no behaviour, so they can be depended on by
+//! `rift-http-proxy`, `rift-lint`, and `rift-tui` without circular dependencies.
+
+pub mod predicate;
+
+pub use predicate::{Predicate, PredicateOperation, PredicateParameters, PredicateSelector};

--- a/crates/rift-types/src/predicate.rs
+++ b/crates/rift-types/src/predicate.rs
@@ -1,0 +1,170 @@
+//! Predicate types for matching requests against stubs.
+//!
+//! These are pure data types (no matching logic) so they can be shared across the
+//! workspace — the proxy for matching, the linter for concrete-type validation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A single predicate: matcher parameters plus the operation to apply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Predicate {
+    #[serde(flatten)]
+    pub parameters: PredicateParameters,
+    #[serde(flatten)]
+    pub operation: PredicateOperation,
+}
+
+/// The matching operation a predicate performs (Mountebank-compatible).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PredicateOperation {
+    Equals(HashMap<String, serde_json::Value>),
+    DeepEquals(HashMap<String, serde_json::Value>),
+    Contains(HashMap<String, serde_json::Value>),
+    StartsWith(HashMap<String, serde_json::Value>),
+    EndsWith(HashMap<String, serde_json::Value>),
+    Matches(HashMap<String, serde_json::Value>),
+    Exists(HashMap<String, serde_json::Value>),
+    Not(Box<Predicate>),
+    Or(Vec<Predicate>),
+    And(Vec<Predicate>),
+    Inject(String),
+}
+
+/// Matcher parameters shared across operations (case sensitivity, selectors, etc.).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PredicateParameters {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub case_sensitive: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_case_sensitive: Option<bool>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub except: String,
+    #[serde(flatten)]
+    pub selector: Option<PredicateSelector>,
+}
+
+/// A structured selector applied to the request body before matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PredicateSelector {
+    XPath {
+        selector: String,
+        #[serde(rename = "ns", default, skip_serializing_if = "Option::is_none")]
+        namespaces: Option<HashMap<String, String>>,
+    },
+    JsonPath {
+        selector: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserializes_into_concrete_operation() {
+        // The headline benefit for the linter: match on a typed operation instead of
+        // poking at a serde_json::Value.
+        let pred: Predicate =
+            serde_json::from_value(json!({ "equals": { "path": "/hello" } })).unwrap();
+        match pred.operation {
+            PredicateOperation::Equals(fields) => {
+                assert_eq!(fields.get("path").unwrap(), "/hello");
+            }
+            other => panic!("expected Equals, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trips_parameters_and_selector() {
+        let value = json!({
+            "equals": { "body": "x" },
+            "caseSensitive": false,
+            "jsonpath": { "selector": "$.id" }
+        });
+        let pred: Predicate = serde_json::from_value(value).unwrap();
+        assert_eq!(pred.parameters.case_sensitive, Some(false));
+        assert!(matches!(
+            pred.parameters.selector,
+            Some(PredicateSelector::JsonPath { .. })
+        ));
+        assert!(matches!(pred.operation, PredicateOperation::Equals(_)));
+
+        // re-serializing keeps the camelCase wire shape
+        let back = serde_json::to_value(&pred).unwrap();
+        assert_eq!(back["caseSensitive"], json!(false));
+        assert!(back["jsonpath"]["selector"] == json!("$.id"));
+    }
+
+    #[test]
+    fn xpath_selector_round_trips_with_namespaces() {
+        // The XPath selector carries the most fragile serde attributes: the enum's
+        // `rename_all = "lowercase"` ("xpath") and `rename = "ns"` on namespaces.
+        let value = json!({
+            "equals": { "body": "x" },
+            "xpath": { "selector": "//a:user", "ns": { "a": "urn:y" } }
+        });
+        let pred: Predicate = serde_json::from_value(value).unwrap();
+        let Some(PredicateSelector::XPath {
+            selector,
+            namespaces,
+        }) = &pred.parameters.selector
+        else {
+            panic!("expected an XPath selector");
+        };
+        assert_eq!(selector, "//a:user");
+        assert_eq!(namespaces.as_ref().unwrap().get("a").unwrap(), "urn:y");
+
+        let back = serde_json::to_value(&pred).unwrap();
+        assert_eq!(back["xpath"]["selector"], json!("//a:user"));
+        assert_eq!(
+            back["xpath"]["ns"]["a"],
+            json!("urn:y"),
+            "the `ns` rename is preserved"
+        );
+    }
+
+    #[test]
+    fn except_and_key_case_sensitive_round_trip() {
+        let pred: Predicate = serde_json::from_value(json!({
+            "matches": { "path": "/x" },
+            "except": "^/skip",
+            "keyCaseSensitive": true
+        }))
+        .unwrap();
+        assert_eq!(pred.parameters.except, "^/skip");
+        assert_eq!(pred.parameters.key_case_sensitive, Some(true));
+        let back = serde_json::to_value(&pred).unwrap();
+        assert_eq!(back["except"], json!("^/skip"));
+        assert_eq!(back["keyCaseSensitive"], json!(true));
+
+        // empty `except` is omitted from the wire form (skip_serializing_if)
+        let empty: Predicate =
+            serde_json::from_value(json!({ "matches": { "path": "/x" } })).unwrap();
+        assert!(serde_json::to_value(&empty)
+            .unwrap()
+            .get("except")
+            .is_none());
+    }
+
+    #[test]
+    fn nests_logical_operators() {
+        let pred: Predicate = serde_json::from_value(json!({
+            "and": [
+                { "equals": { "method": "GET" } },
+                { "not": { "exists": { "headers": { "X": true } } } }
+            ]
+        }))
+        .unwrap();
+        let PredicateOperation::And(subs) = pred.operation else {
+            panic!("expected And");
+        };
+        assert_eq!(subs.len(), 2);
+        assert!(matches!(subs[1].operation, PredicateOperation::Not(_)));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared **`rift-types`** workspace crate and extracts the self-contained **Predicate type family** — `Predicate`, `PredicateOperation`, `PredicateParameters`, `PredicateSelector` — into it, so `rift-http-proxy`, `rift-lint`, and `rift-tui` can share one definition without circular dependencies.

This establishes the `rift-types` foundation crate (and the extraction pattern) for the **M4 embedded-foundation** epic.

## What changed

- New `crates/rift-types/` (depends only on `serde`/`serde_json` — no dep on `rift-http-proxy`, so no cycle).
- The four predicate types move **verbatim** (serde byte-identical: every `rename_all`/`flatten`/`rename = "ns"`/`skip_serializing_if` preserved).
- `rift-http-proxy` depends on `rift-types` and re-exports the types via `pub use rift_types::{...}`, so **every existing `crate::imposter::types::*` / `crate::imposter::*` call site is unchanged**. `mod.rs` also re-exports `PredicateParameters`/`PredicateSelector` for a consistent public surface.

## Why only the Predicate family

The Predicate types are the primary target (the issue's linter-benefit example is entirely predicate-based) and are cleanly self-contained — no inherent `impl`s. The heavier types (`Stub`/`StubResponse`/`IsResponse`/`ProxyResponse`/`ImposterConfig`/`ResponseBehaviors`) carry inherent impls + custom serde (`StubRaw`/`From`, `deserialize_copy_behaviors`, …) that must move with them under the orphan rule, so they're **deferred to incremental follow-up extractions**. Rewiring `rift-lint`'s validation to use the concrete types is likewise a separate follow-up (the crate is now available to it).

## Tests
5 serde tests in `rift-types` (concrete-variant deserialization, parameters+selector round-trip, **XPath with `ns` namespaces**, `except`/`keyCaseSensitive`, nested and/not). The relocation is behavior-neutral, so the existing proxy suite (645 tests) — which parses imposter configs through these types — is the regression gate.

## Verification
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- Full workspace tests green: rift-http-proxy 645, rift-lint 87, rift-tui 63, rift-types 5.

Milestone: M4

Closes #36