### PR TITLE
feat: first-class Correlated isolation — space-scoped stubs + one-call per-space teardown

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -425,6 +425,7 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
                     scenario_name: stub.scenario_name,
                     required_scenario_state: stub.required_scenario_state,
                     new_scenario_state: stub.new_scenario_state,
+                    space: stub.space,
                     recorded_from: stub.recorded_from,
                 })
             }

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -5,7 +5,7 @@
 //! flow (`resolve_flow_id` with no headers ⇒ the `imposter_port` flow) is used.
 
 use crate::admin_api::types::{collect_body, error_response, json_response};
-use crate::imposter::{Imposter, ImposterManager};
+use crate::imposter::{Imposter, ImposterManager, Stub};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
@@ -198,6 +198,103 @@ pub async fn handle_delete_flow_state(
             ),
             Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
         },
+        Err(e) => e.into(),
+    }
+}
+
+// ── Correlated-isolation "space" endpoints (issue #223) ─────────────────────────
+
+/// POST /imposters/:port/spaces/:flowId/stubs — register a stub scoped to that space.
+pub async fn handle_add_space_stub(
+    port: u16,
+    flow_id: &str,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let payload = match parse_json_body(req).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let mut stub: Stub = match serde_json::from_value(payload) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub: {e}")),
+    };
+    // The path `:flowId` is the source of truth for the scope; ignore any `space` in the body.
+    stub.space = Some(flow_id.to_string());
+    match manager.add_stub(port, stub, None).await {
+        Ok(()) => match manager.get_imposter(port) {
+            Ok(imposter) => json_response(
+                StatusCode::CREATED,
+                &serde_json::json!({ "space": flow_id, "stubs": imposter.space_stubs(flow_id) }),
+            ),
+            Err(e) => e.into(),
+        },
+        Err(e) => e.into(),
+    }
+}
+
+/// GET /imposters/:port/spaces/:flowId/stubs — list a space's scoped stubs.
+pub async fn handle_list_space_stubs(
+    port: u16,
+    flow_id: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => json_response(
+            StatusCode::OK,
+            &serde_json::json!({ "space": flow_id, "stubs": imposter.space_stubs(flow_id) }),
+        ),
+        Err(e) => e.into(),
+    }
+}
+
+/// GET /imposters/:port/spaces/:flowId — inspect a space (stubs + scenario states + request count).
+pub async fn handle_get_space(
+    port: u16,
+    flow_id: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => {
+            let scenarios: Vec<_> = imposter
+                .scenario_names()
+                .into_iter()
+                .map(|name| {
+                    let state = imposter.scenario_state(flow_id, &name);
+                    serde_json::json!({ "name": name, "state": state })
+                })
+                .collect();
+            let number_of_requests = imposter
+                .get_recorded_requests()
+                .iter()
+                .filter(|r| imposter.resolve_flow_id(&r.headers) == flow_id)
+                .count();
+            json_response(
+                StatusCode::OK,
+                &serde_json::json!({
+                    "space": flow_id,
+                    "stubs": imposter.space_stubs(flow_id),
+                    "scenarios": scenarios,
+                    "numberOfRequests": number_of_requests
+                }),
+            )
+        }
+        Err(e) => e.into(),
+    }
+}
+
+/// DELETE /imposters/:port/spaces/:flowId — one-call per-space teardown
+/// (scoped stubs + recorded requests + scenario state), never a global reset.
+pub async fn handle_teardown_space(
+    port: u16,
+    flow_id: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.teardown_space(port, flow_id).await {
+        Ok(()) => json_response(
+            StatusCode::OK,
+            &serde_json::json!({ "space": flow_id, "tornDown": true }),
+        ),
         Err(e) => e.into(),
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -34,6 +34,10 @@ enum ImposterRoute {
     ScenarioState(String),
     /// POST /imposters/:port/scenarios/reset
     ScenariosReset,
+    /// GET/DELETE /imposters/:port/spaces/:flowId
+    Space(String),
+    /// POST/GET /imposters/:port/spaces/:flowId/stubs
+    SpaceStubs(String),
 }
 
 impl ImposterRoute {
@@ -50,6 +54,8 @@ impl ImposterRoute {
             ["scenarios"] => Some(ImposterRoute::Scenarios),
             ["scenarios", "reset"] => Some(ImposterRoute::ScenariosReset),
             ["scenarios", name, "state"] => Some(ImposterRoute::ScenarioState((*name).to_string())),
+            ["spaces", flow_id] => Some(ImposterRoute::Space((*flow_id).to_string())),
+            ["spaces", flow_id, "stubs"] => Some(ImposterRoute::SpaceStubs((*flow_id).to_string())),
             _ => None,
         }
     }
@@ -229,6 +235,20 @@ async fn route_imposter(
         }
         (&Method::POST, ImposterRoute::ScenariosReset) => {
             scenarios::handle_reset_scenarios(port, req, manager).await
+        }
+
+        // /imposters/:port/spaces/:flowId — Correlated isolation (issue #223)
+        (&Method::POST, ImposterRoute::SpaceStubs(flow_id)) => {
+            scenarios::handle_add_space_stub(port, &flow_id, req, manager).await
+        }
+        (&Method::GET, ImposterRoute::SpaceStubs(flow_id)) => {
+            scenarios::handle_list_space_stubs(port, &flow_id, manager).await
+        }
+        (&Method::GET, ImposterRoute::Space(flow_id)) => {
+            scenarios::handle_get_space(port, &flow_id, manager).await
+        }
+        (&Method::DELETE, ImposterRoute::Space(flow_id)) => {
+            scenarios::handle_teardown_space(port, &flow_id, manager).await
         }
 
         _ => not_found(),

--- a/crates/rift-http-proxy/src/extensions/stub_analysis.rs
+++ b/crates/rift-http-proxy/src/extensions/stub_analysis.rs
@@ -419,6 +419,7 @@ mod tests {
             scenario_name: None,
             required_scenario_state: None,
             new_scenario_state: None,
+            space: None,
             recorded_from: None,
         }
     }
@@ -432,6 +433,7 @@ mod tests {
             scenario_name: None,
             required_scenario_state: None,
             new_scenario_state: None,
+            space: None,
             recorded_from: None,
         }
     }

--- a/crates/rift-http-proxy/src/imposter/core.rs
+++ b/crates/rift-http-proxy/src/imposter/core.rs
@@ -276,6 +276,14 @@ impl Imposter {
         let flow_id = self.resolve_flow_id(&headers_map);
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
+            // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only
+            // participates in matching when the request's resolved flow_id equals its space.
+            // Unscoped stubs match any space (PerInstance default).
+            if let Some(space) = &stub.space {
+                if flow_id != *space {
+                    continue;
+                }
+            }
             // Scenario FSM eligibility gate (before predicate precedence): a stub guarded by
             // `requiredScenarioState` only participates in matching when the current
             // (flow_id, scenario) state equals it.
@@ -320,14 +328,22 @@ impl Imposter {
     /// `"header:<Name>"` uses that (case-insensitive) header; `"imposter_port"` (the default,
     /// and the fallback when the header is absent) uses the imposter port.
     pub fn resolve_flow_id(&self, headers: &HashMap<String, String>) -> String {
-        let port_id = || self.config.port.unwrap_or(0).to_string();
-        match self.flow_id_source().strip_prefix("header:") {
+        Self::flow_id_for(
+            &self.flow_id_source(),
+            headers,
+            self.config.port.unwrap_or(0),
+        )
+    }
+
+    /// Pure flow_id resolution (no `&self`), so it can be reused over recorded requests.
+    fn flow_id_for(source: &str, headers: &HashMap<String, String>, port: u16) -> String {
+        match source.strip_prefix("header:") {
             Some(name) => headers
                 .iter()
                 .find(|(k, _)| k.eq_ignore_ascii_case(name))
                 .map(|(_, v)| v.clone())
-                .unwrap_or_else(port_id),
-            None => port_id(),
+                .unwrap_or_else(|| port.to_string()),
+            None => port.to_string(),
         }
     }
 
@@ -407,6 +423,36 @@ impl Imposter {
         names.sort();
         names.dedup();
         names
+    }
+
+    /// Stubs scoped to a given correlation space (issue #223).
+    pub fn space_stubs(&self, space: &str) -> Vec<Stub> {
+        self.stubs
+            .read()
+            .iter()
+            .filter(|s| s.stub.space.as_deref() == Some(space))
+            .map(|s| s.stub.clone())
+            .collect()
+    }
+
+    /// Tear down a correlation space (issue #223): remove its scoped stubs, drop its recorded
+    /// requests, and reset its named scenario states. Other spaces and the port are untouched.
+    pub fn teardown_space(&self, space: &str) {
+        // Snapshot scenario names BEFORE pruning stubs: a scenario declared only on this space's
+        // stubs would otherwise vanish from scenario_names() and its state would never be reset.
+        let scenarios = self.scenario_names();
+        self.stubs
+            .write()
+            .retain(|s| s.stub.space.as_deref() != Some(space));
+        let source = self.flow_id_source();
+        self.recorded_requests.write().retain(|r| {
+            Self::flow_id_for(&source, &r.headers, self.config.port.unwrap_or(0)) != space
+        });
+        for scenario in scenarios {
+            if let Err(e) = self.delete_scenario_state(space, &scenario) {
+                warn!("space teardown: failed to reset scenario '{scenario}' for '{space}': {e}");
+            }
+        }
     }
 
     /// Parse form-urlencoded data from body if Content-Type matches

--- a/crates/rift-http-proxy/src/imposter/manager.rs
+++ b/crates/rift-http-proxy/src/imposter/manager.rs
@@ -256,6 +256,14 @@ impl ImposterManager {
         self.persist_imposter_checked(&imposter).await
     }
 
+    /// Tear down a correlation space (issue #223): remove its scoped stubs, recorded requests,
+    /// and scenario state, then persist the updated stub set.
+    pub async fn teardown_space(&self, port: u16, space: &str) -> Result<(), ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        imposter.teardown_space(space);
+        self.persist_imposter_checked(&imposter).await
+    }
+
     /// Replace a stub
     pub async fn replace_stub(
         &self,

--- a/crates/rift-http-proxy/src/imposter/response.rs
+++ b/crates/rift-http-proxy/src/imposter/response.rs
@@ -263,6 +263,7 @@ pub fn create_stub_from_proxy_response(
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
+        space: None,
         recorded_from,
     }
 }

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -59,6 +59,7 @@ fn test_predicate_matching() {
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
+        space: None,
         recorded_from: None,
     };
 
@@ -150,6 +151,7 @@ fn test_execute_stub() {
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
+        space: None,
         recorded_from: None,
     };
 
@@ -2438,6 +2440,7 @@ async fn test_cors_headers_on_stub_response() {
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
+        space: None,
         recorded_from: None,
     };
     let config = ImposterConfig {
@@ -2936,5 +2939,375 @@ mod scenario_fsm_tests {
         );
 
         let _ = manager.delete_imposter(19765).await;
+    }
+}
+
+// Issue #223: Correlated isolation — space-scoped stubs + one-call per-space teardown.
+#[cfg(test)]
+mod correlated_space_tests {
+    use super::*;
+
+    async fn get(
+        c: &reqwest::Client,
+        port: u16,
+        path: &str,
+        space: Option<&str>,
+    ) -> reqwest::Response {
+        let mut req = c.get(format!("http://127.0.0.1:{port}{path}"));
+        if let Some(s) = space {
+            req = req.header("X-Mock-Space", s);
+        }
+        req.send().await.expect("send")
+    }
+
+    /// Imposter whose flow_id = the X-Mock-Space header, with the given stubs.
+    fn correlated_config(port: u16, stubs: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "port": port, "protocol": "http", "recordRequests": true,
+            "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300,
+                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+            "stubs": stubs
+        })
+    }
+
+    #[tokio::test]
+    async fn space_scoped_stubs_isolate_responses() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(correlated_config(
+            19770,
+            serde_json::json!([
+                { "space": "alpha", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "ALPHA" } }] },
+                { "space": "beta", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "BETA" } }] }
+            ]),
+        ))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        assert_eq!(
+            get(&c, 19770, "/data", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "ALPHA"
+        );
+        assert_eq!(
+            get(&c, 19770, "/data", Some("beta"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "BETA"
+        );
+        // a space with no scoped stub for /data matches neither scoped stub (no leak across spaces)
+        let gamma = get(&c, 19770, "/data", Some("gamma"))
+            .await
+            .text()
+            .await
+            .unwrap();
+        assert!(
+            gamma != "ALPHA" && gamma != "BETA",
+            "scoped stubs must not leak to gamma, got: {gamma:?}"
+        );
+
+        let _ = manager.delete_imposter(19770).await;
+    }
+
+    #[tokio::test]
+    async fn global_stub_matches_all_spaces() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(correlated_config(
+            19771,
+            serde_json::json!([
+                { "predicates": [{ "equals": { "path": "/health" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "OK" } }] }
+            ]),
+        ))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        assert_eq!(
+            get(&c, 19771, "/health", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "OK"
+        );
+        assert_eq!(
+            get(&c, 19771, "/health", Some("beta"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "OK"
+        );
+        assert_eq!(
+            get(&c, 19771, "/health", None).await.text().await.unwrap(),
+            "OK"
+        );
+
+        let _ = manager.delete_imposter(19771).await;
+    }
+
+    #[tokio::test]
+    async fn space_scope_composes_with_scenario_fsm() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(correlated_config(19772, serde_json::json!([
+            { "space": "alpha", "scenarioName": "order", "requiredScenarioState": "Started",
+              "predicates": [{ "equals": { "path": "/status" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "unpaid" } }] },
+            { "space": "alpha", "scenarioName": "order", "requiredScenarioState": "Started", "newScenarioState": "paid",
+              "predicates": [{ "equals": { "path": "/pay" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] },
+            { "space": "alpha", "scenarioName": "order", "requiredScenarioState": "paid",
+              "predicates": [{ "equals": { "path": "/status" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "paid" } }] },
+            { "space": "beta", "predicates": [{ "equals": { "path": "/status" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "beta" } }] }
+        ])))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+        let c = reqwest::Client::new();
+
+        assert_eq!(
+            get(&c, 19772, "/status", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "unpaid"
+        );
+        assert_eq!(
+            get(&c, 19772, "/pay", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "ok"
+        );
+        assert_eq!(
+            get(&c, 19772, "/status", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "paid",
+            "alpha FSM advanced"
+        );
+        // beta shares neither stubs nor state with alpha
+        assert_eq!(
+            get(&c, 19772, "/status", Some("beta"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "beta"
+        );
+
+        let _ = manager.delete_imposter(19772).await;
+    }
+
+    #[tokio::test]
+    async fn space_teardown_is_isolated() {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(correlated_config(
+            19773,
+            serde_json::json!([
+                { "space": "alpha", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "ALPHA" } }] },
+                { "space": "beta", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "BETA" } }] }
+            ]),
+        ))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let admin_addr = "127.0.0.1:12592".parse().unwrap();
+        let server = crate::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let c = reqwest::Client::new();
+        let admin = "http://127.0.0.1:12592";
+
+        // record one request per space
+        let _ = get(&c, 19773, "/data", Some("alpha")).await;
+        let _ = get(&c, 19773, "/data", Some("beta")).await;
+
+        // tear down alpha only
+        let r = c
+            .delete(format!("{admin}/imposters/19773/spaces/alpha"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(r.status(), 200);
+
+        // alpha's recorded requests are cleared (check BEFORE any new alpha request below,
+        // which would re-record one).
+        let alpha_reqs = c
+            .get(format!(
+                "{admin}/imposters/19773/requests?match=header:X-Mock-Space=alpha"
+            ))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(alpha_reqs, "[]", "alpha recorded requests cleared");
+        // alpha's stub no longer matches /data
+        let alpha_after = get(&c, 19773, "/data", Some("alpha"))
+            .await
+            .text()
+            .await
+            .unwrap();
+        assert_ne!(alpha_after, "ALPHA", "alpha stubs removed");
+
+        // beta is fully intact
+        assert_eq!(
+            get(&c, 19773, "/data", Some("beta"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "BETA",
+            "beta untouched"
+        );
+        let beta_space = c
+            .get(format!("{admin}/imposters/19773/spaces/beta/stubs"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert!(
+            beta_space.contains("BETA"),
+            "beta stubs intact: {beta_space}"
+        );
+
+        let _ = manager.delete_imposter(19773).await;
+    }
+
+    #[tokio::test]
+    async fn space_teardown_resets_scenario_state_and_leaves_others() {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        // Two spaces each running the "order" FSM, declared only on their own scoped stubs.
+        let fsm = |space: &str| {
+            serde_json::json!({
+                "space": space, "scenarioName": "order",
+                "requiredScenarioState": "Started", "newScenarioState": "paid",
+                "predicates": [{ "equals": { "path": "/pay" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "ok" } }]
+            })
+        };
+        let config = serde_json::from_value(correlated_config(
+            19774,
+            serde_json::json!([fsm("alpha"), fsm("beta")]),
+        ))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let admin_addr = "127.0.0.1:12593".parse().unwrap();
+        let server = crate::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let c = reqwest::Client::new();
+        let admin = "http://127.0.0.1:12593";
+        let state_url =
+            |flow: &str| format!("{admin}/admin/imposters/19774/flow-state/{flow}/order");
+
+        // advance both spaces' "order" scenario to paid
+        let _ = get(&c, 19774, "/pay", Some("alpha")).await;
+        let _ = get(&c, 19774, "/pay", Some("beta")).await;
+        assert_eq!(
+            c.get(state_url("alpha")).send().await.unwrap().status(),
+            200,
+            "alpha order state set before teardown"
+        );
+
+        // tear down alpha
+        let r = c
+            .delete(format!("{admin}/imposters/19774/spaces/alpha"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(r.status(), 200);
+
+        // alpha's scenario state is reset (key deleted ⇒ 404); beta's survives
+        assert_eq!(
+            c.get(state_url("alpha")).send().await.unwrap().status(),
+            404,
+            "alpha scenario state reset by teardown"
+        );
+        let beta_state = c.get(state_url("beta")).send().await.unwrap();
+        assert_eq!(beta_state.status(), 200, "beta scenario state untouched");
+        assert!(beta_state.text().await.unwrap().contains("paid"));
+
+        let _ = manager.delete_imposter(19774).await;
+    }
+
+    #[tokio::test]
+    async fn space_stub_registration_and_inspection_endpoints() {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let config =
+            serde_json::from_value(correlated_config(19775, serde_json::json!([]))).unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let admin_addr = "127.0.0.1:12594".parse().unwrap();
+        let server = crate::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let c = reqwest::Client::new();
+        let admin = "http://127.0.0.1:12594";
+
+        // register a stub scoped to "alpha" via the space endpoint
+        let r = c
+            .post(format!("{admin}/imposters/19775/spaces/alpha/stubs"))
+            .header("content-type", "application/json")
+            .body(r#"{"predicates":[{"equals":{"path":"/data"}}],"responses":[{"is":{"statusCode":200,"body":"ALPHA"}}]}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(r.status(), 201);
+
+        // it matches alpha's requests and is gated from other spaces
+        assert_eq!(
+            get(&c, 19775, "/data", Some("alpha"))
+                .await
+                .text()
+                .await
+                .unwrap(),
+            "ALPHA"
+        );
+        let beta = get(&c, 19775, "/data", Some("beta"))
+            .await
+            .text()
+            .await
+            .unwrap();
+        assert_ne!(
+            beta, "ALPHA",
+            "space-scoped stub must not match other spaces"
+        );
+
+        // inspection: GET /spaces/alpha reports the stub + a per-space request count
+        let body = c
+            .get(format!("{admin}/imposters/19775/spaces/alpha"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        let space: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(space["space"], "alpha");
+        assert_eq!(space["stubs"].as_array().unwrap().len(), 1);
+        assert_eq!(space["numberOfRequests"], 1, "one alpha request recorded");
+
+        let _ = manager.delete_imposter(19775).await;
     }
 }

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -129,6 +129,11 @@ pub struct Stub {
     /// `(flow_id, scenario_name)` state to this. Absent ⇒ no transition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_scenario_state: Option<String>,
+    /// Correlated-isolation scope (issue #223): when set, the stub is eligible only for requests
+    /// whose resolved `flow_id` (see `flowIdSource`) equals this. Absent ⇒ global (matches any
+    /// space), preserving PerInstance behaviour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space: Option<String>,
     /// Optional unique identifier for the stub (Rift extension)
     /// Useful for targeting specific stubs for updates/deletion without relying on index
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,6 +160,8 @@ struct StubRaw {
     required_scenario_state: Option<String>,
     #[serde(default)]
     new_scenario_state: Option<String>,
+    #[serde(default)]
+    space: Option<String>,
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
@@ -219,6 +226,7 @@ impl From<StubRaw> for Stub {
             scenario_name: raw.scenario_name,
             required_scenario_state: raw.required_scenario_state,
             new_scenario_state: raw.new_scenario_state,
+            space: raw.space,
             id: raw.id,
             predicates,
             responses,

--- a/crates/rift-http-proxy/src/scripting/stub_validator.rs
+++ b/crates/rift-http-proxy/src/scripting/stub_validator.rs
@@ -273,6 +273,7 @@ mod tests {
             scenario_name: None,
             required_scenario_state: None,
             new_scenario_state: None,
+            space: None,
             recorded_from: None,
         }
     }
@@ -287,6 +288,7 @@ mod tests {
             scenario_name: None,
             required_scenario_state: None,
             new_scenario_state: None,
+            space: None,
             recorded_from: None,
         }
     }
@@ -374,6 +376,7 @@ mod tests {
                 scenario_name: None,
                 required_scenario_state: None,
                 new_scenario_state: None,
+                space: None,
                 recorded_from: None,
             },
             Stub {
@@ -392,6 +395,7 @@ mod tests {
                 scenario_name: None,
                 required_scenario_state: None,
                 new_scenario_state: None,
+                space: None,
                 recorded_from: None,
             },
         ];


### PR DESCRIPTION
## Summary

Make **Correlated isolation** a first-class Rift mode: many test scenarios share **one imposter on one port**, isolated by a correlation key (`flow_id`, default header `X-Mock-Space`), instead of burning a port per scenario. Completes the Correlated story alongside header-filtered recorded requests (#201) and the flow_id-keyed scenario FSM (#190), and makes Rift a peer of WireMock's shared-baseUri model.

## What changed

- **`Stub.space: Option<String>`** (serde back-compat). When set, the stub is eligible only for requests whose resolved `flow_id` (from `flowIdSource`) equals it. Unscoped stubs match any space → **PerInstance unchanged**.
- **Space gate** in `find_matching_stub_with_client` runs *before* the scenario FSM gate, reusing #190's `resolve_flow_id`. Composes cleanly with `requiredScenarioState`.
- **One-call per-space teardown**: removes a space's scoped stubs **+** drops its recorded requests **+** resets its named scenario states — never a global reset; other spaces and the port untouched. (Scenario names are snapshotted *before* the stub prune so a space-only scenario's state is still reset.)
- **Admin endpoints** under `/imposters/:port/spaces/:flowId`:

| Method | Path | Behaviour |
|--------|------|-----------|
| POST | `/spaces/:flowId/stubs` | register a stub scoped to the space |
| GET | `/spaces/:flowId/stubs` | list the space's scoped stubs |
| GET | `/spaces/:flowId` | inspect: stubs + scenario states + per-space request count |
| DELETE | `/spaces/:flowId` | one-call teardown (stubs + requests + state) |

## Tests (6 new)

Two spaces stub the same path with different responses (+ a no-leak negative case); a global unscoped stub matches any space; the space gate composes with a multi-step scenario FSM; teardown clears a space's stubs/requests **and** scenario state while leaving another space fully intact; and the registration + inspection endpoints. All drive the real imposter and (for admin paths) a spawned `AdminApiServer`.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test --lib` → 651 pass (6 new).

## Relations
- Completes Correlated isolation with #201 (verification) + #190 (state); complements #202 (id-addressed stubs).
- Backs **zio-bdd#156** (`Rift.correlated()` adapter) and zio-bdd #123/#109. Contract pinned in the issue comments on both sides.

Milestone: M2 (Correlated)

Closes #223