### PR TITLE
feat: defaultForward fallback proxy for unmatched requests

### DIFF
--- a/crates/rift-http-proxy/src/imposter/handler.rs
+++ b/crates/rift-http-proxy/src/imposter/handler.rs
@@ -6,7 +6,9 @@
 use super::core::Imposter;
 use super::predicates::parse_query_string;
 use super::response::apply_js_or_rhai_decorate;
-use super::types::{DebugMatchResult, DebugRequest, DebugResponse, RecordedRequest, ResponseMode};
+use super::types::{
+    DebugMatchResult, DebugRequest, DebugResponse, ProxyResponse, RecordedRequest, ResponseMode,
+};
 use crate::admin_api::types::{build_response, build_response_with_headers};
 use crate::behaviors::{
     apply_copy_behaviors, apply_lookup_behaviors, header_to_title_case, CsvCache, RequestContext,
@@ -531,6 +533,56 @@ async fn handle_request_inner(
                 build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
             }));
         }
+    }
+
+    // No matching rule. Issue #196: if `defaultForward` is set, transparently forward the
+    // request to the configured upstream before falling back to a static default. A
+    // defaultForward-only imposter runs in ProxyTransparent mode, so the upstream response is
+    // never cached/replayed. (The request still appears in the audit log when `recordRequests`
+    // is enabled — that is the separate, opt-in recording feature.)
+    if let Some(upstream) = &imposter.config.default_forward {
+        let proxy_config = ProxyResponse {
+            to: upstream.clone(),
+            ..Default::default()
+        };
+        return match imposter
+            .handle_proxy_request(
+                &proxy_config,
+                method_str,
+                &uri,
+                &headers_clone,
+                body_string.as_deref(),
+            )
+            .await
+        {
+            Ok((status, response_headers, body, _latency)) => {
+                let mut response = Response::builder().status(status);
+                for (k, v) in &response_headers {
+                    if !crate::util::is_hop_by_hop_header(k) {
+                        response = response.header(k, v);
+                    }
+                }
+                response = response.header("x-rift-imposter", "true");
+                response = response.header("x-rift-default-forward", "true");
+                Ok(response
+                    .body(Full::new(Bytes::from(body)))
+                    .unwrap_or_else(|e| {
+                        warn!("defaultForward response build failed (bad upstream header?): {e}");
+                        build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+                    }))
+            }
+            Err(e) => {
+                warn!("defaultForward proxy to {} failed: {}", upstream, e);
+                Ok(build_response_with_headers(
+                    StatusCode::BAD_GATEWAY,
+                    [
+                        ("x-rift-imposter", "true"),
+                        ("x-rift-default-forward-error", "true"),
+                    ],
+                    format!(r#"{{"error": "defaultForward upstream error: {e}"}}"#),
+                ))
+            }
+        };
     }
 
     // No matching rule - return default response or 404

--- a/crates/rift-http-proxy/src/imposter/tests.rs
+++ b/crates/rift-http-proxy/src/imposter/tests.rs
@@ -3311,3 +3311,179 @@ mod correlated_space_tests {
         let _ = manager.delete_imposter(19775).await;
     }
 }
+
+// Issue #196: defaultForward — transparently forward unmatched requests upstream.
+#[cfg(test)]
+mod default_forward_tests {
+    use super::*;
+
+    async fn get(port: u16, path: &str) -> reqwest::Response {
+        reqwest::Client::new()
+            .get(format!("http://127.0.0.1:{port}{path}"))
+            .send()
+            .await
+            .expect("send")
+    }
+
+    /// Spin up an upstream imposter that echoes a body per path, on `port`.
+    async fn upstream(manager: &ImposterManager, port: u16) {
+        let config = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http", "stubs": [
+                { "predicates": [{ "equals": { "path": "/ping" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "PONG" } }] },
+                { "predicates": [{ "equals": { "path": "/api/v1/users" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "USERS" } }] }
+            ]
+        }))
+        .unwrap();
+        manager
+            .create_imposter(config)
+            .await
+            .expect("create upstream");
+    }
+
+    #[tokio::test]
+    async fn default_forward_proxies_unmatched() {
+        let manager = ImposterManager::new();
+        upstream(&manager, 19780).await;
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19781, "protocol": "http",
+            "defaultForward": "http://127.0.0.1:19780", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let resp = get(19781, "/ping").await;
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get("x-rift-default-forward")
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+        assert_eq!(
+            resp.text().await.unwrap(),
+            "PONG",
+            "unmatched request forwarded upstream"
+        );
+
+        let _ = manager.delete_imposter(19780).await;
+        let _ = manager.delete_imposter(19781).await;
+    }
+
+    #[tokio::test]
+    async fn default_forward_preserves_path() {
+        let manager = ImposterManager::new();
+        upstream(&manager, 19782).await;
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19783, "protocol": "http",
+            "defaultForward": "http://127.0.0.1:19782", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        // /api/v1/users on the imposter is forwarded to upstream + /api/v1/users
+        assert_eq!(
+            get(19783, "/api/v1/users").await.text().await.unwrap(),
+            "USERS"
+        );
+
+        let _ = manager.delete_imposter(19782).await;
+        let _ = manager.delete_imposter(19783).await;
+    }
+
+    #[tokio::test]
+    async fn matching_stub_takes_precedence_over_default_forward() {
+        let manager = ImposterManager::new();
+        upstream(&manager, 19784).await;
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19785, "protocol": "http",
+            "defaultForward": "http://127.0.0.1:19784",
+            "stubs": [
+                { "predicates": [{ "equals": { "path": "/local" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "LOCAL" } }] }
+            ]
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        // a matched stub responds locally (not proxied)
+        let local = get(19785, "/local").await;
+        assert_eq!(local.headers().get("x-rift-default-forward"), None);
+        assert_eq!(local.text().await.unwrap(), "LOCAL");
+        // an unmatched path still forwards upstream
+        assert_eq!(get(19785, "/ping").await.text().await.unwrap(), "PONG");
+
+        let _ = manager.delete_imposter(19784).await;
+        let _ = manager.delete_imposter(19785).await;
+    }
+
+    #[tokio::test]
+    async fn default_forward_upstream_error_returns_502() {
+        let manager = ImposterManager::new();
+        // defaultForward points at a port with no listener → upstream leg fails
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19787, "protocol": "http",
+            "defaultForward": "http://127.0.0.1:19999", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        let resp = get(19787, "/anything").await;
+        assert_eq!(resp.status(), 502);
+        assert_eq!(
+            resp.headers()
+                .get("x-rift-default-forward-error")
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+
+        let _ = manager.delete_imposter(19787).await;
+    }
+
+    #[tokio::test]
+    async fn default_forward_request_is_audited_when_record_requests_enabled() {
+        // The forwarded request still appears in the recordRequests audit log — that feature is
+        // independent of the proxy replay cache the transparent forward bypasses.
+        let manager = ImposterManager::new();
+        upstream(&manager, 19788).await;
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19789, "protocol": "http", "recordRequests": true,
+            "defaultForward": "http://127.0.0.1:19788", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        assert_eq!(get(19789, "/ping").await.text().await.unwrap(), "PONG");
+
+        let recorded = manager.get_imposter(19789).unwrap().get_recorded_requests();
+        assert_eq!(recorded.len(), 1, "forwarded request is audited");
+        assert_eq!(recorded[0].path, "/ping");
+
+        let _ = manager.delete_imposter(19788).await;
+        let _ = manager.delete_imposter(19789).await;
+    }
+
+    #[tokio::test]
+    async fn without_default_forward_unmatched_is_unchanged() {
+        let manager = ImposterManager::new();
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19786, "protocol": "http", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+
+        // existing no-match behaviour: 200 + x-rift-no-match, not a proxied body
+        let resp = get(19786, "/anything").await;
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get("x-rift-no-match")
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+        assert!(resp.headers().get("x-rift-default-forward").is_none());
+
+        let _ = manager.delete_imposter(19786).await;
+    }
+}

--- a/crates/rift-http-proxy/src/imposter/types.rs
+++ b/crates/rift-http-proxy/src/imposter/types.rs
@@ -665,7 +665,7 @@ pub struct PathRewrite {
     pub to: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProxyResponse {
     pub to: String,
@@ -716,6 +716,11 @@ pub struct ImposterConfig {
     pub stubs: Vec<Stub>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_response: Option<IsResponse>,
+    /// Fallback upstream for unmatched requests (issue #196): when set and no stub matches,
+    /// the request is transparently forwarded to `defaultForward + path` (no recording).
+    /// Takes precedence over `defaultResponse`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_forward: Option<String>,
     /// Allow CORS headers (Mountebank compatible)
     #[serde(
         default,


### PR DESCRIPTION
## Summary

Add an imposter-level **`defaultForward`**: when no stub matches, the request is transparently forwarded to the configured upstream (`defaultForward + path + query`) instead of returning the empty no-match response. This lets teams avoid maintaining stub coverage for every endpoint by falling back to a real upstream.

## What changed

- **`ImposterConfig.default_forward: Option<String>`** (serde camelCase `defaultForward`, optional → back-compat: absent means behaviour is unchanged).
- **`imposter/handler.rs`** — in the no-match path, *before* the static `defaultResponse` fallback, if `defaultForward` is set the request is forwarded via the existing `handle_proxy_request` machinery in **ProxyTransparent** mode (the upstream response is never cached/replayed). A matched stub still takes precedence over the forward.
  - Success → upstream status/headers/body (hop-by-hop headers filtered) + `x-rift-default-forward: true`.
  - Upstream failure → `502` with `{"error": "defaultForward upstream error: …"}` and `x-rift-default-forward-error: true` (mirrors the existing proxy-stub error path).
- Derived `Default` on `ProxyResponse` so the forward config is `{ to, ..Default::default() }`.

## Usage
```json
{ "port": 8080, "protocol": "http", "defaultForward": "https://upstream.example.com", "stubs": [ ... ] }
```

## Tests (6 new)
`default_forward_proxies_unmatched`, `default_forward_preserves_path`, `matching_stub_takes_precedence_over_default_forward`, `default_forward_upstream_error_returns_502`, `default_forward_request_is_audited_when_record_requests_enabled`, `without_default_forward_unmatched_is_unchanged`. Each stands up a real upstream imposter and asserts over real HTTP.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo test --lib` → 657 pass (6 new).

## Relations
Unblocks the **M2 SPI conformance** dependency: zio-bdd#125 (core conformance) requires this for its *unmatched-default* feature. Bundle into the M2 Rift release alongside #201 and #223.

Milestone: M2

Closes #196