### PR TITLE
fix: add rift-types to Dockerfile dependency-cache stubs

### DIFF
--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -29,10 +29,12 @@ COPY Cargo.lock* ./
 COPY crates/rift-http-proxy/Cargo.toml ./crates/rift-http-proxy/
 COPY crates/rift-lint/Cargo.toml ./crates/rift-lint/
 COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
+COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 
 # Create dummy source files to build dependencies
 RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
-             crates/rift-lint/src crates/rift-tui/src && \
+             crates/rift-lint/src crates/rift-tui/src crates/rift-types/src && \
+    echo "" > crates/rift-types/src/lib.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/bin/verify.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/benches/matcher_bench.rs && \

--- a/crates/rift-lint/Dockerfile
+++ b/crates/rift-lint/Dockerfile
@@ -21,9 +21,11 @@ COPY crates/rift-lint/Cargo.toml ./crates/rift-lint/
 # rift-lint depends on rift-http-proxy for types
 COPY crates/rift-http-proxy/Cargo.toml ./crates/rift-http-proxy/
 COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
+COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 
 # Create dummy source files to build dependencies
-RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src && \
+RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src crates/rift-types/src && \
+    echo "" > crates/rift-types/src/lib.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \


### PR DESCRIPTION
The `rift-http-proxy` and `rift-lint` Dockerfiles stub each workspace member's `src/` to cache dependency builds, but the hardcoded crate list wasn't updated when `rift-types` landed (#229). The cached `cargo build` then fails with *failed to load manifest for workspace member rift-types*, which broke **Compatibility Tests** on master.

Fix: `COPY crates/rift-types/Cargo.toml` + stub `src/lib.rs` in both Dockerfiles, matching the existing pattern. (The same lists will gain `rift-core` in #203.)

No behaviour change; CI-only.