### PR TITLE
feat: rift-ffi crate (C-ABI over ImposterManager)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rift-ffi"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "rift-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rift-http-proxy"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/rift-types",
     "crates/rift-core",
+    "crates/rift-ffi",
     "crates/rift-http-proxy",
     "crates/rift-lint",
     "crates/rift-tui",

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rift-ffi"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+
+description = "Rift C-ABI: a tiny opaque-handle + JSON in/out FFI over the rift-core engine, for embedding Rift in-process (e.g. via the JVM Panama FFM backend)."
+readme = "../../README.md"
+
+[lib]
+# cdylib: the C-ABI shared library the JVM downcalls into.
+# rlib: so the in-crate Rust integration test can link and exercise the same extern fns.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+rift-core = { path = "../rift-core", default-features = false, features = ["lua", "javascript", "redis-backend"] }
+tokio = { version = "1.41", features = ["rt-multi-thread"] }
+serde_json = "1.0"
+# Emit a diagnostic before collapsing a typed error into a C sentinel; the embedding host
+# installs the subscriber (no-op if none is set).
+tracing = "0.1"
+
+[dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1,0 +1,194 @@
+//! Rift C-ABI (issue #204): a tiny opaque-handle + JSON in / JSON out FFI over the rift-core
+//! engine, so a host (e.g. the JVM via Panama FFM) can embed Rift in-process.
+//!
+//! Boundary discipline:
+//! - **Opaque handle + JSON only.** No Rust enums/generics cross the line; the JSON codec is the
+//!   same `rift-types`/`rift-core` wire model the admin API uses, so it is version-tolerant.
+//! - **Memory created and freed on the same side.** `rift_start`/`rift_stop` own the
+//!   [`RiftHandle`]; `rift_recorded` returns a `*mut c_char` the caller must hand back to
+//!   [`rift_free`].
+//! - **No futures cross the boundary.** The handle owns a multi-thread Tokio runtime; mutating
+//!   downcalls are blocking `block_on` calls (read-only ones like [`rift_recorded`] are plain
+//!   synchronous reads), so the host wraps them in its own blocking effect.
+//! - **One handle is safe to share across host threads:** the engine is `Sync` and every
+//!   downcall takes `&self`, so concurrent calls on the same handle are permitted.
+//!
+//! All `extern "C"` functions are panic-free; under edition 2021 an unexpected unwind aborts
+//! rather than crossing the boundary (defined behaviour). A failed downcall returns its sentinel
+//! and emits a `tracing` event with the dropped error so the reason is not lost.
+
+use rift_core::imposter::{ImposterConfig, ImposterManager, Stub};
+use std::ffi::{c_char, CStr, CString};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tracing::warn;
+
+/// Opaque handle: a Tokio runtime (on its own threads) plus the engine it drives.
+pub struct RiftHandle {
+    runtime: Runtime,
+    manager: Arc<ImposterManager>,
+}
+
+/// Borrow the handle from a raw pointer, or `None` if null.
+///
+/// # Safety
+/// `h` must be null or a pointer returned by [`rift_start`] and not yet passed to [`rift_stop`].
+unsafe fn handle<'a>(h: *mut RiftHandle) -> Option<&'a RiftHandle> {
+    h.as_ref()
+}
+
+/// Read a borrowed UTF-8 string from a C string pointer, or `None` if null/invalid.
+///
+/// # Safety
+/// `p` must be null or a valid NUL-terminated C string that outlives the borrow.
+unsafe fn c_str<'a>(p: *const c_char) -> Option<&'a str> {
+    if p.is_null() {
+        return None;
+    }
+    CStr::from_ptr(p).to_str().ok()
+}
+
+/// Move a `String` across the boundary as an owned `*mut c_char` the caller frees with
+/// [`rift_free`]. Returns null if the string contains an interior NUL.
+fn into_c_string(s: String) -> *mut c_char {
+    match CString::new(s) {
+        Ok(c) => c.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Start the engine. Returns an opaque handle, or null if the runtime could not be created.
+#[no_mangle]
+pub extern "C" fn rift_start() -> *mut RiftHandle {
+    match Runtime::new() {
+        Ok(runtime) => Box::into_raw(Box::new(RiftHandle {
+            runtime,
+            manager: Arc::new(ImposterManager::new()),
+        })),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Create an imposter from a JSON config. Returns its port, or `0` on any error
+/// (null handle/json, malformed config, or bind failure — `0` is never a live imposter port).
+///
+/// # Safety
+/// `h` must be a live handle and `json` a valid C string (or null).
+#[no_mangle]
+pub unsafe extern "C" fn rift_create_imposter(h: *mut RiftHandle, json: *const c_char) -> u16 {
+    let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+        warn!("rift_create_imposter: null handle or config pointer");
+        return 0;
+    };
+    let config = match serde_json::from_str::<ImposterConfig>(s) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "rift_create_imposter: invalid config JSON");
+            return 0;
+        }
+    };
+    handle
+        .runtime
+        .block_on(handle.manager.create_imposter(config))
+        .unwrap_or_else(|e| {
+            warn!(error = %e, "rift_create_imposter failed");
+            0
+        })
+}
+
+/// Replace all stubs on `port` from a JSON array. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle and `json` a valid C string (or null).
+#[no_mangle]
+pub unsafe extern "C" fn rift_replace_stubs(
+    h: *mut RiftHandle,
+    port: u16,
+    json: *const c_char,
+) -> i32 {
+    let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+        warn!("rift_replace_stubs: null handle or stubs pointer");
+        return -1;
+    };
+    let stubs = match serde_json::from_str::<Vec<Stub>>(s) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "rift_replace_stubs: invalid stubs JSON");
+            return -1;
+        }
+    };
+    match handle
+        .runtime
+        .block_on(handle.manager.replace_stubs(port, stubs))
+    {
+        Ok(()) => 0,
+        Err(e) => {
+            warn!(error = %e, port, "rift_replace_stubs failed");
+            -1
+        }
+    }
+}
+
+/// Remove all imposters. Returns `0` on success, `-1` if the handle is null.
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[no_mangle]
+pub unsafe extern "C" fn rift_delete_all(h: *mut RiftHandle) -> i32 {
+    let Some(handle) = handle(h) else {
+        return -1;
+    };
+    handle.runtime.block_on(handle.manager.delete_all());
+    0
+}
+
+/// Return the recorded requests for `port` as a JSON array string the caller must free with
+/// [`rift_free`]. Returns null on any error (null/unknown handle or port, or encode failure).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[no_mangle]
+pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_char {
+    let Some(handle) = handle(h) else {
+        return std::ptr::null_mut();
+    };
+    let imposter = match handle.manager.get_imposter(port) {
+        Ok(i) => i,
+        Err(e) => {
+            warn!(error = %e, port, "rift_recorded: no such imposter");
+            return std::ptr::null_mut();
+        }
+    };
+    match serde_json::to_string(&imposter.get_recorded_requests()) {
+        Ok(json) => into_c_string(json),
+        Err(e) => {
+            warn!(error = %e, port, "rift_recorded: failed to encode recorded requests");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Free a string previously returned by [`rift_recorded`]. Null is a no-op.
+///
+/// # Safety
+/// `p` must be null or a pointer returned by a `rift-ffi` function and not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn rift_free(p: *mut c_char) {
+    if !p.is_null() {
+        drop(CString::from_raw(p));
+    }
+}
+
+/// Stop the engine: gracefully shut down all imposters and drop the handle + runtime. Null is a
+/// no-op. The handle must not be used after this call.
+///
+/// # Safety
+/// `h` must be null or a pointer returned by [`rift_start`] and not previously stopped.
+#[no_mangle]
+pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
+    if h.is_null() {
+        return;
+    }
+    let handle = Box::from_raw(h);
+    handle.runtime.block_on(handle.manager.shutdown());
+}

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1,0 +1,102 @@
+//! Issue #204 gate: drive the full lifecycle across the C-ABI from a Rust integration test —
+//! start → create imposter (JSON) → replace stubs (JSON) → serve+record → recorded (JSON) →
+//! free → delete_all → stop — plus the null-pointer and error-sentinel paths. (Double-free /
+//! use-after-free are undefined behaviour, so they belong under Miri/ASan, not a normal test.)
+
+use rift_ffi::*;
+use std::ffi::{c_char, CStr, CString};
+
+fn cstr(s: &str) -> CString {
+    CString::new(s).expect("no interior NUL in test input")
+}
+
+unsafe fn take_json(p: *mut c_char) -> String {
+    assert!(!p.is_null(), "expected JSON, got null");
+    let s = CStr::from_ptr(p).to_str().expect("utf8").to_owned();
+    rift_free(p);
+    s
+}
+
+#[test]
+fn ffi_round_trip() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null(), "rift_start returned null");
+
+        // create imposter from JSON config; returns its port
+        let config =
+            cstr(r#"{ "port": 19990, "protocol": "http", "recordRequests": true, "stubs": [] }"#);
+        let port = rift_create_imposter(h, config.as_ptr());
+        assert_eq!(port, 19990);
+
+        // replace stubs from a JSON array
+        let stubs = cstr(
+            r#"[{ "predicates": [{ "equals": { "path": "/hello" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "world" } }] }]"#,
+        );
+        assert_eq!(rift_replace_stubs(h, port, stubs.as_ptr()), 0);
+
+        // the embedded mock serves on its port — drive it like any HTTP service
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let body = rt.block_on(async {
+            let r = reqwest::get("http://127.0.0.1:19990/hello")
+                .await
+                .expect("get");
+            assert_eq!(r.status(), 200);
+            r.text().await.expect("text")
+        });
+        assert_eq!(body, "world");
+
+        // recorded requests come back as JSON; caller frees the buffer
+        let recorded = take_json(rift_recorded(h, port));
+        let parsed: serde_json::Value = serde_json::from_str(&recorded).unwrap();
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+        assert_eq!(parsed[0]["path"], "/hello");
+
+        // teardown removes all imposters — verified by the effect, not just the return code:
+        // the port is gone, so recorded now returns null.
+        assert_eq!(rift_delete_all(h), 0);
+        assert!(
+            rift_recorded(h, port).is_null(),
+            "delete_all must remove the imposter (recorded → null)"
+        );
+
+        // stop drops the handle + runtime
+        rift_stop(h);
+    }
+}
+
+#[test]
+fn ffi_null_and_error_paths() {
+    unsafe {
+        // null handle / null json never abort — they return error sentinels
+        assert_eq!(
+            rift_create_imposter(std::ptr::null_mut(), std::ptr::null()),
+            0
+        );
+        assert_eq!(
+            rift_replace_stubs(std::ptr::null_mut(), 1, std::ptr::null()),
+            -1
+        );
+        assert_eq!(rift_delete_all(std::ptr::null_mut()), -1);
+        assert!(rift_recorded(std::ptr::null_mut(), 1).is_null());
+        // freeing null and stopping null are no-ops
+        rift_free(std::ptr::null_mut());
+        rift_stop(std::ptr::null_mut());
+
+        // a live handle with malformed JSON / unknown port also yields sentinels
+        let h = rift_start();
+        let bad = cstr("not json");
+        assert_eq!(rift_create_imposter(h, bad.as_ptr()), 0);
+        assert_eq!(rift_replace_stubs(h, 12345, bad.as_ptr()), -1);
+        // valid stubs but an unknown port exercises the manager's own NotFound error path
+        let valid = cstr(r#"[{ "predicates": [], "responses": [] }]"#);
+        assert_eq!(
+            rift_replace_stubs(h, 12345, valid.as_ptr()),
+            -1,
+            "unknown port → -1"
+        );
+        assert!(rift_recorded(h, 12345).is_null(), "unknown port → null");
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -31,12 +31,14 @@ COPY crates/rift-lint/Cargo.toml ./crates/rift-lint/
 COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
 COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 COPY crates/rift-core/Cargo.toml ./crates/rift-core/
+COPY crates/rift-ffi/Cargo.toml ./crates/rift-ffi/
 
 # Create dummy source files to build dependencies
 RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
-             crates/rift-lint/src crates/rift-tui/src crates/rift-types/src crates/rift-core/src && \
+             crates/rift-lint/src crates/rift-tui/src crates/rift-types/src crates/rift-core/src crates/rift-ffi/src && \
     echo "" > crates/rift-types/src/lib.rs && \
     echo "" > crates/rift-core/src/lib.rs && \
+    echo "" > crates/rift-ffi/src/lib.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/bin/verify.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/benches/matcher_bench.rs && \

--- a/crates/rift-lint/Dockerfile
+++ b/crates/rift-lint/Dockerfile
@@ -23,11 +23,13 @@ COPY crates/rift-http-proxy/Cargo.toml ./crates/rift-http-proxy/
 COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
 COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 COPY crates/rift-core/Cargo.toml ./crates/rift-core/
+COPY crates/rift-ffi/Cargo.toml ./crates/rift-ffi/
 
 # Create dummy source files to build dependencies
-RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src crates/rift-types/src crates/rift-core/src && \
+RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src crates/rift-types/src crates/rift-core/src crates/rift-ffi/src && \
     echo "" > crates/rift-types/src/lib.rs && \
     echo "" > crates/rift-core/src/lib.rs && \
+    echo "" > crates/rift-ffi/src/lib.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \


### PR DESCRIPTION
## Summary

Add a tiny **`rift-ffi`** crate exposing a **C-ABI** over rift-core's `ImposterManager` — an opaque handle + JSON in / JSON out — so a host (e.g. the JVM via Panama FFM) can embed Rift in-process behind the same `MockControl` interface as the container backend. Builds on the rift-core extraction (#203) and the shared rift-types wire model (#36).

## Surface

| Function | Behaviour |
|----------|-----------|
| `rift_start() -> *mut RiftHandle` | start the engine (owns a tokio runtime + `Arc<ImposterManager>`) |
| `rift_create_imposter(h, json) -> u16` | create from JSON config; returns port, `0` on error |
| `rift_replace_stubs(h, port, json) -> i32` | replace stubs from JSON array; `0` ok / `-1` err |
| `rift_delete_all(h) -> i32` | remove all imposters |
| `rift_recorded(h, port) -> *mut c_char` | recorded requests as JSON (caller frees); null on error |
| `rift_free(p)` | free a string returned by `rift_recorded` |
| `rift_stop(h)` | graceful shutdown + drop the handle/runtime |

## Boundary discipline (from the talk)

- **Opaque handle + JSON only** — no Rust enums/generics cross the line; the JSON codec is the same `rift-types` wire model the admin API uses (version-tolerant).
- **Memory created and freed on the same side** — `CString`/`Box` `into_raw`/`from_raw`; null-guarded.
- **No futures cross the boundary** — the handle owns a multi-thread tokio runtime; each mutating call is a blocking `block_on`, so the host wraps them in its own blocking effect.
- **Panic-free** — edition 2021 aborts on unwind (defined, not UB); a `tracing` event carries the dropped error before each sentinel so the reason is never lost.

## Tests

`ffi_round_trip` drives the full lifecycle (start → create JSON → replace_stubs JSON → **serve+record over real HTTP** → recorded JSON → free → delete_all → stop), verifying the wire contract and the `delete_all` effect. `ffi_null_and_error_paths` covers null pointers, malformed JSON, and the unknown-port sentinels (null never aborts).

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green.
- `cargo tree -p rift-ffi` = **0 clap, 0 rift-http-proxy** — depends only on rift-core, exactly the clean embedded target.

## Relations
M4 embedded-foundation. Depends on **#203** (rift-core) + **#36** (rift-types). Next: **#205** (per-platform cdylib build/packaging) → Rift M4 release → zio-bdd #133/#134.

Milestone: M4

Closes #204