### PR TITLE
build: per-platform cdylib artifacts + release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Run unit tests
         run: cargo test --workspace --all-features --lib
 
+      # Issue #205: prove the librift_ffi cdylib builds and exports the full C-ABI before the
+      # per-platform release matrix relies on it.
+      - name: rift-ffi C-ABI smoke test
+        run: ./scripts/verify-ffi-cdylib.sh
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,12 @@ jobs:
       matrix:
         include:
           # Linux x86_64 (glibc)
+          # `classifier` names the librift_ffi cdylib asset by os/arch for the JVM loader (#205).
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
             archive: tar.gz
             features: lua,javascript,redis-backend
+            classifier: linux-x86_64
 
           # Linux ARM64 (glibc)
           - target: aarch64-unknown-linux-gnu
@@ -45,6 +47,7 @@ jobs:
             features: javascript,redis-backend
             no_default_features: true
             cross: true
+            classifier: linux-aarch64
 
           # Linux x86_64 (musl - static binary)
           - target: x86_64-unknown-linux-musl
@@ -53,6 +56,7 @@ jobs:
             features: javascript,redis-backend
             no_default_features: true
             cross: true
+            classifier: linux-x86_64-musl
 
           # Linux ARM64 (musl - static binary)
           - target: aarch64-unknown-linux-musl
@@ -61,6 +65,7 @@ jobs:
             features: javascript,redis-backend
             no_default_features: true
             cross: true
+            classifier: linux-aarch64-musl
 
           # macOS x86_64 (Intel) - cross-compiled on ARM64 runner
           # Note: Lua disabled because LuaJIT can't be cross-compiled via pkg-config
@@ -69,12 +74,14 @@ jobs:
             archive: tar.gz
             features: javascript,redis-backend
             no_default_features: true
+            classifier: darwin-x86_64
 
           # macOS ARM64 (Apple Silicon)
           - target: aarch64-apple-darwin
             os: macos-14
             archive: tar.gz
             features: lua,javascript,redis-backend
+            classifier: darwin-aarch64
 
           # Windows x86_64
           - target: x86_64-pc-windows-msvc
@@ -82,6 +89,7 @@ jobs:
             archive: zip
             features: javascript,redis-backend
             no_default_features: true
+            classifier: windows-x86_64
 
     steps:
       - name: Checkout
@@ -167,10 +175,13 @@ jobs:
             cross build --release --package rift-http-proxy --target ${{ matrix.target }} $FEATURE_FLAGS
             cross build --release --package rift-lint --target ${{ matrix.target }}
             cross build --release --package rift-tui --target ${{ matrix.target }}
+            # rift-ffi cdylib (issue #205) — same per-target feature set as the proxy
+            cross build --release --package rift-ffi --target ${{ matrix.target }} $FEATURE_FLAGS
           else
             cargo build --release --package rift-http-proxy --target ${{ matrix.target }} $FEATURE_FLAGS
             cargo build --release --package rift-lint --target ${{ matrix.target }}
             cargo build --release --package rift-tui --target ${{ matrix.target }}
+            cargo build --release --package rift-ffi --target ${{ matrix.target }} $FEATURE_FLAGS
           fi
 
       # Package
@@ -210,6 +221,15 @@ jobs:
           echo "CHECKSUM_PATH=target/${{ matrix.target }}/release/$ARCHIVE_NAME.tar.gz.sha256" >> $GITHUB_ENV
           echo "CHECKSUM_NAME=$ARCHIVE_NAME.tar.gz.sha256" >> $GITHUB_ENV
 
+          # rift-ffi cdylib as a standalone, classifier-named release asset (issue #205): the JVM
+          # embedded backend loads the raw library by os/arch, so it ships outside the binary tarball.
+          if [[ "$OSTYPE" == "darwin"* ]]; then EXT="dylib"; else EXT="so"; fi
+          FFI_NAME="librift_ffi-${{ matrix.classifier }}.$EXT"
+          cp "librift_ffi.$EXT" "$FFI_NAME"
+          shasum -a 256 "$FFI_NAME" > "$FFI_NAME.sha256"
+          echo "FFI_ASSET_PATH=target/${{ matrix.target }}/release/$FFI_NAME" >> $GITHUB_ENV
+          echo "FFI_CHECKSUM_PATH=target/${{ matrix.target }}/release/$FFI_NAME.sha256" >> $GITHUB_ENV
+
       - name: Package (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -243,6 +263,15 @@ jobs:
           echo "CHECKSUM_PATH=target/${{ matrix.target }}/release/$ARCHIVE_NAME.zip.sha256" >> $env:GITHUB_ENV
           echo "CHECKSUM_NAME=$ARCHIVE_NAME.zip.sha256" >> $env:GITHUB_ENV
 
+          # rift-ffi cdylib as a standalone, classifier-named release asset (issue #205).
+          # The Windows cdylib has no 'lib' prefix (rift_ffi.dll); rename to the librift_ffi-* convention.
+          $FFI_NAME = "librift_ffi-${{ matrix.classifier }}.dll"
+          Copy-Item "rift_ffi.dll" "$FFI_NAME"
+          $ffiHash = (Get-FileHash -Algorithm SHA256 "$FFI_NAME").Hash.ToLower()
+          "$ffiHash  $FFI_NAME" | Out-File -Encoding utf8 "$FFI_NAME.sha256"
+          echo "FFI_ASSET_PATH=target/${{ matrix.target }}/release/$FFI_NAME" >> $env:GITHUB_ENV
+          echo "FFI_CHECKSUM_PATH=target/${{ matrix.target }}/release/$FFI_NAME.sha256" >> $env:GITHUB_ENV
+
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
@@ -250,6 +279,8 @@ jobs:
           path: |
             ${{ env.ASSET_PATH }}
             ${{ env.CHECKSUM_PATH }}
+            ${{ env.FFI_ASSET_PATH }}
+            ${{ env.FFI_CHECKSUM_PATH }}
           retention-days: 1
 
   # =============================================================================
@@ -445,6 +476,9 @@ jobs:
             artifacts/**/*.tar.gz
             artifacts/**/*.zip
             artifacts/**/*.sha256
+            artifacts/**/*.so
+            artifacts/**/*.dylib
+            artifacts/**/*.dll
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -17,7 +17,9 @@ readme = "../../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-rift-core = { path = "../rift-core", default-features = false, features = ["lua", "javascript", "redis-backend"] }
+# Features are forwarded (not hard-coded) so the per-platform cdylib build can drop engines that
+# can't cross-compile for a given target (e.g. LuaJIT for x86_64-apple-darwin) — issue #205.
+rift-core = { path = "../rift-core", default-features = false }
 tokio = { version = "1.41", features = ["rt-multi-thread"] }
 serde_json = "1.0"
 # Emit a diagnostic before collapsing a typed error into a C sentinel; the embedding host
@@ -26,3 +28,9 @@ tracing = "0.1"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+
+[features]
+default = ["redis-backend", "lua", "javascript"]
+redis-backend = ["rift-core/redis-backend"]
+lua = ["rift-core/lua"]
+javascript = ["rift-core/javascript"]

--- a/scripts/verify-ffi-cdylib.sh
+++ b/scripts/verify-ffi-cdylib.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Issue #205 C-ABI smoke test: build the rift-ffi cdylib for the host and assert it exports the
+# full C-ABI symbol set. Runs locally and as a CI step before the per-platform release matrix.
+#
+# Any extra args are forwarded to `cargo build` (e.g. feature flags).
+set -euo pipefail
+
+SYMBOLS=(
+  rift_start
+  rift_create_imposter
+  rift_replace_stubs
+  rift_delete_all
+  rift_recorded
+  rift_free
+  rift_stop
+)
+
+echo "[info] building librift_ffi cdylib (release)..."
+cargo build -p rift-ffi --release "$@"
+
+case "$(uname -s)" in
+  Darwin)
+    lib="target/release/librift_ffi.dylib"
+    list_symbols() { nm -gU "$1"; }
+    ;;
+  Linux)
+    lib="target/release/librift_ffi.so"
+    list_symbols() { nm -D --defined-only "$1"; }
+    ;;
+  *)
+    echo "[error] unsupported host OS '$(uname -s)' for symbol check" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$lib" ]; then
+  echo "[error] cdylib not found at $lib" >&2
+  exit 1
+fi
+
+echo "[info] checking exported symbols in $lib"
+exported="$(list_symbols "$lib")"
+missing=0
+for sym in "${SYMBOLS[@]}"; do
+  # macOS prefixes C symbols with a leading underscore; match either form.
+  if printf '%s\n' "$exported" | grep -qE " _?${sym}\$"; then
+    echo "  [ok]      $sym"
+  else
+    echo "  [MISSING] $sym"
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  echo "[fail] librift_ffi is missing one or more C-ABI symbols" >&2
+  exit 1
+fi
+echo "[pass] all ${#SYMBOLS[@]} C-ABI symbols exported by $lib"


### PR DESCRIPTION
## Summary

Build the **`librift_ffi` cdylib** for all seven release targets and attach a classifier-named native library per platform to GitHub releases, so the JVM embedded backend (zio-bdd #133/#134) can load `librift_ffi` by `os.name`/`os.arch`. **Completes the M4 chain** (rift-types → rift-core → rift-ffi → cdylib packaging).

## What changed

- **`release.yml`** — extend the existing 7-target build matrix to also build `rift-ffi` (`cargo`/`cross build -p rift-ffi`, same per-target `$FEATURE_FLAGS` as the proxy). Each cdylib is packaged as **`librift_ffi-<os>-<arch>.{so,dylib,dll}` + `.sha256`** (a `classifier` per matrix row) and attached to the release via the uploaded artifact + the `files:` glob.

  | Target | classifier | artifact |
  |--------|-----------|----------|
  | linux gnu/musl × x86_64/aarch64 | `linux-{x86_64,aarch64}[-musl]` | `.so` |
  | macOS x86_64/aarch64 | `darwin-{x86_64,aarch64}` | `.dylib` |
  | windows x86_64 | `windows-x86_64` | `.dll` |

- **`crates/rift-ffi/Cargo.toml`** — forward the rift-core features (`default = [lua, javascript, redis-backend]`) instead of hard-coding, so the cdylib can drop engines that can't cross-compile for a target (e.g. LuaJIT on x86_64-apple-darwin). Default build behaviour is unchanged.
- **`scripts/verify-ffi-cdylib.sh`** (new) — a C-ABI smoke test that builds the host cdylib and asserts all 7 `extern "C"` symbols are exported; wired into **`ci.yml`** to run on every PR.

## Verification
- Smoke test passes locally (7/7 symbols on `librift_ffi.dylib`); `bash -n` + YAML valid.
- `cargo test -p rift-ffi` green (no regression from feature-forward); the lua-less feature path compiles (so the x86_64-darwin/musl/windows cross-targets won't break on LuaJIT); clippy/fmt clean.

## Notes (verified on the first release run, inherent to packaging)
The 7-target cross-build, classifier naming, and release attachment are exercised when the release workflow runs — the per-step `set -e` fails fast if any cdylib is absent, so no broken/missing artifact can ship silently (same as how prior releases surfaced the Windows build issue).

## Relations
M4 embedded-foundation. Depends on **#204** (rift-ffi). Pairs with zio-bdd **#134** (native lib packaging/loading), which consumes these artifacts.

Milestone: M4

Closes #205