### PR TITLE
feat: id-addressed stub operations (add/replace/delete by Stub.id)

### DIFF
--- a/crates/rift-core/src/imposter/core.rs
+++ b/crates/rift-core/src/imposter/core.rs
@@ -1149,6 +1149,61 @@ impl Imposter {
         stubs.insert(idx, StubState::new(stub));
     }
 
+    /// Add a stub, rejecting it if its `id` duplicates an existing stub (issue #202). The
+    /// duplicate check and the insert happen under one write lock so concurrent adds can't race.
+    /// Returns `false` (not added) on id conflict — the caller holds the id for the error.
+    #[must_use]
+    pub fn add_stub_unique(&self, stub: Stub, index: Option<usize>) -> bool {
+        let mut stubs = self.stubs.write();
+        if let Some(id) = stub.id.as_deref() {
+            if stubs.iter().any(|s| s.stub.id.as_deref() == Some(id)) {
+                return false;
+            }
+        }
+        let idx = index.unwrap_or(stubs.len()).min(stubs.len());
+        stubs.insert(idx, StubState::new(stub));
+        true
+    }
+
+    /// Replace the stub with `id` in place (position preserved). The replacement keeps `id` as its
+    /// addressable id regardless of the supplied stub's `id`. Returns `false` if no such id.
+    #[must_use]
+    pub fn replace_stub_by_id(&self, id: &str, mut stub: Stub) -> bool {
+        let mut stubs = self.stubs.write();
+        match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
+            Some(i) => {
+                stub.id = Some(id.to_string());
+                // Swap the stub in place (like the index-based replace) to keep the slot's
+                // response-cycling state, rather than replacing the whole StubState.
+                stubs[i].stub = stub;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Delete the stub with `id`. Returns `false` if no such id.
+    #[must_use]
+    pub fn delete_stub_by_id(&self, id: &str) -> bool {
+        let mut stubs = self.stubs.write();
+        match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
+            Some(i) => {
+                stubs.remove(i);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Get a clone of the stub with `id`, if present.
+    pub fn get_stub_by_id(&self, id: &str) -> Option<Stub> {
+        self.stubs
+            .read()
+            .iter()
+            .find(|s| s.stub.id.as_deref() == Some(id))
+            .map(|s| s.stub.clone())
+    }
+
     /// Replace a stub at a specific index
     pub fn replace_stub(&self, index: usize, stub: Stub) -> Result<(), String> {
         let mut stubs = self.stubs.write();

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -252,8 +252,43 @@ impl ImposterManager {
         index: Option<usize>,
     ) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
-        imposter.add_stub(stub, index);
+        // Reject a duplicate `id` atomically (issue #202); stubs without an id are unaffected.
+        let id = stub.id.clone();
+        if !imposter.add_stub_unique(stub, index) {
+            return Err(ImposterError::StubIdConflict(id.unwrap_or_default()));
+        }
         self.persist_imposter_checked(&imposter).await
+    }
+
+    /// Replace the stub addressed by `id` in place (issue #202), preserving its position.
+    pub async fn replace_stub_by_id(
+        &self,
+        port: u16,
+        id: &str,
+        stub: Stub,
+    ) -> Result<(), ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        if !imposter.replace_stub_by_id(id, stub) {
+            return Err(ImposterError::StubNotFound(id.to_string()));
+        }
+        self.persist_imposter_checked(&imposter).await
+    }
+
+    /// Delete the stub addressed by `id` (issue #202).
+    pub async fn delete_stub_by_id(&self, port: u16, id: &str) -> Result<(), ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        if !imposter.delete_stub_by_id(id) {
+            return Err(ImposterError::StubNotFound(id.to_string()));
+        }
+        self.persist_imposter_checked(&imposter).await
+    }
+
+    /// Get the stub addressed by `id` (issue #202).
+    pub fn get_stub_by_id(&self, port: u16, id: &str) -> Result<Stub, ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        imposter
+            .get_stub_by_id(id)
+            .ok_or_else(|| ImposterError::StubNotFound(id.to_string()))
     }
 
     /// Tear down a correlation space (issue #223): remove its scoped stubs, recorded requests,

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -3168,3 +3168,174 @@ mod default_forward_tests {
         let _ = manager.delete_imposter(19786).await;
     }
 }
+
+// Issue #202: id-addressed stub operations (get/replace/delete by Stub.id), race-free.
+#[cfg(test)]
+mod id_addressed_stub_tests {
+    use super::*;
+
+    fn stub_with_id(id: &str, body: &str) -> Stub {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "predicates": [{ "equals": { "path": format!("/{id}") } }],
+            "responses": [{ "is": { "statusCode": 200, "body": body } }]
+        }))
+        .unwrap()
+    }
+
+    async fn imposter_on(port: u16) -> std::sync::Arc<ImposterManager> {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http", "stubs": []
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create");
+        manager
+    }
+
+    #[tokio::test]
+    async fn delete_stub_by_id_preserves_position() {
+        let manager = imposter_on(19810).await;
+        for id in ["a", "b", "c"] {
+            manager
+                .add_stub(19810, stub_with_id(id, id), None)
+                .await
+                .unwrap();
+        }
+        manager.delete_stub_by_id(19810, "b").await.unwrap();
+
+        let stubs = manager.get_imposter(19810).unwrap().get_stubs();
+        let ids: Vec<_> = stubs.iter().map(|s| s.id.clone().unwrap()).collect();
+        assert_eq!(ids, vec!["a", "c"], "b removed; a/c keep relative order");
+        assert!(matches!(
+            manager.get_stub_by_id(19810, "b"),
+            Err(ImposterError::StubNotFound(_))
+        ));
+        let _ = manager.delete_imposter(19810).await;
+    }
+
+    #[tokio::test]
+    async fn duplicate_stub_id_conflicts() {
+        let manager = imposter_on(19811).await;
+        manager
+            .add_stub(19811, stub_with_id("x", "first"), None)
+            .await
+            .unwrap();
+        let dup = manager
+            .add_stub(19811, stub_with_id("x", "second"), None)
+            .await;
+        assert!(
+            matches!(dup, Err(ImposterError::StubIdConflict(_))),
+            "duplicate id rejected"
+        );
+        // the original is untouched
+        assert_eq!(
+            manager.get_stub_by_id(19811, "x").unwrap().responses.len(),
+            1
+        );
+        let _ = manager.delete_imposter(19811).await;
+    }
+
+    #[tokio::test]
+    async fn replace_stub_by_id_in_place() {
+        let manager = imposter_on(19812).await;
+        for id in ["a", "b", "c"] {
+            manager
+                .add_stub(19812, stub_with_id(id, id), None)
+                .await
+                .unwrap();
+        }
+        // replace b's content; a PUT body whose id differs must not change the addressable id
+        let mut replacement = stub_with_id("ignored", "B2");
+        replacement.id = Some("ignored".into());
+        manager
+            .replace_stub_by_id(19812, "b", replacement)
+            .await
+            .unwrap();
+
+        let stubs = manager.get_imposter(19812).unwrap().get_stubs();
+        let ids: Vec<_> = stubs.iter().map(|s| s.id.clone().unwrap()).collect();
+        assert_eq!(
+            ids,
+            vec!["a", "b", "c"],
+            "position + addressable id preserved"
+        );
+        // content updated, still addressable by the path id
+        let got = manager.get_stub_by_id(19812, "b").unwrap();
+        assert_eq!(got.id.as_deref(), Some("b"));
+        let body = serde_json::to_value(&got).unwrap();
+        assert_eq!(
+            body["responses"][0]["is"]["body"], "B2",
+            "content actually replaced"
+        );
+
+        assert!(matches!(
+            manager
+                .replace_stub_by_id(19812, "missing", stub_with_id("missing", "z"))
+                .await,
+            Err(ImposterError::StubNotFound(_))
+        ));
+        let _ = manager.delete_imposter(19812).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_id_add_exactly_one_wins() {
+        let manager = imposter_on(19814).await;
+        // 12 tasks race to add the SAME id — the atomic dedup-under-lock must admit exactly one.
+        let mut adds = tokio::task::JoinSet::new();
+        for _ in 0..12 {
+            let m = manager.clone();
+            adds.spawn(async move { m.add_stub(19814, stub_with_id("dup", "v"), None).await });
+        }
+        let mut wins = 0;
+        let mut conflicts = 0;
+        while let Some(r) = adds.join_next().await {
+            match r.unwrap() {
+                Ok(()) => wins += 1,
+                Err(ImposterError::StubIdConflict(_)) => conflicts += 1,
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+        }
+        assert_eq!(wins, 1, "exactly one add succeeds");
+        assert_eq!(conflicts, 11, "the rest are conflicts");
+        assert_eq!(manager.get_imposter(19814).unwrap().get_stubs().len(), 1);
+        let _ = manager.delete_imposter(19814).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_id_ops_stay_consistent() {
+        let manager = imposter_on(19813).await;
+        // add 0..20 concurrently, then delete the even ids concurrently
+        let mut adds = tokio::task::JoinSet::new();
+        for i in 0..20u32 {
+            let m = manager.clone();
+            adds.spawn(async move {
+                m.add_stub(19813, stub_with_id(&i.to_string(), "v"), None)
+                    .await
+            });
+        }
+        while let Some(r) = adds.join_next().await {
+            r.unwrap().unwrap();
+        }
+        let mut dels = tokio::task::JoinSet::new();
+        for i in (0..20u32).step_by(2) {
+            let m = manager.clone();
+            dels.spawn(async move { m.delete_stub_by_id(19813, &i.to_string()).await });
+        }
+        while let Some(r) = dels.join_next().await {
+            r.unwrap().unwrap();
+        }
+
+        let stubs = manager.get_imposter(19813).unwrap().get_stubs();
+        assert_eq!(
+            stubs.len(),
+            10,
+            "20 added, 10 deleted → 10 remain, no lost/dup"
+        );
+        for i in 0..20u32 {
+            let present = manager.get_stub_by_id(19813, &i.to_string()).is_ok();
+            assert_eq!(present, i % 2 == 1, "only odd ids survive ({i})");
+        }
+        let _ = manager.delete_imposter(19813).await;
+    }
+}

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -974,6 +974,10 @@ pub enum ImposterError {
     InvalidProtocol(String),
     #[error("Stub index {0} out of bounds")]
     StubIndexOutOfBounds(usize),
+    #[error("No stub with id '{0}'")]
+    StubNotFound(String),
+    #[error("A stub with id '{0}' already exists")]
+    StubIdConflict(String),
     #[error("Failed to persist imposter: {0}")]
     PersistError(String),
 }

--- a/crates/rift-core/src/response/mod.rs
+++ b/crates/rift-core/src/response/mod.rs
@@ -57,6 +57,13 @@ impl From<ImposterError> for Response<Full<Bytes>> {
             ImposterError::StubIndexOutOfBounds(i) => {
                 error_response(StatusCode::NOT_FOUND, &format!("Stub index {i} not found"))
             }
+            ImposterError::StubNotFound(id) => {
+                error_response(StatusCode::NOT_FOUND, &format!("No stub with id '{id}'"))
+            }
+            ImposterError::StubIdConflict(id) => error_response(
+                StatusCode::CONFLICT,
+                &format!("A stub with id '{id}' already exists"),
+            ),
             ImposterError::PersistError(msg) => error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 &format!("Persistence error: {msg}"),

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -43,6 +43,9 @@ serde_json = "1.0"
 rift-types = { path = "../rift-types" }
 rift-core = { path = "../rift-core", default-features = false }
 
+# Stable stub id generation for id-addressed stub ops (issue #202)
+uuid = { version = "1.8", features = ["v4"] }
+
 # Logging & Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -91,7 +94,6 @@ reqwest = { version = "0.12", features = ["json"] }
 tokio-test = "0.4"
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["redis"] }
-uuid = { version = "1.8", features = ["v4"] }
 assert-json-diff = "2.0"
 serial_test = "3.0"
 tracing-test = "0.2"

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -27,12 +27,18 @@ pub async fn handle_add(
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e),
     };
 
-    let add_req: AddStubRequest = match serde_json::from_slice(&body) {
+    let mut add_req: AddStubRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"))
         }
     };
+
+    // Issue #202: honor a caller-supplied `id`, but generate a stable one if absent so every
+    // stub is addressable via the by-id endpoints.
+    if add_req.stub.id.is_none() {
+        add_req.stub.id = Some(uuid::Uuid::new_v4().to_string());
+    }
 
     // Validate scripts in the stub before adding
     let insert_index = add_req.index.unwrap_or(0);
@@ -222,6 +228,67 @@ pub async fn handle_delete(
     manager: Arc<ImposterManager>,
 ) -> Response<Full<Bytes>> {
     match manager.delete_stub(port, index).await {
+        Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
+        Err(e) => e.into(),
+    }
+}
+
+// ── Id-addressed stub operations (issue #202) ───────────────────────────────────
+
+/// GET /imposters/:port/stubs/by-id/:id — fetch the stub addressed by id.
+pub async fn handle_get_by_id(
+    port: u16,
+    id: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_stub_by_id(port, id) {
+        Ok(stub) => json_response(StatusCode::OK, &stub),
+        Err(e) => e.into(),
+    }
+}
+
+/// PUT /imposters/:port/stubs/by-id/:id — replace the stub addressed by id, in place.
+pub async fn handle_replace_by_id(
+    port: u16,
+    id: &str,
+    req: Request<Incoming>,
+    base_url: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let body = match collect_body(req).await {
+        Ok(b) => b,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e),
+    };
+    let stub: Stub = match serde_json::from_slice(&body) {
+        Ok(s) => s,
+        Err(e) => {
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"))
+        }
+    };
+    let validation_result = validate_stub(&stub, 0);
+    if !validation_result.is_valid() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            &format!(
+                "Script validation failed: {}",
+                validation_result.into_error_message().unwrap_or_default()
+            ),
+        );
+    }
+    match manager.replace_stub_by_id(port, id, stub).await {
+        Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
+        Err(e) => e.into(),
+    }
+}
+
+/// DELETE /imposters/:port/stubs/by-id/:id — delete the stub addressed by id.
+pub async fn handle_delete_by_id(
+    port: u16,
+    id: &str,
+    base_url: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.delete_stub_by_id(port, id).await {
         Ok(()) => handle_get_imposter(port, None, base_url, manager).await,
         Err(e) => e.into(),
     }

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -20,6 +20,8 @@ enum ImposterRoute {
     Stubs,
     /// GET/PUT/DELETE /imposters/:port/stubs/:index
     StubByIndex(usize),
+    /// GET/PUT/DELETE /imposters/:port/stubs/by-id/:id (issue #202)
+    StubById(String),
     /// DELETE /imposters/:port/savedRequests
     SavedRequests,
     /// DELETE /imposters/:port/savedProxyResponses
@@ -46,6 +48,7 @@ impl ImposterRoute {
         match segments {
             [] => Some(ImposterRoute::Root),
             ["stubs"] => Some(ImposterRoute::Stubs),
+            ["stubs", "by-id", id] => Some(ImposterRoute::StubById((*id).to_string())),
             ["stubs", index_str] => index_str.parse().ok().map(ImposterRoute::StubByIndex),
             ["savedRequests"] | ["requests"] => Some(ImposterRoute::SavedRequests),
             ["savedProxyResponses"] => Some(ImposterRoute::SavedProxyResponses),
@@ -207,6 +210,17 @@ async fn route_imposter(
         }
         (&Method::DELETE, ImposterRoute::StubByIndex(index)) => {
             stubs::handle_delete(port, index, base_url, manager).await
+        }
+
+        // /imposters/:port/stubs/by-id/:id (issue #202)
+        (&Method::GET, ImposterRoute::StubById(id)) => {
+            stubs::handle_get_by_id(port, &id, manager).await
+        }
+        (&Method::PUT, ImposterRoute::StubById(id)) => {
+            stubs::handle_replace_by_id(port, &id, req, base_url, manager).await
+        }
+        (&Method::DELETE, ImposterRoute::StubById(id)) => {
+            stubs::handle_delete_by_id(port, &id, base_url, manager).await
         }
 
         // /imposters/:port/savedRequests (alias /requests)

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -370,3 +370,125 @@ async fn space_stub_registration_and_inspection_endpoints() {
 
     let _ = manager.delete_imposter(19775).await;
 }
+
+// Issue #202: id-addressed stub operations over the admin HTTP API.
+#[tokio::test]
+async fn stub_by_id_admin_endpoints() {
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19776, "protocol": "http", "stubs": []
+    }))
+    .unwrap();
+    manager.create_imposter(config).await.expect("create");
+
+    let admin_addr = "127.0.0.1:12596".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12596";
+
+    let add = |id: serde_json::Value, body: &str| {
+        let stub = serde_json::json!({
+            "id": id,
+            "predicates": [{ "equals": { "path": "/p" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": body } }]
+        });
+        c.post(format!("{admin}/imposters/19776/stubs"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "stub": stub }).to_string())
+            .send()
+    };
+
+    // add a stub with an explicit id
+    assert_eq!(
+        add(serde_json::json!("s1"), "one").await.unwrap().status(),
+        200
+    );
+
+    // GET by id → 200 with the stub
+    let got: serde_json::Value =
+        serde_json::from_str(&text(&c, format!("{admin}/imposters/19776/stubs/by-id/s1")).await)
+            .unwrap();
+    assert_eq!(got["id"], "s1");
+
+    // duplicate id → 409 Conflict
+    assert_eq!(
+        add(serde_json::json!("s1"), "dup").await.unwrap().status(),
+        409
+    );
+
+    // PUT by id replaces in place
+    let put = c
+        .put(format!("{admin}/imposters/19776/stubs/by-id/s1"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "id": "s1",
+                "predicates": [{ "equals": { "path": "/p" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "two" } }]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put.status(), 200);
+    // GET back confirms the content actually changed (not just the id preserved)
+    let after: serde_json::Value =
+        serde_json::from_str(&text(&c, format!("{admin}/imposters/19776/stubs/by-id/s1")).await)
+            .unwrap();
+    assert_eq!(
+        after["responses"][0]["is"]["body"], "two",
+        "PUT replaced the content"
+    );
+
+    // unknown id → 404 on GET and DELETE
+    assert_eq!(
+        c.get(format!("{admin}/imposters/19776/stubs/by-id/nope"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    assert_eq!(
+        c.delete(format!("{admin}/imposters/19776/stubs/by-id/nope"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    // DELETE by id → 200, then it's gone
+    assert_eq!(
+        c.delete(format!("{admin}/imposters/19776/stubs/by-id/s1"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    assert_eq!(
+        c.get(format!("{admin}/imposters/19776/stubs/by-id/s1"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    // POST without an id generates one so it is by-id addressable
+    assert_eq!(
+        add(serde_json::Value::Null, "auto").await.unwrap().status(),
+        200
+    );
+    let imposter = manager.get_imposter(19776).unwrap();
+    assert!(
+        imposter.get_stubs()[0].id.is_some(),
+        "POST without id should generate one"
+    );
+
+    let _ = manager.delete_imposter(19776).await;
+}


### PR DESCRIPTION
## Summary

Address stubs by their stable **`Stub.id`** (in addition to array index), so concurrent **revertible overlays** don't race on shifting indices. Adding/removing stub *N* renumbers every later stub, so an index-based finalizer that remembers "index 3" can delete the wrong stub — addressing by `id` removes that race and lets the zio-bdd adapter drop its fragile id↔index map.

## What changed

- **rift-core `Imposter`**: `add_stub_unique` (rejects a duplicate id), `replace_stub_by_id` (replace **in place** — preserves position, the addressable id, and the response cycler), `delete_stub_by_id`, `get_stub_by_id`. Each does the find-and-mutate **under one `stubs` lock**, so check-and-act is atomic — **no TOCTOU** under concurrent overlays.
- **`ImposterManager`**: `add_stub` now rejects a duplicate id (`StubIdConflict`); new `replace_stub_by_id` / `delete_stub_by_id` / `get_stub_by_id`, each persisting on mutation and mapping a miss to `StubNotFound`.
- **`ImposterError`**: `StubNotFound` → **404**, `StubIdConflict` → **409**, wired into the `From<ImposterError>` response mapping.
- **Admin API**:

  | Method | Path | Result |
  |--------|------|--------|
  | GET | `/imposters/:port/stubs/by-id/:id` | 200 Stub / 404 |
  | PUT | `/imposters/:port/stubs/by-id/:id` | 200 (replace in place) / 404 |
  | DELETE | `/imposters/:port/stubs/by-id/:id` | 200 / 404 |
  | POST | `/imposters/:port/stubs` | honors body `id`, **generates a uuid v4 if absent** |

  The `by-id` route is parsed before the numeric-index arm; a numeric or literal-`by-id` id routes correctly.

## Tests
`delete_stub_by_id_preserves_position`, `duplicate_stub_id_conflicts`, `replace_stub_by_id_in_place` (asserts position + addressable id + **content** changed), `concurrent_id_ops_stay_consistent` (20 concurrent adds, then concurrent deletes → exactly the odd ids survive), `concurrent_same_id_add_exactly_one_wins` (12 racing adds of the same id → exactly one succeeds), and `stub_by_id_admin_endpoints` (full HTTP lifecycle incl. 409/404 + auto-id).

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green (6 new tests).

## Notes
- Stub ids are a **global namespace within an imposter** (across correlation spaces #223): reusing an id across spaces → 409. Intentional (the by-id endpoints are space-agnostic).
- `POST` now stamps a uuid on previously id-less stubs, so persisted imposter JSON carries generated ids.
- Like the existing index methods, mutate-then-persist is not transactional (a persist failure returns 503 after the in-memory change); transactional persistence is out of scope for this issue.

## Relations
M4. Retires the M1 adapter-side id↔index workaround (zio-bdd #109).

Milestone: M4

Closes #202