### PR TITLE
docs: correct unmatched-request comment (returns 200, not 404)

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -585,7 +585,9 @@ async fn handle_request_inner(
         };
     }
 
-    // No matching rule - return default response or 404
+    // No matching rule — return the configured `defaultResponse`, else fall through to a 200
+    // with an empty body below (Mountebank parity — Rift never returns 404 for an unmatched
+    // request). A `defaultForward` upstream, if configured, was already handled above.
     if let Some(ref default) = imposter.config.default_response {
         let body_str = default
             .body


### PR DESCRIPTION
The comment in the imposter request handler (`crates/rift-core/src/imposter/handler.rs`) read `// No matching rule - return default response or 404`, but Rift never returns 404 for an unmatched request: it returns the configured `defaultResponse`, else **200 with an empty body** (Mountebank parity), and forwards via `defaultForward` (#196) when set.

Comment-only correction so the doc matches the behaviour — no code change.

Closes #234