### PR TITLE
feat: implement hot-reload via POST /admin/reload endpoint

### DIFF
--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -11,6 +11,7 @@ use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -59,10 +60,16 @@ impl ImposterManager {
             if self.imposters.read().contains_key(&p) {
                 return Err(ImposterError::PortInUse(p));
             }
+            // Bind with SO_REUSEADDR/REUSEPORT so a hot-reload (#197) can re-bind the same port
+            // immediately after the previous imposter's listener is torn down.
+            let addr = (bind_host, p)
+                .to_socket_addrs()
+                .map_err(|e| ImposterError::BindError(p, e.to_string()))?
+                .next()
+                .ok_or_else(|| ImposterError::BindError(p, "no socket address".to_string()))?;
             (
                 p,
-                TcpListener::bind((bind_host, p))
-                    .await
+                crate::proxy::network::create_reusable_listener(addr)
                     .map_err(|e| ImposterError::BindError(p, e.to_string()))?,
             )
         } else {
@@ -141,9 +148,16 @@ impl ImposterManager {
             }
         });
 
-        // Store imposter
+        // Store imposter. Re-check the port under the write lock to close the TOCTOU between the
+        // earlier read-only check and the bind: with SO_REUSEADDR/REUSEPORT two concurrent creates
+        // for the same explicit port can both bind, so the loser of the insert race must stop the
+        // listener it just started rather than leave an orphan accepting on the shared port.
         {
             let mut imposters = self.imposters.write();
+            if imposters.contains_key(&port) {
+                let _ = shutdown_tx.send(());
+                return Err(ImposterError::PortInUse(port));
+            }
             imposters.insert(port, Arc::clone(&imposter));
         }
 
@@ -237,6 +251,36 @@ impl ImposterManager {
         }
 
         configs
+    }
+
+    /// Replace all imposters with a fresh set (issue #197 hot-reload). The whole set is validated
+    /// — parseable already (the caller parsed it), plus protocol validity and no duplicate ports
+    /// here — **before** the running imposters are torn down, so an invalid config leaves them
+    /// intact rather than half-applied. Once validation passes, the old imposters are removed
+    /// (releasing their ports) and the new ones created; in-flight requests against the old
+    /// imposters complete naturally (each is held behind its own `Arc`). A residual bind failure
+    /// after teardown (e.g. a port grabbed by an external process) is returned and may leave a
+    /// partial set — the caller surfaces it as a 5xx. Reload resets all imposter state (recorded
+    /// requests, scenario state, response cyclers).
+    pub async fn reload(&self, configs: Vec<ImposterConfig>) -> Result<(), ImposterError> {
+        let mut seen = std::collections::HashSet::new();
+        for config in &configs {
+            match config.protocol.as_str() {
+                "http" | "https" => {}
+                other => return Err(ImposterError::InvalidProtocol(other.to_string())),
+            }
+            if let Some(port) = config.port {
+                if !seen.insert(port) {
+                    return Err(ImposterError::PortInUse(port));
+                }
+            }
+        }
+
+        self.delete_all().await;
+        for config in configs {
+            self.create_imposter(config).await?;
+        }
+        Ok(())
     }
 
     /// Get imposter count (for future metrics)

--- a/crates/rift-core/src/proxy/mod.rs
+++ b/crates/rift-core/src/proxy/mod.rs
@@ -22,7 +22,7 @@ mod client;
 mod forwarding;
 mod handler;
 mod headers;
-mod network;
+pub(crate) mod network;
 mod response_ext;
 mod server;
 mod tls;

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -116,12 +116,47 @@ pub fn handle_logs(query: Option<&str>) -> Response<Full<Bytes>> {
     json_response(StatusCode::OK, &logs)
 }
 
-/// POST /admin/reload - Reload configuration (Rift extension)
-pub fn handle_reload() -> Response<Full<Bytes>> {
-    json_response(
-        StatusCode::OK,
-        &serde_json::json!({"message": "Reload not implemented yet"}),
-    )
+/// POST /admin/reload - re-read the startup config source and replace all imposters (issue #197,
+/// Rift extension). No-op (200) when no `--configfile`/`--datadir` was given. The new set is
+/// validated before the running imposters are touched, so a parse or semantic error (bad
+/// protocol, duplicate port) returns 500 with the running imposters left unchanged. Reload resets
+/// all imposter state (recorded requests, scenario state, response cyclers).
+pub async fn handle_reload(
+    manager: Arc<ImposterManager>,
+    config_source: Option<Arc<crate::config_loader::ConfigSource>>,
+) -> Response<Full<Bytes>> {
+    let Some(source) = config_source else {
+        return json_response(
+            StatusCode::OK,
+            &serde_json::json!({"message": "No config source configured; nothing to reload"}),
+        );
+    };
+
+    // Parse before touching state — a bad config leaves the running imposters intact.
+    let configs = match crate::config_loader::load_configs(&source) {
+        Ok(configs) => configs,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Reload failed (imposters unchanged): {e}"),
+            )
+        }
+    };
+
+    let count = configs.len();
+    match manager.reload(configs).await {
+        Ok(()) => json_response(
+            StatusCode::OK,
+            &serde_json::json!({ "message": format!("Reloaded {count} imposter(s)") }),
+        ),
+        // A reload failure is a server-side config problem, not a bad client request — report 5xx.
+        // Protocol/duplicate-port errors are caught before teardown (running imposters intact); a
+        // residual error here is a post-teardown bind failure.
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Reload failed: {e}"),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -146,9 +181,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
-    #[test]
-    fn test_handle_reload() {
-        let resp = handle_reload();
+    #[tokio::test]
+    async fn test_handle_reload_no_source_is_noop() {
+        let manager = Arc::new(ImposterManager::new());
+        let resp = handle_reload(manager, None).await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -4,6 +4,7 @@
 
 use crate::admin_api::handlers::{imposters, scenarios, stubs, system};
 use crate::admin_api::types::{error_response, get_base_url, not_found};
+use crate::config_loader::ConfigSource;
 use crate::imposter::ImposterManager;
 use bytes::Bytes;
 use http_body_util::Full;
@@ -68,6 +69,7 @@ impl ImposterRoute {
 pub async fn route_request(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
+    config_source: Option<Arc<ConfigSource>>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
@@ -76,11 +78,21 @@ pub async fn route_request(
 
     debug!("Admin API: {} {}", method, path);
 
-    let response = route_by_path(&method, &path, query.as_deref(), req, &base_url, manager).await;
+    let response = route_by_path(
+        &method,
+        &path,
+        query.as_deref(),
+        req,
+        &base_url,
+        manager,
+        config_source,
+    )
+    .await;
     Ok(response)
 }
 
 /// Route based on path
+#[allow(clippy::too_many_arguments)]
 async fn route_by_path(
     method: &Method,
     path: &str,
@@ -88,6 +100,7 @@ async fn route_by_path(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    config_source: Option<Arc<ConfigSource>>,
 ) -> Response<Full<Bytes>> {
     // Fast path for common routes
     match (method, path) {
@@ -95,7 +108,9 @@ async fn route_by_path(
         (&Method::GET, "/health") => return system::handle_health(),
         (&Method::GET, "/config") => return system::handle_config(),
         (&Method::GET, "/logs") => return system::handle_logs(query),
-        (&Method::POST, "/admin/reload") => return system::handle_reload(),
+        (&Method::POST, "/admin/reload") => {
+            return system::handle_reload(manager, config_source).await
+        }
         (&Method::GET, "/metrics") => return system::handle_metrics(manager).await,
         _ => {}
     }

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -1,6 +1,7 @@
 //! Admin API server.
 
 use crate::admin_api::router::route_request;
+use crate::config_loader::ConfigSource;
 use crate::imposter::ImposterManager;
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -18,6 +19,7 @@ pub struct AdminApiServer {
     addr: SocketAddr,
     manager: Arc<ImposterManager>,
     api_key: Option<Arc<String>>,
+    config_source: Option<Arc<ConfigSource>>,
 }
 
 impl AdminApiServer {
@@ -27,7 +29,16 @@ impl AdminApiServer {
             addr,
             manager,
             api_key: api_key.map(Arc::new),
+            config_source: None,
         }
+    }
+
+    /// Set the config source (`--configfile`/`--datadir`) so `POST /admin/reload` can re-read it
+    /// (issue #197). Without it, reload is a no-op.
+    #[must_use]
+    pub fn with_config_source(mut self, source: ConfigSource) -> Self {
+        self.config_source = Some(Arc::new(source));
+        self
     }
 
     /// Run the admin API server
@@ -47,11 +58,13 @@ impl AdminApiServer {
             let io = TokioIo::new(stream);
             let manager = Arc::clone(&self.manager);
             let api_key = self.api_key.clone();
+            let config_source = self.config_source.clone();
 
             tokio::spawn(async move {
                 let service = service_fn(move |req| {
                     let manager = Arc::clone(&manager);
                     let api_key = api_key.clone();
+                    let config_source = config_source.clone();
                     async move {
                         if let Some(ref key) = api_key {
                             let auth = req
@@ -63,7 +76,7 @@ impl AdminApiServer {
                                 return Ok::<_, hyper::Error>(unauthorized_response());
                             }
                         }
-                        route_request(req, manager).await
+                        route_request(req, manager, config_source).await
                     }
                 });
 

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -1,0 +1,294 @@
+//! Loading imposter configs from the CLI-provided source (`--configfile` / `--datadir`), shared
+//! by startup and the `POST /admin/reload` hot-reload endpoint (issue #197). Parsing is pure (no
+//! running state is touched), so a parse error is returned rather than applied.
+
+use crate::imposter::ImposterConfig;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+/// Where the running imposters were loaded from, retained so reload can re-read the same source.
+#[derive(Debug, Clone)]
+pub enum ConfigSource {
+    /// A single `--configfile` (Mountebank JSON/YAML, with optional EJS preprocessing).
+    File { path: PathBuf, no_parse: bool },
+    /// A `--datadir` of one-imposter-per-`.json` files.
+    Dir(PathBuf),
+}
+
+/// Parse the source into imposter configs without creating any imposters. A parse error is
+/// returned so the caller (startup or hot-reload) decides whether to apply the result.
+pub fn load_configs(source: &ConfigSource) -> anyhow::Result<Vec<ImposterConfig>> {
+    match source {
+        ConfigSource::File { path, no_parse } => load_file(path, *no_parse),
+        ConfigSource::Dir(dir) => load_dir(dir),
+    }
+}
+
+fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>> {
+    let raw = std::fs::read_to_string(path)?;
+    let content = if no_parse {
+        raw
+    } else {
+        preprocess_ejs(&raw, path)?
+    };
+
+    let trimmed = content.trim_start();
+    let configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
+        // Single imposter, or a `{ "imposters": [...] }` wrapper (Mountebank format).
+        let value: serde_json::Value = serde_json::from_str(&content)?;
+        match value.get("imposters") {
+            Some(imposters) => serde_json::from_value(imposters.clone())?,
+            None => vec![serde_json::from_value(value)?],
+        }
+    } else if trimmed.starts_with('[') {
+        serde_json::from_str(&content)?
+    } else {
+        serde_yaml::from_str(&content)?
+    };
+    Ok(configs)
+}
+
+fn load_dir(dir: &Path) -> anyhow::Result<Vec<ImposterConfig>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut configs = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.extension().map(|e| e == "json").unwrap_or(false) {
+            let content = std::fs::read_to_string(&path)?;
+            configs.push(serde_json::from_str::<ImposterConfig>(&content)?);
+        }
+    }
+    Ok(configs)
+}
+
+/// Pre-process EJS tokens in a config file before JSON/YAML parsing.
+///
+/// Handles the patterns emitted by Mountebank and compatible tooling:
+/// - `<% include 'path' %>` — inline the referenced file (relative to the config file)
+/// - `<%= process.env.VAR %>` — substitute with the env var value (empty string if unset)
+/// - `<%= process.env.VAR || 'default' %>` — substitute with env var or the literal default
+///
+/// Any other `<%= expr %>` token is replaced with an empty string and logged as a warning.
+/// `<% expr %>` (without `=`) statements (e.g., `<% for (...) %>`) are removed and logged.
+fn preprocess_ejs(content: &str, config_path: &Path) -> anyhow::Result<String> {
+    if !content.contains("<%") {
+        return Ok(content.to_string());
+    }
+
+    let config_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Process include directives first:
+    // `<% include 'path' %>`, `<% include "path" %>`, or `<% include path %>`
+    let include_re = regex::Regex::new(r#"<%\s*include\s+['"]?([^'">\s]+)['"]?\s*%>"#).unwrap();
+    let mut result = String::new();
+    let mut last = 0;
+    for cap in include_re.captures_iter(content) {
+        let full = cap.get(0).unwrap();
+        let include_path = cap.get(1).unwrap().as_str();
+        result.push_str(&content[last..full.start()]);
+        let abs_path = config_dir.join(include_path);
+        match std::fs::read_to_string(&abs_path) {
+            Ok(included) => result.push_str(&included),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "EJS include file '{}' not found ({}): {}",
+                    include_path,
+                    abs_path.display(),
+                    e
+                ));
+            }
+        }
+        last = full.end();
+    }
+    result.push_str(&content[last..]);
+    let content = result;
+
+    // Process expression tags: `<%= expr %>`
+    let expr_re = regex::Regex::new(r"<%=\s*(.*?)\s*%>").unwrap();
+    let env_var_re = regex::Regex::new(
+        r#"^process\.env\.([A-Za-z_][A-Za-z0-9_]*)(?:\s*\|\|\s*['"]([^'"]*)['"]\s*)?$"#,
+    )
+    .unwrap();
+
+    let mut result = String::new();
+    let mut last = 0;
+    for cap in expr_re.captures_iter(&content) {
+        let full = cap.get(0).unwrap();
+        let expr = cap.get(1).unwrap().as_str().trim();
+        result.push_str(&content[last..full.start()]);
+
+        if let Some(env_cap) = env_var_re.captures(expr) {
+            let var_name = env_cap.get(1).unwrap().as_str();
+            let default_val = env_cap.get(2).map(|m| m.as_str()).unwrap_or("");
+            let value = std::env::var(var_name).unwrap_or_else(|_| default_val.to_string());
+            result.push_str(&value);
+        } else {
+            warn!(
+                "EJS expression '{}' is not supported; substituting empty string",
+                expr
+            );
+        }
+        last = full.end();
+    }
+    result.push_str(&content[last..]);
+    let content = result;
+
+    // Strip remaining `<% ... %>` control blocks (non-expression tags); (?s) enables dotall
+    let stmt_re = regex::Regex::new(r"(?s)<%[^=].*?%>").unwrap();
+    if stmt_re.is_match(&content) {
+        warn!("EJS statement blocks (<% ... %>) are not supported and will be removed");
+    }
+    Ok(stmt_re.replace_all(&content, "").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        p
+    }
+
+    #[test]
+    fn parses_single_wrapper_and_array_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let single = write(
+            dir.path(),
+            "single.json",
+            r#"{"port":8000,"protocol":"http"}"#,
+        );
+        let wrapper = write(
+            dir.path(),
+            "wrap.json",
+            r#"{"imposters":[{"port":8001,"protocol":"http"},{"port":8002,"protocol":"http"}]}"#,
+        );
+        let array = write(
+            dir.path(),
+            "arr.json",
+            r#"[{"port":8003,"protocol":"http"}]"#,
+        );
+
+        let one = load_configs(&ConfigSource::File {
+            path: single,
+            no_parse: false,
+        })
+        .unwrap();
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].port, Some(8000));
+        let two = load_configs(&ConfigSource::File {
+            path: wrapper,
+            no_parse: false,
+        })
+        .unwrap();
+        assert_eq!(two.len(), 2);
+        let arr = load_configs(&ConfigSource::File {
+            path: array,
+            no_parse: false,
+        })
+        .unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn dir_loads_all_json_and_errors_propagate() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.json", r#"{"port":8100,"protocol":"http"}"#);
+        write(dir.path(), "b.json", r#"{"port":8101,"protocol":"http"}"#);
+        write(dir.path(), "notes.txt", "ignored"); // non-json skipped
+        let configs = load_configs(&ConfigSource::Dir(dir.path().to_path_buf())).unwrap();
+        assert_eq!(configs.len(), 2);
+
+        write(dir.path(), "bad.json", "not json");
+        assert!(
+            load_configs(&ConfigSource::Dir(dir.path().to_path_buf())).is_err(),
+            "a malformed file makes the whole reload fail (no partial apply)"
+        );
+    }
+
+    #[test]
+    fn parse_error_is_returned_not_panicked() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad = write(dir.path(), "bad.json", "{ not valid json");
+        assert!(load_configs(&ConfigSource::File {
+            path: bad,
+            no_parse: false
+        })
+        .is_err());
+    }
+
+    // EJS configfile pre-processing (relocated from main.rs with preprocess_ejs in issue #197)
+
+    #[test]
+    fn test_ejs_no_tokens_passthrough() {
+        let content = r#"{"imposters": []}"#;
+        let path = PathBuf::from("config.json");
+        assert_eq!(preprocess_ejs(content, &path).unwrap(), content);
+    }
+
+    #[test]
+    fn test_ejs_env_var_substitution() {
+        std::env::set_var("RIFT_TEST_HOST", "myhost");
+        let content = r#"{"body": "<%= process.env.RIFT_TEST_HOST %>"}"#;
+        let path = PathBuf::from("config.json");
+        let result = preprocess_ejs(content, &path).unwrap();
+        assert_eq!(result, r#"{"body": "myhost"}"#);
+        std::env::remove_var("RIFT_TEST_HOST");
+    }
+
+    #[test]
+    fn test_ejs_env_var_with_default() {
+        std::env::remove_var("RIFT_TEST_UNSET_VAR");
+        let content = r#"{"port": "<%= process.env.RIFT_TEST_UNSET_VAR || '4545' %>"}"#;
+        let path = PathBuf::from("config.json");
+        let result = preprocess_ejs(content, &path).unwrap();
+        assert_eq!(result, r#"{"port": "4545"}"#);
+    }
+
+    #[test]
+    fn test_ejs_env_var_present_overrides_default() {
+        std::env::set_var("RIFT_TEST_PORT", "8080");
+        let content = r#"{"port": "<%= process.env.RIFT_TEST_PORT || '4545' %>"}"#;
+        let path = PathBuf::from("config.json");
+        let result = preprocess_ejs(content, &path).unwrap();
+        assert_eq!(result, r#"{"port": "8080"}"#);
+        std::env::remove_var("RIFT_TEST_PORT");
+    }
+
+    #[test]
+    fn test_ejs_include_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("partial.json"), r#"{"key": "value"}"#).unwrap();
+        let content = r#"<% include 'partial.json' %>"#.to_string();
+        let config_path = dir.path().join("config.ejs");
+        let result = preprocess_ejs(&content, &config_path).unwrap();
+        assert_eq!(result, r#"{"key": "value"}"#);
+    }
+
+    #[test]
+    fn test_ejs_include_unquoted_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("partial.json"), r#"[1,2,3]"#).unwrap();
+        let content = r#"<% include partial.json %>"#;
+        let config_path = dir.path().join("config.ejs");
+        let result = preprocess_ejs(content, &config_path).unwrap();
+        assert_eq!(result, "[1,2,3]");
+    }
+
+    #[test]
+    fn test_ejs_missing_include_is_fatal_error() {
+        let content = r#"<% include 'nonexistent.json' %>"#;
+        let path = PathBuf::from("config.json");
+        let result = preprocess_ejs(content, &path);
+        assert!(result.is_err(), "missing include file should return Err");
+        assert!(
+            result.unwrap_err().to_string().contains("nonexistent.json"),
+            "error message should name the missing file"
+        );
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -12,3 +12,6 @@ pub use rift_core::{
 
 // ===== Admin HTTP server (control plane — server crate only) =====
 pub mod admin_api;
+
+// Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
+pub mod config_loader;

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -25,6 +25,9 @@ use rift_core::{extensions, imposter, scripting};
 // ===== Admin HTTP server (control plane — server crate only) =====
 mod admin_api;
 
+// Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
+mod config_loader;
+
 // Re-export extension modules for convenience
 use extensions::metrics;
 
@@ -319,7 +322,16 @@ fn run_mountebank_mode(cli: Cli) -> Result<(), anyhow::Error> {
             );
         }
 
-        let server = AdminApiServer::new(addr, manager, cli.api_key);
+        // Retain the config source so POST /admin/reload can re-read it (issue #197).
+        let mut server = AdminApiServer::new(addr, manager, cli.api_key);
+        if let Some(ref configfile) = cli.configfile {
+            server = server.with_config_source(config_loader::ConfigSource::File {
+                path: configfile.clone(),
+                no_parse: cli.no_parse,
+            });
+        } else if let Some(ref datadir) = cli.datadir {
+            server = server.with_config_source(config_loader::ConfigSource::Dir(datadir.clone()));
+        }
         server.run().await?;
 
         Ok(())
@@ -334,32 +346,12 @@ async fn load_imposters_from_file(
 ) -> Result<(), anyhow::Error> {
     info!("Loading imposters from configfile: {:?}", path);
 
-    let raw = std::fs::read_to_string(path)?;
-    let content = if no_parse {
-        raw
-    } else {
-        preprocess_ejs(&raw, path)?
-    };
+    let configs = config_loader::load_configs(&config_loader::ConfigSource::File {
+        path: path.clone(),
+        no_parse,
+    })?;
 
-    // Try to parse as JSON (Mountebank format)
-    let imposters: Vec<ImposterConfig> = if content.trim().starts_with('{') {
-        // Single imposter or wrapper object
-        let value: serde_json::Value = serde_json::from_str(&content)?;
-        if let Some(imposters) = value.get("imposters") {
-            serde_json::from_value(imposters.clone())?
-        } else {
-            // Single imposter
-            vec![serde_json::from_value(value)?]
-        }
-    } else if content.trim().starts_with('[') {
-        // Array of imposters
-        serde_json::from_str(&content)?
-    } else {
-        // Try YAML
-        serde_yaml::from_str(&content)?
-    };
-
-    for config in imposters {
+    for config in configs {
         info!(
             "Creating imposter on port {:?} from configfile",
             config.port
@@ -371,88 +363,6 @@ async fn load_imposters_from_file(
     }
 
     Ok(())
-}
-
-/// Pre-process EJS tokens in a config file before JSON/YAML parsing.
-///
-/// Handles the patterns emitted by Mountebank and compatible tooling:
-/// - `<% include 'path' %>` — inline the referenced file (relative to the config file)
-/// - `<%= process.env.VAR %>` — substitute with the env var value (empty string if unset)
-/// - `<%= process.env.VAR || 'default' %>` — substitute with env var or the literal default
-///
-/// Any other `<%= expr %>` token is replaced with an empty string and logged as a warning.
-/// `<% expr %>` (without `=`) statements (e.g., `<% for (...) %>`) are removed and logged.
-fn preprocess_ejs(content: &str, config_path: &std::path::Path) -> Result<String, anyhow::Error> {
-    if !content.contains("<%") {
-        return Ok(content.to_string());
-    }
-
-    let config_dir = config_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
-
-    // Process include directives first:
-    // `<% include 'path' %>`, `<% include "path" %>`, or `<% include path %>`
-    let include_re = regex::Regex::new(r#"<%\s*include\s+['"]?([^'">\s]+)['"]?\s*%>"#).unwrap();
-    let mut result = String::new();
-    let mut last = 0;
-    for cap in include_re.captures_iter(content) {
-        let full = cap.get(0).unwrap();
-        let include_path = cap.get(1).unwrap().as_str();
-        result.push_str(&content[last..full.start()]);
-        let abs_path = config_dir.join(include_path);
-        match std::fs::read_to_string(&abs_path) {
-            Ok(included) => result.push_str(&included),
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "EJS include file '{}' not found ({}): {}",
-                    include_path,
-                    abs_path.display(),
-                    e
-                ));
-            }
-        }
-        last = full.end();
-    }
-    result.push_str(&content[last..]);
-    let content = result;
-
-    // Process expression tags: `<%= expr %>`
-    let expr_re = regex::Regex::new(r"<%=\s*(.*?)\s*%>").unwrap();
-    let env_var_re = regex::Regex::new(
-        r#"^process\.env\.([A-Za-z_][A-Za-z0-9_]*)(?:\s*\|\|\s*['"]([^'"]*)['"]\s*)?$"#,
-    )
-    .unwrap();
-
-    let mut result = String::new();
-    let mut last = 0;
-    for cap in expr_re.captures_iter(&content) {
-        let full = cap.get(0).unwrap();
-        let expr = cap.get(1).unwrap().as_str().trim();
-        result.push_str(&content[last..full.start()]);
-
-        if let Some(env_cap) = env_var_re.captures(expr) {
-            let var_name = env_cap.get(1).unwrap().as_str();
-            let default_val = env_cap.get(2).map(|m| m.as_str()).unwrap_or("");
-            let value = std::env::var(var_name).unwrap_or_else(|_| default_val.to_string());
-            result.push_str(&value);
-        } else {
-            warn!(
-                "EJS expression '{}' is not supported; substituting empty string",
-                expr
-            );
-        }
-        last = full.end();
-    }
-    result.push_str(&content[last..]);
-    let content = result;
-
-    // Strip remaining `<% ... %>` control blocks (non-expression tags); (?s) enables dotall
-    let stmt_re = regex::Regex::new(r"(?s)<%[^=].*?%>").unwrap();
-    if stmt_re.is_match(&content) {
-        warn!("EJS statement blocks (<% ... %>) are not supported and will be removed");
-    }
-    Ok(stmt_re.replace_all(&content, "").to_string())
 }
 
 /// Load imposters from a data directory
@@ -700,82 +610,5 @@ mod tests {
         let cli = Cli::try_parse_from(["rift"]).expect("default parse");
         assert!(!cli.nologfile);
         assert!(cli.log.is_none());
-    }
-
-    // =========================================================================
-    // Gap 8.1: EJS configfile pre-processing
-    // =========================================================================
-
-    #[test]
-    fn test_ejs_no_tokens_passthrough() {
-        let content = r#"{"imposters": []}"#;
-        let path = std::path::PathBuf::from("config.json");
-        assert_eq!(preprocess_ejs(content, &path).unwrap(), content);
-    }
-
-    #[test]
-    fn test_ejs_env_var_substitution() {
-        std::env::set_var("RIFT_TEST_HOST", "myhost");
-        let content = r#"{"body": "<%= process.env.RIFT_TEST_HOST %>"}"#;
-        let path = std::path::PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
-        assert_eq!(result, r#"{"body": "myhost"}"#);
-        std::env::remove_var("RIFT_TEST_HOST");
-    }
-
-    #[test]
-    fn test_ejs_env_var_with_default() {
-        std::env::remove_var("RIFT_TEST_UNSET_VAR");
-        let content = r#"{"port": "<%= process.env.RIFT_TEST_UNSET_VAR || '4545' %>"}"#;
-        let path = std::path::PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
-        assert_eq!(result, r#"{"port": "4545"}"#);
-    }
-
-    #[test]
-    fn test_ejs_env_var_present_overrides_default() {
-        std::env::set_var("RIFT_TEST_PORT", "8080");
-        let content = r#"{"port": "<%= process.env.RIFT_TEST_PORT || '4545' %>"}"#;
-        let path = std::path::PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
-        assert_eq!(result, r#"{"port": "8080"}"#);
-        std::env::remove_var("RIFT_TEST_PORT");
-    }
-
-    #[test]
-    fn test_ejs_include_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let partial_path = dir.path().join("partial.json");
-        std::fs::write(&partial_path, r#"{"key": "value"}"#).unwrap();
-
-        let content = r#"<% include 'partial.json' %>"#.to_string();
-        let config_path = dir.path().join("config.ejs");
-        let result = preprocess_ejs(&content, &config_path).unwrap();
-        assert_eq!(result, r#"{"key": "value"}"#);
-    }
-
-    #[test]
-    fn test_ejs_include_unquoted_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let partial_path = dir.path().join("partial.json");
-        std::fs::write(&partial_path, r#"[1,2,3]"#).unwrap();
-
-        let content = r#"<% include partial.json %>"#;
-        let config_path = dir.path().join("config.ejs");
-        let result = preprocess_ejs(content, &config_path).unwrap();
-        assert_eq!(result, "[1,2,3]");
-    }
-
-    #[test]
-    fn test_ejs_missing_include_is_fatal_error() {
-        let content = r#"<% include 'nonexistent.json' %>"#;
-        let path = std::path::PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path);
-        assert!(result.is_err(), "missing include file should return Err");
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("nonexistent.json"),
-            "error message should name the missing file"
-        );
     }
 }

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -492,3 +492,167 @@ async fn stub_by_id_admin_endpoints() {
 
     let _ = manager.delete_imposter(19776).await;
 }
+
+// Issue #197: POST /admin/reload re-reads the config source and replaces imposters.
+mod reload {
+    use super::*;
+    use rift_http_proxy::config_loader::{load_configs, ConfigSource};
+
+    fn cfg(port: u16, body: &str) -> String {
+        format!(
+            r#"{{"imposters":[{{"port":{port},"protocol":"http","stubs":[
+                {{"predicates":[{{"equals":{{"path":"/p"}}}}],
+                 "responses":[{{"is":{{"statusCode":200,"body":"{body}"}}}}]}}]}}]}}"#
+        )
+    }
+
+    fn stub_body(manager: &ImposterManager, port: u16) -> String {
+        let stubs = manager.get_imposter(port).unwrap().get_stubs();
+        serde_json::to_value(&stubs[0]).unwrap()["responses"][0]["is"]["body"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    async fn start(port: u16, src: Option<ConfigSource>) -> std::sync::Arc<ImposterManager> {
+        let manager = std::sync::Arc::new(ImposterManager::new());
+        let mut server = rift_http_proxy::admin_api::AdminApiServer::new(
+            format!("127.0.0.1:{port}").parse().unwrap(),
+            manager.clone(),
+            None,
+        );
+        if let Some(src) = src {
+            server = server.with_config_source(src);
+        }
+        tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        manager
+    }
+
+    #[tokio::test]
+    async fn reload_replaces_imposters_from_configfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, cfg(19790, "v1")).unwrap();
+        let source = ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        };
+
+        let manager = start(12597, Some(source.clone())).await;
+        manager
+            .reload(load_configs(&source).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(stub_body(&manager, 19790), "v1");
+
+        // change the file on disk, then reload via the admin endpoint
+        std::fs::write(&path, cfg(19790, "v2")).unwrap();
+        let resp = reqwest::Client::new()
+            .post("http://127.0.0.1:12597/admin/reload")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            stub_body(&manager, 19790),
+            "v2",
+            "reload picked up the file change"
+        );
+        // the listener was actually re-bound on the same port and now serves v2 over the wire
+        let served = reqwest::get("http://127.0.0.1:19790/p")
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(served, "v2", "reloaded imposter serves the new content");
+
+        let _ = manager.delete_imposter(19790).await;
+    }
+
+    #[tokio::test]
+    async fn reload_semantic_error_keeps_existing_imposters() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, cfg(19792, "good")).unwrap();
+        let source = ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        };
+
+        let manager = start(12600, Some(source.clone())).await;
+        manager
+            .reload(load_configs(&source).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(stub_body(&manager, 19792), "good");
+
+        // parses fine, but the protocol is invalid → must be rejected BEFORE delete_all,
+        // leaving the running imposter intact (the destructive partial-teardown guard)
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19792,"protocol":"tcp","stubs":[]}]}"#,
+        )
+        .unwrap();
+        let resp = reqwest::Client::new()
+            .post("http://127.0.0.1:12600/admin/reload")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 500);
+        assert_eq!(
+            stub_body(&manager, 19792),
+            "good",
+            "a semantically-invalid config must not tear down the running imposters"
+        );
+
+        let _ = manager.delete_imposter(19792).await;
+    }
+
+    #[tokio::test]
+    async fn reload_parse_error_keeps_existing_imposters() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, cfg(19791, "good")).unwrap();
+        let source = ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        };
+
+        let manager = start(12598, Some(source.clone())).await;
+        manager
+            .reload(load_configs(&source).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(stub_body(&manager, 19791), "good");
+
+        // corrupt the file → reload must 500 and leave the running imposter intact
+        std::fs::write(&path, "{ not valid json").unwrap();
+        let resp = reqwest::Client::new()
+            .post("http://127.0.0.1:12598/admin/reload")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 500);
+        assert_eq!(
+            stub_body(&manager, 19791),
+            "good",
+            "existing imposter unchanged on parse error"
+        );
+
+        let _ = manager.delete_imposter(19791).await;
+    }
+
+    #[tokio::test]
+    async fn reload_with_no_source_is_noop_200() {
+        let manager = start(12599, None).await;
+        let resp = reqwest::Client::new()
+            .post("http://127.0.0.1:12599/admin/reload")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let _ = manager;
+    }
+}


### PR DESCRIPTION
## Summary

`POST /admin/reload` was a no-op stub (`{"message":"Reload not implemented yet"}`). It now re-reads the startup config source (`--configfile`/`--datadir`) and replaces all imposters, so teams pick up stub file changes without restarting the container (useful for local dev and CI where stubs change between runs).

## What changed

- **New `config_loader` module** — `ConfigSource { File{path,no_parse}, Dir(path) }` + `load_configs()`. `preprocess_ejs` moved here from main.rs (tests too), so startup and reload share one parser and EJS/wrapper/array files reload exactly as they load.
- **`ImposterManager::reload`** — **validates the whole set (protocol + no duplicate ports) before tearing anything down**, so a parseable-but-invalid config leaves the running imposters intact rather than a destructive partial reload; then `delete_all` + recreate. Resets imposter state (recorded requests, scenario state, response cyclers) — documented.
- **`handle_reload`** — no source → `200` informational; parse/semantic error → `500` with imposters unchanged; success → summary. Config source threaded via `AdminApiServer::with_config_source` → `route_request`.
- **Bind hardening** — imposter listeners bind via `create_reusable_listener` (`SO_REUSEADDR`/`SO_REUSEPORT`) so reload re-binds the same port immediately after the old listener is torn down. The port-conflict guard is now an **atomic re-check under the write lock at insert**, so a concurrent same-port create can't leave an orphaned listener.

## Behaviour
- no `--configfile`/`--datadir` → `200` no-op
- `--configfile` changed → re-reads and replaces imposters (same port, new stubs)
- parse error or invalid config (bad protocol / duplicate port) → `500`, running imposters unchanged
- in-flight requests complete against the old imposter state (each held behind its own `Arc`)

## Tests
`config_loader` unit suite (10: single/wrapper/array/dir/EJS/error). `mod reload` integration: replace-from-file (asserts the served body changes v1→v2 **over HTTP**, proving the listener re-bound), parse-error-keeps-existing, **semantic-error-keeps-existing** (`protocol:"tcp"` → 500 + intact), no-source-noop.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green.

## Relations
Post-M4 backlog (developer-experience). Distinct from the per-flow scenario reset (#190) and per-space teardown (#223).

Closes #197