### PR TITLE
feat: multi-value header support (response IsResponse.headers + recorded RecordedRequest.headers)

### DIFF
--- a/crates/rift-core/src/imposter/core.rs
+++ b/crates/rift-core/src/imposter/core.rs
@@ -328,6 +328,21 @@ impl Imposter {
     /// `"header:<Name>"` uses that (case-insensitive) header; `"imposter_port"` (the default,
     /// and the fallback when the header is absent) uses the imposter port.
     pub fn resolve_flow_id(&self, headers: &HashMap<String, String>) -> String {
+        // Live path uses the single-value header view (`headers_clone`); kept separate from the
+        // multi-value `flow_id_for` (used over recorded requests) to avoid a per-request alloc.
+        let port = self.config.port.unwrap_or(0);
+        match self.flow_id_source().strip_prefix("header:") {
+            Some(name) => headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| port.to_string()),
+            None => port.to_string(),
+        }
+    }
+
+    /// Resolve the correlation `flow_id` for an already-recorded request (multi-value headers).
+    pub fn resolve_flow_id_recorded(&self, headers: &HashMap<String, Vec<String>>) -> String {
         Self::flow_id_for(
             &self.flow_id_source(),
             headers,
@@ -336,12 +351,13 @@ impl Imposter {
     }
 
     /// Pure flow_id resolution (no `&self`), so it can be reused over recorded requests.
-    fn flow_id_for(source: &str, headers: &HashMap<String, String>, port: u16) -> String {
+    /// A flow id derives from a single header value; the first is taken if multi-valued (#238).
+    fn flow_id_for(source: &str, headers: &HashMap<String, Vec<String>>, port: u16) -> String {
         match source.strip_prefix("header:") {
             Some(name) => headers
                 .iter()
                 .find(|(k, _)| k.eq_ignore_ascii_case(name))
-                .map(|(_, v)| v.clone())
+                .and_then(|(_, v)| v.first().cloned())
                 .unwrap_or_else(|| port.to_string()),
             None => port.to_string(),
         }
@@ -565,7 +581,7 @@ impl Imposter {
         stub_state: &StubState,
     ) -> Option<(
         u16,
-        HashMap<String, String>,
+        HashMap<String, Vec<String>>,
         String,
         Option<serde_json::Value>,
         Option<RiftResponseExtension>,
@@ -1499,7 +1515,7 @@ mod tests {
 
         let req = |space: &str| {
             let mut headers = std::collections::HashMap::new();
-            headers.insert("X-Mock-Space".to_string(), space.to_string());
+            headers.insert("X-Mock-Space".to_string(), vec![space.to_string()]);
             RecordedRequest {
                 request_from: "127.0.0.1".to_string(),
                 method: "GET".to_string(),
@@ -1517,7 +1533,13 @@ mod tests {
             imposter.increment_request_count();
         }
 
-        imposter.retain_recorded_requests(|r| r.headers.get("X-Mock-Space").unwrap() != "A");
+        imposter.retain_recorded_requests(|r| {
+            r.headers
+                .get("X-Mock-Space")
+                .and_then(|v| v.first())
+                .map(String::as_str)
+                != Some("A")
+        });
         assert_eq!(imposter.get_recorded_requests().len(), 1, "only B kept");
         assert_eq!(
             imposter.get_request_count(),

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -99,6 +99,20 @@ async fn handle_request_inner(
             )
         })
         .collect();
+    // Capture ALL values per header for the recorded request (issue #238) — hyper's HeaderMap
+    // yields one entry per value, so a header sent twice is preserved here (headers_clone above
+    // collapses to one value and stays the single-value view used for matching/context).
+    let headers_multi: HashMap<String, Vec<String>> = if imposter.config.record_requests {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for (k, v) in req.headers().iter() {
+            map.entry(header_to_title_case(k.as_str()))
+                .or_default()
+                .push(v.to_str().unwrap_or("").to_string());
+        }
+        map
+    } else {
+        HashMap::new()
+    };
     let path = uri.path().to_string();
     let query_str = uri.query().unwrap_or("").to_string();
 
@@ -155,7 +169,7 @@ async fn handle_request_inner(
             method: method.clone(),
             path: path.clone(),
             query: parse_query_string(&query_str),
-            headers: headers_clone.clone(),
+            headers: headers_multi,
             body: body_string.clone(),
             timestamp: chrono::Utc::now().to_rfc3339(),
         };
@@ -462,54 +476,80 @@ async fn handle_request_inner(
                         }
                     }
 
-                    // Apply copy behaviors
-                    if !parsed_behaviors.copy.is_empty() {
-                        body = apply_copy_behaviors(
-                            &body,
-                            &mut headers,
-                            &parsed_behaviors.copy,
-                            &request_context,
-                        );
-                    }
+                    // Behaviors (copy/lookup/decorate) operate on single-value headers (Mountebank
+                    // semantics). Collapse the multi-value map to a single-value view for them and
+                    // fold the result back, so a plain multi-value `is` response (no behaviors)
+                    // keeps its multiple values while a response that also uses behaviors degrades
+                    // to single-value (issue #238).
+                    let has_behaviors = !parsed_behaviors.copy.is_empty()
+                        || !parsed_behaviors.lookup.is_empty()
+                        || parsed_behaviors.decorate.is_some();
+                    if has_behaviors {
+                        if headers.values().any(|v| v.len() > 1) {
+                            warn!(
+                                "response uses behaviors (copy/lookup/decorate); multi-value \
+                                 headers are collapsed to single-value (comma-joined), so e.g. \
+                                 multiple Set-Cookie become one line (issue #238 boundary). \
+                                 Affected: {:?}",
+                                headers
+                                    .iter()
+                                    .filter(|(_, v)| v.len() > 1)
+                                    .map(|(k, _)| k)
+                                    .collect::<Vec<_>>()
+                            );
+                        }
+                        let mut single: HashMap<String, String> = headers
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.join(", ")))
+                            .collect();
 
-                    // Apply lookup behaviors (CSV-backed token replacement)
-                    if !parsed_behaviors.lookup.is_empty() {
-                        body = apply_lookup_behaviors(
-                            &body,
-                            &mut headers,
-                            &parsed_behaviors.lookup,
-                            &request_context,
-                            csv_cache(),
-                        );
-                    }
-
-                    // Apply decorate behavior
-                    if let Some(ref decorate_script) = parsed_behaviors.decorate {
-                        // Handle JavaScript-style decorate (Mountebank format)
-                        // Convert to Rhai or execute as JS
-                        match apply_js_or_rhai_decorate(
-                            decorate_script,
-                            &request_context,
-                            &body,
-                            status,
-                            &mut headers,
-                        ) {
-                            Ok((new_body, new_status)) => {
-                                body = new_body;
-                                status = new_status;
-                            }
-                            Err(e) => {
-                                warn!("Decorate script error: {}", e);
+                        if !parsed_behaviors.copy.is_empty() {
+                            body = apply_copy_behaviors(
+                                &body,
+                                &mut single,
+                                &parsed_behaviors.copy,
+                                &request_context,
+                            );
+                        }
+                        if !parsed_behaviors.lookup.is_empty() {
+                            body = apply_lookup_behaviors(
+                                &body,
+                                &mut single,
+                                &parsed_behaviors.lookup,
+                                &request_context,
+                                csv_cache(),
+                            );
+                        }
+                        if let Some(ref decorate_script) = parsed_behaviors.decorate {
+                            match apply_js_or_rhai_decorate(
+                                decorate_script,
+                                &request_context,
+                                &body,
+                                status,
+                                &mut single,
+                            ) {
+                                Ok((new_body, new_status)) => {
+                                    body = new_body;
+                                    status = new_status;
+                                }
+                                Err(e) => {
+                                    warn!("Decorate script error: {}", e);
+                                }
                             }
                         }
+
+                        headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
                     }
                 }
             }
 
             let mut response = Response::builder().status(status);
 
-            for (k, v) in &headers {
-                response = response.header(k, v);
+            // One header line per value (issue #238 multi-value headers, e.g. multiple Set-Cookie).
+            for (k, values) in &headers {
+                for v in values {
+                    response = response.header(k, v);
+                }
             }
 
             response = response.header("x-rift-imposter", "true");
@@ -619,8 +659,10 @@ async fn handle_request_inner(
         };
 
         let mut response = Response::builder().status(default.status_code);
-        for (k, v) in &default.headers {
-            response = response.header(k, v);
+        for (k, values) in &default.headers {
+            for v in values {
+                response = response.header(k, v);
+            }
         }
         response = response.header("x-rift-imposter", "true");
         response = response.header("x-rift-default-response", "true");

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -56,7 +56,7 @@ pub fn create_response_preview(response: &StubResponse) -> DebugResponsePreview 
                 Some(
                     is.headers
                         .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .map(|(k, v)| (k.clone(), v.join(", ")))
                         .collect(),
                 )
             };
@@ -114,7 +114,7 @@ pub fn execute_stub_response_with_rift(
     response: &StubResponse,
 ) -> Option<(
     u16,
-    HashMap<String, String>,
+    HashMap<String, Vec<String>>,
     String,
     Option<serde_json::Value>,
     Option<RiftResponseExtension>,
@@ -140,8 +140,10 @@ pub fn execute_stub_response_with_rift(
                         if !headers.contains_key("content-type")
                             && !headers.contains_key("Content-Type")
                         {
-                            headers
-                                .insert("Content-Type".to_string(), "application/json".to_string());
+                            headers.insert(
+                                "Content-Type".to_string(),
+                                vec!["application/json".to_string()],
+                            );
                         }
                         serde_json::to_string(b).unwrap_or_default()
                     }
@@ -188,9 +190,9 @@ pub fn get_rift_script_config(response: &StubResponse) -> Option<RiftScriptConfi
 /// and the stub uses `_mode: "binary"` so it can be replayed correctly.
 ///
 /// Headers are accepted as `&[(String, String)]` to preserve multi-valued
-/// headers (e.g., multiple `Set-Cookie`). They are converted to a HashMap
-/// for storage in the stub's `IsResponse`, which uses Mountebank's single-value
-/// header format. Multi-valued headers are comma-joined per HTTP spec.
+/// headers (e.g., multiple `Set-Cookie`), which are stored as separate values in
+/// the stub's `IsResponse` (multi-value headers, issue #238). Hop-by-hop headers
+/// are dropped.
 pub fn create_stub_from_proxy_response(
     predicates: Vec<serde_json::Value>,
     status: u16,
@@ -200,14 +202,15 @@ pub fn create_stub_from_proxy_response(
     decorate_fn: Option<String>,
     recorded_from: Option<String>,
 ) -> super::types::Stub {
-    // Convert to HashMap, comma-joining multi-valued headers (per HTTP spec).
-    // Filter out hop-by-hop headers.
-    let response_headers: HashMap<String, String> = {
-        let merged = crate::util::merge_headers_to_map(headers);
-        merged
-            .into_iter()
-            .filter(|(k, _)| !crate::util::is_hop_by_hop_header(k))
-            .collect()
+    // Group values per key so multiple values for one header (e.g. Set-Cookie) survive replay.
+    let response_headers: HashMap<String, Vec<String>> = {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for (k, v) in headers {
+            if !crate::util::is_hop_by_hop_header(k) {
+                map.entry(k.clone()).or_default().push(v.clone());
+            }
+        }
+        map
     };
 
     let (body_value, is_binary) = crate::util::encode_body_for_stub(body);
@@ -334,8 +337,8 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_create_stub_multi_valued_headers_comma_joined() {
-        // Multiple Set-Cookie headers should be comma-joined in the stub
+    fn test_create_stub_preserves_multi_valued_headers() {
+        // Multiple Set-Cookie headers are preserved as separate values in the stub (issue #238)
         let headers = vec![
             ("Set-Cookie".to_string(), "session=abc".to_string()),
             ("Set-Cookie".to_string(), "theme=dark".to_string()),
@@ -346,12 +349,16 @@ mod tests {
 
         match &stub.responses[0] {
             StubResponse::Is { is, .. } => {
+                let cookies = is.headers.get("Set-Cookie").unwrap();
                 assert_eq!(
-                    is.headers.get("Set-Cookie").unwrap(),
-                    "session=abc, theme=dark",
-                    "Multi-valued Set-Cookie headers should be comma-joined"
+                    cookies,
+                    &vec!["session=abc".to_string(), "theme=dark".to_string()],
+                    "Multi-valued Set-Cookie headers are preserved as separate values"
                 );
-                assert_eq!(is.headers.get("Content-Type").unwrap(), "text/html");
+                assert_eq!(
+                    is.headers.get("Content-Type").unwrap(),
+                    &vec!["text/html".to_string()]
+                );
             }
             _ => panic!("Expected StubResponse::Is"),
         }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -5,6 +5,50 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Serde for multi-value headers (issue #238). Accepts the Mountebank-style `"k": "v"` *and*
+/// `"k": ["v1", "v2"]` on the wire; serializes a single value back as a plain string and multiple
+/// values as an array, so existing single-value consumers are unaffected.
+pub(crate) mod multi_value_headers {
+    use serde::de::Deserializer;
+    use serde::ser::{SerializeMap, Serializer};
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        headers: &HashMap<String, Vec<String>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(headers.len()))?;
+        for (key, values) in headers {
+            match values.as_slice() {
+                [] => continue, // a key with no values would emit no header line; omit it
+                [single] => map.serialize_entry(key, single)?,
+                many => map.serialize_entry(key, many)?,
+            }
+        }
+        map.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<String, Vec<String>>, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany {
+            One(String),
+            Many(Vec<String>),
+        }
+        let raw = HashMap::<String, OneOrMany>::deserialize(deserializer)?;
+        Ok(raw
+            .into_iter()
+            .map(|(k, v)| match v {
+                OneOrMany::One(s) => (k, vec![s]),
+                OneOrMany::Many(v) => (k, v),
+            })
+            .collect())
+    }
+}
+
 // ============================================================================
 // Recorded Request Types
 // ============================================================================
@@ -17,7 +61,8 @@ pub struct RecordedRequest {
     pub method: String,
     pub path: String,
     pub query: HashMap<String, String>,
-    pub headers: HashMap<String, String>,
+    #[serde(default, with = "multi_value_headers")]
+    pub headers: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
     pub timestamp: String,
@@ -365,8 +410,8 @@ pub(crate) struct IsResponseRaw {
         deserialize_with = "deserialize_status_code"
     )]
     pub status_code: u16,
-    #[serde(default)]
-    pub headers: HashMap<String, String>,
+    #[serde(default, deserialize_with = "multi_value_headers::deserialize")]
+    pub headers: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<serde_json::Value>,
     /// Response mode: "text" (default) or "binary" (body is base64-encoded)
@@ -381,8 +426,8 @@ pub(crate) struct IsResponseOut {
     /// Status code serialized as string for Mountebank compatibility
     #[serde(serialize_with = "serialize_status_code_as_string")]
     pub status_code: u16,
-    #[serde(default)]
-    pub headers: HashMap<String, String>,
+    #[serde(default, serialize_with = "multi_value_headers::serialize")]
+    pub headers: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<serde_json::Value>,
     /// Response mode: "text" (default) or "binary" (body is base64-encoded)
@@ -597,8 +642,8 @@ pub enum ResponseMode {
 pub struct IsResponse {
     #[serde(default = "default_status_code")]
     pub status_code: u16,
-    #[serde(default)]
-    pub headers: HashMap<String, String>,
+    #[serde(default, with = "multi_value_headers")]
+    pub headers: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<serde_json::Value>,
     /// Response mode: "text" (default) or "binary" (body is base64-encoded)
@@ -986,6 +1031,50 @@ pub enum ImposterError {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Issue #238: multi-value headers accept "k":"v" and "k":["v1","v2"]; serialize back as
+    // a string for one value and an array for many (via IsResponse, which uses the helper).
+    #[test]
+    fn multi_value_headers_deserialize_string_or_array() {
+        let single: IsResponse =
+            serde_json::from_str(r#"{"statusCode":200,"headers":{"X-One":"v"}}"#).unwrap();
+        assert_eq!(single.headers["X-One"], vec!["v".to_string()]);
+
+        let many: IsResponse =
+            serde_json::from_str(r#"{"statusCode":200,"headers":{"Set-Cookie":["a","b"]}}"#)
+                .unwrap();
+        assert_eq!(
+            many.headers["Set-Cookie"],
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn multi_value_headers_serialize_single_as_string_many_as_array() {
+        let mut headers = HashMap::new();
+        headers.insert("X-One".to_string(), vec!["v".to_string()]);
+        headers.insert(
+            "Set-Cookie".to_string(),
+            vec!["a".to_string(), "b".to_string()],
+        );
+        let out = IsResponseOut {
+            status_code: 200,
+            headers,
+            body: None,
+            mode: ResponseMode::Text,
+        };
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(
+            v["headers"]["X-One"],
+            json!("v"),
+            "one value -> bare string"
+        );
+        assert_eq!(
+            v["headers"]["Set-Cookie"],
+            json!(["a", "b"]),
+            "multiple values -> array"
+        );
+    }
 
     // Fix #107: Stub.responses now has #[serde(default)]
     #[test]

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -443,9 +443,9 @@ mod requests_filter_tests {
 
     fn rec(space: &str, tenant: Option<&str>) -> RecordedRequest {
         let mut headers = HashMap::new();
-        headers.insert("X-Mock-Space".to_string(), space.to_string());
+        headers.insert("X-Mock-Space".to_string(), vec![space.to_string()]);
         if let Some(t) = tenant {
-            headers.insert("X-Tenant".to_string(), t.to_string());
+            headers.insert("X-Tenant".to_string(), vec![t.to_string()]);
         }
         RecordedRequest {
             request_from: "127.0.0.1".to_string(),
@@ -506,9 +506,12 @@ mod requests_filter_tests {
         let resp = handle_get_requests(19732, Some("match=header:X-Mock-Space=A"), m.clone()).await;
         let got = requests(resp).await;
         assert_eq!(got.len(), 2, "only the two X-Mock-Space=A requests");
-        assert!(got
-            .iter()
-            .all(|r| r.headers.get("X-Mock-Space").unwrap() == "A"));
+        assert!(got.iter().all(|r| r
+            .headers
+            .get("X-Mock-Space")
+            .and_then(|v| v.first())
+            .map(String::as_str)
+            == Some("A")));
         let _ = m.delete_imposter(19732).await;
     }
 
@@ -537,7 +540,7 @@ mod requests_filter_tests {
         )
         .await;
         assert_eq!(by_flow_id.len(), 1);
-        assert_eq!(by_flow_id[0].headers.get("X-Mock-Space").unwrap(), "A");
+        assert_eq!(by_flow_id[0].headers.get("X-Mock-Space").unwrap()[0], "A");
         assert_eq!(
             serde_json::to_value(&by_flow_id).unwrap(),
             serde_json::to_value(&by_header).unwrap(),
@@ -607,7 +610,7 @@ mod requests_filter_tests {
         handle_clear_requests(19739, Some("match=header:X-Mock-Space=A"), base, m.clone()).await;
         let remaining = requests(handle_get_requests(19739, None, m.clone()).await).await;
         assert_eq!(remaining.len(), 1, "only the B request survives");
-        assert_eq!(remaining[0].headers.get("X-Mock-Space").unwrap(), "B");
+        assert_eq!(remaining[0].headers.get("X-Mock-Space").unwrap()[0], "B");
         let _ = m.delete_imposter(19739).await;
     }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -267,7 +267,7 @@ pub async fn handle_get_space(
             let number_of_requests = imposter
                 .get_recorded_requests()
                 .iter()
-                .filter(|r| imposter.resolve_flow_id(&r.headers) == flow_id)
+                .filter(|r| imposter.resolve_flow_id_recorded(&r.headers) == flow_id)
                 .count();
             json_response(
                 StatusCode::OK,

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -68,18 +68,19 @@ fn resolve_flow_id(req: &RecordedRequest, flow_id_source: &str, port: u16) -> Op
     if flow_id_source == "imposter_port" {
         Some(port.to_string())
     } else if let Some(name) = flow_id_source.strip_prefix("header:") {
-        header_value(req, name)
+        // A flow id derives from a single header value; take the first if multi-valued (#238).
+        header_values(req, name).and_then(|values| values.first().cloned())
     } else {
         None
     }
 }
 
-/// Case-insensitive header lookup against a recorded request.
-fn header_value(req: &RecordedRequest, name: &str) -> Option<String> {
+/// Case-insensitive header lookup against a recorded request — returns all values for the key.
+fn header_values<'a>(req: &'a RecordedRequest, name: &str) -> Option<&'a Vec<String>> {
     req.headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case(name))
-        .map(|(_, v)| v.clone())
+        .map(|(_, v)| v)
 }
 
 /// Does `req` satisfy ALL clauses (AND)?
@@ -91,7 +92,8 @@ pub(crate) fn request_matches(
 ) -> bool {
     clauses.iter().all(|clause| match clause {
         MatchClause::Header { name, value } => {
-            header_value(req, name).as_deref() == Some(value.as_str())
+            // Match if ANY recorded value for the header equals the target (#238 multi-value).
+            header_values(req, name).is_some_and(|values| values.iter().any(|v| v == value))
         }
         MatchClause::FlowId(value) => {
             resolve_flow_id(req, flow_id_source, port).as_deref() == Some(value.as_str())
@@ -106,7 +108,7 @@ mod tests {
 
     fn req_with_header(name: &str, value: &str) -> RecordedRequest {
         let mut headers = HashMap::new();
-        headers.insert(name.to_string(), value.to_string());
+        headers.insert(name.to_string(), vec![value.to_string()]);
         RecordedRequest {
             request_from: "127.0.0.1".to_string(),
             method: "GET".to_string(),
@@ -202,7 +204,8 @@ mod tests {
     #[test]
     fn multiple_clauses_are_anded() {
         let mut req = req_with_header("X-Mock-Space", "abc");
-        req.headers.insert("X-Tenant".to_string(), "t1".to_string());
+        req.headers
+            .insert("X-Tenant".to_string(), vec!["t1".to_string()]);
         let clauses = vec![
             MatchClause::Header {
                 name: "X-Mock-Space".to_string(),

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -492,3 +492,134 @@ async fn stub_by_id_admin_endpoints() {
 
     let _ = manager.delete_imposter(19776).await;
 }
+
+// Issue #238: multi-value header support on the served response and the recorded request.
+mod multi_value_headers {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn serve(config: serde_json::Value) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new());
+        manager
+            .create_imposter(serde_json::from_value(config).unwrap())
+            .await
+            .expect("create imposter");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        manager
+    }
+
+    #[tokio::test]
+    async fn serves_both_values_of_a_response_header() {
+        let manager = serve(serde_json::json!({
+            "port": 19820, "protocol": "http",
+            "stubs": [{"responses": [{"is": {"statusCode": 200,
+                "headers": {"Set-Cookie": ["a=1", "b=2"]}, "body": "ok"}}]}]
+        }))
+        .await;
+
+        let resp = reqwest::get("http://127.0.0.1:19820/x").await.unwrap();
+        let cookies: Vec<String> = resp
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            cookies.len(),
+            2,
+            "both Set-Cookie lines served, got {cookies:?}"
+        );
+        assert!(cookies.contains(&"a=1".to_string()) && cookies.contains(&"b=2".to_string()));
+
+        let _ = manager.delete_imposter(19820).await;
+    }
+
+    #[tokio::test]
+    async fn default_response_serves_both_values_of_a_header() {
+        // No stub matches → the imposter's defaultResponse is served (a separate emission site).
+        let manager = serve(serde_json::json!({
+            "port": 19823, "protocol": "http",
+            "defaultResponse": {"statusCode": 200,
+                "headers": {"Set-Cookie": ["a=1", "b=2"]}, "body": "def"},
+            "stubs": []
+        }))
+        .await;
+
+        let resp = reqwest::get("http://127.0.0.1:19823/nomatch")
+            .await
+            .unwrap();
+        let cookies: Vec<String> = resp
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            cookies.len(),
+            2,
+            "defaultResponse serves both Set-Cookie lines, got {cookies:?}"
+        );
+        assert!(cookies.contains(&"a=1".to_string()) && cookies.contains(&"b=2".to_string()));
+
+        let _ = manager.delete_imposter(19823).await;
+    }
+
+    #[tokio::test]
+    async fn single_value_response_header_still_works() {
+        let manager = serve(serde_json::json!({
+            "port": 19821, "protocol": "http",
+            "stubs": [{"responses": [{"is": {"statusCode": 200,
+                "headers": {"X-Custom": "v"}, "body": "ok"}}]}]
+        }))
+        .await;
+
+        let resp = reqwest::get("http://127.0.0.1:19821/x").await.unwrap();
+        assert_eq!(resp.headers().get("x-custom").unwrap(), "v");
+        let _ = manager.delete_imposter(19821).await;
+    }
+
+    #[tokio::test]
+    async fn records_both_values_of_a_request_header() {
+        let manager = serve(serde_json::json!({
+            "port": 19822, "protocol": "http", "recordRequests": true,
+            "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "ok"}}]}]
+        }))
+        .await;
+
+        reqwest::Client::new()
+            .get("http://127.0.0.1:19822/x")
+            .header("X-Multi", "one")
+            .header("X-Multi", "two")
+            .send()
+            .await
+            .unwrap();
+
+        let admin = "127.0.0.1:12720";
+        let server = rift_http_proxy::admin_api::AdminApiServer::new(
+            admin.parse().unwrap(),
+            manager.clone(),
+            None,
+        );
+        tokio::spawn(server.run());
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let recorded = json(
+            &reqwest::Client::new(),
+            format!("http://{admin}/imposters/19822/requests"),
+        )
+        .await;
+        let values: Vec<String> = recorded[0]["headers"]["X-Multi"]
+            .as_array()
+            .expect("multi-value header serialized as array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            values.contains(&"one".to_string()) && values.contains(&"two".to_string()),
+            "both request header values recorded, got {values:?}"
+        );
+
+        let _ = manager.delete_imposter(19822).await;
+    }
+}


### PR DESCRIPTION
## Summary

Rift represented HTTP headers as `HashMap<String, String>` — one value per key — so it could not serve or record multi-value headers (e.g. multiple `Set-Cookie`, or a header sent twice). Both `IsResponse.headers` (stub response) and `RecordedRequest.headers` (recorded request) now hold `HashMap<String, Vec<String>>`.

## What changed

- **`multi_value_headers` serde adapter** — accepts the Mountebank-style `"k":"v"` **and** `"k":["v1","v2"]` on the wire; serializes a single value back as a plain string and multiple values as an array, so single-value JSON stays backward-compatible.
- **Serve:** a stub `is`/`defaultResponse` with two values for one header key emits two header lines.
- **Record:** the handler captures *all* values per key from the hyper `HeaderMap` (which yields one entry per value); the single-value `headers_clone` is kept for predicate matching / flow-id so the request hot path is unchanged. `request_filter` matches if **any** recorded value equals the target; flow-id derivation takes the first value of its header.
- **Behavior boundary:** copy/lookup/decorate behaviors run on a single-value view and fold the result back, so a plain multi-value `is` response keeps its values while a response that *also* uses behaviors collapses to single-value (now logged via `warn!`).
- **Proxy bonus:** proxy-recorded stubs preserve multiple response header values (e.g. `Set-Cookie`) as separate values instead of comma-joining (the previous limitation this issue called out).

## Behaviour
- Single-value `{"X":"v"}` → served/recorded unchanged (back-compat).
- `{"Set-Cookie":["a=1","b=2"]}` → two `Set-Cookie` lines on the wire.
- Request sent with one header twice → recorded with both values (array in `GET /imposters/:port/requests`).

## Tests
- Unit: `multi_value_headers` deserialize (string|array) + serialize (single→string / multi→array).
- Integration (`mod multi_value_headers`, in-process manager + reqwest): `is` serves both `Set-Cookie` lines; **`defaultResponse`** serves both; single-value back-compat; both request-header values recorded. Updated the proxy-capture test to assert preservation instead of comma-join.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green.

## Relations
Unblocks downstream **zio-bdd #162**.

Closes #238