### PR TITLE
feat: real connection-level TCP faults + EMPTY_RESPONSE/MALFORMED_RESPONSE_CHUNK (_rift.fault.tcp)

### DIFF
--- a/crates/rift-core/src/imposter/fault_io.rs
+++ b/crates/rift-core/src/imposter/fault_io.rs
@@ -1,0 +1,166 @@
+//! Real connection-level TCP faults for `_rift.fault.tcp` (issue #239).
+//!
+//! A normal `Response` is framed and sent by hyper, so it can never reproduce a transport-level
+//! failure. Instead, the matched fault is recorded in a per-connection [`FaultCell`] (set by the
+//! request handler via a `Response` extension) and applied by [`FaultIo`], a thin wrapper around
+//! the connection's `TcpStream`: on the next write hyper attempts (the response), `FaultIo`
+//! performs the fault on the raw socket and returns an error so hyper aborts the connection. The
+//! client then observes a genuine reset / empty / malformed / random-data failure, matching
+//! WireMock's `Fault` semantics.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+use tracing::debug;
+
+/// The four WireMock-equivalent connection faults.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TcpFaultKind {
+    /// Reset the connection (client sees `ECONNRESET`).
+    Reset,
+    /// Close the connection after the request with no response bytes.
+    Empty,
+    /// Send random bytes then close (client sees a protocol error).
+    RandomData,
+    /// Send a status line + a malformed chunked body then close.
+    MalformedChunk,
+}
+
+impl TcpFaultKind {
+    /// Parse a `_rift.fault.tcp` string. Accepts the WireMock names and Rift's short aliases.
+    #[must_use]
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "reset" | "CONNECTION_RESET_BY_PEER" => Some(Self::Reset),
+            "empty" | "EMPTY_RESPONSE" => Some(Self::Empty),
+            "garbage" | "random" | "RANDOM_DATA_THEN_CLOSE" => Some(Self::RandomData),
+            "malformed" | "MALFORMED_RESPONSE_CHUNK" => Some(Self::MalformedChunk),
+            _ => None,
+        }
+    }
+}
+
+/// Per-connection slot the handler sets when a request matches a TCP fault; read by [`FaultIo`].
+pub(crate) type FaultCell = Arc<Mutex<Option<TcpFaultKind>>>;
+
+/// A `TcpStream` wrapper that, when [`FaultCell`] is armed, applies a connection fault on the next
+/// write instead of forwarding hyper's response. Reads and (un-armed) writes pass straight through.
+pub(crate) struct FaultIo {
+    inner: TcpStream,
+    fault: FaultCell,
+}
+
+impl FaultIo {
+    pub(crate) fn new(inner: TcpStream, fault: FaultCell) -> Self {
+        Self { inner, fault }
+    }
+
+    /// Apply the fault to the raw socket. Returns the error used to abort the hyper connection so
+    /// the socket is dropped (and closed) immediately afterwards. The raw socket calls are
+    /// best-effort: on failure the connection still breaks, but the *observed* fault may degrade
+    /// (e.g. a failed `set_linger` reset becomes a graceful close), so each failure is logged.
+    fn trip(&self, kind: TcpFaultKind) -> io::Error {
+        match kind {
+            // SO_LINGER(0): dropping the socket now emits RST rather than a graceful FIN.
+            TcpFaultKind::Reset => {
+                if let Err(e) = self.inner.set_linger(Some(Duration::ZERO)) {
+                    debug!("rift fault reset: set_linger(0) failed, degraded to graceful close: {e}");
+                }
+            }
+            // Nothing written; the abort closes the connection with no response bytes.
+            TcpFaultKind::Empty => {}
+            // Best-effort raw write, then a graceful close delivers the bytes before EOF.
+            TcpFaultKind::RandomData => {
+                if let Err(e) = self.inner.try_write(b"\x00\xff\xfe\xfd\x13\x37\xde\xad\xbe\xef") {
+                    debug!("rift fault random-data: write failed, degraded to empty close: {e}");
+                }
+            }
+            TcpFaultKind::MalformedChunk => {
+                if let Err(e) = self.inner.try_write(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nZZZZZ not a valid chunk size\r\n",
+                ) {
+                    debug!("rift fault malformed-chunk: write failed, degraded to empty close: {e}");
+                }
+            }
+        }
+        io::Error::other("rift: injected _rift.fault.tcp")
+    }
+}
+
+impl AsyncRead for FaultIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for FaultIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        // Take (not just read) the armed fault so it fires exactly once.
+        if let Some(kind) = self.fault.lock().take() {
+            return Poll::Ready(Err(self.trip(kind)));
+        }
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_wiremock_names_and_aliases() {
+        assert_eq!(
+            TcpFaultKind::parse("CONNECTION_RESET_BY_PEER"),
+            Some(TcpFaultKind::Reset)
+        );
+        assert_eq!(TcpFaultKind::parse("reset"), Some(TcpFaultKind::Reset));
+        assert_eq!(
+            TcpFaultKind::parse("EMPTY_RESPONSE"),
+            Some(TcpFaultKind::Empty)
+        );
+        assert_eq!(TcpFaultKind::parse("empty"), Some(TcpFaultKind::Empty));
+        assert_eq!(
+            TcpFaultKind::parse("RANDOM_DATA_THEN_CLOSE"),
+            Some(TcpFaultKind::RandomData)
+        );
+        assert_eq!(
+            TcpFaultKind::parse("garbage"),
+            Some(TcpFaultKind::RandomData)
+        );
+        assert_eq!(
+            TcpFaultKind::parse("random"),
+            Some(TcpFaultKind::RandomData)
+        );
+        assert_eq!(
+            TcpFaultKind::parse("malformed"),
+            Some(TcpFaultKind::MalformedChunk)
+        );
+        assert_eq!(
+            TcpFaultKind::parse("MALFORMED_RESPONSE_CHUNK"),
+            Some(TcpFaultKind::MalformedChunk)
+        );
+        assert_eq!(TcpFaultKind::parse("nonsense"), None);
+    }
+}

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -836,27 +836,20 @@ async fn apply_rift_fault(
 
     // Check for TCP fault
     if let Some(ref tcp_fault) = fault_config.tcp {
-        match tcp_fault.as_str() {
-            "reset" | "CONNECTION_RESET_BY_PEER" => {
-                debug!("Applying _rift.fault TCP reset");
-                return Some(build_response_with_headers(
-                    StatusCode::BAD_GATEWAY,
-                    [("x-rift-fault", "CONNECTION_RESET_BY_PEER")],
-                    Bytes::new(),
-                ));
-            }
-            "garbage" | "RANDOM_DATA_THEN_CLOSE" => {
-                debug!("Applying _rift.fault TCP garbage");
-                return Some(build_response_with_headers(
-                    StatusCode::BAD_GATEWAY,
-                    [("x-rift-fault", "RANDOM_DATA_THEN_CLOSE")],
-                    Bytes::from_static(b"\x00\xff\xfe\xfd"),
-                ));
-            }
-            _ => {
-                warn!("Unknown TCP fault type: {}", tcp_fault);
-            }
+        if let Some(kind) = super::fault_io::TcpFaultKind::parse(tcp_fault) {
+            debug!("Applying _rift.fault.tcp: {:?}", kind);
+            // Carrier response: the serve loop's `FaultIo` aborts the connection before this is
+            // ever sent. The `TcpFaultKind` extension tells it which real transport fault to apply
+            // (issue #239) — the status/body here are never observed by the client.
+            let mut response = build_response_with_headers(
+                StatusCode::BAD_GATEWAY,
+                [("x-rift-fault", tcp_fault.as_str())],
+                Bytes::new(),
+            );
+            response.extensions_mut().insert(kind);
+            return Some(response);
         }
+        warn!("Unknown TCP fault type: {}", tcp_fault);
     }
 
     None

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -4,12 +4,13 @@
 //! each running on its own port.
 
 use super::core::Imposter;
+use super::fault_io::{FaultCell, FaultIo, TcpFaultKind};
 use super::handler::handle_imposter_request;
 use super::types::{ImposterConfig, ImposterError, Stub};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -99,11 +100,25 @@ impl ImposterManager {
                                 // not just new connections (issue #207).
                                 let mut conn_shutdown_rx = conn_shutdown_tx.subscribe();
                                 tokio::spawn(async move {
-                                    let io = TokioIo::new(stream);
+                                    // Per-connection slot for a real transport fault (issue #239);
+                                    // armed by the handler, applied by FaultIo on the response write.
+                                    let fault_cell: FaultCell = Arc::new(Mutex::new(None));
+                                    let io =
+                                        TokioIo::new(FaultIo::new(stream, Arc::clone(&fault_cell)));
                                     let service = service_fn(move |req| {
                                         let imposter = Arc::clone(&imposter);
+                                        let fault_cell = Arc::clone(&fault_cell);
                                         async move {
-                                            handle_imposter_request(req, imposter, addr).await
+                                            let response =
+                                                handle_imposter_request(req, imposter, addr).await?;
+                                            if let Some(kind) = response
+                                                .extensions()
+                                                .get::<TcpFaultKind>()
+                                                .copied()
+                                            {
+                                                *fault_cell.lock() = Some(kind);
+                                            }
+                                            Ok::<_, std::convert::Infallible>(response)
                                         }
                                     });
                                     let conn = http1::Builder::new().serve_connection(io, service);

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -17,6 +17,7 @@
 //! - `core`: Core Imposter struct and implementation
 
 mod core;
+mod fault_io;
 mod handler;
 mod manager;
 mod predicates;

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -492,3 +492,104 @@ async fn stub_by_id_admin_endpoints() {
 
     let _ = manager.delete_imposter(19776).await;
 }
+
+// Issue #239: _rift.fault.tcp must produce a REAL client-observable transport failure (not a 502).
+mod tcp_faults {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn fault_imposter(port: u16, kind: &str) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http",
+            "stubs": [{"responses": [{
+                "is": {"statusCode": 200, "body": "should-never-be-seen"},
+                "_rift": {"fault": {"tcp": kind}}
+            }]}]
+        }))
+        .unwrap();
+        manager
+            .create_imposter(config)
+            .await
+            .expect("create imposter");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        manager
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Observed {
+        /// The request failed before a valid HTTP response (reset / empty close / bad framing).
+        SendFailed,
+        /// Response headers parsed (real status line) but the body read failed.
+        BodyFailed,
+        /// A complete, normal HTTP response — the fault did NOT fire (regression).
+        FullResponse,
+    }
+
+    /// What an HTTP client observes against the imposter — used to assert that a real transport
+    /// failure occurred and to distinguish the fault kinds (never `FullResponse`).
+    async fn observe(port: u16) -> Observed {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .build()
+            .unwrap();
+        match client
+            .get(format!("http://127.0.0.1:{port}/x"))
+            .send()
+            .await
+        {
+            Err(_) => Observed::SendFailed,
+            Ok(resp) => match resp.bytes().await {
+                Err(_) => Observed::BodyFailed,
+                Ok(_) => Observed::FullResponse,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_fault_reset_is_real() {
+        let manager = fault_imposter(19830, "CONNECTION_RESET_BY_PEER").await;
+        assert_eq!(
+            observe(19830).await,
+            Observed::SendFailed,
+            "reset must fail the request at the transport layer, not return a 502"
+        );
+        let _ = manager.delete_imposter(19830).await;
+    }
+
+    #[tokio::test]
+    async fn tcp_fault_empty_response_is_real() {
+        let manager = fault_imposter(19831, "EMPTY_RESPONSE").await;
+        assert_eq!(
+            observe(19831).await,
+            Observed::SendFailed,
+            "empty-response must close with no response, failing the request"
+        );
+        let _ = manager.delete_imposter(19831).await;
+    }
+
+    #[tokio::test]
+    async fn tcp_fault_malformed_chunk_is_real() {
+        let manager = fault_imposter(19832, "MALFORMED_RESPONSE_CHUNK").await;
+        // Distinct signal: the real status line parses (send succeeds) but the malformed chunked
+        // body fails to decode — proves this kind is not collapsed into reset/empty.
+        assert_eq!(
+            observe(19832).await,
+            Observed::BodyFailed,
+            "malformed-chunk must deliver a status line then fail the body read"
+        );
+        let _ = manager.delete_imposter(19832).await;
+    }
+
+    #[tokio::test]
+    async fn tcp_fault_random_data_is_real() {
+        let manager = fault_imposter(19833, "RANDOM_DATA_THEN_CLOSE").await;
+        assert_eq!(
+            observe(19833).await,
+            Observed::SendFailed,
+            "random-data must fail HTTP parsing, not return a normal response"
+        );
+        let _ = manager.delete_imposter(19833).await;
+    }
+}


### PR DESCRIPTION
## Summary

`_rift.fault.tcp` previously (a) supported only 2 of the 4 standard connection-fault kinds and (b) **simulated** them as a normal HTTP 502 with an `x-rift-fault` marker — the client received a valid HTTP response, not a transport error. It now produces **real** client-observable transport failures for all four WireMock-equivalent kinds:

- `CONNECTION_RESET_BY_PEER` — `SO_LINGER(0)` then close → the client sees a connection reset (RST).
- `EMPTY_RESPONSE` — close the connection after the request with no response bytes.
- `MALFORMED_RESPONSE_CHUNK` — send a valid status line + a malformed chunked body, then close.
- `RANDOM_DATA_THEN_CLOSE` — send random bytes, then close.

## How

A normal `Response` is always framed and sent by hyper, so a fault can't be reproduced through one. Instead the fault is applied **below** hyper:

- The matched fault is recorded in a per-connection cell, set by the handler via a `TcpFaultKind` response extension (the carrier 502 is never sent).
- `FaultIo` (new `imposter/fault_io.rs`) wraps the connection's `TcpStream`. When the cell is armed, `poll_write` performs the fault on the raw socket and returns an error so hyper aborts the connection. Reads and un-armed writes pass straight through, so **normal traffic is unaffected**.

Best-effort socket calls (`set_linger`/`try_write`) log at `debug!` if a fault degrades, so a downgrade leaves a trace.

## Tests
`mod tcp_faults` (in-process manager + reqwest) — one test per kind asserting a real transport failure, discriminated by stage: reset/empty/random fail the request (`SendFailed`), malformed delivers a status line then fails the body read (`BodyFailed`); none returns a normal response. Plus a `TcpFaultKind::parse` unit test (WireMock names + short aliases). The normal path stays covered by the existing suite, which now drives all traffic through `FaultIo`'s passthrough.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green (no regression from wrapping every connection in `FaultIo`).

## Relations
Unblocks downstream **zio-bdd #128**. Out of scope: the Mountebank-style `fault` field (`handle_fault_response`) and latency/error faults (already correct).

Closes #239