### PR TITLE
feat: per-imposter HTTPS — terminate TLS on imposters declared protocol: https

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,6 +2757,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +3227,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3443,7 @@ dependencies = [
  "prometheus",
  "r2d2",
  "rand 0.8.5",
+ "rcgen",
  "redis",
  "regex",
  "reqwest",
@@ -3486,6 +3510,7 @@ dependencies = [
  "port_check",
  "prometheus",
  "rand 0.8.5",
+ "rcgen",
  "regex",
  "reqwest",
  "rift-core",
@@ -5401,6 +5426,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.2",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -26,6 +26,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["http1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 rustls-pemfile = "2.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
+rcgen = "0.13"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -19,6 +19,69 @@ use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tracing::{debug, error, info};
 
+/// Server-level TLS defaults for HTTPS imposters that don't carry their own cert/key (issue #206).
+#[derive(Debug, Clone)]
+pub struct TlsDefaults {
+    /// Default cert/key PEM applied to any HTTPS imposter without inline `cert`/`key`.
+    pub default_cert: Option<String>,
+    pub default_key: Option<String>,
+    /// Generate an in-memory self-signed cert when no other material is available (Mountebank
+    /// zero-config default). When `false`, an HTTPS imposter without cert material is an error.
+    pub allow_self_signed: bool,
+}
+
+impl Default for TlsDefaults {
+    fn default() -> Self {
+        Self {
+            default_cert: None,
+            default_key: None,
+            allow_self_signed: true,
+        }
+    }
+}
+
+/// Serve one HTTP/1 connection (over plaintext or an already-handshaked TLS stream) until it
+/// completes or the imposter is torn down. Shared by the plain and HTTPS serve paths (issue #206).
+async fn run_http1<I>(
+    io: I,
+    imposter: Arc<Imposter>,
+    addr: std::net::SocketAddr,
+    fault_cell: FaultCell,
+    mut conn_shutdown_rx: broadcast::Receiver<()>,
+    port: u16,
+) where
+    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let service = service_fn(move |req| {
+        let imposter = Arc::clone(&imposter);
+        let fault_cell = Arc::clone(&fault_cell);
+        async move {
+            let response = handle_imposter_request(req, imposter, addr).await?;
+            if let Some(kind) = response.extensions().get::<TcpFaultKind>().copied() {
+                *fault_cell.lock() = Some(kind);
+            }
+            Ok::<_, std::convert::Infallible>(response)
+        }
+    });
+    let conn = http1::Builder::new().serve_connection(io, service);
+    tokio::pin!(conn);
+    tokio::select! {
+        res = conn.as_mut() => {
+            if let Err(e) = res {
+                debug!("Connection error on port {}: {}", port, e);
+            }
+        }
+        _ = conn_shutdown_rx.recv() => {
+            // Stop accepting new requests on this connection and close it once any in-flight
+            // request completes (issue #207).
+            conn.as_mut().graceful_shutdown();
+            if let Err(e) = conn.as_mut().await {
+                debug!("Connection error on port {} during shutdown: {}", port, e);
+            }
+        }
+    }
+}
+
 /// Manages the lifecycle of multiple imposters
 pub struct ImposterManager {
     /// Active imposters by port
@@ -27,6 +90,8 @@ pub struct ImposterManager {
     shutdown_tx: broadcast::Sender<()>,
     /// Optional data directory for persistence write-through
     datadir: Option<Arc<PathBuf>>,
+    /// TLS defaults for HTTPS imposters (issue #206)
+    tls_defaults: TlsDefaults,
 }
 
 impl ImposterManager {
@@ -42,7 +107,58 @@ impl ImposterManager {
             imposters: RwLock::new(HashMap::new()),
             shutdown_tx,
             datadir: datadir.map(Arc::new),
+            tls_defaults: TlsDefaults::default(),
         }
+    }
+
+    /// Set the server-level TLS defaults for HTTPS imposters (issue #206).
+    #[must_use]
+    pub fn with_tls_defaults(mut self, tls_defaults: TlsDefaults) -> Self {
+        self.tls_defaults = tls_defaults;
+        self
+    }
+
+    /// Resolve the TLS acceptor for an HTTPS imposter by precedence: inline imposter cert/key →
+    /// server default → self-signed fallback → error (never silent cleartext, issue #206).
+    fn resolve_tls_acceptor(
+        &self,
+        config: &ImposterConfig,
+    ) -> Result<tokio_rustls::TlsAcceptor, ImposterError> {
+        let from_pem = |cert: &str, key: &str| {
+            crate::proxy::tls::tls_acceptor_from_pem(cert.as_bytes(), key.as_bytes())
+                .map_err(|e| ImposterError::Tls(e.to_string()))
+        };
+        match (&config.cert, &config.key) {
+            (Some(cert), Some(key)) => return from_pem(cert, key),
+            (None, None) => {}
+            _ => {
+                return Err(ImposterError::Tls(
+                    "https imposter must provide both `cert` and `key`, or neither".to_string(),
+                ))
+            }
+        }
+        // Same both-or-neither rule for the server default: a half-configured default (e.g. only
+        // --default-tls-cert) must error, not silently downgrade to a self-signed cert.
+        match (
+            &self.tls_defaults.default_cert,
+            &self.tls_defaults.default_key,
+        ) {
+            (Some(cert), Some(key)) => return from_pem(cert, key),
+            (None, None) => {}
+            _ => {
+                return Err(ImposterError::Tls(
+                    "server default TLS must provide both cert and key, or neither".to_string(),
+                ))
+            }
+        }
+        if self.tls_defaults.allow_self_signed {
+            return crate::proxy::tls::generate_self_signed_acceptor()
+                .map_err(|e| ImposterError::Tls(e.to_string()));
+        }
+        Err(ImposterError::Tls(
+            "protocol \"https\" requested but no cert/key provided and self-signed generation is disabled"
+                .to_string(),
+        ))
     }
 
     /// Create and start an imposter
@@ -53,6 +169,14 @@ impl ImposterManager {
             "http" | "https" => {}
             proto => return Err(ImposterError::InvalidProtocol(proto.to_string())),
         }
+
+        // For HTTPS, resolve the per-imposter TLS acceptor up front so a missing/invalid cert
+        // fails loudly at creation rather than silently serving cleartext (issue #206).
+        let tls_acceptor = if config.protocol.eq_ignore_ascii_case("https") {
+            Some(self.resolve_tls_acceptor(&config)?)
+        } else {
+            None
+        };
 
         let bind_host: &str = config.host.as_deref().unwrap_or("0.0.0.0");
         // Determine port - either from config or auto-assign
@@ -105,47 +229,53 @@ impl ImposterManager {
                                 // Each connection watches the shutdown signal so existing
                                 // keep-alive connections are gracefully closed on delete,
                                 // not just new connections (issue #207).
-                                let mut conn_shutdown_rx = conn_shutdown_tx.subscribe();
+                                let conn_shutdown_rx = conn_shutdown_tx.subscribe();
+                                // Per-imposter TLS acceptor is cheap to clone (Arc-backed).
+                                let tls_acceptor = tls_acceptor.clone();
                                 tokio::spawn(async move {
                                     // Per-connection slot for a real transport fault (issue #239);
                                     // armed by the handler, applied by FaultIo on the response write.
                                     let fault_cell: FaultCell = Arc::new(Mutex::new(None));
-                                    let io =
-                                        TokioIo::new(FaultIo::new(stream, Arc::clone(&fault_cell)));
-                                    let service = service_fn(move |req| {
-                                        let imposter = Arc::clone(&imposter);
-                                        let fault_cell = Arc::clone(&fault_cell);
-                                        async move {
-                                            let response =
-                                                handle_imposter_request(req, imposter, addr).await?;
-                                            if let Some(kind) = response
-                                                .extensions()
-                                                .get::<TcpFaultKind>()
-                                                .copied()
-                                            {
-                                                *fault_cell.lock() = Some(kind);
+                                    // FaultIo sits beneath TLS so #239 connection faults still break
+                                    // an HTTPS connection.
+                                    let faulted = FaultIo::new(stream, Arc::clone(&fault_cell));
+                                    match tls_acceptor {
+                                        // Bound the TLS handshake so a stalled/half-open client
+                                        // can't pin the connection task indefinitely.
+                                        Some(acceptor) => match tokio::time::timeout(
+                                            std::time::Duration::from_secs(10),
+                                            acceptor.accept(faulted),
+                                        )
+                                        .await
+                                        {
+                                            Ok(Ok(tls)) => {
+                                                run_http1(
+                                                    TokioIo::new(tls),
+                                                    imposter,
+                                                    addr,
+                                                    fault_cell,
+                                                    conn_shutdown_rx,
+                                                    port,
+                                                )
+                                                .await
                                             }
-                                            Ok::<_, std::convert::Infallible>(response)
-                                        }
-                                    });
-                                    let conn = http1::Builder::new().serve_connection(io, service);
-                                    tokio::pin!(conn);
-                                    tokio::select! {
-                                        res = conn.as_mut() => {
-                                            if let Err(e) = res {
-                                                debug!("Connection error on port {}: {}", port, e);
+                                            Ok(Err(e)) => {
+                                                debug!("TLS handshake failed on port {}: {}", port, e)
                                             }
-                                        }
-                                        _ = conn_shutdown_rx.recv() => {
-                                            // Stop accepting new requests on this connection and
-                                            // close it once any in-flight request completes.
-                                            conn.as_mut().graceful_shutdown();
-                                            if let Err(e) = conn.as_mut().await {
-                                                debug!(
-                                                    "Connection error on port {} during shutdown: {}",
-                                                    port, e
-                                                );
+                                            Err(_) => {
+                                                debug!("TLS handshake timed out on port {}", port)
                                             }
+                                        },
+                                        None => {
+                                            run_http1(
+                                                TokioIo::new(faulted),
+                                                imposter,
+                                                addr,
+                                                fault_cell,
+                                                conn_shutdown_rx,
+                                                port,
+                                            )
+                                            .await
                                         }
                                     }
                                 });

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -44,7 +44,7 @@ pub use types::{
 pub use core::Imposter;
 
 // Re-export manager
-pub use manager::ImposterManager;
+pub use manager::{ImposterManager, TlsDefaults};
 
 // Re-export predicate utilities (used in tests and for external consumers)
 #[allow(unused_imports)]

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -704,6 +704,12 @@ pub struct ImposterConfig {
     pub host: Option<String>,
     #[serde(default = "default_protocol")]
     pub protocol: String,
+    /// Inline PEM certificate for `protocol: "https"` (Mountebank-compatible). Paired with `key`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cert: Option<String>,
+    /// Inline PEM private key for `protocol: "https"` (Mountebank-compatible). Paired with `cert`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default)]
@@ -1025,6 +1031,8 @@ pub enum ImposterError {
     StubIdConflict(String),
     #[error("Failed to persist imposter: {0}")]
     PersistError(String),
+    #[error("TLS configuration error: {0}")]
+    Tls(String),
 }
 
 #[cfg(test)]

--- a/crates/rift-core/src/proxy/mod.rs
+++ b/crates/rift-core/src/proxy/mod.rs
@@ -25,7 +25,7 @@ mod headers;
 pub(crate) mod network;
 mod response_ext;
 mod server;
-mod tls;
+pub(crate) mod tls;
 
 mod context;
 #[cfg(test)]

--- a/crates/rift-core/src/proxy/tls.rs
+++ b/crates/rift-core/src/proxy/tls.rs
@@ -58,35 +58,51 @@ impl ServerCertVerifier for NoVerifier {
 
 /// Create TLS acceptor from certificate and key files.
 pub fn create_tls_acceptor(cert_path: &str, key_path: &str) -> Result<TlsAcceptor, anyhow::Error> {
-    // Load certificate chain
-    let cert_file = std::fs::File::open(cert_path)
+    let cert_pem = std::fs::read(cert_path)
         .map_err(|e| anyhow::anyhow!("Failed to open certificate file '{cert_path}': {e}"))?;
-    let mut cert_reader = std::io::BufReader::new(cert_file);
-    let certs: Vec<CertificateDer> = rustls_pemfile::certs(&mut cert_reader)
+    let key_pem = std::fs::read(key_path)
+        .map_err(|e| anyhow::anyhow!("Failed to open private key file '{key_path}': {e}"))?;
+    tls_acceptor_from_pem(&cert_pem, &key_pem)
+}
+
+/// Create a TLS acceptor from in-memory PEM bytes (per-imposter HTTPS, issue #206).
+pub fn tls_acceptor_from_pem(
+    cert_pem: &[u8],
+    key_pem: &[u8],
+) -> Result<TlsAcceptor, anyhow::Error> {
+    let certs: Vec<CertificateDer> = rustls_pemfile::certs(&mut &cert_pem[..])
         .collect::<Result<_, _>>()
-        .map_err(|e| anyhow::anyhow!("Failed to parse certificate file: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to parse certificate PEM: {e}"))?;
 
     if certs.is_empty() {
-        anyhow::bail!("No certificates found in certificate file: {cert_path}");
+        anyhow::bail!("No certificates found in certificate PEM");
     }
 
-    // Load private key
-    let key_file = std::fs::File::open(key_path)
-        .map_err(|e| anyhow::anyhow!("Failed to open private key file '{key_path}': {e}"))?;
-    let mut key_reader = std::io::BufReader::new(key_file);
+    // Accepts PKCS8, RSA, or EC private keys.
+    let key = rustls_pemfile::private_key(&mut &key_pem[..])
+        .map_err(|e| anyhow::anyhow!("Failed to parse private key PEM: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("No private key found in key PEM"))?;
 
-    // Try reading as PKCS8, RSA, or EC private key
-    let key = rustls_pemfile::private_key(&mut key_reader)
-        .map_err(|e| anyhow::anyhow!("Failed to parse private key file: {e}"))?
-        .ok_or_else(|| anyhow::anyhow!("No private key found in key file: {key_path}"))?;
-
-    // Build TLS server configuration
     let config = rustls::ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(certs, key)
-        .map_err(|e| anyhow::anyhow!("Failed to build TLS configuration: {e}"))?;
+        .map_err(|e| {
+            anyhow::anyhow!("Failed to build TLS configuration (cert/key mismatch?): {e}")
+        })?;
 
     Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+/// Generate an in-memory self-signed acceptor for zero-config HTTPS imposters (issue #206),
+/// matching Mountebank's built-in self-signed default. Valid for `localhost`/`127.0.0.1`.
+pub fn generate_self_signed_acceptor() -> Result<TlsAcceptor, anyhow::Error> {
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .map_err(|e| anyhow::anyhow!("Failed to generate self-signed certificate: {e}"))?;
+    tls_acceptor_from_pem(
+        cert.cert.pem().as_bytes(),
+        cert.key_pair.serialize_pem().as_bytes(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/rift-core/src/response/mod.rs
+++ b/crates/rift-core/src/response/mod.rs
@@ -68,6 +68,10 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 StatusCode::SERVICE_UNAVAILABLE,
                 &format!("Persistence error: {msg}"),
             ),
+            ImposterError::Tls(msg) => error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("TLS configuration error: {msg}"),
+            ),
         }
     }
 }

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -87,6 +87,7 @@ serde_json_path = "0.7"
 
 [dev-dependencies]
 tempfile = "3.8"
+rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Integration testing

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -133,6 +133,19 @@ struct Cli {
     /// RC file with default flag values (Mountebank compatibility; partial support — port/host/loglevel only)
     #[arg(long, value_name = "FILE")]
     rcfile: Option<PathBuf>,
+
+    /// Default TLS certificate (PEM) for HTTPS imposters that don't carry their own (issue #206)
+    #[arg(long, value_name = "FILE", env = "RIFT_DEFAULT_TLS_CERT")]
+    default_tls_cert: Option<PathBuf>,
+
+    /// Default TLS private key (PEM), paired with --default-tls-cert
+    #[arg(long, value_name = "FILE", env = "RIFT_DEFAULT_TLS_KEY")]
+    default_tls_key: Option<PathBuf>,
+
+    /// Disable the self-signed fallback: an HTTPS imposter without cert material becomes an error
+    /// instead of serving with a generated self-signed cert (issue #206)
+    #[arg(long, env = "RIFT_NO_SELF_SIGNED_TLS")]
+    no_self_signed_tls: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -268,7 +281,28 @@ fn run_mountebank_mode(cli: Cli) -> Result<(), anyhow::Error> {
 
     runtime.block_on(async move {
         // Create imposter manager (with write-through if --datadir is set)
-        let manager = Arc::new(ImposterManager::with_datadir(cli.datadir.clone()));
+        // Per-imposter HTTPS defaults (issue #206): an optional server-wide cert/key applied to
+        // HTTPS imposters without their own, and whether to fall back to a generated self-signed.
+        let tls_defaults = {
+            let default_cert = cli
+                .default_tls_cert
+                .as_ref()
+                .map(std::fs::read_to_string)
+                .transpose()?;
+            let default_key = cli
+                .default_tls_key
+                .as_ref()
+                .map(std::fs::read_to_string)
+                .transpose()?;
+            imposter::TlsDefaults {
+                default_cert,
+                default_key,
+                allow_self_signed: !cli.no_self_signed_tls,
+            }
+        };
+        let manager = Arc::new(
+            ImposterManager::with_datadir(cli.datadir.clone()).with_tls_defaults(tls_defaults),
+        );
 
         // Load imposters from configfile if provided
         if let Some(ref configfile) = cli.configfile {

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -493,6 +493,238 @@ async fn stub_by_id_admin_endpoints() {
     let _ = manager.delete_imposter(19776).await;
 }
 
+// Issue #206: an imposter declared `protocol: "https"` terminates TLS on its own port.
+mod https {
+    use super::*;
+    use rift_http_proxy::imposter::TlsDefaults;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn gen_cert() -> (String, String) {
+        let c = rcgen::generate_simple_self_signed(vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+        ])
+        .unwrap();
+        (c.cert.pem(), c.key_pair.serialize_pem())
+    }
+
+    fn stub_config(port: u16, protocol: &str, cert: Option<(&str, &str)>) -> serde_json::Value {
+        let mut cfg = serde_json::json!({
+            "port": port, "protocol": protocol,
+            "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "secure-ok"}}]}]
+        });
+        if let Some((cert, key)) = cert {
+            cfg["cert"] = serde_json::json!(cert);
+            cfg["key"] = serde_json::json!(key);
+        }
+        cfg
+    }
+
+    fn tls_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .danger_accept_invalid_certs(true) // self-signed / test certs
+            .timeout(Duration::from_secs(3))
+            .build()
+            .unwrap()
+    }
+
+    async fn serve(manager: &Arc<ImposterManager>, cfg: serde_json::Value) {
+        manager
+            .create_imposter(serde_json::from_value(cfg).unwrap())
+            .await
+            .expect("create imposter");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    #[tokio::test]
+    async fn https_imposter_with_inline_cert_serves_tls() {
+        let (cert, key) = gen_cert();
+        let manager = Arc::new(ImposterManager::new());
+        serve(&manager, stub_config(19840, "https", Some((&cert, &key)))).await;
+
+        let body = tls_client()
+            .get("https://127.0.0.1:19840/x")
+            .send()
+            .await
+            .expect("TLS request should succeed")
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(body, "secure-ok");
+        let _ = manager.delete_imposter(19840).await;
+    }
+
+    #[tokio::test]
+    async fn http_imposter_unchanged() {
+        let manager = Arc::new(ImposterManager::new());
+        serve(&manager, stub_config(19841, "http", None)).await;
+        let body = reqwest::get("http://127.0.0.1:19841/x")
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(body, "secure-ok", "plain http imposter unaffected");
+        let _ = manager.delete_imposter(19841).await;
+    }
+
+    #[tokio::test]
+    async fn https_zero_config_uses_self_signed() {
+        // No cert/key, default manager (self-signed enabled) → still serves over TLS.
+        let manager = Arc::new(ImposterManager::new());
+        serve(&manager, stub_config(19842, "https", None)).await;
+        let body = tls_client()
+            .get("https://127.0.0.1:19842/x")
+            .send()
+            .await
+            .expect("zero-config https should serve via self-signed cert")
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(body, "secure-ok");
+        let _ = manager.delete_imposter(19842).await;
+    }
+
+    #[tokio::test]
+    async fn https_uses_server_default_cert() {
+        // Self-signed DISABLED + a server default cert → the default must be used (proves the
+        // default path, not the self-signed fallback).
+        let (cert, key) = gen_cert();
+        let manager = Arc::new(ImposterManager::new().with_tls_defaults(TlsDefaults {
+            default_cert: Some(cert),
+            default_key: Some(key),
+            allow_self_signed: false,
+        }));
+        serve(&manager, stub_config(19843, "https", None)).await;
+        let body = tls_client()
+            .get("https://127.0.0.1:19843/x")
+            .send()
+            .await
+            .expect("server-default cert should serve the https imposter")
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(body, "secure-ok");
+        let _ = manager.delete_imposter(19843).await;
+    }
+
+    #[tokio::test]
+    async fn https_no_cert_and_self_signed_disabled_errors() {
+        let manager = Arc::new(ImposterManager::new().with_tls_defaults(TlsDefaults {
+            default_cert: None,
+            default_key: None,
+            allow_self_signed: false,
+        }));
+        let result = manager
+            .create_imposter(serde_json::from_value(stub_config(19844, "https", None)).unwrap())
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(rift_http_proxy::imposter::ImposterError::Tls(_))
+            ),
+            "https with no cert + self-signed disabled must error, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn https_invalid_cert_errors_not_panics() {
+        let manager = Arc::new(ImposterManager::new());
+        let result = manager
+            .create_imposter(
+                serde_json::from_value(stub_config(
+                    19845,
+                    "https",
+                    Some((
+                        "-----BEGIN CERTIFICATE-----\nnonsense\n-----END CERTIFICATE-----",
+                        "bad",
+                    )),
+                ))
+                .unwrap(),
+            )
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(rift_http_proxy::imposter::ImposterError::Tls(_))
+            ),
+            "invalid cert/key must be a defined Tls error, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn https_cert_without_key_errors() {
+        let (cert, _key) = gen_cert();
+        let manager = Arc::new(ImposterManager::new());
+        let mut cfg = stub_config(19846, "https", None);
+        cfg["cert"] = serde_json::json!(cert); // cert present, key absent
+        let result = manager
+            .create_imposter(serde_json::from_value(cfg).unwrap())
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(rift_http_proxy::imposter::ImposterError::Tls(_))
+            ),
+            "cert without key must error (both-or-neither), got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn https_partial_server_default_errors() {
+        // Only a default cert (operator forgot --default-tls-key) must error, NOT silently
+        // downgrade to self-signed.
+        let (cert, _key) = gen_cert();
+        let manager = Arc::new(ImposterManager::new().with_tls_defaults(TlsDefaults {
+            default_cert: Some(cert),
+            default_key: None,
+            allow_self_signed: true,
+        }));
+        let result = manager
+            .create_imposter(serde_json::from_value(stub_config(19847, "https", None)).unwrap())
+            .await;
+        assert!(
+            matches!(result, Err(rift_http_proxy::imposter::ImposterError::Tls(_))),
+            "half-configured server default must error, not downgrade to self-signed, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn https_mismatched_valid_pair_never_serves_cleartext() {
+        // cert from one keypair, key from another — both individually valid. rustls does not
+        // cross-validate at build time, so this may bind; the TLS handshake must then fail and the
+        // client must NEVER receive a normal response. Either outcome (creation error OR handshake
+        // failure) is acceptable; serving the stub would not be (criterion 6 + no silent cleartext).
+        let (cert_a, _key_a) = gen_cert();
+        let (_cert_b, key_b) = gen_cert();
+        let manager = Arc::new(ImposterManager::new());
+        let mut cfg = stub_config(19848, "https", None);
+        cfg["cert"] = serde_json::json!(cert_a);
+        cfg["key"] = serde_json::json!(key_b);
+
+        match manager
+            .create_imposter(serde_json::from_value(cfg).unwrap())
+            .await
+        {
+            Err(rift_http_proxy::imposter::ImposterError::Tls(_)) => {} // caught at creation — ideal
+            Ok(port) => {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                let r = tls_client()
+                    .get(format!("https://127.0.0.1:{port}/x"))
+                    .send()
+                    .await;
+                assert!(
+                    r.is_err(),
+                    "mismatched cert/key must fail the TLS handshake, never serve a response"
+                );
+                let _ = manager.delete_imposter(port).await;
+            }
+            Err(other) => panic!("unexpected non-Tls error: {other:?}"),
+        }
+    }
+}
+
 // Issue #239: _rift.fault.tcp must produce a REAL client-observable transport failure (not a 502).
 mod tcp_faults {
     use super::*;


### PR DESCRIPTION
## Summary

An imposter declared `protocol: "https"` was accepted but never gated TLS — it silently served **cleartext**, so a TLS client got a handshake failure with no server-side error. It now **terminates TLS on that imposter's own port**, making `protocol: "https"` configs behave exactly as under Mountebank.

## What changed

- **Cert/key precedence** (`resolve_tls_acceptor`): inline `cert`/`key` PEM (Mountebank fields) → server-default → **generated self-signed** (rcgen, zero-config, matches Mountebank's built-in default) → loud `ImposterError::Tls`. **Both-or-neither** is enforced on *both* the inline and the server-default paths, so a half-configured pair (e.g. only `--default-tls-cert`) errors instead of silently downgrading to self-signed. The acceptor is resolved **before** the listener binds, so a cert failure aborts creation with no cleartext window.
- **Serve loop:** extracted a generic `run_http1` shared by the HTTP and HTTPS paths. The HTTPS branch handshakes via `acceptor.accept(...)` (bounded by a 10s timeout) with the **#239 `FaultIo` beneath TLS**, so connection faults still break HTTPS connections.
- `proxy/tls.rs`: `tls_acceptor_from_pem` (in-memory PEM) + `generate_self_signed_acceptor`; `create_tls_acceptor` now delegates.
- `ImposterConfig` gains `cert`/`key`; `ImposterError::Tls` → HTTP 400.
- **CLI:** `--default-tls-cert` / `--default-tls-key` / `--no-self-signed-tls` (+ env vars).

## Behaviour
- `protocol: "https"` + inline `cert`/`key` → serves over TLS.
- `protocol: "https"` with no cert → self-signed (zero-config); `--no-self-signed-tls` makes it a hard error instead.
- `protocol: "http"` → unchanged (reverse-proxy-fronted deployments keep working).
- Invalid / half / mismatched cert+key → defined `ImposterError::Tls` or a failed handshake — **never silent cleartext, never a panic**.

## Tests
`mod https` (in-process manager + TLS reqwest): inline-cert serves TLS, http unchanged, zero-config self-signed, server-default (proved by disabling self-signed), no-cert+disabled errors, invalid-cert errors, cert-without-key errors, partial-server-default errors, and mismatched-valid-pair never serves cleartext.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green (the `run_http1` refactor serves all imposter traffic — no regression).

## Relations
High adoption value; out of scope (noted): `mutualAuth` client-cert verification (v1-deferred).

Closes #206