### PR TITLE
feat: single-port imposter access (reach imposters via the admin/gateway port)

### DIFF
--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -43,6 +43,9 @@ pub use types::{
 #[allow(unused_imports)]
 pub use core::Imposter;
 
+// Re-export the imposter request handler (single-port gateway dispatch, issue #212)
+pub use handler::handle_imposter_request;
+
 // Re-export manager
 pub use manager::ImposterManager;
 

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -91,6 +91,59 @@ pub async fn route_request(
     Ok(response)
 }
 
+/// Dispatch a `/__rift/:port/<path>` gateway request to the imposter on `:port` (issue #212),
+/// rewriting the URI to the imposter-relative `/<path>` (+ query) so its predicates and handler
+/// behave exactly as if the request had arrived on the imposter's own port.
+async fn handle_gateway(
+    rest: &str,
+    query: Option<&str>,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    let (port_str, sub_path) = match rest.split_once('/') {
+        Some((port, sub)) => (port, format!("/{sub}")),
+        None => (rest, "/".to_string()),
+    };
+    let Ok(port) = port_str.parse::<u16>() else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("invalid gateway target '{port_str}' (expected /__rift/<port>/<path>)"),
+        );
+    };
+    let imposter = match manager.get_imposter(port) {
+        Ok(imposter) => imposter,
+        Err(_) => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                &format!("no imposter on port {port}"),
+            )
+        }
+    };
+
+    let target = match query {
+        Some(q) => format!("{sub_path}?{q}"),
+        None => sub_path,
+    };
+    let (mut parts, body) = req.into_parts();
+    parts.uri = match target.parse() {
+        Ok(uri) => uri,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid gateway path"),
+    };
+
+    // The gateway is the imposter's client; recorded `request_from` reflects the loopback gateway.
+    let gateway_addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+    match crate::imposter::handle_imposter_request(
+        Request::from_parts(parts, body),
+        imposter,
+        gateway_addr,
+    )
+    .await
+    {
+        Ok(resp) => resp,
+        Err(e) => match e {}, // handle_imposter_request is Infallible
+    }
+}
+
 /// Route based on path
 #[allow(clippy::too_many_arguments)]
 async fn route_by_path(
@@ -102,6 +155,12 @@ async fn route_by_path(
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
 ) -> Response<Full<Bytes>> {
+    // Single-port gateway (issue #212): `/__rift/:port/<path>` dispatches to that imposter,
+    // so a containerized Rift only needs the one admin port published.
+    if let Some(rest) = path.strip_prefix("/__rift/") {
+        return handle_gateway(rest, query, req, manager).await;
+    }
+
     // Fast path for common routes
     match (method, path) {
         (&Method::GET, "/") => return system::handle_root(base_url),

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -66,14 +66,22 @@ impl AdminApiServer {
                     let api_key = api_key.clone();
                     let config_source = config_source.clone();
                     async move {
+                        // The single-port gateway (`/__rift/...`, issue #212) is data-plane
+                        // imposter traffic, not the admin control plane — it mirrors direct
+                        // per-imposter-port access and so is NOT gated by the admin `--apikey`
+                        // (which would otherwise force app-under-test traffic to carry the admin
+                        // key and would leak that Authorization header into imposter predicates).
+                        let is_gateway = req.uri().path().starts_with("/__rift/");
                         if let Some(ref key) = api_key {
-                            let auth = req
-                                .headers()
-                                .get("authorization")
-                                .and_then(|v| v.to_str().ok())
-                                .unwrap_or("");
-                            if auth != key.as_str() {
-                                return Ok::<_, hyper::Error>(unauthorized_response());
+                            if !is_gateway {
+                                let auth = req
+                                    .headers()
+                                    .get("authorization")
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("");
+                                if auth != key.as_str() {
+                                    return Ok::<_, hyper::Error>(unauthorized_response());
+                                }
                             }
                         }
                         route_request(req, manager, config_source).await

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -888,3 +888,205 @@ mod reload {
         let _ = manager;
     }
 }
+
+// Issue #212: reach imposters through the single admin port via `/__rift/:port/<path>`.
+mod gateway {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Start an imposter (with the given stubs) + an AdminApiServer; returns (manager, admin_base).
+    async fn setup(
+        imposter_port: u16,
+        admin_port: u16,
+        stubs: serde_json::Value,
+    ) -> (Arc<ImposterManager>, String) {
+        let manager = Arc::new(ImposterManager::new());
+        manager
+            .create_imposter(
+                serde_json::from_value(serde_json::json!({
+                    "port": imposter_port, "protocol": "http", "stubs": stubs
+                }))
+                .unwrap(),
+            )
+            .await
+            .expect("create imposter");
+        let server = rift_http_proxy::admin_api::AdminApiServer::new(
+            format!("127.0.0.1:{admin_port}").parse().unwrap(),
+            manager.clone(),
+            None,
+        );
+        tokio::spawn(server.run());
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        (manager, format!("http://127.0.0.1:{admin_port}"))
+    }
+
+    #[tokio::test]
+    async fn gateway_routes_to_imposter() {
+        let (manager, admin) = setup(
+            19850,
+            12750,
+            serde_json::json!([{
+                "predicates": [{"equals": {"path": "/api/data"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "routed"}}]
+            }]),
+        )
+        .await;
+
+        // Hit the imposter through the admin port — the imposter must see path /api/data.
+        let resp = reqwest::get(format!("{admin}/__rift/19850/api/data"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "routed");
+        let _ = manager.delete_imposter(19850).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_preserves_method_and_query() {
+        let (manager, admin) = setup(
+            19851,
+            12751,
+            serde_json::json!([{
+                "predicates": [{"equals": {"method": "POST", "path": "/submit", "query": {"q": "1"}}}],
+                "responses": [{"is": {"statusCode": 201, "body": "posted"}}]
+            }]),
+        )
+        .await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("{admin}/__rift/19851/submit?q=1"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 201, "method + query must reach the imposter");
+        assert_eq!(resp.text().await.unwrap(), "posted");
+        let _ = manager.delete_imposter(19851).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_unknown_port_404() {
+        let (manager, admin) = setup(
+            19852,
+            12752,
+            serde_json::json!([{"responses": [{"is": {"statusCode": 200, "body": "x"}}]}]),
+        )
+        .await;
+        let resp = reqwest::get(format!("{admin}/__rift/59999/anything"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404, "no imposter on that port → 404");
+        let _ = manager.delete_imposter(19852).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_forwards_post_body() {
+        let (manager, admin) = setup(
+            19854,
+            12754,
+            serde_json::json!([{
+                "predicates": [{"equals": {"method": "POST", "path": "/echo", "body": "hello-body"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "got-body"}}]
+            }]),
+        )
+        .await;
+        let resp = reqwest::Client::new()
+            .post(format!("{admin}/__rift/19854/echo"))
+            .body("hello-body")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.text().await.unwrap(),
+            "got-body",
+            "the POST body must reach the imposter through the gateway"
+        );
+        let _ = manager.delete_imposter(19854).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_no_subpath_routes_to_root() {
+        let (manager, admin) = setup(
+            19855,
+            12755,
+            serde_json::json!([{
+                "predicates": [{"equals": {"path": "/"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "root"}}]
+            }]),
+        )
+        .await;
+        let resp = reqwest::get(format!("{admin}/__rift/19855")).await.unwrap();
+        assert_eq!(
+            resp.text().await.unwrap(),
+            "root",
+            "no sub-path → imposter root"
+        );
+        let _ = manager.delete_imposter(19855).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_non_numeric_port_400() {
+        let (manager, admin) = setup(
+            19856,
+            12756,
+            serde_json::json!([{"responses": [{"is": {"statusCode": 200, "body": "x"}}]}]),
+        )
+        .await;
+        let resp = reqwest::get(format!("{admin}/__rift/notaport/x"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            400,
+            "non-numeric port is a malformed gateway target → 400, distinct from 404"
+        );
+        let _ = manager.delete_imposter(19856).await;
+    }
+
+    #[tokio::test]
+    async fn gateway_not_gated_by_admin_apikey() {
+        // The gateway is data-plane imposter traffic: it must work WITHOUT the admin key, even
+        // when --apikey is set (otherwise the app-under-test would need the admin key).
+        let manager = Arc::new(ImposterManager::new());
+        manager
+            .create_imposter(
+                serde_json::from_value(serde_json::json!({
+                    "port": 19857, "protocol": "http",
+                    "stubs": [{"predicates": [{"equals": {"path": "/x"}}],
+                              "responses": [{"is": {"statusCode": 200, "body": "open"}}]}]
+                }))
+                .unwrap(),
+            )
+            .await
+            .expect("create imposter");
+        let server = rift_http_proxy::admin_api::AdminApiServer::new(
+            "127.0.0.1:12757".parse().unwrap(),
+            manager.clone(),
+            Some("secret".to_string()),
+        );
+        tokio::spawn(server.run());
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Admin route without the key → 401 (control plane stays protected).
+        let admin_resp = reqwest::get("http://127.0.0.1:12757/imposters")
+            .await
+            .unwrap();
+        assert_eq!(
+            admin_resp.status(),
+            401,
+            "admin route still requires the apikey"
+        );
+
+        // Gateway without the key → serves (data plane is not gated).
+        let gw = reqwest::get("http://127.0.0.1:12757/__rift/19857/x")
+            .await
+            .unwrap();
+        assert_eq!(gw.status(), 200);
+        assert_eq!(
+            gw.text().await.unwrap(),
+            "open",
+            "gateway works without the admin key"
+        );
+        let _ = manager.delete_imposter(19857).await;
+    }
+}


### PR DESCRIPTION
## Summary

The per-imposter-port model creates container friction: imposter ports aren't known until runtime, but Docker `-p` publishing is fixed at container start — so you must pre-expose a guessed port range. This adds a mode where imposters are reachable through the **single admin port** via a path-prefix gateway, so a containerized Rift needs only **one published port** (`2525`).

## What changed

- **Gateway:** `/__rift/:port/<path>` on the admin port routes to the imposter on `:port`, rewriting the request URI to the imposter-relative `/<path>` (+ query, + body) before dispatching to the imposter's handler — so its predicates and responses behave **exactly** as if the request arrived on its own port. Bad/non-numeric port → `400`; unknown imposter → `404`.
- **Auth:** the gateway is **data-plane** imposter traffic, not the admin control plane, so it is **exempt from the admin `--apikey`**. It mirrors direct per-imposter-port access (no admin key required) and doesn't leak an `Authorization` header into imposter predicates. The admin control plane (`/imposters`, etc.) stays gated.
- Complements (does not replace) the per-imposter-port model — imposters still bind and serve on their own ports.

## Behaviour
- `GET admin:2525/__rift/4545/api/data` → routed to imposter 4545, which sees `GET /api/data`.
- Method, query string, and request body all transit the gateway.
- `/__rift/4545` (no sub-path) → imposter root `/`.

## Tests
`mod gateway` (in-process manager + `AdminApiServer` + reqwest): routes+path-rewrite, method+query preserved, POST body forwarded, no-sub-path→root, unknown-port→404, non-numeric-port→400, and **not-gated-by-apikey** (admin route 401s without the key while the gateway serves).

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green (only intercepts the `/__rift/` prefix — no regression).

## Relations
Slots into the zio-bdd portable mock SPI's `Correlated` deployment path (one shared base URI). Out of scope (noted): Host-header / correlation-header routing variants — the path prefix satisfies "single port".

Closes #212