### PR TITLE
fix: support JS config calling convention in decorate behavior

### DIFF
--- a/crates/rift-core/src/behaviors/mod.rs
+++ b/crates/rift-core/src/behaviors/mod.rs
@@ -35,7 +35,9 @@ pub use lookup::{
     apply_lookup_behaviors, CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey,
 };
 pub use request::{header_to_title_case, RequestContext};
-pub use transform::{apply_decorate, apply_shell_transform};
+pub use transform::{
+    apply_decorate, apply_shell_transform, is_js_config_decorate, rewrite_js_config_to_rhai,
+};
 pub use types::ResponseBehaviors;
 #[allow(unused_imports)]
 pub use wait::WaitBehavior;

--- a/crates/rift-core/src/behaviors/transform.rs
+++ b/crates/rift-core/src/behaviors/transform.rs
@@ -47,6 +47,52 @@ pub fn apply_shell_transform(
     }
 }
 
+/// Detect Mountebank's JavaScript `config =>` decorate calling convention (issue #191): an arrow or
+/// `function(config)` whose body reads/writes `config.request`/`config.response`. These can't run in
+/// Rhai as-is (arrow syntax + the `config` variable model), so they need rewriting/routing.
+pub fn is_js_config_decorate(script: &str) -> bool {
+    let t = script.trim_start();
+    t.starts_with("config =>")
+        || t.starts_with("config=>")
+        || t.starts_with("(config) =>")
+        || t.starts_with("(config)=>")
+        || t.starts_with("function(config)")
+        || t.starts_with("function (config)")
+        || t.contains("config.request.")
+        || t.contains("config.response.")
+}
+
+static JSON_FN_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+
+/// Rewrite a simple JS `config` decorate script into Rhai (issue #191, Part A). The body's field
+/// reads/writes on `config.request`/`config.response` map onto the `request`/`response` maps that
+/// `apply_decorate` already exposes. This covers inline scripts that do simple field access; full
+/// JavaScript (require/closures, JSON parsing of objects, spreads) is the separate JS-engine route.
+pub fn rewrite_js_config_to_rhai(script: &str) -> String {
+    // Strip a `config =>` / `function(config)` wrapper down to the function body.
+    let body = if script.contains("=>") || script.trim_start().starts_with("function") {
+        match (script.find('{'), script.rfind('}')) {
+            (Some(open), Some(close)) if close > open => &script[open + 1..close],
+            _ => script,
+        }
+    } else {
+        script
+    };
+
+    let mut rhai = body.trim().to_string();
+    rhai = rhai.replace("config.request.", "request.");
+    rhai = rhai.replace("config.response.", "response.");
+    // JS declarations → Rhai `let`.
+    rhai = rhai.replace("const ", "let ").replace("var ", "let ");
+    // Best-effort: JSON.parse(x) / JSON.stringify(x) with a simple (non-nested) arg → the arg
+    // itself — the body is already a string in Rhai scope, so simple field access needs no JSON.
+    let json_re = JSON_FN_RE
+        .get_or_init(|| regex::Regex::new(r"JSON\.(?:parse|stringify)\(([^()]*)\)").unwrap());
+    rhai = json_re.replace_all(&rhai, "$1").to_string();
+    // Mountebank scripts commonly use single-quoted strings; Rhai needs double quotes.
+    rhai.replace('\'', "\"")
+}
+
 /// Apply decorate behavior using Rhai script (Mountebank-compatible)
 /// The script can access and modify `request` and `response` variables
 pub fn apply_decorate(
@@ -291,5 +337,51 @@ mod tests {
         let result = apply_decorate(script, &request, "body", 200, &mut headers);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Decorate script error"));
+    }
+
+    // Issue #191: JS `config =>` decorate convention detection + rewrite.
+    #[test]
+    fn is_js_config_decorate_detects_convention() {
+        assert!(is_js_config_decorate(
+            "config => { config.response.body = 'x'; }"
+        ));
+        assert!(is_js_config_decorate(
+            "(config) => { config.response.body = 'x'; }"
+        ));
+        assert!(is_js_config_decorate(
+            "function(config) { config.response.body = 'x'; }"
+        ));
+        assert!(is_js_config_decorate("config.response.statusCode = 404;"));
+        // Plain Rhai and the 2-arg `function(request, response)` JS form are NOT this convention.
+        assert!(!is_js_config_decorate("response.body = request.body;"));
+        assert!(!is_js_config_decorate(
+            "function(request, response) { response.body = 'x'; }"
+        ));
+    }
+
+    #[test]
+    fn rewrite_js_config_maps_to_rhai() {
+        assert_eq!(
+            rewrite_js_config_to_rhai("config => { config.response.body = 'hello'; }").trim(),
+            r#"response.body = "hello";"#
+        );
+        assert_eq!(
+            rewrite_js_config_to_rhai("config => { config.response.body = config.request.body; }")
+                .trim(),
+            "response.body = request.body;"
+        );
+    }
+
+    #[test]
+    fn rewrite_js_config_simple_json_helpers_drop_to_arg() {
+        // Best-effort: a non-nested JSON.parse/stringify arg becomes the arg (the body is already
+        // a string in Rhai scope). Nested-paren args are left for the JS-engine route (Part B).
+        assert_eq!(
+            rewrite_js_config_to_rhai(
+                "config => { config.response.body = JSON.stringify(config.request.body); }"
+            )
+            .trim(),
+            "response.body = request.body;"
+        );
     }
 }

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -7,7 +7,10 @@ use super::types::{
     DebugResponsePreview, IsResponse, ResponseMode, RiftResponseExtension, RiftScriptConfig,
     StubResponse,
 };
-use crate::behaviors::{apply_decorate, HasRepeatBehavior, RequestContext};
+use crate::behaviors::{
+    apply_decorate, is_js_config_decorate, rewrite_js_config_to_rhai, HasRepeatBehavior,
+    RequestContext,
+};
 use crate::imposter::Predicate;
 use std::collections::HashMap;
 
@@ -279,6 +282,14 @@ pub fn apply_js_or_rhai_decorate(
     status: u16,
     headers: &mut HashMap<String, String>,
 ) -> Result<(String, u16), String> {
+    // Mountebank's JS `config =>` convention (issue #191): rewrite simple field access onto the
+    // Rhai request/response maps. Checked before the `function` route since arrow scripts don't
+    // start with "function" and `function(config)` uses the config model, not (request, response).
+    if is_js_config_decorate(script) {
+        let rhai_script = rewrite_js_config_to_rhai(script);
+        return apply_decorate(&rhai_script, request, body, status, headers);
+    }
+
     // Check if it's a JavaScript function declaration
     if script.trim().starts_with("function") {
         #[cfg(feature = "javascript")]
@@ -331,6 +342,106 @@ pub fn apply_js_or_rhai_decorate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Issue #191: the JS `config =>` decorate convention runs (rewritten to Rhai) end-to-end.
+    fn decorate_req() -> RequestContext {
+        RequestContext {
+            method: "GET".to_string(),
+            path: "/orders".to_string(),
+            query: std::collections::HashMap::new(),
+            headers: std::collections::HashMap::new(),
+            body: Some("REQ-BODY".to_string()),
+        }
+    }
+
+    #[test]
+    fn decorate_js_config_sets_body() {
+        let mut headers = std::collections::HashMap::new();
+        let (body, status) = apply_js_or_rhai_decorate(
+            "config => { config.response.body = 'hello'; }",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(body, "hello");
+        assert_eq!(status, 200);
+    }
+
+    #[test]
+    fn decorate_js_config_reads_request_body() {
+        let mut headers = std::collections::HashMap::new();
+        let (body, _) = apply_js_or_rhai_decorate(
+            "config => { config.response.body = config.request.body; }",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(body, "REQ-BODY");
+    }
+
+    #[test]
+    fn decorate_js_config_sets_status() {
+        let mut headers = std::collections::HashMap::new();
+        let (_, status) = apply_js_or_rhai_decorate(
+            "config => { config.response.statusCode = 404; }",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(status, 404);
+    }
+
+    #[test]
+    fn decorate_js_config_function_wrapper_executes() {
+        // `function(config) { ... }` must take the config-rewrite route, NOT the `function`→JS-engine
+        // route (it uses the config model, not (request, response)). Locks the detection ordering.
+        let mut headers = std::collections::HashMap::new();
+        let (body, _) = apply_js_or_rhai_decorate(
+            "function(config) { config.response.body = 'fn'; }",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(body, "fn");
+    }
+
+    #[test]
+    fn decorate_js_config_no_wrapper_executes() {
+        // A bare body (no arrow/function wrapper) is detected via `config.response.` and rewritten
+        // in place (no brace stripping).
+        let mut headers = std::collections::HashMap::new();
+        let (body, _) = apply_js_or_rhai_decorate(
+            "config.response.body = 'bare';",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(body, "bare");
+    }
+
+    #[test]
+    fn decorate_plain_rhai_still_works() {
+        let mut headers = std::collections::HashMap::new();
+        let (body, _) = apply_js_or_rhai_decorate(
+            "response.body = request.path;",
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+        )
+        .unwrap();
+        assert_eq!(body, "/orders", "existing Rhai decorate must be unchanged");
+    }
 
     // =========================================================================
     // Issue #116: Multi-valued headers preserved via create_stub_from_proxy_response


### PR DESCRIPTION
## Summary

The `decorate` behavior runs scripts through Rhai, but the legacy Mountebank fleet uses **JavaScript** with the `config` calling convention (`config => { ... config.request ... config.response.body ... }`). The dispatcher only routed to the JS path when a script started with `function`, so arrow `config =>` scripts fell through to the Rhai engine and failed — arrow syntax and the `config` variable model are invalid Rhai. Several internal consumers using this convention were all broken on Rift.

## Fix (issue's Part A — the immediate unblock)

- **`is_js_config_decorate`** — detect the convention: `config =>`, `(config) =>`, `function(config)`, or a body referencing `config.request.`/`config.response.`.
- **`rewrite_js_config_to_rhai`** — strip the wrapper to the body and map `config.request.`→`request.`, `config.response.`→`response.` (plus `const`/`var`→`let`, best-effort `JSON.parse/stringify` of a simple non-nested arg, single→double quotes), then run the existing Rhai `apply_decorate` (whose `request`/`response` maps already match).
- **`apply_js_or_rhai_decorate`** checks `is_js_config_decorate` **first** — `function(config)` must beat the `function`→JS-engine route (it uses the config model, not `(request, response)`). The 2-arg `function(request, response)` JS path and plain-Rhai path are unchanged.

A rewritten script that is invalid Rhai surfaces as a decorate error — never silent wrong output.

## Behaviour
```json
"decorate": "config => { config.response.body = JSON.stringify({...}); }"   // now runs (simple field access)
"decorate": "response.body = request.body + ' x';"                          // existing Rhai — unchanged
```

## Tests
`transform.rs` units: detection (matches the convention forms; rejects plain Rhai and 2-arg `function(request, response)`) + rewrite mapping + simple JSON helper. `response.rs` end-to-end through the real dispatcher: `config =>` sets body / reads `config.request.body` / sets `statusCode`; `function(config)` ordering; bare no-wrapper; and a plain-Rhai regression guard.

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; full workspace suite green.

## Scope / follow-on
Out of scope (the issue's own separations, tracked separately): **Part B** — full JS-engine `config` wrapping (QuickJS) for scripts using `require()`, closures, or `JSON.parse` of objects/spreads; and the `inject` response type's same calling-convention issue.

Closes #191