### PR TITLE
fix(rift-verify): detect dynamic behaviors in both _behaviors and behaviors-array forms

### DIFF
--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -633,17 +633,44 @@ fn check_if_dynamic(responses: &[serde_json::Value]) -> (bool, Option<String>) {
         return (true, Some("fault injection".to_string()));
     }
 
-    // Check for _rift script extension
+    // Check for _rift script extension and _rift.fault (tcp/latency/error are non-deterministic
+    // or transport-level; can't be asserted as a normal HTTP response).
     if let Some(rift) = first.get("_rift") {
         if rift.get("script").is_some() {
             return (true, Some("Rift script response".to_string()));
         }
+        if rift.get("fault").is_some() {
+            return (true, Some("Rift fault (_rift.fault)".to_string()));
+        }
     }
 
-    // Check for _behaviors with repeat (stateful)
-    if let Some(behaviors) = first.get("_behaviors") {
-        if behaviors.get("repeat").is_some() {
-            return (true, Some("repeat behavior (stateful)".to_string()));
+    // Behaviors whose output depends on the request or external state can't be predicted from
+    // the stub alone (repeat=stateful; decorate/copy/lookup/shellTransform=dynamic body/headers).
+    // Handle BOTH the input config form (`_behaviors` object) and the form returned by
+    // GET /imposters (`behaviors` array of single-key objects, Mountebank-style).
+    let label = |k: &str| match k {
+        "repeat" => "repeat behavior (stateful)",
+        "decorate" => "decorate behavior (dynamic)",
+        "copy" => "copy behavior (request-derived)",
+        "lookup" => "lookup behavior (data-source)",
+        "shellTransform" => "shellTransform behavior (external)",
+        _ => "dynamic behavior",
+    };
+    const DYNAMIC_BEHAVIORS: [&str; 5] = ["repeat", "decorate", "copy", "lookup", "shellTransform"];
+    if let Some(obj) = first.get("_behaviors").and_then(|v| v.as_object()) {
+        for k in DYNAMIC_BEHAVIORS {
+            if obj.contains_key(k) {
+                return (true, Some(label(k).to_string()));
+            }
+        }
+    }
+    if let Some(arr) = first.get("behaviors").and_then(|v| v.as_array()) {
+        for item in arr.iter().filter_map(|v| v.as_object()) {
+            for k in DYNAMIC_BEHAVIORS {
+                if item.contains_key(k) {
+                    return (true, Some(label(k).to_string()));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
`rift-verify`'s `check_if_dynamic` only recognised `_rift.script` and `repeat`, and only in the `_behaviors` config form — not the `behaviors` array form that `GET /imposters` actually returns, nor `_rift.fault`. So decorate/copy/lookup/fault stubs were asserted as static responses and **false-failed** (e.g. decorate adds a header → HeaderMissing; a TCP-fault stub → RequestError).

This skips `repeat`/`decorate`/`copy`/`lookup`/`shellTransform` in **either** serialization, plus `_rift.fault`. On the `rift-imposter-samples` suite it cuts `--skip-dynamic` false-failures from **6 → 1** (the remaining one is the `not`/`xpath` predicate-generation gap, tracked separately).

## Context
Found during a v0.7.0 conformance pass — the engine behaves correctly in all these cases; the verifier was the gap.

Refs #249 (this is finding #2; #1 not/xpath, #3 transport-aware faults, and the new modes remain open there). Dynamic-*assertion* (turning these SKIPs into real checks) is proposed in #251.

## Verification
`cargo fmt` + `cargo clippy --release --bin rift-verify` clean; re-ran `rift-verify --skip-dynamic` against the sample suite (6 → 1).