### PR TITLE
fix: rift-verify predicate/dynamic-detection gaps produce false results on v0.7.0 features

### DIFF
--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -73,6 +73,21 @@ struct Args {
     /// Run a demo showing enhanced error output examples
     #[arg(long)]
     demo: bool,
+
+    /// Route requests through the single-port gateway (`{admin_url}/__rift/<port>/...`, issue #212)
+    /// instead of connecting to each imposter port directly.
+    #[arg(long)]
+    gateway: bool,
+
+    /// Accept self-signed / invalid TLS certificates (needed for `protocol: https` imposters,
+    /// issue #206, which typically present a self-signed cert).
+    #[arg(long)]
+    insecure: bool,
+
+    /// Correlation value sent for correlated-isolation imposters (issue #223): when an imposter
+    /// declares `flowIdSource: "header:<Name>"`, every request carries `<Name>: <space>`.
+    #[arg(long, default_value = "rift-verify")]
+    space: String,
 }
 
 // ============================================================================
@@ -106,6 +121,23 @@ struct ImposterDetails {
     name: Option<String>,
     #[serde(default)]
     stubs: Vec<Stub>,
+    /// Raw `flowState` block (issue #223). Parsed loosely so the verifier doesn't couple to the
+    /// engine's full config schema — we only need `mountebankStateMapping.flowIdSource`.
+    #[serde(default)]
+    flow_state: Option<serde_json::Value>,
+}
+
+impl ImposterDetails {
+    /// The header name carrying the correlation/space id, when this imposter isolates flows by a
+    /// request header (`flowIdSource: "header:<Name>"`). `None` for the default `imposter_port`.
+    fn flow_header(&self) -> Option<String> {
+        self.flow_state
+            .as_ref()?
+            .get("mountebankStateMapping")?
+            .get("flowIdSource")?
+            .as_str()
+            .and_then(flow_id_header_name)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -135,6 +167,13 @@ struct TestCase {
     skip_reason: Option<String>,
     /// Stub is designed to never match (contains "DONT MATCH" or similar in predicates)
     is_no_match_stub: bool,
+    /// Imposter protocol ("http"/"https") — selects the request scheme (issue #206).
+    protocol: String,
+    /// Stub injects a `_rift.fault.tcp` reset (issue #239): a connection error is the expected
+    /// outcome, not a failure (finding #3).
+    expects_transport_error: bool,
+    /// Correlated-isolation header name to send (issue #223), value = `--space`.
+    flow_header: Option<String>,
 }
 
 #[derive(Debug)]
@@ -179,6 +218,9 @@ enum FailureReason {
     BodyMismatch { expected: String, actual: String },
     /// Expected body but got none
     BodyMissing { expected: String },
+    /// A `_rift.fault.tcp` stub answered with an HTTP response instead of resetting the
+    /// connection — the fault did not fire (issue #249 finding #3).
+    TransportResetExpected { actual: u16 },
 }
 
 impl FailureReason {
@@ -213,6 +255,9 @@ impl FailureReason {
             FailureReason::BodyMissing { .. } => {
                 "Hint: Expected a response body but got an empty response.".to_string()
             }
+            FailureReason::TransportResetExpected { actual } => {
+                format!("Hint: This stub injects a _rift.fault.tcp reset, so the connection should drop; instead it answered HTTP {actual}. The fault did not fire.")
+            }
         }
     }
 }
@@ -240,6 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = Client::builder()
         .timeout(Duration::from_secs(args.timeout))
+        .danger_accept_invalid_certs(args.insecure)
         .build()?;
 
     // Check if demo mode
@@ -284,8 +330,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
+        let flow_header = imposter.flow_header();
         for (stub_index, stub) in imposter.stubs.iter().enumerate() {
-            let test_cases = generate_test_cases(stub_index, stub, args.skip_dynamic);
+            let test_cases = generate_test_cases(
+                stub_index,
+                stub,
+                args.skip_dynamic,
+                &imposter.protocol,
+                flow_header.as_deref(),
+            );
             summary.total_tests += test_cases.len();
 
             for test_case in test_cases {
@@ -338,8 +391,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     continue;
                 }
 
-                let result =
-                    execute_test(&client, imposter.port, &test_case, args.status_only).await;
+                let result = execute_test(
+                    &client,
+                    &args.admin_url,
+                    args.gateway,
+                    &args.space,
+                    imposter.port,
+                    &test_case,
+                    args.status_only,
+                )
+                .await;
 
                 if result.success {
                     summary.passed += 1;
@@ -483,17 +544,28 @@ async fn fetch_imposters(
 // Test Case Generation
 // ============================================================================
 
-fn generate_test_cases(stub_index: usize, stub: &Stub, skip_dynamic: bool) -> Vec<TestCase> {
+fn generate_test_cases(
+    stub_index: usize,
+    stub: &Stub,
+    skip_dynamic: bool,
+    protocol: &str,
+    flow_header: Option<&str>,
+) -> Vec<TestCase> {
     let mut test_cases = Vec::new();
 
     // Check if this stub has dynamic responses
     let (is_dynamic, dynamic_type) = check_if_dynamic(&stub.responses);
+
+    // A `_rift.fault.tcp` stub resets the connection (issue #239): a transport error is the
+    // expected outcome rather than a failure (finding #3).
+    let expects_transport_error = expects_tcp_fault(&stub.responses);
 
     // Check if this stub is designed to never match
     let is_no_match_stub = check_if_no_match_stub(&stub.predicates);
 
     // Parse predicates to build test request (needed for all cases)
     let (method, path, headers, query_params, body) = parse_predicates(&stub.predicates);
+    let flow_header = flow_header.map(str::to_string);
 
     // No-match stubs (e.g., "DONT MATCH THIS") are designed to never match any request.
     // We mark them as passed because:
@@ -515,6 +587,9 @@ fn generate_test_cases(stub_index: usize, stub: &Stub, skip_dynamic: bool) -> Ve
             is_dynamic: false,
             skip_reason: Some("no-match stub (passes by design)".to_string()),
             is_no_match_stub: true,
+            protocol: protocol.to_string(),
+            expects_transport_error: false,
+            flow_header: flow_header.clone(),
         });
         return test_cases;
     }
@@ -535,6 +610,9 @@ fn generate_test_cases(stub_index: usize, stub: &Stub, skip_dynamic: bool) -> Ve
             is_dynamic: true,
             skip_reason: dynamic_type,
             is_no_match_stub: false,
+            protocol: protocol.to_string(),
+            expects_transport_error,
+            flow_header: flow_header.clone(),
         });
         return test_cases;
     }
@@ -557,6 +635,9 @@ fn generate_test_cases(stub_index: usize, stub: &Stub, skip_dynamic: bool) -> Ve
         is_dynamic,
         skip_reason: None,
         is_no_match_stub: false,
+        protocol: protocol.to_string(),
+        expects_transport_error,
+        flow_header,
     });
 
     test_cases
@@ -675,6 +756,65 @@ fn check_if_dynamic(responses: &[serde_json::Value]) -> (bool, Option<String>) {
     }
 
     (false, None)
+}
+
+/// True when the stub's first response injects a connection-level TCP fault
+/// (`_rift.fault.tcp`, issue #239), for which a transport error is the expected outcome.
+fn expects_tcp_fault(responses: &[serde_json::Value]) -> bool {
+    responses
+        .first()
+        .and_then(|r| r.get("_rift"))
+        .and_then(|r| r.get("fault"))
+        .and_then(|f| f.get("tcp"))
+        .is_some()
+}
+
+/// Classify a request error string as a connection-level reset/abort (the signature of a TCP
+/// fault) rather than an application error. Used to PASS `_rift.fault.tcp` stubs (finding #3).
+fn is_transport_reset_error(err: &str) -> bool {
+    let e = err.to_lowercase();
+    e.contains("connection reset")
+        || e.contains("connection closed")
+        || e.contains("connection aborted")
+        || e.contains("broken pipe")
+        || e.contains("incomplete message")
+}
+
+/// A `_rift.fault.tcp` stub passes when (and only when) the request fails with a connection-level
+/// reset. Scoping to `expects_transport_error` keeps normal stubs failing on any connection error.
+fn is_expected_reset(expects_transport_error: bool, error_msg: &str) -> bool {
+    expects_transport_error && is_transport_reset_error(error_msg)
+}
+
+/// Build the request URL for a stub. With `--gateway`, route through the single admin port
+/// (`{admin_url}/__rift/<port>/...`, issue #212); otherwise connect to the imposter port directly,
+/// choosing the scheme from the imposter protocol (`https` for issue #206).
+fn build_target_url(
+    admin_url: &str,
+    gateway: bool,
+    protocol: &str,
+    port: u16,
+    path: &str,
+) -> String {
+    if gateway {
+        let base = admin_url.trim_end_matches('/');
+        return format!("{base}/__rift/{port}{path}");
+    }
+    let scheme = if protocol.eq_ignore_ascii_case("https") {
+        "https"
+    } else {
+        "http"
+    };
+    format!("{scheme}://localhost:{port}{path}")
+}
+
+/// Extract the correlation header name from a `flowIdSource` value (issue #223): `"header:X-Foo"`
+/// yields `Some("X-Foo")`; `"imposter_port"` (or anything without the prefix) yields `None`.
+fn flow_id_header_name(flow_id_source: &str) -> Option<String> {
+    flow_id_source
+        .strip_prefix("header:")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 fn extract_expected_response(
@@ -817,12 +957,26 @@ fn parse_predicates(
                 }
             }
         }
+        // Handle xpath predicates - build a matching XML body from the selector and the
+        // expected `equals.body` value (mirrors the jsonpath handling above). Issue #249 finding #1.
+        if let Some(xpath) = predicate.get("xpath") {
+            if let Some(selector) = xpath.get("selector").and_then(|v| v.as_str()) {
+                if let Some(value) = predicate
+                    .get("equals")
+                    .and_then(|e| e.get("body"))
+                    .and_then(|v| v.as_str())
+                {
+                    body = Some(build_xml_from_xpath(selector, value));
+                }
+            }
+        }
+
         // Handle various predicate formats
         // Note: startsWith is already processed in first pass
 
-        // "equals" predicate - skip body if this predicate has a jsonpath (body handled above)
+        // "equals" predicate - skip body when handled by jsonpath/xpath above
         if let Some(equals) = predicate.get("equals") {
-            let skip_body = predicate.get("jsonpath").is_some();
+            let skip_body = predicate.get("jsonpath").is_some() || predicate.get("xpath").is_some();
             parse_equals_predicate(
                 equals,
                 &mut method,
@@ -856,9 +1010,9 @@ fn parse_predicates(
             }
         }
 
-        // "deepEquals" predicate - skip body if this predicate has a jsonpath (body handled above)
+        // "deepEquals" predicate - skip body when handled by jsonpath/xpath above
         if let Some(deep_equals) = predicate.get("deepEquals") {
-            let skip_body = predicate.get("jsonpath").is_some();
+            let skip_body = predicate.get("jsonpath").is_some() || predicate.get("xpath").is_some();
             parse_equals_predicate(
                 deep_equals,
                 &mut method,
@@ -932,6 +1086,12 @@ fn parse_predicates(
                 }
             }
         }
+
+        // "not" predicate - the stub matches when the inner predicate is FALSE, so build a
+        // request that deliberately violates it (issue #249 finding #1).
+        if let Some(inner) = predicate.get("not") {
+            apply_not_predicate(inner, &mut method, &mut path);
+        }
     }
 
     // If we built a jsonpath body and no explicit body was set, use it
@@ -940,6 +1100,59 @@ fn parse_predicates(
     }
 
     (method, path, headers, query_params, body)
+}
+
+/// Mutate the working request so it does NOT satisfy `inner` (the body of a `not` predicate).
+/// We parse what WOULD satisfy `inner`, then steer each field the inner predicate actually
+/// constrains to a guaranteed-different value. Path and method cover the predicates the verifier
+/// generates requests from; an inner constraint on body/headers/query is already violated by the
+/// default empty request.
+fn apply_not_predicate(inner: &serde_json::Value, method: &mut String, path: &mut String) {
+    let (inner_method, _inner_path, _h, _q, _b) = parse_predicates(std::slice::from_ref(inner));
+    if predicate_mentions_field(inner, "path") {
+        // A sentinel path won't equal / start-with / match a real constrained path (including "/").
+        *path = "/__rift_verify_no_match__".to_string();
+    }
+    if predicate_mentions_field(inner, "method") {
+        // Pick any method other than the one the inner predicate constrains (its default is GET).
+        *method = if inner_method.eq_ignore_ascii_case("GET") {
+            "DELETE".to_string()
+        } else {
+            "GET".to_string()
+        };
+    }
+}
+
+/// Recursively report whether any object inside `value` carries the key `field` (used to detect
+/// which request fields a `not` predicate actually constrains, regardless of operator/nesting).
+fn predicate_mentions_field(value: &serde_json::Value, field: &str) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.contains_key(field) || map.values().any(|v| predicate_mentions_field(v, field))
+        }
+        serde_json::Value::Array(items) => items.iter().any(|v| predicate_mentions_field(v, field)),
+        _ => false,
+    }
+}
+
+/// Build a matching XML body from an xpath selector and a leaf value, mirroring
+/// `build_json_from_jsonpath`. e.g. ("/order/id", "728839") -> "<order><id>728839</id></order>".
+fn build_xml_from_xpath(selector: &str, value: &str) -> String {
+    let parts: Vec<&str> = selector.split('/').filter(|s| !s.is_empty()).collect();
+    if parts.is_empty() {
+        return value.to_string();
+    }
+    let mut xml = value.to_string();
+    for part in parts.iter().rev() {
+        // Strip positional predicates / attribute markers (e.g. `item[1]`, `@id`) to the bare tag.
+        let tag = part
+            .split('[')
+            .next()
+            .unwrap_or(part)
+            .trim_start_matches('@');
+        xml = format!("<{tag}>{xml}</{tag}>");
+    }
+    xml
 }
 
 /// Build a JSON object from a jsonpath selector and value
@@ -1147,14 +1360,23 @@ fn generate_sample_from_regex(pattern: &str) -> String {
 
 async fn execute_test(
     client: &Client,
+    admin_url: &str,
+    gateway: bool,
+    space: &str,
     imposter_port: u16,
     test_case: &TestCase,
     status_only: bool,
 ) -> TestResult {
     let start = std::time::Instant::now();
 
-    // Build URL with query params
-    let mut url = format!("http://localhost:{}{}", imposter_port, test_case.path);
+    // Build URL with query params (gateway/https-aware, issues #212/#206)
+    let mut url = build_target_url(
+        admin_url,
+        gateway,
+        &test_case.protocol,
+        imposter_port,
+        &test_case.path,
+    );
     if !test_case.query_params.is_empty() {
         let query_string: Vec<String> = test_case
             .query_params
@@ -1180,6 +1402,11 @@ async fn execute_test(
         request = request.header(name, value);
     }
 
+    // Correlated-isolation header (issue #223): route this request to the verifier's space.
+    if let Some(flow_header) = &test_case.flow_header {
+        request = request.header(flow_header, space);
+    }
+
     // Add body if present
     if let Some(ref body) = test_case.body {
         request = request.body(body.clone());
@@ -1202,6 +1429,21 @@ async fn execute_test(
             let body_text = response.text().await.ok();
 
             let duration_ms = start.elapsed().as_millis();
+
+            // A `_rift.fault.tcp` stub must reset the connection; receiving any HTTP response means
+            // the fault did not fire — the exact regression this verifier exists to catch (finding #3).
+            if test_case.expects_transport_error {
+                return TestResult {
+                    test_case: test_case.clone(),
+                    success: false,
+                    actual_status: Some(status),
+                    actual_headers: Some(headers),
+                    actual_body: body_text,
+                    error: None,
+                    duration_ms,
+                    failure_reasons: vec![FailureReason::TransportResetExpected { actual: status }],
+                };
+            }
 
             // Verify response
             // If status_only mode, only check status code (no body/header checks)
@@ -1243,15 +1485,22 @@ async fn execute_test(
         }
         Err(e) => {
             let error_msg = e.to_string();
+            // A `_rift.fault.tcp` stub is expected to reset the connection (issue #239): a
+            // transport-level error is the PASS condition, not a failure (finding #3).
+            let expected_reset = is_expected_reset(test_case.expects_transport_error, &error_msg);
             TestResult {
                 test_case: test_case.clone(),
-                success: false,
+                success: expected_reset,
                 actual_status: None,
                 actual_headers: None,
                 actual_body: None,
                 error: Some(error_msg.clone()),
                 duration_ms: start.elapsed().as_millis(),
-                failure_reasons: vec![FailureReason::RequestError(error_msg)],
+                failure_reasons: if expected_reset {
+                    vec![]
+                } else {
+                    vec![FailureReason::RequestError(error_msg)]
+                },
             }
         }
     }
@@ -1590,6 +1839,10 @@ fn print_failure_reason(reason: &FailureReason) {
             println!("   - {YELLOW}Request error:{RESET} {err}");
             println!("     {DIM}{}{RESET}", reason.hint());
         }
+        FailureReason::TransportResetExpected { actual } => {
+            println!("   - {YELLOW}Fault not triggered:{RESET} expected connection reset, got HTTP {actual}");
+            println!("     {DIM}{}{RESET}", reason.hint());
+        }
     }
 }
 
@@ -1700,4 +1953,182 @@ fn demo_enhanced_error_output() {
 
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     println!("{GREEN}Demo complete!{RESET}");
+}
+
+#[cfg(test)]
+mod verify_tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── #1: not predicate ──────────────────────────────────────────────────
+    #[test]
+    fn not_predicate_generates_non_matching_path() {
+        let preds = vec![json!({ "not": { "equals": { "path": "/secret" } } })];
+        let (_method, path, _h, _q, _b) = parse_predicates(&preds);
+        assert_ne!(
+            path, "/secret",
+            "generated path must NOT satisfy the inner equals"
+        );
+    }
+
+    #[test]
+    fn not_predicate_flips_method() {
+        let preds = vec![json!({ "not": { "equals": { "method": "POST" } } })];
+        let (method, _p, _h, _q, _b) = parse_predicates(&preds);
+        assert_ne!(
+            method, "POST",
+            "generated method must NOT satisfy the inner equals"
+        );
+    }
+
+    #[test]
+    fn not_predicate_steers_away_from_default_method_and_path() {
+        // The forbidden value equals the parser default (GET / "/"), so a naive `!= default`
+        // guard would leave the request satisfying the inner predicate — it must still be steered.
+        let (method, _p, _h, _q, _b) =
+            parse_predicates(&[json!({ "not": { "equals": { "method": "GET" } } })]);
+        assert_ne!(method, "GET");
+        let (_m, path, _h, _q, _b) =
+            parse_predicates(&[json!({ "not": { "equals": { "path": "/" } } })]);
+        assert_ne!(path, "/");
+    }
+
+    // ── #1: xpath predicate ────────────────────────────────────────────────
+    #[test]
+    fn build_xml_from_xpath_nests_elements() {
+        assert_eq!(
+            build_xml_from_xpath("/order/id", "728839"),
+            "<order><id>728839</id></order>"
+        );
+    }
+
+    #[test]
+    fn build_xml_from_xpath_single_element() {
+        assert_eq!(build_xml_from_xpath("/root", "x"), "<root>x</root>");
+    }
+
+    #[test]
+    fn xpath_builds_matching_xml_body() {
+        let preds = vec![json!({
+            "xpath": { "selector": "/order/id" },
+            "equals": { "body": "728839" }
+        })];
+        let (_m, _p, _h, _q, body) = parse_predicates(&preds);
+        assert_eq!(body.as_deref(), Some("<order><id>728839</id></order>"));
+    }
+
+    // ── #3: tcp fault detection + classification ───────────────────────────
+    #[test]
+    fn expects_tcp_fault_detects_rift_fault_tcp() {
+        let responses = vec![json!({ "_rift": { "fault": { "tcp": "reset" } } })];
+        assert!(expects_tcp_fault(&responses));
+    }
+
+    #[test]
+    fn expects_tcp_fault_false_for_normal_and_latency() {
+        assert!(!expects_tcp_fault(&[
+            json!({ "is": { "statusCode": 200 } })
+        ]));
+        assert!(!expects_tcp_fault(&[
+            json!({ "_rift": { "fault": { "latency": 50 } } })
+        ]));
+    }
+
+    #[test]
+    fn is_transport_reset_error_matches_connection_errors() {
+        for msg in [
+            "error sending request: connection reset by peer",
+            "connection closed before message completed",
+            "incomplete message",
+            "tcp connect error: Connection reset",
+            "connection aborted by peer",
+            "broken pipe (os error 32)",
+        ] {
+            assert!(is_transport_reset_error(msg), "should match: {msg}");
+        }
+    }
+
+    #[test]
+    fn is_expected_reset_truth_table() {
+        // Only a fault-expecting stub AND a transport reset counts as the expected outcome.
+        assert!(is_expected_reset(true, "connection reset by peer"));
+        assert!(!is_expected_reset(false, "connection reset by peer"));
+        assert!(!is_expected_reset(true, "connection refused (os error 61)"));
+        assert!(!is_expected_reset(false, "200 OK"));
+    }
+
+    #[test]
+    fn is_transport_reset_error_ignores_status_like_errors() {
+        assert!(!is_transport_reset_error("builder error: invalid URL"));
+    }
+
+    // ── #4a/#4b: URL construction ──────────────────────────────────────────
+    #[test]
+    fn build_target_url_direct_http() {
+        assert_eq!(
+            build_target_url("http://localhost:2525", false, "http", 4511, "/api/data"),
+            "http://localhost:4511/api/data"
+        );
+    }
+
+    #[test]
+    fn build_target_url_https() {
+        assert_eq!(
+            build_target_url("http://localhost:2525", false, "https", 4545, "/secure"),
+            "https://localhost:4545/secure"
+        );
+    }
+
+    #[test]
+    fn build_target_url_gateway() {
+        assert_eq!(
+            build_target_url("http://localhost:2525", true, "http", 4511, "/api/data"),
+            "http://localhost:2525/__rift/4511/api/data"
+        );
+    }
+
+    #[test]
+    fn build_target_url_gateway_trims_trailing_slash() {
+        assert_eq!(
+            build_target_url("http://localhost:2525/", true, "http", 9, "/x"),
+            "http://localhost:2525/__rift/9/x"
+        );
+    }
+
+    // ── #4c: correlated isolation header ───────────────────────────────────
+    #[test]
+    fn flow_id_header_name_extracts_header_source() {
+        assert_eq!(
+            flow_id_header_name("header:X-Mock-Space").as_deref(),
+            Some("X-Mock-Space")
+        );
+    }
+
+    #[test]
+    fn flow_id_header_name_none_for_port_source() {
+        assert_eq!(flow_id_header_name("imposter_port"), None);
+    }
+
+    #[test]
+    fn imposter_flow_header_navigates_flow_state() {
+        let with_header: ImposterDetails = serde_json::from_value(json!({
+            "port": 4500, "protocol": "http", "stubs": [],
+            "flowState": { "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } }
+        }))
+        .unwrap();
+        assert_eq!(with_header.flow_header().as_deref(), Some("X-Mock-Space"));
+
+        let port_source: ImposterDetails = serde_json::from_value(json!({
+            "port": 4500, "protocol": "http", "stubs": [],
+            "flowState": { "mountebankStateMapping": { "flowIdSource": "imposter_port" } }
+        }))
+        .unwrap();
+        assert_eq!(port_source.flow_header(), None);
+
+        let no_flow_state: ImposterDetails = serde_json::from_value(json!({
+            "port": 4500, "protocol": "http", "stubs": []
+        }))
+        .unwrap();
+        assert_eq!(no_flow_state.flow_header(), None);
+    }
 }


### PR DESCRIPTION
`rift-verify` had not kept up with the engine and reported false PASS/FAIL on several valid v0.7.0 stubs (engine behaviour verified correct via curl). This closes the remaining gaps; finding #2 (dynamic-stub detection) already landed via #252.

## What changed (all in `crates/rift-http-proxy/src/bin/verify.rs`)
- **#1 `not` / `xpath` predicates** — `not` now generates a request that violates the inner predicate (steering whichever field it constrains, including the default-valued `GET`/`/` cases via `predicate_mentions_field`); `xpath` builds a matching nested XML body from the selector + `equals.body`, mirroring the jsonpath handling.
- **#3 `_rift.fault.tcp`** — a connection reset is now the PASS condition; a fault stub that answers with an HTTP response is an explicit failure (`FailureReason::TransportResetExpected`), so the exact regression the verifier exists to catch is no longer masked as success.
- **#4 new modes** — `--gateway` (route via `{admin_url}/__rift/<port>/...`, #212), `--insecure` HTTPS client + protocol-driven scheme (#206), and correlated-isolation awareness sending the auto-detected `flowIdSource` header with `--space` (#223).

Detection / URL / predicate logic is extracted into pure helpers covered by 18 unit tests; runtime wiring (TLS handshake, gateway routing, on-the-wire headers) is integration-level. Out of scope: actually *asserting* dynamic behaviors — follow-up #251.

Closes #249

Milestone: v0.7.0 conformance