### PR TITLE
fix: rift-lint W009 false-positive on Rhai decorate scripts

### DIFF
--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -699,6 +699,7 @@ pub fn validate_behavior(
                 &format!("{location}.wait"),
                 result,
                 options,
+                false,
             );
         } else if wait.is_number() {
             // fixed millisecond delay — valid
@@ -740,6 +741,7 @@ pub fn validate_behavior(
                 &format!("{location}.decorate"),
                 result,
                 options,
+                true,
             );
         }
     }
@@ -774,37 +776,22 @@ pub fn validate_behavior(
     }
 }
 
-/// Detect Mountebank's `config`-calling decorate convention (arrow or `function(config)`,
-/// or a body that reads/writes `config.request`/`config.response`). These are valid decorate
-/// scripts since #191, so W009 must not flag them. Mirrors
-/// `rift_core::behaviors::transform::is_js_config_decorate` — kept local to avoid pulling the
-/// engine crate into the standalone linter.
-fn is_js_config_decorate(script: &str) -> bool {
-    let t = script.trim_start();
-    t.starts_with("config =>")
-        || t.starts_with("config=>")
-        || t.starts_with("(config) =>")
-        || t.starts_with("(config)=>")
-        || t.starts_with("function(config)")
-        || t.starts_with("function (config)")
-        || t.contains("config.request.")
-        || t.contains("config.response.")
-}
-
-/// Validate JavaScript in a behavior.
+/// Validate JavaScript in a behavior. `allow_rhai` is set for behaviors that also accept a Rhai
+/// script (`decorate`): the engine routes any non-function decorate body — including the Mountebank
+/// `config =>` convention and bare Rhai — to its script engine (`apply_js_or_rhai_decorate`), so
+/// the "should be a function expression" nudge (W009) must not fire there (issues #248/#257). For
+/// JS-only behaviors (`wait`) it stays off, and a non-function script still warns.
 fn validate_javascript_behavior(
     file: &Path,
     script: &str,
     location: &str,
     result: &mut LintResult,
     _options: &LintOptions,
+    allow_rhai: bool,
 ) {
     let script_trimmed = script.trim();
 
-    if !script_trimmed.starts_with("function")
-        && !script_trimmed.is_empty()
-        && !is_js_config_decorate(script_trimmed)
-    {
+    if !allow_rhai && !script_trimmed.starts_with("function") && !script_trimmed.is_empty() {
         result.add_issue(
             LintIssue::warning(
                 "W009",
@@ -946,6 +933,7 @@ mod js_behavior_tests {
             "loc",
             &mut result,
             &LintOptions::default(),
+            false,
         );
         result
     }
@@ -956,14 +944,17 @@ mod js_behavior_tests {
 
     #[test]
     fn w009_not_fired_for_arrow_config_decorate() {
-        // Mountebank `config =>` decorate convention, valid since #191.
+        // Mountebank `config =>` decorate convention, valid since #191/#248.
         for script in [
             "config => { config.response.statusCode = 202; }",
             "config=>{ config.response.statusCode = 202; }",
             "(config) => { config.response.body = 'x'; }",
             "(config)=>{ config.response.body = 'x'; }",
         ] {
-            assert!(!has_code(&lint(script), "W009"), "W009 fired for: {script}");
+            assert!(
+                !has_code(&lint_decorate(script), "W009"),
+                "W009 fired for: {script}"
+            );
         }
     }
 
@@ -973,7 +964,10 @@ mod js_behavior_tests {
             "function(config) { config.response.statusCode = 202; }",
             "function (config) { config.response.statusCode = 202; }",
         ] {
-            assert!(!has_code(&lint(script), "W009"), "W009 fired for: {script}");
+            assert!(
+                !has_code(&lint_decorate(script), "W009"),
+                "W009 fired for: {script}"
+            );
         }
     }
 
@@ -981,24 +975,21 @@ mod js_behavior_tests {
     fn w009_not_fired_for_bare_config_body() {
         // A decorate body that just mutates `config.response`/`config.request`.
         assert!(!has_code(
-            &lint("config.response.statusCode = 404;"),
+            &lint_decorate("config.response.statusCode = 404;"),
             "W009"
         ));
-        assert!(!has_code(&lint("config.request.body;"), "W009"));
+        assert!(!has_code(&lint_decorate("config.request.body;"), "W009"));
     }
 
     #[test]
     fn w009_not_fired_for_legacy_function_form() {
         let script = "function(request, response) { response.body = 'x'; }";
-        assert!(!has_code(&lint(script), "W009"));
+        assert!(!has_code(&lint_decorate(script), "W009"));
     }
 
     #[test]
     fn w009_still_fired_for_non_function_junk() {
-        // Not a function expression and not a config-decorate form — keep warning.
-        // Near-boundary cases guard the exact `.contains("config.response.")` predicate
-        // against accidental over-suppression: `config` without the `config.request.`/
-        // `config.response.` prefix, and the substring without its trailing dot.
+        // `wait` is JS-only (allow_rhai=false): any non-function, non-empty script warns.
         for script in [
             "response.body = 'x';",
             "response.statusCode = config.statusCode;",
@@ -1007,6 +998,44 @@ mod js_behavior_tests {
             assert!(
                 has_code(&lint(script), "W009"),
                 "W009 should fire for: {script}"
+            );
+        }
+    }
+
+    fn lint_decorate(script: &str) -> LintResult {
+        let mut result = LintResult::new();
+        validate_javascript_behavior(
+            Path::new("test.json"),
+            script,
+            "loc.decorate",
+            &mut result,
+            &LintOptions::default(),
+            true,
+        );
+        result
+    }
+
+    #[test]
+    fn w009_not_fired_for_rhai_decorate() {
+        // A Rhai decorate (bare `response.`/`request.` assignment) is valid; the engine routes any
+        // non-function, non-config-arrow script to Rhai (issue #257).
+        assert!(!has_code(
+            &lint_decorate("response.body = \"rhai-\" + request.path;"),
+            "W009"
+        ));
+    }
+
+    #[test]
+    fn w009_not_fired_for_any_decorate_script() {
+        // decorate accepts JS-function, config-arrow, AND Rhai — the "must be a function
+        // expression" nudge never applies to decorate.
+        for script in [
+            "let x = request.path; response.body = x;",
+            "response.statusCode = 503;",
+        ] {
+            assert!(
+                !has_code(&lint_decorate(script), "W009"),
+                "W009 fired for decorate: {script}"
             );
         }
     }

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -575,7 +575,9 @@ fn w008_not_fired_for_safe_command() {
 
 #[test]
 fn w009_js_behavior_not_function_expression() {
-    let behavior = json!({ "decorate": "console.log('hi')" });
+    // W009 ("should be a function expression") applies to JS-only behaviors. `decorate` also
+    // accepts Rhai (issue #257), so the check is scoped to `wait` here.
+    let behavior = json!({ "wait": "console.log('hi')" });
     let mut r = LintResult::new();
     validate_behavior(path(), &behavior, "loc", &mut r, &opts());
     assert!(has_code(&r, "W009"));
@@ -910,4 +912,27 @@ fn single_imposter_still_validates() {
         "single imposter must still validate cleanly, got {:?}",
         codes(&r)
     );
+}
+
+// ─── Issue #257: W009 must not fire on Rhai decorate (wiring through validate_behavior) ──────
+
+#[test]
+fn w009_not_fired_for_rhai_decorate_through_behavior() {
+    let behavior = json!({ "decorate": "response.body = \"rhai-\" + request.path;" });
+    let mut r = LintResult::new();
+    validate_behavior(path(), &behavior, "loc", &mut r, &opts());
+    assert!(
+        !has_code(&r, "W009"),
+        "Rhai decorate must not warn W009: {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn w009_still_fired_for_non_function_wait_through_behavior() {
+    // wait is JS-only — a non-function wait script still warns (regression guard).
+    let behavior = json!({ "wait": "response.body = 'x';" });
+    let mut r = LintResult::new();
+    validate_behavior(path(), &behavior, "loc", &mut r, &opts());
+    assert!(has_code(&r, "W009"), "non-function wait should warn W009");
 }


### PR DESCRIPTION
`rift-lint` emitted **W009** (`JavaScript behavior should be a function expression` → "Wrap code in: function() { ... }") on a **Rhai** `decorate` body, but Rhai decorate is a supported engine feature — the engine routes any non-function decorate body (the `config =>` convention and bare Rhai alike) to its script engine via `apply_js_or_rhai_decorate`. So a valid config was flagged. Sibling of #248 (which handled the JS `config =>` arrow form), for the Rhai form.

## Fix
Thread an `allow_rhai` flag into `validate_javascript_behavior`: the `decorate` caller passes `true` (W009 never applies — decorate accepts JS-function, `config =>`, and Rhai), the `wait` caller passes `false` (JS-only; a non-function script still warns). This subsumes the config-arrow detection from #248, so the now-vestigial `is_js_config_decorate` helper is removed and the W009 condition simplified. The brace/paren/JS-syntax checks (E026/E027/E028) are untouched.

## Repro (now clean)
```json
{ "responses": [{ "is": { "statusCode": 200 },
  "_behaviors": { "decorate": "response.body = \"rhai-\" + request.path;" } }] }
```
`rift-imposter-samples` sample 13 now lints with 0 warnings; the engine serves `/rhai` → `rhai-/rhai`.

Found during the v0.7.0 conformance pass (#254). Closes #257.

Milestone: v0.7.0 conformance