### PR TITLE
fix: rift-verify tcp-fault assertion misclassifies reqwest connection-reset

### DIFF
--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -870,10 +870,27 @@ fn expects_tcp_fault(responses: &[serde_json::Value]) -> bool {
         .is_some()
 }
 
+/// Render an error together with its full `source()` chain. reqwest's top-level `Display` is only
+/// `error sending request for url (...)`; the actual cause (e.g. "connection reset by peer") lives
+/// in the source chain, so classifying on `to_string()` alone misses transport resets (issue #258).
+fn error_chain_string(err: &dyn std::error::Error) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        out.push_str(": ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
+}
+
 /// Classify a request error string as a connection-level reset/abort (the signature of a TCP
 /// fault) rather than an application error. Used to PASS `_rift.fault.tcp` stubs (finding #3).
+/// Pass the full chain from `error_chain_string` — the reset cause is not in reqwest's top Display.
 fn is_transport_reset_error(err: &str) -> bool {
     let e = err.to_lowercase();
+    // `connection closed`/`incomplete message` can't distinguish an intentional reset from an
+    // imposter crash mid-response; the dynamic path's control-request health check guards that.
     e.contains("connection reset")
         || e.contains("connection closed")
         || e.contains("connection aborted")
@@ -1585,7 +1602,7 @@ async fn execute_test(
             }
         }
         Err(e) => {
-            let error_msg = e.to_string();
+            let error_msg = error_chain_string(&e);
             // A `_rift.fault.tcp` stub is expected to reset the connection (issue #239): a
             // transport-level error is the PASS condition, not a failure (finding #3).
             let expected_reset = is_expected_reset(test_case.expects_transport_error, &error_msg);
@@ -2161,6 +2178,40 @@ mod verify_tests {
     #[test]
     fn is_transport_reset_error_ignores_status_like_errors() {
         assert!(!is_transport_reset_error("builder error: invalid URL"));
+    }
+
+    #[test]
+    fn error_chain_string_walks_source() {
+        use std::fmt;
+        #[derive(Debug)]
+        struct Outer(std::io::Error);
+        impl fmt::Display for Outer {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "error sending request for url (http://127.0.0.1:1/x)")
+            }
+        }
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+        let err = Outer(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset by peer (os error 54)",
+        ));
+        let chain = error_chain_string(&err);
+        // The top-level Display alone is NOT classifiable; the chained cause makes it so.
+        assert!(!is_transport_reset_error(&err.to_string()));
+        assert!(chain.contains("connection reset by peer"));
+        assert!(is_transport_reset_error(&chain));
+    }
+
+    #[test]
+    fn is_transport_reset_error_rejects_connection_refused_chain() {
+        // A down imposter (connection refused) must NOT be mistaken for a reset (no false PASS).
+        let refused = "error sending request for url (http://127.0.0.1:1/x): \
+                       tcp connect error: connection refused (os error 61)";
+        assert!(!is_transport_reset_error(refused));
     }
 
     // ── #4a/#4b: URL construction ──────────────────────────────────────────

--- a/crates/rift-http-proxy/src/bin/verify/dynamic.rs
+++ b/crates/rift-http-proxy/src/bin/verify/dynamic.rs
@@ -495,9 +495,15 @@ impl<'a> DynamicVerifier<'a> {
         if let Some(body) = &request.body {
             req = req.body(body.clone());
         }
-        let resp = req.send().await.map_err(|e| e.to_string())?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| super::error_chain_string(&e))?;
         let status = resp.status().as_u16();
-        let body = resp.text().await.map_err(|e| e.to_string())?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| super::error_chain_string(&e))?;
         Ok((status, body))
     }
 

--- a/crates/rift-http-proxy/tests/verify_dynamic.rs
+++ b/crates/rift-http-proxy/tests/verify_dynamic.rs
@@ -185,3 +185,78 @@ async fn dynamic_skipped_without_flag() {
         "no proxy assertion should run without the flag:\n{stdout}"
     );
 }
+
+#[tokio::test]
+async fn verify_dynamic_asserts_tcp_fault() {
+    // Issue #258: a real `_rift.fault.tcp` reset surfaces as a reqwest error whose top-level
+    // Display is only "error sending request for url (...)"; the verifier must classify it as a
+    // transport reset (via the source chain) and report PASS, not FAIL.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19891, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/reset" } }],
+                "responses": [{ "is": { "statusCode": 200 },
+                    "_rift": { "fault": { "tcp": "CONNECTION_RESET_BY_PEER" } } }]
+            }]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12701, manager).await;
+    let out = run_verify(&admin).await;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "tcp-fault assertion should PASS; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("tcp reset"),
+        "missing tcp reset check:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "tcp reset must not FAIL:\n{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn verify_normal_pass_asserts_tcp_fault() {
+    // Issue #258: the NORMAL verification pass (no --verify-dynamic) also classifies a real
+    // `_rift.fault.tcp` reset via execute_test's Err arm — guards that fix site against regression.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19901, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/reset" } }],
+                "responses": [{ "is": { "statusCode": 200 },
+                    "_rift": { "fault": { "tcp": "CONNECTION_RESET_BY_PEER" } } }]
+            }]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12711, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin]) // normal mode: no --skip-dynamic, no --verify-dynamic
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "normal-pass tcp-fault must PASS (reset is the expected outcome); stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "tcp reset must not FAIL in the normal pass:\n{stdout}"
+    );
+}


### PR DESCRIPTION
With `rift-verify --verify-dynamic`, a `_rift.fault.tcp` stub that correctly resets the connection was reported **FAIL** ("non-reset error"). reqwest's top-level `Display` is only `error sending request for url (...)`; the actual `connection reset` cause lives in the error `source()` chain, which `e.to_string()` drops — so `is_transport_reset_error` never matched it. (`curl` on the same stub exits 56 — the engine genuinely resets.)

## Fix
Add `error_chain_string(&dyn std::error::Error)` that renders an error with its full source chain, and use it at the three reqwest-stringification sites: `execute_test`'s `Err` arm and `drive_step`'s `send`/`text`. The classifier's keyword set is **intentionally unchanged** — a loose "error sending request" match was rejected because it would false-PASS a connection-refused/down imposter.

## Tests
- `error_chain_string_walks_source` (unit) — the top-level Display alone is not classifiable, the chained string is.
- `is_transport_reset_error_rejects_connection_refused_chain` (unit) — refused chain is not a reset (false-PASS guard).
- `verify_dynamic_asserts_tcp_fault` + `verify_normal_pass_asserts_tcp_fault` (integration) — drive a **real** engine TCP reset through both the `--verify-dynamic` runner and the normal verification pass, asserting PASS. These exercise the actual reqwest reset the original bug fell through.

Found during the v0.7.0 conformance pass (#254); this path was unit-tested only with hand-written strings and end-to-end-tested only with the error fault, never the tcp fault. Closes #258.

Milestone: v0.7.0 conformance