### PR TITLE
fix: rift-verify literal date-template response bodies cause false body-mismatch failures

### DIFF
--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -1722,7 +1722,8 @@ fn verify_response(
                         serde_json::Value::String(s) => s.clone(),
                         _ => expected_normalized.to_string(),
                     };
-                    if actual_text != &expected_plain {
+                    // A template body is expanded by the engine; the literal can't be asserted.
+                    if !contains_template(&expected_plain) && actual_text != &expected_plain {
                         failures.push(FailureReason::BodyMismatch {
                             expected: expected_plain,
                             actual: actual_text.clone(),
@@ -1758,11 +1759,21 @@ fn normalize_json_value(value: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+/// True when a string carries a Rift `{{...}}` template (`{{NOW}}`, `{{DAYS+N}}`, `{{MONTHS+N}}`,
+/// #245). The engine expands these, so the literal source value cannot be asserted (issue #259).
+/// Requires a `{{` followed by a later `}}` so stray/reversed braces (`}} x {{`) don't suppress a
+/// real body assertion.
+fn contains_template(s: &str) -> bool {
+    s.find("{{")
+        .is_some_and(|open| s[open + 2..].contains("}}"))
+}
+
 /// Checks if two JSON values are semantically equal.
 /// This handles:
 /// - Different key ordering in objects
 /// - Compact vs pretty-printed formatting
 /// - String values that contain JSON (parses and compares them)
+/// - `{{...}}` template strings on the expected side (wildcards — the engine expands them)
 fn json_matches(expected: &serde_json::Value, actual: &serde_json::Value) -> bool {
     match (expected, actual) {
         (serde_json::Value::Object(exp_obj), serde_json::Value::Object(act_obj)) => {
@@ -1784,6 +1795,10 @@ fn json_matches(expected: &serde_json::Value, actual: &serde_json::Value) -> boo
                     .zip(act_arr.iter())
                     .all(|(e, a)| json_matches(e, a))
         }
+        // A `{{...}}` Rift template (e.g. `{{NOW}}`, `{{DAYS+N}}`, #245/#259) is expanded by the
+        // engine, so the literal source value can't be asserted — treat it as a wildcard. Sibling
+        // (non-template) fields are still compared by the surrounding object/array recursion.
+        (serde_json::Value::String(exp_str), _) if contains_template(exp_str) => true,
         // Handle case where one side is a JSON string that needs parsing
         (serde_json::Value::String(exp_str), actual) => {
             // Try to parse the expected string as JSON
@@ -2212,6 +2227,67 @@ mod verify_tests {
         let refused = "error sending request for url (http://127.0.0.1:1/x): \
                        tcp connect error: connection refused (os error 61)";
         assert!(!is_transport_reset_error(refused));
+    }
+
+    // ── #259: date-template bodies are not asserted literally ───────────────
+    #[test]
+    fn contains_template_detects_rift_templates() {
+        assert!(contains_template("{{NOW}}"));
+        assert!(contains_template("expires {{DAYS+30}} from now"));
+        assert!(contains_template("{{MONTHS+12}}"));
+        assert!(!contains_template("2026-06-30T00:00:00+00:00"));
+        assert!(!contains_template("plain body"));
+        // Stray / reversed braces must NOT be treated as a template (no over-suppression).
+        assert!(!contains_template("}} literal {{"));
+        assert!(!contains_template("only {{ open"));
+        assert!(!contains_template("only }} close"));
+    }
+
+    #[test]
+    fn json_matches_template_in_array_element() {
+        // The wildcard also applies inside arrays; a non-template element is still compared.
+        assert!(json_matches(
+            &serde_json::json!(["{{NOW}}", "fixed"]),
+            &serde_json::json!(["2026-06-30T00:00:00+00:00", "fixed"])
+        ));
+        assert!(!json_matches(
+            &serde_json::json!(["{{NOW}}", "fixed"]),
+            &serde_json::json!(["2026-06-30T00:00:00+00:00", "WRONG"])
+        ));
+    }
+
+    #[test]
+    fn json_matches_template_string_is_wildcard() {
+        // An expected `{{NOW}}` matches the engine's expanded timestamp.
+        assert!(json_matches(
+            &serde_json::json!("{{NOW}}"),
+            &serde_json::json!("2026-06-30T16:06:39.878853+00:00")
+        ));
+    }
+
+    #[test]
+    fn json_matches_template_in_object_field() {
+        let expected = serde_json::json!({
+            "issued": "{{NOW}}", "expires": "{{DAYS+30}}", "kind": "token"
+        });
+        // Template fields are wildcards, but a non-template sibling is still compared.
+        assert!(json_matches(
+            &expected,
+            &serde_json::json!({ "issued": "2026-06-30T00:00:00+00:00", "expires": "2026-07-30T00:00:00+00:00", "kind": "token" })
+        ));
+        assert!(!json_matches(
+            &expected,
+            &serde_json::json!({ "issued": "2026-06-30T00:00:00+00:00", "expires": "2026-07-30T00:00:00+00:00", "kind": "WRONG" })
+        ));
+    }
+
+    #[test]
+    fn json_matches_non_template_still_strict() {
+        // Regression: a plain value mismatch must still fail.
+        assert!(!json_matches(
+            &serde_json::json!({ "a": "x" }),
+            &serde_json::json!({ "a": "y" })
+        ));
     }
 
     // ── #4a/#4b: URL construction ──────────────────────────────────────────

--- a/crates/rift-http-proxy/tests/verify_dynamic.rs
+++ b/crates/rift-http-proxy/tests/verify_dynamic.rs
@@ -260,3 +260,77 @@ async fn verify_normal_pass_asserts_tcp_fault() {
         "tcp reset must not FAIL in the normal pass:\n{stdout}"
     );
 }
+
+#[tokio::test]
+async fn verify_normal_pass_accepts_date_template_body() {
+    // Issue #259: a stub whose is.body carries Rift date templates ({{NOW}}/{{DAYS+N}}) is
+    // expanded by the engine; the verifier must not assert the literal template body and FAIL.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19911, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/token" } }],
+                "responses": [{ "is": { "statusCode": 200,
+                    "body": { "issued": "{{NOW}}", "expires": "{{DAYS+30}}", "kind": "token" } } }]
+            }]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12721, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin]) // normal verification pass
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "date-template body must not FAIL; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "no body-mismatch FAIL for template body:\n{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn verify_normal_pass_accepts_plaintext_template_body() {
+    // Issue #259: a NON-JSON (plain-text) body carrying a template expands to a bare string that
+    // is not valid JSON, so it exercises verify_response's plain-text-compare branch — which must
+    // also skip the literal assertion rather than report a body mismatch.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19921, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/snapshot" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "snapshot taken at {{NOW}}" } }]
+            }]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12731, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin])
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "plain-text template body must not FAIL; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "no mismatch FAIL for plain-text template body:\n{stdout}"
+    );
+}


### PR DESCRIPTION
`rift-verify` reported a **body mismatch** for stubs whose `is.body` contains Rift date templates (`{{NOW}}`, `{{DAYS+N}}`, `{{MONTHS+N}}`, #245) — it compared the literal template string against the engine's correctly-**expanded** response. The engine is right; the verifier asserted the un-expanded source body.

## Fix
Add `contains_template(s)` (a `{{` followed by a later `}}`, so stray/reversed braces like `}} x {{` don't over-suppress a real assertion). In `json_matches`, an expected string carrying a `{{...}}` template is treated as a **wildcard** — the engine expands these — while the surrounding object/array structure and non-template sibling fields are still compared strictly. The non-JSON plain-text-compare branch likewise skips a template body. A genuine mismatch on a non-template field still FAILs.

## Repro (now passes)
```
$ rift-verify --admin-url http://localhost:2525
# was: FAIL Imposter :4511 Stub #1 - GET /token
#   Expected: {"issued":"{{NOW}}","expires":"{{DAYS+30}}",...}
#   Actual:   {"issued":"2026-06-30T...","expires":"2026-07-30T...",...}
```

## Tests
- Unit: template string / object field / array element are wildcards while non-template siblings are still asserted; non-template mismatch still FAILs; `contains_template` rejects stray/reversed braces (no over-suppression).
- Integration: a `{{NOW}}`/`{{DAYS+30}}` JSON body and a plain-text `{{NOW}}` body, both served and expanded by the in-process engine, verified end-to-end (no FAIL) — covering both the JSON and plain-text comparison branches.

Found during the v0.7.0 conformance pass (#254). Closes #259.

Milestone: v0.7.0 conformance