### PR TITLE
fix: rift-verify correlated-isolation (space) stubs not driven with their own space

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -203,7 +203,7 @@ pub async fn handle_get(
             }
 
             let analysis = analyze_stubs(&stubs);
-            let rift_extensions = if analysis.has_warnings() {
+            if analysis.has_warnings() {
                 for warning in &analysis.warnings {
                     warn!(
                         port = port,
@@ -212,8 +212,19 @@ pub async fn handle_get(
                         warning.message
                     );
                 }
+            }
+            // Expose the imposter's flow-state config (issue #260) so tools can read the
+            // correlated-isolation `flowIdSource`.
+            let flow_state = imposter
+                .config
+                .rift
+                .as_ref()
+                .and_then(|r| r.flow_state.as_ref())
+                .map(expose_flow_state);
+            let rift_extensions = if analysis.has_warnings() || flow_state.is_some() {
                 Some(RiftImposterExtensions {
                     warnings: analysis.warnings,
+                    flow_state,
                 })
             } else {
                 None
@@ -311,6 +322,22 @@ async fn handle_set_enabled(
         }
         Err(e) => e.into(),
     }
+}
+
+/// Build the public projection of a `flowState` for `GET /imposters` (issue #260). Fail-closed
+/// allowlist: only the non-sensitive fields tools need are exposed, so a credential-bearing field
+/// added to the config later (e.g. inside `redis`, or a new backend's auth block) is excluded by
+/// default rather than leaked.
+fn expose_flow_state(fs: &rift_core::imposter::RiftFlowStateConfig) -> serde_json::Value {
+    let mut out = serde_json::Map::new();
+    out.insert("backend".to_string(), serde_json::json!(fs.backend));
+    out.insert("ttlSeconds".to_string(), serde_json::json!(fs.ttl_seconds));
+    if let Some(mapping) = &fs.mountebank_state_mapping {
+        if let Ok(value) = serde_json::to_value(mapping) {
+            out.insert("mountebankStateMapping".to_string(), value);
+        }
+    }
+    serde_json::Value::Object(out)
 }
 
 /// Resolve the imposter's `flow_id_source` (default `"imposter_port"`).
@@ -436,6 +463,36 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
 
 // Issue #201: filter recorded requests by header / flow_id via
 // GET /imposters/:port/requests?match=...  (and targeted DELETE).
+#[cfg(test)]
+mod redact_tests {
+    use super::expose_flow_state;
+    use serde_json::json;
+
+    #[test]
+    fn expose_flow_state_allowlists_safe_fields_only() {
+        let fs: rift_core::imposter::RiftFlowStateConfig = serde_json::from_value(json!({
+            "backend": "redis",
+            "ttlSeconds": 300,
+            "redis": { "url": "redis://user:secret@host:6379", "keyPrefix": "rift:" },
+            "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" }
+        }))
+        .unwrap();
+        let out = expose_flow_state(&fs);
+        assert!(
+            out.get("redis").is_none(),
+            "redis (credentialed URL) must never be exposed"
+        );
+        assert_eq!(
+            out.pointer("/mountebankStateMapping/flowIdSource")
+                .and_then(|v| v.as_str()),
+            Some("header:X-Mock-Space")
+        );
+        assert_eq!(out.get("backend").and_then(|v| v.as_str()), Some("redis"));
+        // The credential string must not survive anywhere in the exposed value.
+        assert!(!out.to_string().contains("secret"));
+    }
+}
+
 #[cfg(test)]
 mod requests_filter_tests {
     use super::*;

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -84,6 +84,11 @@ pub struct ImposterDetail {
 pub struct RiftImposterExtensions {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<StubWarning>,
+    /// The imposter's flow-state config (issue #260), so tools like `rift-verify` can learn the
+    /// correlated-isolation `flowIdSource` header. Redacted: the `redis` block (which may carry a
+    /// credentialed connection URL) is stripped before exposure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flow_state: Option<serde_json::Value>,
 }
 
 // Error types + `error_response` + the `From<ImposterError>` conversion moved to

--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -97,6 +97,12 @@ struct Args {
     /// and asserts deterministic `_rift.fault` outcomes. Off by default (safe-skip preserved).
     #[arg(long)]
     verify_dynamic: bool,
+
+    /// Fallback correlated-isolation header name (issue #260): used only when the imposter's
+    /// `flowIdSource` isn't discoverable from `GET /imposters`. A detected per-imposter header takes
+    /// precedence, so this never clobbers a correctly-detected, differently-named imposter.
+    #[arg(long)]
+    flow_id_header: Option<String>,
 }
 
 // ============================================================================
@@ -130,18 +136,19 @@ struct ImposterDetails {
     name: Option<String>,
     #[serde(default)]
     stubs: Vec<Stub>,
-    /// Raw `flowState` block (issue #223). Parsed loosely so the verifier doesn't couple to the
-    /// engine's full config schema — we only need `mountebankStateMapping.flowIdSource`.
-    #[serde(default)]
-    flow_state: Option<serde_json::Value>,
+    /// Raw `_rift` extensions block. `GET /imposters` exposes the flow-state config under
+    /// `_rift.flowState` (issue #260); parsed loosely — we only need `flowIdSource`.
+    #[serde(default, rename = "_rift")]
+    rift: Option<serde_json::Value>,
 }
 
 impl ImposterDetails {
     /// The header name carrying the correlation/space id, when this imposter isolates flows by a
     /// request header (`flowIdSource: "header:<Name>"`). `None` for the default `imposter_port`.
     fn flow_header(&self) -> Option<String> {
-        self.flow_state
+        self.rift
             .as_ref()?
+            .get("flowState")?
             .get("mountebankStateMapping")?
             .get("flowIdSource")?
             .as_str()
@@ -154,6 +161,10 @@ impl ImposterDetails {
 struct Stub {
     #[serde(default)]
     id: Option<String>,
+    /// Correlated-isolation partition (issue #223): when set, the stub is eligible only for the
+    /// flow id equal to this. The verifier must drive it with this value (issue #260).
+    #[serde(default)]
+    space: Option<String>,
     #[serde(default)]
     predicates: Vec<serde_json::Value>,
     #[serde(default)]
@@ -181,8 +192,11 @@ struct TestCase {
     /// Stub injects a `_rift.fault.tcp` reset (issue #239): a connection error is the expected
     /// outcome, not a failure (finding #3).
     expects_transport_error: bool,
-    /// Correlated-isolation header name to send (issue #223), value = `--space`.
+    /// Correlated-isolation header name to send (issue #223).
     flow_header: Option<String>,
+    /// The stub's own `space` partition, if any (issue #260): sent as the flow header value so a
+    /// space-gated stub is eligible. `None` ⇒ use the global `--space`.
+    flow_space: Option<String>,
 }
 
 #[derive(Debug)]
@@ -339,7 +353,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        let flow_header = imposter.flow_header();
+        let flow_header =
+            resolve_flow_header(imposter.flow_header(), args.flow_id_header.as_deref());
         for (stub_index, stub) in imposter.stubs.iter().enumerate() {
             let test_cases = generate_test_cases(
                 stub_index,
@@ -667,6 +682,7 @@ fn generate_test_cases(
     // Parse predicates to build test request (needed for all cases)
     let (method, path, headers, query_params, body) = parse_predicates(&stub.predicates);
     let flow_header = flow_header.map(str::to_string);
+    let flow_space = stub.space.clone();
 
     // No-match stubs (e.g., "DONT MATCH THIS") are designed to never match any request.
     // We mark them as passed because:
@@ -691,6 +707,36 @@ fn generate_test_cases(
             protocol: protocol.to_string(),
             expects_transport_error: false,
             flow_header: flow_header.clone(),
+            flow_space: flow_space.clone(),
+        });
+        return test_cases;
+    }
+
+    // Correlated isolation declared (stub has a `space`) but the verifier couldn't resolve the
+    // flowIdSource header — driving it would silently mis-route. Surface it as a visible skip
+    // rather than running a degraded check (issue #260).
+    if flow_space.is_some() && flow_header.is_none() {
+        test_cases.push(TestCase {
+            stub_index,
+            stub_id: stub.id.clone(),
+            method,
+            path,
+            headers,
+            query_params,
+            body,
+            expected_status: 200,
+            expected_headers: HashMap::new(),
+            expected_body: None,
+            is_dynamic,
+            skip_reason: Some(
+                "stub declares `space` but flowIdSource is not discoverable — pass --flow-id-header"
+                    .to_string(),
+            ),
+            is_no_match_stub: false,
+            protocol: protocol.to_string(),
+            expects_transport_error,
+            flow_header: flow_header.clone(),
+            flow_space,
         });
         return test_cases;
     }
@@ -714,6 +760,7 @@ fn generate_test_cases(
             protocol: protocol.to_string(),
             expects_transport_error,
             flow_header: flow_header.clone(),
+            flow_space: flow_space.clone(),
         });
         return test_cases;
     }
@@ -739,6 +786,7 @@ fn generate_test_cases(
         protocol: protocol.to_string(),
         expects_transport_error,
         flow_header,
+        flow_space,
     });
 
     test_cases
@@ -933,6 +981,13 @@ fn flow_id_header_name(flow_id_source: &str) -> Option<String> {
         .strip_prefix("header:")
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+/// Resolve the correlated-isolation header name for an imposter (issue #260): prefer what the
+/// imposter exposes; fall back to the `--flow-id-header` override only when detection is
+/// unavailable, so a global override never clobbers a correctly-detected, differently-named imposter.
+fn resolve_flow_header(detected: Option<String>, fallback: Option<&str>) -> Option<String> {
+    detected.or_else(|| fallback.map(str::to_string))
 }
 
 fn extract_expected_response(
@@ -1520,9 +1575,11 @@ async fn execute_test(
         request = request.header(name, value);
     }
 
-    // Correlated-isolation header (issue #223): route this request to the verifier's space.
+    // Correlated-isolation header (issue #223): route this request to the stub's own space when it
+    // declares one (issue #260), else the global `--space`.
     if let Some(flow_header) = &test_case.flow_header {
-        request = request.header(flow_header, space);
+        let value = test_case.flow_space.as_deref().unwrap_or(space);
+        request = request.header(flow_header, value);
     }
 
     // Add body if present
@@ -2341,14 +2398,14 @@ mod verify_tests {
     fn imposter_flow_header_navigates_flow_state() {
         let with_header: ImposterDetails = serde_json::from_value(json!({
             "port": 4500, "protocol": "http", "stubs": [],
-            "flowState": { "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } }
+            "_rift": { "flowState": { "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } }
         }))
         .unwrap();
         assert_eq!(with_header.flow_header().as_deref(), Some("X-Mock-Space"));
 
         let port_source: ImposterDetails = serde_json::from_value(json!({
             "port": 4500, "protocol": "http", "stubs": [],
-            "flowState": { "mountebankStateMapping": { "flowIdSource": "imposter_port" } }
+            "_rift": { "flowState": { "mountebankStateMapping": { "flowIdSource": "imposter_port" } } }
         }))
         .unwrap();
         assert_eq!(port_source.flow_header(), None);
@@ -2358,5 +2415,60 @@ mod verify_tests {
         }))
         .unwrap();
         assert_eq!(no_flow_state.flow_header(), None);
+    }
+
+    #[test]
+    fn test_case_carries_stub_space() {
+        // Issue #260: a space-gated stub must drive requests with its own space, not the global one.
+        let with_space: Stub = serde_json::from_value(json!({
+            "space": "alice",
+            "predicates": [{ "equals": { "path": "/data" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "A" } }]
+        }))
+        .unwrap();
+        let cases = generate_test_cases(0, &with_space, false, "http", Some("X-Mock-Space"));
+        assert_eq!(cases[0].flow_space.as_deref(), Some("alice"));
+
+        let no_space: Stub = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/data" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "A" } }]
+        }))
+        .unwrap();
+        let cases = generate_test_cases(0, &no_space, false, "http", Some("X-Mock-Space"));
+        assert_eq!(cases[0].flow_space, None);
+    }
+
+    #[test]
+    fn resolve_flow_header_prefers_detection_then_override() {
+        // Detection wins; the --flow-id-header override only fills the gap (no clobber).
+        assert_eq!(
+            resolve_flow_header(Some("X-Detected".to_string()), Some("X-Override")),
+            Some("X-Detected".to_string())
+        );
+        assert_eq!(
+            resolve_flow_header(None, Some("X-Override")),
+            Some("X-Override".to_string())
+        );
+        assert_eq!(resolve_flow_header(None, None), None);
+    }
+
+    #[test]
+    fn space_stub_skipped_when_flow_header_unresolved() {
+        let stub: Stub = serde_json::from_value(json!({
+            "space": "alice",
+            "predicates": [{ "equals": { "path": "/data" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "A" } }]
+        }))
+        .unwrap();
+        // No flow header resolved → the space-gated stub is a visible SKIP, not a silent degraded run.
+        let cases = generate_test_cases(0, &stub, false, "http", None);
+        assert!(cases[0]
+            .skip_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("flowIdSource"));
+        // With a header resolved, it is verified normally (no skip).
+        let cases = generate_test_cases(0, &stub, false, "http", Some("X-Mock-Space"));
+        assert!(cases[0].skip_reason.is_none());
     }
 }

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -1395,3 +1395,44 @@ mod gateway {
         let _ = manager.delete_imposter(19857).await;
     }
 }
+
+// Issue #260: GET /imposters/:port exposes the imposter's flowState (so tools can read
+// flowIdSource), with the redis block redacted.
+#[tokio::test]
+async fn get_imposter_exposes_flowstate_redacted() {
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    // inmemory backend ignores a stray `redis` block (no connection attempted) — include one with a
+    // credentialed URL to prove the GET projection actually strips it end-to-end.
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19771, "protocol": "http",
+        "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300,
+            "redis": { "url": "redis://user:topsecret@host:6379" },
+            "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+        "stubs": [{ "predicates": [{ "equals": { "path": "/x" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] }]
+    }))
+    .unwrap();
+    manager.create_imposter(config).await.expect("create");
+
+    let admin_addr = "127.0.0.1:12596".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let c = reqwest::Client::new();
+    let v = json(&c, "http://127.0.0.1:12596/imposters/19771".to_string()).await;
+    assert_eq!(
+        v.pointer("/_rift/flowState/mountebankStateMapping/flowIdSource")
+            .and_then(|x| x.as_str()),
+        Some("header:X-Mock-Space"),
+        "GET must expose flowIdSource so rift-verify can drive correlated isolation: {v}"
+    );
+    assert!(
+        v.pointer("/_rift/flowState/redis").is_none(),
+        "redis config must be redacted from the exposed flowState: {v}"
+    );
+    assert!(
+        !v.to_string().contains("topsecret"),
+        "the redis credential must not survive anywhere in the GET response"
+    );
+}

--- a/crates/rift-http-proxy/tests/verify_dynamic.rs
+++ b/crates/rift-http-proxy/tests/verify_dynamic.rs
@@ -334,3 +334,118 @@ async fn verify_normal_pass_accepts_plaintext_template_body() {
         "no mismatch FAIL for plain-text template body:\n{stdout}"
     );
 }
+
+#[tokio::test]
+async fn verify_normal_pass_drives_space_partitioned_stubs() {
+    // Issue #260: a correlated-isolation imposter with two stubs partitioned by `space` on the
+    // same path. The verifier must drive each stub with its OWN space value.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19931, "protocol": "http",
+            "_rift": { "flowState": { "backend": "inmemory",
+                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+            "stubs": [
+                { "space": "alice", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice" } } }] },
+                { "space": "bob", "predicates": [{ "equals": { "path": "/data" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": { "owner": "bob" } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12741, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin])
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "space-partitioned stubs must each PASS; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "no space-mismatch FAIL:\n{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn verify_flow_id_header_does_not_clobber_detection() {
+    // Issue #260: a detected per-imposter header takes precedence over --flow-id-header, so a
+    // (here deliberately wrong) global override does NOT clobber a correctly-detected imposter.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19951, "protocol": "http",
+            "_rift": { "flowState": { "backend": "inmemory",
+                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+            "stubs": [
+                { "space": "alice", "predicates": [{ "equals": { "path": "/d" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": { "o": "alice" } } }] },
+                { "space": "bob", "predicates": [{ "equals": { "path": "/d" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": { "o": "bob" } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12761, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin, "--flow-id-header", "X-Wrong-Header"])
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Detection (X-Mock-Space) wins over the wrong override, so both stubs still PASS.
+    assert!(
+        out.status.success(),
+        "detection must win over a wrong --flow-id-header; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "no FAIL when detection wins:\n{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn verify_skips_space_stub_when_flow_id_unresolvable() {
+    // Issue #260 (silent-failure guard): a stub declares `space` but the imposter exposes no
+    // flowIdSource and no --flow-id-header is given → the verifier must SKIP it with a reason,
+    // not silently run a degraded (mis-routed) check.
+    let manager = Arc::new(ImposterManager::new());
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19961, "protocol": "http",
+            "stubs": [{ "space": "alice", "predicates": [{ "equals": { "path": "/d" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "A" } }] }]
+        }),
+    )
+    .await;
+
+    let admin = start_admin(12771, manager).await;
+    let out = Command::new(BIN)
+        .args(["--admin-url", &admin, "--verbose"])
+        .output()
+        .await
+        .expect("run rift-verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "an unverifiable space stub is a skip, not a failure:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("flowIdSource"),
+        "the skip reason must explain the unresolved flowIdSource:\n{stdout}"
+    );
+}


### PR DESCRIPTION
`rift-verify` couldn't verify correlated-isolation stubs partitioned by `space`. The root cause (found during the fix): `GET /imposters` omitted the imposter's flow config entirely, so the verifier could never learn the `flowIdSource` header name — correlated-isolation support (#249) never actually worked end-to-end.

## Engine
`GET /imposters/:port` now exposes the flow-state under `_rift.flowState` via a **fail-closed allowlist** (`expose_flow_state`) that emits only `backend` / `ttlSeconds` / `mountebankStateMapping`. The credentialed `redis` block is never included, so a future credential-bearing field is excluded by default rather than leaked.

## rift-verify
- Reads `_rift.flowState.mountebankStateMapping.flowIdSource`.
- Drives each stub with its **own** `space` (`Stub.space` → `TestCase.flow_space`, sent as the flow-header value; stubs without a space fall back to the global `--space`).
- `--flow-id-header` is a **fallback** (detection wins, override fills the gap) — it never clobbers a correctly-detected, differently-named imposter.
- A `space` stub whose flow header can't be resolved is a **visible SKIP** with a reason, not a silent mis-routed check.

## Tests
- Engine integration: GET exposes `flowIdSource`, and a credentialed `redis` block is stripped (the secret doesn't survive anywhere in the response).
- Unit: `expose_flow_state` allowlist; stub `space` → TestCase; `resolve_flow_header` precedence; space-stub-skip-when-unresolved.
- rift-verify integration: two `space`-partitioned stubs on one path each PASS; a wrong `--flow-id-header` does not clobber detection; an unresolvable space stub is SKIPped.

Found during the v0.7.0 conformance pass (#254). Closes #260.

Note (pre-existing, out of scope): `GET /imposters?replayable=true` and `DELETE /imposters` still return the full config including `redis.url` unredacted — worth a follow-up.

Milestone: v0.7.0 conformance