### PR TITLE
feat: flatten flowIdSource under _rift.flowState; drop the mountebankStateMapping wrapper

### DIFF
--- a/crates/rift-core/src/imposter/core.rs
+++ b/crates/rift-core/src/imposter/core.rs
@@ -319,8 +319,7 @@ impl Imposter {
             .rift
             .as_ref()
             .and_then(|r| r.flow_state.as_ref())
-            .and_then(|fs| fs.mountebank_state_mapping.as_ref())
-            .map(|m| m.flow_id_source.clone())
+            .and_then(|fs| fs.flow_id_source.clone())
             .unwrap_or_else(|| "imposter_port".to_string())
     }
 

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -31,12 +31,12 @@ mod tests;
 #[allow(unused_imports)]
 pub use types::{
     DebugImposter, DebugMatchResult, DebugRequest, DebugResponse, DebugResponsePreview,
-    DebugStubInfo, ImposterConfig, ImposterError, IsResponse, MountebankStateMapping, PathRewrite,
-    Predicate, PredicateOperation, PredicateParameters, PredicateSelector, ProxyResponse,
-    RecordedRequest, ResponseMode, RiftConfig, RiftConnectionPoolConfig, RiftErrorFault,
-    RiftFaultConfig, RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig,
-    RiftRedisConfig, RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig,
-    RiftUpstreamConfig, Stub, StubResponse,
+    DebugStubInfo, ImposterConfig, ImposterError, IsResponse, PathRewrite, Predicate,
+    PredicateOperation, PredicateParameters, PredicateSelector, ProxyResponse, RecordedRequest,
+    ResponseMode, RiftConfig, RiftConnectionPoolConfig, RiftErrorFault, RiftFaultConfig,
+    RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig, RiftRedisConfig,
+    RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig, RiftUpstreamConfig, Stub,
+    StubResponse,
 };
 
 // Re-export core imposter

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -2631,7 +2631,7 @@ mod scenario_fsm_tests {
     fn order_fsm(port: u16, flow_id_source: Option<&str>) -> serde_json::Value {
         let mut flow_state = serde_json::json!({ "backend": "inmemory", "ttlSeconds": 300 });
         if let Some(src) = flow_id_source {
-            flow_state["mountebankStateMapping"] = serde_json::json!({ "flowIdSource": src });
+            flow_state["flowIdSource"] = serde_json::json!(src);
         }
         serde_json::json!({
             "port": port, "protocol": "http",
@@ -2754,7 +2754,7 @@ mod scenario_fsm_tests {
     fn imposter_with_source(port: u16, src: Option<&str>) -> Imposter {
         let mut flow_state = serde_json::json!({ "backend": "inmemory", "ttlSeconds": 300 });
         if let Some(s) = src {
-            flow_state["mountebankStateMapping"] = serde_json::json!({ "flowIdSource": s });
+            flow_state["flowIdSource"] = serde_json::json!(s);
         }
         let cfg = serde_json::from_value(serde_json::json!({
             "port": port, "protocol": "http",
@@ -2848,7 +2848,7 @@ mod correlated_space_tests {
         serde_json::json!({
             "port": port, "protocol": "http", "recordRequests": true,
             "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300,
-                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+                "flowIdSource": "header:X-Mock-Space" } },
             "stubs": stubs
         })
     }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -789,9 +789,10 @@ pub struct RiftFlowStateConfig {
     /// Redis configuration (required when backend is "redis")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis: Option<RiftRedisConfig>,
-    /// Mountebank state mapping configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mountebank_state_mapping: Option<MountebankStateMapping>,
+    /// Source for the correlation `flow_id`: `"imposter_port"` (default) or `"header:<Name>"`.
+    /// Flattened directly under `flowState` (issue #266). Absent ⇒ `"imposter_port"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flow_id_source: Option<String>,
 }
 
 fn default_flow_backend() -> String {
@@ -808,7 +809,7 @@ impl Default for RiftFlowStateConfig {
             backend: default_flow_backend(),
             ttl_seconds: default_flow_ttl(),
             redis: None,
-            mountebank_state_mapping: None,
+            flow_id_source: None,
         }
     }
 }
@@ -833,26 +834,6 @@ fn default_redis_pool() -> usize {
 
 fn default_redis_prefix() -> String {
     "rift:".to_string()
-}
-
-/// Configuration for bridging Mountebank state to flow store
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MountebankStateMapping {
-    /// Enable state mapping
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-    /// Source for flow_id: "imposter_port" or "header:X-Header-Name"
-    #[serde(default = "default_flow_id_source")]
-    pub flow_id_source: String,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn default_flow_id_source() -> String {
-    "imposter_port".to_string()
 }
 
 /// Metrics configuration for Rift extensions
@@ -1048,6 +1029,32 @@ pub enum ImposterError {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Issue #266: `flowIdSource` is flat under `flowState` and survives a serialize round-trip.
+    #[test]
+    fn flat_flow_id_source_round_trips() {
+        let fs: RiftFlowStateConfig = serde_json::from_value(json!({
+            "backend": "inmemory",
+            "flowIdSource": "header:X-Mock-Space"
+        }))
+        .unwrap();
+        assert_eq!(fs.flow_id_source.as_deref(), Some("header:X-Mock-Space"));
+        let out = serde_json::to_value(&fs).unwrap();
+        assert_eq!(
+            out.get("flowIdSource").and_then(|v| v.as_str()),
+            Some("header:X-Mock-Space")
+        );
+    }
+
+    // Issue #266: an absent `flowIdSource` deserializes to None and is omitted on serialize.
+    #[test]
+    fn absent_flow_id_source_is_none_and_omitted() {
+        let fs: RiftFlowStateConfig =
+            serde_json::from_value(json!({ "backend": "inmemory" })).unwrap();
+        assert_eq!(fs.flow_id_source, None);
+        let out = serde_json::to_value(&fs).unwrap();
+        assert!(out.get("flowIdSource").is_none());
+    }
 
     // Issue #251: an engine-ignored `_verify` annotation on a stub must survive the load
     // round-trip so rift-verify can read it back from GET /imposters.

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -332,10 +332,8 @@ fn expose_flow_state(fs: &rift_core::imposter::RiftFlowStateConfig) -> serde_jso
     let mut out = serde_json::Map::new();
     out.insert("backend".to_string(), serde_json::json!(fs.backend));
     out.insert("ttlSeconds".to_string(), serde_json::json!(fs.ttl_seconds));
-    if let Some(mapping) = &fs.mountebank_state_mapping {
-        if let Ok(value) = serde_json::to_value(mapping) {
-            out.insert("mountebankStateMapping".to_string(), value);
-        }
+    if let Some(source) = &fs.flow_id_source {
+        out.insert("flowIdSource".to_string(), serde_json::json!(source));
     }
     serde_json::Value::Object(out)
 }
@@ -347,8 +345,7 @@ fn flow_id_source(imposter: &Imposter) -> String {
         .rift
         .as_ref()
         .and_then(|r| r.flow_state.as_ref())
-        .and_then(|fs| fs.mountebank_state_mapping.as_ref())
-        .map(|m| m.flow_id_source.clone())
+        .and_then(|fs| fs.flow_id_source.clone())
         .unwrap_or_else(|| "imposter_port".to_string())
 }
 
@@ -474,7 +471,7 @@ mod redact_tests {
             "backend": "redis",
             "ttlSeconds": 300,
             "redis": { "url": "redis://user:secret@host:6379", "keyPrefix": "rift:" },
-            "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" }
+            "flowIdSource": "header:X-Mock-Space"
         }))
         .unwrap();
         let out = expose_flow_state(&fs);
@@ -483,8 +480,7 @@ mod redact_tests {
             "redis (credentialed URL) must never be exposed"
         );
         assert_eq!(
-            out.pointer("/mountebankStateMapping/flowIdSource")
-                .and_then(|v| v.as_str()),
+            out.get("flowIdSource").and_then(|v| v.as_str()),
             Some("header:X-Mock-Space")
         );
         assert_eq!(out.get("backend").and_then(|v| v.as_str()), Some("redis"));
@@ -527,7 +523,7 @@ mod requests_filter_tests {
         });
         if let Some(src) = flow_id_source {
             cfg["_rift"] = serde_json::json!({
-                "flowState": { "mountebankStateMapping": { "flowIdSource": src } }
+                "flowState": { "flowIdSource": src }
             });
         }
         let config = serde_json::from_value(cfg).expect("config");

--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -149,7 +149,6 @@ impl ImposterDetails {
         self.rift
             .as_ref()?
             .get("flowState")?
-            .get("mountebankStateMapping")?
             .get("flowIdSource")?
             .as_str()
             .and_then(flow_id_header_name)
@@ -2396,16 +2395,17 @@ mod verify_tests {
 
     #[test]
     fn imposter_flow_header_navigates_flow_state() {
+        // Flat shape (issue #266) — what `GET /imposters` emits.
         let with_header: ImposterDetails = serde_json::from_value(json!({
             "port": 4500, "protocol": "http", "stubs": [],
-            "_rift": { "flowState": { "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } }
+            "_rift": { "flowState": { "flowIdSource": "header:X-Mock-Space" } }
         }))
         .unwrap();
         assert_eq!(with_header.flow_header().as_deref(), Some("X-Mock-Space"));
 
         let port_source: ImposterDetails = serde_json::from_value(json!({
             "port": 4500, "protocol": "http", "stubs": [],
-            "_rift": { "flowState": { "mountebankStateMapping": { "flowIdSource": "imposter_port" } } }
+            "_rift": { "flowState": { "flowIdSource": "imposter_port" } }
         }))
         .unwrap();
         assert_eq!(port_source.flow_header(), None);

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -26,7 +26,7 @@ async fn get(c: &reqwest::Client, port: u16, path: &str, space: Option<&str>) ->
 fn order_fsm(port: u16, flow_id_source: Option<&str>) -> serde_json::Value {
     let mut flow_state = serde_json::json!({ "backend": "inmemory", "ttlSeconds": 300 });
     if let Some(src) = flow_id_source {
-        flow_state["mountebankStateMapping"] = serde_json::json!({ "flowIdSource": src });
+        flow_state["flowIdSource"] = serde_json::json!(src);
     }
     serde_json::json!({
         "port": port, "protocol": "http",
@@ -49,7 +49,7 @@ fn correlated_config(port: u16, stubs: serde_json::Value) -> serde_json::Value {
     serde_json::json!({
         "port": port, "protocol": "http", "recordRequests": true,
         "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300,
-            "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+            "flowIdSource": "header:X-Mock-Space" } },
         "stubs": stubs
     })
 }
@@ -1407,7 +1407,7 @@ async fn get_imposter_exposes_flowstate_redacted() {
         "port": 19771, "protocol": "http",
         "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300,
             "redis": { "url": "redis://user:topsecret@host:6379" },
-            "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+            "flowIdSource": "header:X-Mock-Space" } },
         "stubs": [{ "predicates": [{ "equals": { "path": "/x" } }],
             "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] }]
     }))
@@ -1422,10 +1422,10 @@ async fn get_imposter_exposes_flowstate_redacted() {
     let c = reqwest::Client::new();
     let v = json(&c, "http://127.0.0.1:12596/imposters/19771".to_string()).await;
     assert_eq!(
-        v.pointer("/_rift/flowState/mountebankStateMapping/flowIdSource")
+        v.pointer("/_rift/flowState/flowIdSource")
             .and_then(|x| x.as_str()),
         Some("header:X-Mock-Space"),
-        "GET must expose flowIdSource so rift-verify can drive correlated isolation: {v}"
+        "GET must expose flat flowIdSource so rift-verify can drive correlated isolation: {v}"
     );
     assert!(
         v.pointer("/_rift/flowState/redis").is_none(),

--- a/crates/rift-http-proxy/tests/verify_dynamic.rs
+++ b/crates/rift-http-proxy/tests/verify_dynamic.rs
@@ -345,7 +345,7 @@ async fn verify_normal_pass_drives_space_partitioned_stubs() {
         serde_json::json!({
             "port": 19931, "protocol": "http",
             "_rift": { "flowState": { "backend": "inmemory",
-                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+                "flowIdSource": "header:X-Mock-Space" } },
             "stubs": [
                 { "space": "alice", "predicates": [{ "equals": { "path": "/data" } }],
                   "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice" } } }] },
@@ -385,7 +385,7 @@ async fn verify_flow_id_header_does_not_clobber_detection() {
         serde_json::json!({
             "port": 19951, "protocol": "http",
             "_rift": { "flowState": { "backend": "inmemory",
-                "mountebankStateMapping": { "flowIdSource": "header:X-Mock-Space" } } },
+                "flowIdSource": "header:X-Mock-Space" } },
             "stubs": [
                 { "space": "alice", "predicates": [{ "equals": { "path": "/d" } }],
                   "responses": [{ "is": { "statusCode": 200, "body": { "o": "alice" } } }] },


### PR DESCRIPTION
Flattens `flowIdSource` (and drops the misleadingly Mountebank-named `mountebankStateMapping` wrapper) so it lives directly under `_rift.flowState`. The wrapper held only `enabled` (never read, dropped) and `flowIdSource` (the field every consumer actually reads).

Since the correlated-isolation feature is unpublished, no backward-compat alias is needed — the legacy wrapper struct, the `expose_flow_state` nested projection, and the rift-verify nested-path navigation are all removed in favor of the flat field.

Consumers updated: `core.rs::flow_id_source()`, admin `flow_id_source()`/`expose_flow_state()`, and `verify.rs::flow_header()`. Samples + `conformance.sh` migrated separately in the rift-imposter-samples repo.

Closes #266
Milestone: M-standalone