### PR TITLE
fix: apply request templates, shellTransform, and metrics on the static response path

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -10,9 +10,10 @@ use super::types::{
     DebugMatchResult, DebugRequest, DebugResponse, ProxyResponse, RecordedRequest, ResponseMode,
 };
 use crate::behaviors::{
-    apply_copy_behaviors, apply_lookup_behaviors, header_to_title_case, CsvCache, RequestContext,
-    ResponseBehaviors,
+    apply_copy_behaviors, apply_lookup_behaviors, apply_shell_transform, header_to_title_case,
+    CsvCache, RequestContext, ResponseBehaviors,
 };
+use crate::extensions::template::{has_template_variables, process_template, RequestData};
 #[cfg(feature = "javascript")]
 use crate::scripting::{execute_mountebank_inject, MountebankRequest};
 use crate::scripting::{FaultDecision, ScriptEngine, ScriptRequest};
@@ -48,7 +49,13 @@ pub async fn handle_imposter_request(
     client_addr: SocketAddr,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     let allow_cors = imposter.config.allow_cors;
+    // Capture the method before `req` is consumed so we can record the request metric (issue #269).
+    let method = req.method().to_string();
     let mut response = handle_request_inner(req, imposter, client_addr).await?;
+    // Record `rift_requests_total` once per request the imposter serves (issue #269). The imposter
+    // serve path recorded no Prometheus metrics before; the recording proxy engine
+    // (`proxy/handler.rs`) is a disjoint path, so there is no double-count.
+    crate::extensions::record_request(&method, response.status().as_u16());
     if allow_cors {
         inject_cors_headers(response.headers_mut());
     }
@@ -462,6 +469,38 @@ async fn handle_request_inner(
                 }
             }
 
+            // Expand `${request.*}` request templates (issue #269) BEFORE behaviors — matching the
+            // proxy path's ordering so `shellTransform`/`decorate` operate on the expanded body.
+            // Header values are templated too (the static path's AC1 requirement; the proxy path
+            // templates only the body). Serve-time date templates ({{NOW}}/{{DAYS+N}}) are expanded
+            // later, at body finalization.
+            {
+                let need_body = has_template_variables(&body);
+                let need_headers = headers
+                    .values()
+                    .flatten()
+                    .any(|v| has_template_variables(v));
+                if need_body || need_headers {
+                    let request_data = RequestData::new(
+                        method_str,
+                        path_str,
+                        query_opt,
+                        &headers_for_context,
+                        body_string.as_deref(),
+                    );
+                    if need_body {
+                        body = process_template(&body, &request_data);
+                    }
+                    for values in headers.values_mut() {
+                        for v in values.iter_mut() {
+                            if has_template_variables(v) {
+                                *v = process_template(v, &request_data);
+                            }
+                        }
+                    }
+                }
+            }
+
             // Apply behaviors if present
             if let Some(ref behaviors_json) = behaviors {
                 // Parse behaviors
@@ -539,6 +578,16 @@ async fn handle_request_inner(
                         }
 
                         headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
+                    }
+
+                    // shellTransform (issue #269): pipe the body through external command(s);
+                    // stdout becomes the new body. Runs on the static `is` path too, not only the
+                    // proxy path, and independently of copy/lookup/decorate.
+                    for cmd in &parsed_behaviors.shell_transform {
+                        match apply_shell_transform(cmd, &request_context, &body, status) {
+                            Ok(transformed) => body = transformed,
+                            Err(e) => warn!("shellTransform command {cmd:?} failed: {e}"),
+                        }
                     }
                 }
             }

--- a/crates/rift-http-proxy/tests/issue_269_static_wiring.rs
+++ b/crates/rift-http-proxy/tests/issue_269_static_wiring.rs
@@ -1,0 +1,160 @@
+//! Issue #269 gate: the static `is` response path must apply `${request.*}` templates,
+//! `shellTransform`, and Prometheus request metrics — parity with the proxy path.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+async fn mk(manager: &ImposterManager, cfg: serde_json::Value) {
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+}
+
+/// AC1 — `${request.*}` expands on a static `is` body AND in response headers.
+#[tokio::test]
+async fn static_response_expands_request_templates() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19881, "protocol": "http", "stubs": [
+                { "predicates": [{ "equals": { "path": "/tpl" } }],
+                  "responses": [{ "is": { "statusCode": 200,
+                    "headers": { "X-Echo-Path": "${request.path}" },
+                    "body": "m=${request.method} p=${request.path} q=${request.query.x} h=${request.headers.x-foo}" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let c = reqwest::Client::new();
+    let resp = c
+        .get("http://127.0.0.1:19881/tpl?x=1")
+        .header("X-Foo", "bar")
+        .send()
+        .await
+        .expect("send");
+    let echo = resp
+        .headers()
+        .get("x-echo-path")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let body = resp.text().await.expect("body");
+    assert_eq!(
+        body, "m=GET p=/tpl q=1 h=bar",
+        "request templates must expand on a static `is` body"
+    );
+    assert_eq!(
+        echo.as_deref(),
+        Some("/tpl"),
+        "request templates must expand in response headers"
+    );
+    let _ = manager.delete_imposter(19881).await;
+}
+
+/// AC2 — `shellTransform` runs on a static `is` response.
+#[tokio::test]
+async fn static_response_applies_shell_transform() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19882, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "shellTransform": "printf transformed" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let c = reqwest::Client::new();
+    let body = c
+        .get("http://127.0.0.1:19882/x")
+        .send()
+        .await
+        .expect("send")
+        .text()
+        .await
+        .expect("body");
+    assert_eq!(
+        body, "transformed",
+        "shellTransform must run on a static `is` response"
+    );
+    let _ = manager.delete_imposter(19882).await;
+}
+
+/// AC3 — a non-proxied request increments `rift_requests_total` with the served status label.
+/// Uses a unique status (418) so the counter is isolated from sibling `GET 200` tests AND the
+/// recorded `status` label is verified to match the served status.
+#[tokio::test]
+async fn static_response_records_request_metric() {
+    fn requests_total_418() -> u64 {
+        rift_core::extensions::collect_metrics()
+            .lines()
+            .filter(|l| l.starts_with("rift_requests_total") && l.contains("status=\"418\""))
+            .filter_map(|l| l.rsplit(' ').next())
+            .filter_map(|n| n.parse::<f64>().ok())
+            .map(|f| f as u64)
+            .sum()
+    }
+
+    let before = requests_total_418();
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19883, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 418, "body": "teapot" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let c = reqwest::Client::new();
+    let resp = c
+        .get("http://127.0.0.1:19883/x")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 418, "served status");
+    let _ = resp.text().await;
+
+    let after = requests_total_418();
+    assert_eq!(
+        after,
+        before + 1,
+        "rift_requests_total{{status=418}} must increment by exactly one for the served request (before={before} after={after})"
+    );
+    let _ = manager.delete_imposter(19883).await;
+}
+
+/// AC2 (failure path) — a failing `shellTransform` leaves the body unchanged (warn-and-keep).
+#[tokio::test]
+async fn static_response_shell_transform_failure_keeps_body() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19884, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "shellTransform": "exit 1" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let c = reqwest::Client::new();
+    let body = c
+        .get("http://127.0.0.1:19884/x")
+        .send()
+        .await
+        .expect("send")
+        .text()
+        .await
+        .expect("body");
+    assert_eq!(
+        body, "original",
+        "a failing shellTransform must leave the body unchanged"
+    );
+    let _ = manager.delete_imposter(19884).await;
+}


### PR DESCRIPTION
The static `is` response handler (`crates/rift-core/src/imposter/handler.rs`) was missing three feature wirings the proxy handler (`crates/rift-core/src/proxy/handler.rs`) already had, so each was silently inert for non-proxied responses (found during the #254 conformance pass):

- **`${request.*}` templates** now expand on the response body **and** header values, applied **before** behaviors so the ordering matches the proxy path (`shellTransform`/`decorate` see the expanded body).
- **`shellTransform`** now runs on static `is` responses, independently of copy/lookup/decorate; a failing command warns (with the command) and keeps the prior body.
- **`rift_requests_total`** is recorded once per served request in the `handle_imposter_request` wrapper. The imposter serve path recorded no Prometheus metrics before; the recording proxy engine is a disjoint path, so there is no double-count.

### Tests
New gate `crates/rift-http-proxy/tests/issue_269_static_wiring.rs` — 4 end-to-end tests over a real imposter: request-template expansion (body+headers), shellTransform success **and** failure-keeps-body, and the metric increment verified by a unique status (418) label.

Verification: `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` (zero warnings), `cargo test --all-features` (639 core + integration, all green).

Closes #269