### PR TITLE
fix: multi-value response headers are comma-folded when a copy/lookup/decorate behavior is present — corrupts Set-Cookie

### DIFF
--- a/crates/rift-core/src/behaviors/copy.rs
+++ b/crates/rift-core/src/behaviors/copy.rs
@@ -59,7 +59,7 @@ impl CopySource {
 /// Apply copy behaviors to response body
 pub fn apply_copy_behaviors(
     body: &str,
-    headers: &mut HashMap<String, String>,
+    headers: &mut HashMap<String, Vec<String>>,
     behaviors: &[CopyBehavior],
     request: &RequestContext,
 ) -> String {
@@ -75,14 +75,15 @@ pub fn apply_copy_behaviors(
             // Replace token in body
             result = result.replace(&behavior.into, &replacement);
 
-            // Also replace in headers
-            for value in headers.values_mut() {
+            // Also replace in headers — per value, so multi-value headers (e.g. multiple
+            // Set-Cookie) keep their multiplicity (RFC 7230 §3.2.2 forbids folding Set-Cookie).
+            for value in headers.values_mut().flatten() {
                 *value = value.replace(&behavior.into, &replacement);
             }
         } else {
             // Source not found, replace with empty string
             result = result.replace(&behavior.into, "");
-            for value in headers.values_mut() {
+            for value in headers.values_mut().flatten() {
                 *value = value.replace(&behavior.into, "");
             }
         }
@@ -186,5 +187,84 @@ mod tests {
 
         let result = apply_copy_behaviors(body, &mut headers, &behaviors, &request);
         assert_eq!(result, r#"{"userId": "123", "greeting": "Hello, Alice!"}"#);
+    }
+
+    #[test]
+    fn copy_preserves_multi_value_headers_and_substitutes_each() {
+        let mut query = HashMap::new();
+        query.insert("q".to_string(), "hi".to_string());
+        let request = RequestContext {
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query,
+            headers: HashMap::new(),
+            body: None,
+        };
+
+        let behaviors = vec![CopyBehavior {
+            from: {
+                let mut map = HashMap::new();
+                map.insert("query".to_string(), "q".to_string());
+                CopySource::Nested(map)
+            },
+            into: "${q}".to_string(),
+            extraction: ExtractionMethod::Regex {
+                selector: ".*".to_string(),
+                options: None,
+            },
+        }];
+
+        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+        headers.insert(
+            "Set-Cookie".to_string(),
+            vec!["a=1".to_string(), "b=${q}".to_string()],
+        );
+
+        apply_copy_behaviors("", &mut headers, &behaviors, &request);
+
+        // Both cookie lines survive (no fold) and the token is substituted in place.
+        assert_eq!(
+            headers["Set-Cookie"],
+            vec!["a=1".to_string(), "b=hi".to_string()]
+        );
+    }
+
+    #[test]
+    fn copy_missing_source_clears_token_per_value_without_folding() {
+        // No `q` query param → the source is absent, so the token is replaced with "" in each
+        // value; the untouched value and the multiplicity both survive.
+        let request = RequestContext {
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+
+        let behaviors = vec![CopyBehavior {
+            from: {
+                let mut map = HashMap::new();
+                map.insert("query".to_string(), "q".to_string());
+                CopySource::Nested(map)
+            },
+            into: "${q}".to_string(),
+            extraction: ExtractionMethod::Regex {
+                selector: ".*".to_string(),
+                options: None,
+            },
+        }];
+
+        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+        headers.insert(
+            "Set-Cookie".to_string(),
+            vec!["a=1".to_string(), "b=${q}".to_string()],
+        );
+
+        apply_copy_behaviors("", &mut headers, &behaviors, &request);
+
+        assert_eq!(
+            headers["Set-Cookie"],
+            vec!["a=1".to_string(), "b=".to_string()]
+        );
     }
 }

--- a/crates/rift-core/src/behaviors/lookup.rs
+++ b/crates/rift-core/src/behaviors/lookup.rs
@@ -187,7 +187,7 @@ impl CsvData {
 /// Apply lookup behaviors to response body
 pub fn apply_lookup_behaviors(
     body: &str,
-    headers: &mut HashMap<String, String>,
+    headers: &mut HashMap<String, Vec<String>>,
     behaviors: &[LookupBehavior],
     request: &RequestContext,
     csv_cache: &CsvCache,
@@ -215,7 +215,9 @@ pub fn apply_lookup_behaviors(
                 for (token, value) in replacements {
                     let full_token = format!("{}{}", behavior.into, token);
                     result = result.replace(&full_token, &value);
-                    for header_value in headers.values_mut() {
+                    // Per value, so multi-value headers keep their multiplicity (RFC 7230 §3.2.2
+                    // forbids folding Set-Cookie).
+                    for header_value in headers.values_mut().flatten() {
                         *header_value = header_value.replace(&full_token, &value);
                     }
                 }
@@ -224,4 +226,61 @@ pub fn apply_lookup_behaviors(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_preserves_multi_value_headers_and_substitutes_each() {
+        let path = std::env::temp_dir().join(format!("rift_lookup_272_{}.csv", std::process::id()));
+        std::fs::write(&path, "id,name\nhi,World\n").expect("write csv");
+
+        let mut query = HashMap::new();
+        query.insert("q".to_string(), "hi".to_string());
+        let request = RequestContext {
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query,
+            headers: HashMap::new(),
+            body: None,
+        };
+
+        let behaviors = vec![LookupBehavior {
+            key: LookupKey {
+                from: {
+                    let mut map = HashMap::new();
+                    map.insert("query".to_string(), "q".to_string());
+                    CopySource::Nested(map)
+                },
+                extraction: ExtractionMethod::Regex {
+                    selector: ".*".to_string(),
+                    options: None,
+                },
+            },
+            from_data_source: DataSource {
+                csv: CsvDataSource {
+                    path: path.to_string_lossy().into_owned(),
+                    key_column: "id".to_string(),
+                    delimiter: ',',
+                },
+            },
+            into: "${row}".to_string(),
+        }];
+
+        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+        headers.insert(
+            "Set-Cookie".to_string(),
+            vec!["a=1".to_string(), "n=${row}[name]".to_string()],
+        );
+
+        apply_lookup_behaviors("", &mut headers, &behaviors, &request, &CsvCache::default());
+
+        assert_eq!(
+            headers["Set-Cookie"],
+            vec!["a=1".to_string(), "n=World".to_string()]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -515,69 +515,81 @@ async fn handle_request_inner(
                         }
                     }
 
-                    // Behaviors (copy/lookup/decorate) operate on single-value headers (Mountebank
-                    // semantics). Collapse the multi-value map to a single-value view for them and
-                    // fold the result back, so a plain multi-value `is` response (no behaviors)
-                    // keeps its multiple values while a response that also uses behaviors degrades
-                    // to single-value (issue #238).
-                    let has_behaviors = !parsed_behaviors.copy.is_empty()
-                        || !parsed_behaviors.lookup.is_empty()
-                        || parsed_behaviors.decorate.is_some();
-                    if has_behaviors {
-                        if headers.values().any(|v| v.len() > 1) {
+                    // copy/lookup are pure token substitution — apply them across each value of
+                    // multi-value headers so multiplicity survives (e.g. multiple Set-Cookie;
+                    // RFC 7230 §3.2.2 forbids folding Set-Cookie). decorate uses a single-value
+                    // JS/Rhai object model, so only that path collapses — and even there Set-Cookie
+                    // is held aside, never comma-folded.
+                    if !parsed_behaviors.copy.is_empty() {
+                        body = apply_copy_behaviors(
+                            &body,
+                            &mut headers,
+                            &parsed_behaviors.copy,
+                            &request_context,
+                        );
+                    }
+                    if !parsed_behaviors.lookup.is_empty() {
+                        body = apply_lookup_behaviors(
+                            &body,
+                            &mut headers,
+                            &parsed_behaviors.lookup,
+                            &request_context,
+                            csv_cache(),
+                        );
+                    }
+                    if let Some(ref decorate_script) = parsed_behaviors.decorate {
+                        // decorate uses a single-value JS/Rhai object model. Set-Cookie is held
+                        // aside and never folded (RFC 7230 §3.2.2); other multi-value headers
+                        // degrade to single-value for the script (issue #238 boundary) — warn so
+                        // the collapse is not silent (e.g. WWW-Authenticate is also corrupted by
+                        // comma-folding).
+                        let is_set_cookie = |k: &str| k.eq_ignore_ascii_case("set-cookie");
+                        let folded: Vec<&String> = headers
+                            .iter()
+                            .filter(|(k, v)| v.len() > 1 && !is_set_cookie(k))
+                            .map(|(k, _)| k)
+                            .collect();
+                        if !folded.is_empty() {
                             warn!(
-                                "response uses behaviors (copy/lookup/decorate); multi-value \
-                                 headers are collapsed to single-value (comma-joined), so e.g. \
-                                 multiple Set-Cookie become one line (issue #238 boundary). \
-                                 Affected: {:?}",
-                                headers
-                                    .iter()
-                                    .filter(|(_, v)| v.len() > 1)
-                                    .map(|(k, _)| k)
-                                    .collect::<Vec<_>>()
+                                "decorate uses a single-value object model; multi-value headers \
+                                 {folded:?} are comma-folded (issue #238 boundary). Set-Cookie is \
+                                 exempt; other headers that forbid list-folding will be corrupted."
                             );
                         }
+
+                        let set_cookie: Vec<(String, Vec<String>)> = headers
+                            .iter()
+                            .filter(|(k, _)| is_set_cookie(k))
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
                         let mut single: HashMap<String, String> = headers
                             .iter()
+                            .filter(|(k, _)| !is_set_cookie(k))
                             .map(|(k, v)| (k.clone(), v.join(", ")))
                             .collect();
-
-                        if !parsed_behaviors.copy.is_empty() {
-                            body = apply_copy_behaviors(
-                                &body,
-                                &mut single,
-                                &parsed_behaviors.copy,
-                                &request_context,
-                            );
-                        }
-                        if !parsed_behaviors.lookup.is_empty() {
-                            body = apply_lookup_behaviors(
-                                &body,
-                                &mut single,
-                                &parsed_behaviors.lookup,
-                                &request_context,
-                                csv_cache(),
-                            );
-                        }
-                        if let Some(ref decorate_script) = parsed_behaviors.decorate {
-                            match apply_js_or_rhai_decorate(
-                                decorate_script,
-                                &request_context,
-                                &body,
-                                status,
-                                &mut single,
-                            ) {
-                                Ok((new_body, new_status)) => {
-                                    body = new_body;
-                                    status = new_status;
-                                }
-                                Err(e) => {
-                                    warn!("Decorate script error: {}", e);
+                        match apply_js_or_rhai_decorate(
+                            decorate_script,
+                            &request_context,
+                            &body,
+                            status,
+                            &mut single,
+                        ) {
+                            Ok((new_body, new_status)) => {
+                                body = new_body;
+                                status = new_status;
+                                // Restore the held-aside Set-Cookie lines unless the script set its
+                                // own (case-insensitively) — a script override wins deterministically.
+                                let script_set_cookie = single.keys().any(|k| is_set_cookie(k));
+                                headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
+                                if !script_set_cookie {
+                                    headers.extend(set_cookie);
                                 }
                             }
+                            // Behave as if decorate was absent: keep the original multi-value
+                            // `headers` and pre-decorate body/status rather than serving a folded,
+                            // undecorated response.
+                            Err(e) => warn!("Decorate script error: {e}"),
                         }
-
-                        headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
                     }
 
                     // shellTransform (issue #269): pipe the body through external command(s);

--- a/crates/rift-core/src/proxy/handler.rs
+++ b/crates/rift-core/src/proxy/handler.rs
@@ -516,33 +516,37 @@ async fn handle_yaml_rule(
                 body
             };
 
-            // Clone headers for mutation
+            // Clone headers for mutation. copy/lookup operate on multi-value headers; proxy
+            // fault responses are single-value, so wrap losslessly for the substitution and fold
+            // the (still single) result back for decorate / response building.
             let mut response_headers = fault_headers.clone();
-
-            // Apply copy behaviors (Mountebank-compatible)
             if let Some(ref bhvs) = behaviors {
-                if !bhvs.copy.is_empty() {
-                    debug!("Applying {} copy behaviors", bhvs.copy.len());
-                    processed_body = apply_copy_behaviors(
-                        &processed_body,
-                        &mut response_headers,
-                        &bhvs.copy,
-                        &request_context,
-                    );
-                }
-            }
-
-            // Apply lookup behaviors (Mountebank-compatible)
-            if let Some(ref bhvs) = behaviors {
-                if !bhvs.lookup.is_empty() {
-                    debug!("Applying {} lookup behaviors", bhvs.lookup.len());
-                    processed_body = apply_lookup_behaviors(
-                        &processed_body,
-                        &mut response_headers,
-                        &bhvs.lookup,
-                        &request_context,
-                        ctx.csv_cache,
-                    );
+                if !bhvs.copy.is_empty() || !bhvs.lookup.is_empty() {
+                    let mut multi: std::collections::HashMap<String, Vec<String>> =
+                        response_headers
+                            .drain()
+                            .map(|(k, v)| (k, vec![v]))
+                            .collect();
+                    if !bhvs.copy.is_empty() {
+                        debug!("Applying {} copy behaviors", bhvs.copy.len());
+                        processed_body = apply_copy_behaviors(
+                            &processed_body,
+                            &mut multi,
+                            &bhvs.copy,
+                            &request_context,
+                        );
+                    }
+                    if !bhvs.lookup.is_empty() {
+                        debug!("Applying {} lookup behaviors", bhvs.lookup.len());
+                        processed_body = apply_lookup_behaviors(
+                            &processed_body,
+                            &mut multi,
+                            &bhvs.lookup,
+                            &request_context,
+                            ctx.csv_cache,
+                        );
+                    }
+                    response_headers = multi.into_iter().map(|(k, v)| (k, v.join(", "))).collect();
                 }
             }
 

--- a/crates/rift-http-proxy/tests/issue_272_set_cookie_multi_value.rs
+++ b/crates/rift-http-proxy/tests/issue_272_set_cookie_multi_value.rs
@@ -1,0 +1,219 @@
+//! Issue #272 gate: multi-value response headers (e.g. multiple `Set-Cookie`) must NOT be
+//! comma-folded when a `copy`/`lookup`/`decorate` behavior is present. RFC 7230 §3.2.2 exempts
+//! `Set-Cookie` from list folding, so folding two cookie lines into one corrupts cookies.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+async fn mk(manager: &ImposterManager, cfg: serde_json::Value) {
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+}
+
+fn set_cookie_count(resp: &reqwest::Response) -> usize {
+    resp.headers().get_all("set-cookie").iter().count()
+}
+
+/// AC1 — a `copy` behavior must not collapse multiple `Set-Cookie` lines into one.
+#[tokio::test]
+async fn copy_behavior_preserves_multi_value_set_cookie() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19272, "protocol": "http", "stubs": [
+                { "responses": [{
+                    "is": { "statusCode": 200,
+                        "headers": { "Set-Cookie": ["a=1", "b=2"] },
+                        "body": "x=${q}" },
+                    "_behaviors": { "copy": { "from": { "query": "q" }, "into": "${q}",
+                        "using": { "method": "regex", "selector": ".*" } } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19272/x?q=hi")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        set_cookie_count(&resp),
+        2,
+        "two Set-Cookie lines must survive a copy behavior"
+    );
+    let _ = manager.delete_imposter(19272).await;
+}
+
+/// AC2 — a `lookup` behavior must not collapse multiple `Set-Cookie` lines into one.
+#[tokio::test]
+async fn lookup_behavior_preserves_multi_value_set_cookie() {
+    let csv = std::env::temp_dir().join(format!("rift_272_lookup_{}.csv", std::process::id()));
+    std::fs::write(&csv, "id,name\nhi,World\n").expect("write csv");
+
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19275, "protocol": "http", "stubs": [
+                { "responses": [{
+                    "is": { "statusCode": 200,
+                        "headers": { "Set-Cookie": ["a=1", "n=${row}[name]"] },
+                        "body": "n=${row}[name]" },
+                    "_behaviors": { "lookup": {
+                        "key": { "from": { "query": "q" },
+                            "using": { "method": "regex", "selector": ".*" } },
+                        "fromDataSource": { "csv": { "path": csv.to_string_lossy(), "keyColumn": "id" } },
+                        "into": "${row}" } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19275/x?q=hi")
+        .send()
+        .await
+        .expect("send");
+    let cookies: Vec<String> = resp
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .map(String::from)
+        .collect();
+    assert_eq!(
+        cookies,
+        vec!["a=1".to_string(), "n=World".to_string()],
+        "two Set-Cookie lines must survive a lookup behavior, each substituted"
+    );
+    let _ = manager.delete_imposter(19275).await;
+    let _ = std::fs::remove_file(&csv);
+}
+
+/// AC3 — the `decorate` path uses a single-value object model but must still exempt `Set-Cookie`,
+/// including a lowercase header key, while leaving ordinary single-value headers intact.
+#[tokio::test]
+async fn decorate_behavior_preserves_multi_value_set_cookie() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19274, "protocol": "http", "stubs": [
+                { "responses": [{
+                    "is": { "statusCode": 200,
+                        "headers": { "set-cookie": ["a=1", "b=2"], "X-Keep": "kept" },
+                        "body": "original" },
+                    "_behaviors": { "decorate": "config => { config.response.body = 'decorated'; }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19274/x")
+        .send()
+        .await
+        .expect("send");
+    let count = set_cookie_count(&resp);
+    let keep = resp
+        .headers()
+        .get("x-keep")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let body = resp.text().await.expect("body");
+    assert_eq!(
+        count, 2,
+        "two Set-Cookie lines must survive a decorate behavior (lowercase key)"
+    );
+    assert_eq!(
+        keep.as_deref(),
+        Some("kept"),
+        "ordinary single-value headers must survive the decorate round-trip"
+    );
+    assert_eq!(body, "decorated", "decorate must still transform the body");
+    let _ = manager.delete_imposter(19274).await;
+}
+
+/// AC3 (override) — a decorate script that sets its own Set-Cookie wins; the held-aside originals
+/// are not silently re-added on top of it.
+#[tokio::test]
+async fn decorate_script_set_cookie_overrides_originals() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19276, "protocol": "http", "stubs": [
+                { "responses": [{
+                    "is": { "statusCode": 200,
+                        "headers": { "Set-Cookie": ["a=1", "b=2"] },
+                        "body": "original" },
+                    "_behaviors": { "decorate": "config => { config.response.headers['Set-Cookie'] = 'z=9'; }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19276/x")
+        .send()
+        .await
+        .expect("send");
+    let cookies: Vec<String> = resp
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .map(String::from)
+        .collect();
+    assert_eq!(
+        cookies,
+        vec!["z=9".to_string()],
+        "a script-set Set-Cookie must win, replacing the held-aside originals"
+    );
+    let _ = manager.delete_imposter(19276).await;
+}
+
+/// AC4 — token substitution still works on single-value headers and the body when behaviors run.
+#[tokio::test]
+async fn copy_behavior_substitutes_single_value_header_and_body() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19273, "protocol": "http", "stubs": [
+                { "responses": [{
+                    "is": { "statusCode": 200,
+                        "headers": { "X-Token": "v=${q}" },
+                        "body": "x=${q}" },
+                    "_behaviors": { "copy": { "from": { "query": "q" }, "into": "${q}",
+                        "using": { "method": "regex", "selector": ".*" } } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19273/x?q=hi")
+        .send()
+        .await
+        .expect("send");
+    let token = resp
+        .headers()
+        .get("x-token")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let body = resp.text().await.expect("body");
+    assert_eq!(
+        token.as_deref(),
+        Some("v=hi"),
+        "copy substitution must still apply to a single-value header"
+    );
+    assert_eq!(
+        body, "x=hi",
+        "copy substitution must still apply to the body"
+    );
+    let _ = manager.delete_imposter(19273).await;
+}


### PR DESCRIPTION
Multi-value response headers (notably multiple `Set-Cookie`) were comma-folded whenever a `copy`/`lookup`/`decorate` behavior ran, corrupting cookies — RFC 7230 §3.2.2 exempts `Set-Cookie` from list folding. The footgun: adding an unrelated `${token}` copy to the body silently collapsed the response's cookies.

- `copy`/`lookup` now substitute tokens per value over `HashMap<String, Vec<String>>`, preserving multiplicity.
- `decorate` (single-value object model) holds `Set-Cookie` aside and never folds it; a script-set cookie wins; a scoped `warn!` names any other multi-value header it must fold.
- Proxy fault path adapted losslessly to the new signature.

Covered by new e2e tests (copy/lookup/decorate + script-override + single-value substitution) and unit tests.

Milestone: standalone bug fix (refs #254, #238).

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)