### PR TITLE
docs: sync CLI/API reference to code and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to Rift are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This changelog was backfilled from git history and release tags; it summarizes user-facing
+changes and omits internal refactors, CI, and test-only commits. See the git log for the full
+record.
+
+## [Unreleased]
+
+## [0.8.0] - 2026-07-01
+
+### Added
+- Past offsets in date templates: `{{DAYS-N}}` / `{{MONTHS-N}}` (complementing `{{DAYS+N}}` / `{{MONTHS+N}}` / `{{NOW}}`).
+- `rift-verify --verify-dynamic` asserts dynamic behaviors (inject/proxy/script, faults, binary mode, inline-flag regex, exists-query).
+
+### Changed
+- Flow-state config: `flowIdSource` is now flattened under `_rift.flowState`; the `mountebankStateMapping` wrapper was dropped.
+
+### Fixed
+- TCP faults now take precedence over error faults in `_rift.fault`.
+- Multi-value response headers are preserved under `copy` / `lookup` / `decorate` behaviors.
+- Request templates, `shellTransform`, and metrics are applied on the static-response path.
+- `rift-lint` no longer emits W009 on Rhai or Mountebank config-arrow `decorate` scripts, and accepts multi-value header string arrays (E018).
+
+## [0.7.0] - 2026-06-29
+
+### Added
+- Per-imposter HTTPS: imposters declared with `protocol: https` terminate TLS.
+- Single-port imposter access via the `/__rift/:port/<path>` gateway.
+- Date templates in response bodies: `{{DAYS+N}}`, `{{MONTHS+N}}`, `{{NOW}}`.
+
+### Fixed
+- `decorate` behavior supports the JavaScript `config =>` calling convention.
+
+## [0.6.0] - 2026-06-29
+
+### Added
+- Real connection-level TCP faults for `_rift.fault.tcp`.
+- Multi-value header support for responses and recorded requests.
+- Hot-reload of imposters via `POST /admin/reload`.
+
+## [0.5.0] - 2026-06-29
+
+### Added
+- Id-addressed stub operations: add / replace / delete a stub by its `Stub.id` (`/imposters/:port/stubs/by-id/:id`).
+- `rift-ffi` crate: a C-ABI over `ImposterManager` for embedding Rift in-process.
+
+### Changed
+- Engine extracted into the CLI-free `rift-core` crate; shared types moved to `rift-types`.
+
+## [0.4.0] - 2026-06-29
+
+### Added
+- Declarative stateful scenarios (`requiredScenarioState` / `newScenarioState`) plus flow-state admin inspection endpoints.
+- First-class correlated isolation ("spaces"): space-scoped stubs and per-space teardown.
+- `defaultForward` fallback proxy for unmatched requests.
+
+## [0.3.0] - 2026-06-28
+
+### Added
+- Filter recorded requests by header or flow id (`GET /imposters/:port/savedRequests?match=...`).
+
+### Fixed
+- Script request headers are exposed with lowercase keys.
+- `lookup` behavior applies on direct imposter responses.
+- `rift-lint` accepts the imposters-wrapper and bare-array config shapes.
+
+## [0.2.0] - 2026-06-28
+
+### Added
+- `--apikey` flag for admin API authentication.
+- `--datadir` write-through persistence for live imposter mutations.
+- `--rcfile` defaults merging and `save` defaults.
+- EJS token preprocessing in `--configfile` (`<% include %>`, `<%= process.env.X %>`).
+- `inject` predicate operation and `predicateGenerators` support in proxy recording.
+- `?list=true` query parameter on `GET /imposters`.
+- `--log` file logging (via tracing-appender); accepts `--noParse`, `--formatter`, `--protofile` for Mountebank compatibility.
+
+### Fixed
+- `allowCORS` injects CORS headers and handles `OPTIONS` preflight.
+- Keep-alive connections are closed on imposter delete.
+- XPath namespace maps (`ns`) are applied during predicate evaluation.
+- Proxy pipeline preserves multi-valued headers and binary response bodies; recording race conditions and memory-exhaustion risks fixed.
+- Numerous predicate-matching correctness fixes (`exists`, `except`, `deepEquals`, multi-valued query params, regex flags).
+
+## [0.1.0-RC1 .. 0.1.0-RC13] - 2025-11-28 .. 2026-01-04
+
+Initial release-candidate series establishing the Mountebank-compatible core: imposters, stubs,
+predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
+injection, multi-engine scripting, flow state).
+
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/EtaCassiopeia/rift/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/EtaCassiopeia/rift/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/EtaCassiopeia/rift/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/EtaCassiopeia/rift/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/EtaCassiopeia/rift/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/EtaCassiopeia/rift/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/EtaCassiopeia/rift/compare/v0.1.0-RC13...v0.2.0
+[0.1.0-RC13]: https://github.com/EtaCassiopeia/rift/releases/tag/v0.1.0-RC13

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,6 +19,18 @@ http://localhost:2525
 
 ---
 
+## Authentication
+
+When Rift is started with `--api-key <TOKEN>` (or `MB_APIKEY`), every admin API request must send the
+token in the `Authorization` header. Requests without a matching token receive `401 Unauthorized`.
+Data-plane traffic — direct imposter ports and the `/__rift/:port/...` gateway — is not gated.
+
+```bash
+curl -H "Authorization: <TOKEN>" http://localhost:2525/imposters
+```
+
+---
+
 ## Root
 
 ### GET /
@@ -221,6 +233,12 @@ curl -X DELETE http://localhost:2525/imposters
 
 ## Stub Management
 
+### GET /imposters/{port}/stubs
+
+List all stubs for an imposter (with HATEOAS `_links`).
+
+---
+
 ### POST /imposters/{port}/stubs
 
 Add a stub to an existing imposter.
@@ -252,6 +270,12 @@ curl -X POST http://localhost:2525/imposters/4545/stubs \
 
 ---
 
+### GET /imposters/{port}/stubs/{index}
+
+Get a single stub by its array index.
+
+---
+
 ### PUT /imposters/{port}/stubs/{index}
 
 Replace a stub at a specific index.
@@ -272,42 +296,175 @@ Delete a stub at a specific index.
 
 ---
 
-## Requests
+### Stub operations by stable id
 
-### GET /imposters/{port}/requests
+Every stub has a stable `id` (auto-generated as a UUID when omitted). These endpoints address a stub
+by that id instead of by positional index, so concurrent edits don't shift the target.
 
-Get recorded requests (if `recordRequests: true`).
+| Method | Path | Action |
+|:-------|:-----|:-------|
+| `GET` | `/imposters/{port}/stubs/by-id/{id}` | Get the stub with this id |
+| `PUT` | `/imposters/{port}/stubs/by-id/{id}` | Replace the stub with this id (position preserved) |
+| `DELETE` | `/imposters/{port}/stubs/by-id/{id}` | Delete the stub with this id |
 
-**Response:**
-```json
-{
-  "requests": [
-    {
-      "method": "GET",
-      "path": "/api/users",
-      "query": {},
-      "headers": {
-        "host": "localhost:4545",
-        "user-agent": "curl/7.88.0"
-      },
-      "body": "",
-      "timestamp": "2024-01-15T10:30:00.000Z"
-    }
-  ]
-}
+```bash
+curl http://localhost:2525/imposters/4545/stubs/by-id/6f1c...e2
 ```
 
 ---
 
-### DELETE /imposters/{port}/requests
+## Imposter State
 
-Clear recorded requests.
+### POST /imposters/{port}/enable
+
+Re-enable a disabled imposter.
+
+### POST /imposters/{port}/disable
+
+Disable an imposter — it stops matching stubs and returns a default response — without deleting it.
+
+```bash
+curl -X POST http://localhost:2525/imposters/4545/disable
+curl -X POST http://localhost:2525/imposters/4545/enable
+```
+
+---
+
+## Requests
+
+### GET /imposters/{port}/savedRequests
+
+Get recorded requests (if `recordRequests: true`). Also available under the alias
+`GET /imposters/{port}/requests`.
+
+**Query Parameters:**
+- `match=header:<Name>=<Value>` — keep only requests carrying a matching header
+- `match=flow_id=<Value>` — keep only requests whose resolved flow id matches
+
+Multiple `match` clauses are AND-ed together.
+
+**Response:** a JSON array of recorded requests. Each element carries `request_from` (the client
+`ip:port`); `body` is present only when the request had one.
+```json
+[
+  {
+    "request_from": "127.0.0.1:52344",
+    "method": "GET",
+    "path": "/api/users",
+    "query": {},
+    "headers": {
+      "host": "localhost:4545",
+      "user-agent": "curl/7.88.0"
+    },
+    "timestamp": "2024-01-15T10:30:00.000Z"
+  }
+]
+```
 
 ---
 
 ### DELETE /imposters/{port}/savedRequests
 
-Clear saved proxy requests.
+Clear recorded requests. Also available under the alias `DELETE /imposters/{port}/requests`.
+Accepts the same `match=` query parameters as the `GET`, in which case only matching requests are
+removed.
+
+---
+
+### DELETE /imposters/{port}/savedProxyResponses
+
+Clear responses recorded by proxy stubs (`proxyOnce` / `proxyAlways`), leaving the imposter's other
+state intact.
+
+---
+
+## Scenarios
+
+Declarative state machines (Mountebank/WireMock style) gate stubs by `requiredScenarioState` and
+transition via `newScenarioState`. State is partitioned per flow id.
+
+### GET /imposters/{port}/scenarios
+
+List scenario states. Accepts an optional `?flowId=<id>` query parameter (defaults to the imposter port).
+
+### PUT /imposters/{port}/scenarios/{name}/state
+
+Arrange a scenario's state directly.
+
+**Request Body:** `{ "state": "AWAITING_PAYMENT", "flowId": "order-42" }` (`flowId` optional)
+
+### POST /imposters/{port}/scenarios/reset
+
+Reset scenarios. **Request Body:** `{ "flowId": "order-42" }` (optional; omit to reset the default flow).
+
+---
+
+## Spaces (Correlated Isolation)
+
+A "space" isolates stubs and state to a correlation id (`flowId`), so parallel test runs don't collide.
+
+### POST /imposters/{port}/spaces/{flowId}/stubs
+
+Add a stub scoped to this space.
+
+### GET /imposters/{port}/spaces/{flowId}/stubs
+
+List this space's stubs.
+
+### GET /imposters/{port}/spaces/{flowId}
+
+Inspect the space — its stubs, scenario state, and request count.
+
+### DELETE /imposters/{port}/spaces/{flowId}
+
+Tear down the space, removing its scoped stubs, recorded requests, and scenario state.
+
+---
+
+## Flow State
+
+A per-flow key/value store backing stateful stubs (e.g. retry-then-succeed). These admin endpoints
+inspect and arrange it directly.
+
+| Method | Path | Action |
+|:-------|:-----|:-------|
+| `GET` | `/admin/imposters/{port}/flow-state/{flow_id}/{key}` | Read a value (404 if absent) |
+| `PUT` | `/admin/imposters/{port}/flow-state/{flow_id}/{key}` | Set a value — body `{ "value": <any JSON> }` |
+| `DELETE` | `/admin/imposters/{port}/flow-state/{flow_id}/{key}` | Delete a key |
+
+---
+
+## Gateway
+
+### /__rift/{port}/&lt;path&gt;
+
+Dispatch any request to the imposter on `{port}`, rewriting the URI to `/<path>`. Lets a
+containerized Rift publish only the admin port while still reaching every imposter. Works with any
+HTTP method and is not gated by `--api-key`.
+
+```bash
+# equivalent to hitting the imposter on port 4545 at /api/users
+curl http://localhost:2525/__rift/4545/api/users
+```
+
+---
+
+## System
+
+### GET /health
+
+Liveness check. Returns `{"status":"ok"}`.
+
+### GET /metrics
+
+Prometheus-format metrics (imposter count, per-imposter request counts). Also exposed on the
+dedicated metrics port (`--metrics-port`, default 9090).
+
+### POST /admin/reload
+
+Hot-reload imposters from the startup config source (`--configfile` / `--datadir`), replacing all
+running imposters atomically. A no-op (200) when no config source was provided. New config is
+validated before running imposters are torn down.
 
 ---
 

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -32,23 +32,60 @@ rift-http-proxy --port 3525
 rift-http-proxy [OPTIONS]
 
 Options:
-      --port <PORT>          Admin API port [default: 2525]
-      --host <HOST>          Bind hostname [default: 0.0.0.0]
-      --configfile <FILE>    Load imposters from JSON file
-      --datadir <DIR>        Directory for persistent imposter storage
-      --allow-injection      Enable JavaScript injection in responses
-      --local-only           Only accept connections from localhost
-      --loglevel <LEVEL>     Log level: debug, info, warn, error
-      --metrics-port <PORT>  Prometheus metrics port [default: 9090]
-      --ip-whitelist <IPS>   Comma-separated allowed IPs
-      --mock                 Run in mock mode
-      --debug                Enable debug mode
-      --nologfile            Disable log file (stdout only)
-      --log <FILE>           Log file path
-      --pidfile <FILE>       PID file path
-      --origin <ORIGIN>      CORS allowed origin
-  -h, --help                 Print help
-  -V, --version              Print version
+      --port <PORT>                Admin API port [default: 2525]
+      --host <HOST>                Bind hostname [default: 0.0.0.0]
+      --configfile <FILE>          Load imposters from a JSON/YAML file on startup
+      --datadir <DIR>              Directory for persistent imposter storage
+      --allow-injection            Enable JavaScript injection in responses (alias: --allowInjection)
+      --local-only                 Only accept connections from localhost
+      --loglevel <LEVEL>           Log level: debug, info, warn, error [default: info]
+      --metrics-port <PORT>        Prometheus metrics port [default: 9090]
+      --ip-whitelist <IPS>         Comma-separated allowed IPs
+      --mock                       Run in mock mode
+      --debug                      Enable debug mode
+      --nologfile                  Disable log file (stdout only)
+      --log <FILE>                 Log file path
+      --pidfile <FILE>             PID file path
+      --origin <ORIGIN>            CORS allowed origin
+      --api-key <TOKEN>            Require this token in the Authorization header for all admin API requests
+      --rcfile <FILE>              RC file of default flag values (a subset: port/host/loglevel/allowInjection/localOnly/datadir/configfile)
+      --default-tls-cert <FILE>    Default TLS certificate (PEM) for HTTPS imposters without their own
+      --default-tls-key <FILE>     Default TLS private key (PEM), paired with --default-tls-cert
+      --no-self-signed-tls         Disable the self-signed fallback; an HTTPS imposter with no cert is an error
+      --no-parse                   Disable EJS preprocessing of --configfile (alias: --noParse)
+      --formatter <NAME>           Custom config formatter module (no-op; Rift auto-detects JSON/YAML)
+      --protofile <FILE>           Custom protocol definitions file (no-op; custom protocols unsupported)
+  -h, --help                       Print help
+  -V, --version                    Print version
+```
+
+`--no-parse` disables EJS preprocessing of `--configfile` (`<% include %>` / `<%= process.env.X %>`
+expansion), which is otherwise applied on load. `--formatter` and `--protofile` are accepted for
+Mountebank command-line compatibility but have no effect in Rift.
+
+### API-key authentication
+
+`--api-key` (or `MB_APIKEY`) requires every admin API request to carry the token in the
+`Authorization` header. Data-plane traffic — direct imposter ports and the `/__rift/:port/...`
+gateway — is **not** gated by this key.
+
+```bash
+rift-http-proxy --api-key s3cr3t
+curl -H "Authorization: s3cr3t" http://localhost:2525/imposters
+```
+
+### Default TLS for HTTPS imposters
+
+An imposter declared with `protocol: https` terminates TLS. If it carries no `cert`/`key`, Rift
+falls back to `--default-tls-cert` / `--default-tls-key` when set, otherwise to a generated
+self-signed certificate. Pass `--no-self-signed-tls` to turn a missing certificate into a startup
+error instead of silently self-signing.
+
+```bash
+rift-http-proxy \
+  --default-tls-cert ./certs/server.pem \
+  --default-tls-key ./certs/server-key.pem \
+  --no-self-signed-tls
 ```
 
 ### Examples
@@ -86,7 +123,11 @@ Environment variables override CLI defaults:
 | `MB_ALLOW_INJECTION` | Enable injection (`true`/`false`) | `false` |
 | `MB_LOCAL_ONLY` | Localhost only | `false` |
 | `MB_LOGLEVEL` | Log level | `info` |
+| `MB_APIKEY` | Admin API authorization token (see `--api-key`) | |
 | `RIFT_METRICS_PORT` | Prometheus metrics port | `9090` |
+| `RIFT_DEFAULT_TLS_CERT` | Default TLS certificate (PEM) for HTTPS imposters | |
+| `RIFT_DEFAULT_TLS_KEY` | Default TLS private key (PEM) | |
+| `RIFT_NO_SELF_SIGNED_TLS` | Disable self-signed TLS fallback (`true`/`false`) | `false` |
 | `RUST_LOG` | Detailed log configuration | `info` |
 
 ### Docker Example


### PR DESCRIPTION
Delivers the **P0 "Reference truth"** slice of #280 — bringing the reference docs back in line with the current engine (v0.8.0) and adding a release history.

## What changed
- **`docs/configuration/cli.md`** — document the 8 missing clap flags (`--api-key`, `--rcfile`, `--default-tls-cert`, `--default-tls-key`, `--no-self-signed-tls`, `--no-parse`, `--formatter`, `--protofile`) and 4 missing env vars, plus API-key and default-TLS sections. `--no-parse` is documented as functional (disables EJS preprocessing); `--formatter`/`--protofile` are the accepted no-ops.
- **`docs/api/index.md`** — add every previously undocumented admin endpoint (stub list / get-by-index / by-id, enable/disable, scenarios, spaces, flow-state, gateway, health/metrics/reload) and an Authentication section; fix the mislabeled `savedRequests` vs `savedProxyResponses` DELETEs and correct the `savedRequests` response shape (bare array with `request_from`).
- **`CHANGELOG.md`** (new) — backfill `v0.1.0-RC` → `v0.8.0` in keep-a-changelog format.

## Verification
- A coverage gate (extracting every flag/env from `main.rs` and every route from `router.rs`) confirms all are now documented.
- API-doc JSON examples validated (16 blocks, 0 invalid).
- Doc-vs-code accuracy review surfaced 3 factual defects, all fixed in this branch.

## Scope
This is one slice of umbrella issue #280. Remaining follow-ups: IA restructure (Concepts + Feature Gallery), reconciling `examples/`/`docs/demo/` with `rift-imposter-samples`, and validation CI.

Part of #280