### PR TITLE
docs: add feature guides for scenarios, spaces, flow-state, date templates, gateway, hot-reload, stub-by-id

### DIFF
--- a/docs/features/date-templates.md
+++ b/docs/features/date-templates.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Date Templates
+parent: Features
+nav_order: 23
+---
+
+# Date Templates
+
+Rift expands a small set of date tokens in **response bodies** at serve time, so a mock can return
+"now" or a date relative to it without scripting.
+
+---
+
+## Tokens
+
+| Token | Expands to |
+|:------|:-----------|
+| `{{NOW}}` | The current instant. |
+| `{{DAYS+N}}` / `{{DAYS-N}}` | N days after / before now. |
+| `{{MONTHS+N}}` / `{{MONTHS-N}}` | N months after / before now. |
+
+Each renders as an **RFC 3339 / ISO 8601 timestamp**, e.g. `2026-07-01T16:54:03.803691+00:00`.
+Tokens are expanded only in the response body (not headers). An offset that overflows the
+representable date range is left unchanged rather than erroring. No other tokens (`UUID`, `RANDOM`,
+…) are supported.
+
+---
+
+## Example — an issued/expiry token
+
+```json
+{
+  "port": 4511,
+  "protocol": "http",
+  "stubs": [{
+    "predicates": [{ "equals": { "path": "/token" } }],
+    "responses": [{
+      "is": {
+        "statusCode": 200,
+        "headers": { "Content-Type": "application/json" },
+        "body": "{\"issued\":\"{{NOW}}\",\"expires\":\"{{DAYS+30}}\",\"renews\":\"{{MONTHS+12}}\"}"
+      }
+    }]
+  }]
+}
+```
+
+```bash
+curl http://localhost:4511/token
+# {"issued":"2026-07-01T16:54:03.80Z...","expires":"2026-07-31T...","renews":"2027-07-01T..."}
+```
+
+Date tokens are independent of Mountebank `${request.*}` request templates — both can appear in the
+same body.

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -1,0 +1,104 @@
+---
+layout: default
+title: Flow State
+parent: Features
+nav_order: 22
+---
+
+# Flow State
+
+Flow state is a per-flow key/value store that scripts read and write to build stateful mocks —
+retry-then-succeed, call counters, saga progress. It is keyed by `(flow_id, key)`, where the flow id
+is resolved exactly as for [Spaces]({{ site.baseurl }}/features/spaces/).
+
+---
+
+## Configuration
+
+```json
+{
+  "_rift": {
+    "flowState": {
+      "backend": "inmemory",
+      "ttlSeconds": 300,
+      "flowIdSource": "header:X-Flow-Id"
+    }
+  }
+}
+```
+
+| Field | Default | Notes |
+|:------|:--------|:------|
+| `backend` | `inmemory` | `inmemory` or `redis`. |
+| `ttlSeconds` | `300` | Default entry TTL. |
+| `flowIdSource` | `imposter_port` | How the flow id is derived (`imposter_port` or `header:<Name>`). |
+
+With `backend: "redis"` you may also set `url`, `poolSize` (default 10), and `keyPrefix`
+(default `"rift:"`).
+
+---
+
+## Script API
+
+The `flow_store` handle is passed to scripts (Rhai shown; Lua uses `flow_store:get(...)` method
+syntax). All operations take the flow id explicitly.
+
+| Call | Result |
+|:-----|:-------|
+| `flow_store.get(flow_id, key)` | value, or `()` / `nil` if absent |
+| `flow_store.set(flow_id, key, value)` | store a value |
+| `flow_store.exists(flow_id, key)` | bool |
+| `flow_store.delete(flow_id, key)` | remove a key |
+| `flow_store.increment(flow_id, key)` | atomically increment, returns the new number |
+| `flow_store.set_ttl(flow_id, ttl_seconds)` | override the TTL for a flow |
+
+---
+
+## Example — fail twice, then succeed
+
+Requires `--allow-injection`. The counter is keyed by the `X-Flow-Id` header so each caller retries
+independently.
+
+```json
+{
+  "port": 4506,
+  "protocol": "http",
+  "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300 } },
+  "stubs": [{
+    "predicates": [{ "equals": { "method": "GET", "path": "/api/resource" } }],
+    "responses": [{
+      "_rift": {
+        "script": {
+          "engine": "rhai",
+          "code": "fn should_inject(request, flow_store) { let id = request.headers[\"x-flow-id\"]; if id == () { id = \"default\"; } let n = flow_store.get(id, \"attempts\"); if n == () { n = 0; } n += 1; flow_store.set(id, \"attempts\", n); if n <= 2 { #{ inject: true, fault: \"error\", status: 503, body: `try ${n}` } } else { #{ inject: true, fault: \"error\", status: 200, body: `ok ${n}` } } }"
+        }
+      }
+    }]
+  }]
+}
+```
+
+```bash
+curl -i -H 'X-Flow-Id: t1' http://localhost:4506/api/resource   # 503 try 1
+curl -i -H 'X-Flow-Id: t1' http://localhost:4506/api/resource   # 503 try 2
+curl -i -H 'X-Flow-Id: t1' http://localhost:4506/api/resource   # 200 ok 3
+```
+
+---
+
+## Inspecting and arranging state (admin API)
+
+```bash
+# Read a value (404 if the key is absent)
+curl http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts
+
+# Set a value directly
+curl -X PUT http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts \
+  -d '{"value": 0}'
+
+# Delete a key
+curl -X DELETE http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts
+```
+
+Note: an imposter gets a real store only when `_rift.flowState` is configured (or it declares
+scenario stubs); otherwise a no-op store is used and values never persist.

--- a/docs/features/gateway.md
+++ b/docs/features/gateway.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Single-Port Gateway
+parent: Features
+nav_order: 25
+---
+
+# Single-Port Gateway
+
+The gateway dispatches to any imposter through the admin port, so a containerized Rift only needs to
+publish **one** port yet still reach every imposter.
+
+---
+
+## Usage
+
+```
+/__rift/{port}/{path}
+```
+
+Rift extracts `{port}`, rewrites the URI to `/{path}` (query string passed through unchanged), and
+serves the request as if it had arrived on the imposter's own port. Any HTTP method works, and the
+gateway is **not** gated by `--api-key` (it is data-plane traffic, not the admin control plane).
+
+```bash
+# imposter on 4545 has a stub for GET /api/users
+curl http://localhost:2525/__rift/4545/api/users?id=1
+# identical to:
+curl http://localhost:4545/api/users?id=1
+```
+
+`/__rift/4545` with no trailing path dispatches to `/`. An unknown port returns `404`; a
+non-numeric port returns `400`.
+
+Recorded requests made through the gateway show `request_from` as the loopback address, since the
+gateway is the imposter's local client.

--- a/docs/features/hot-reload.md
+++ b/docs/features/hot-reload.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Hot Reload
+parent: Features
+nav_order: 26
+---
+
+# Hot Reload
+
+`POST /admin/reload` re-reads the startup config source and atomically replaces every running
+imposter — useful for editing imposters in a file and applying them without restarting the process.
+
+---
+
+## Requirements & behavior
+
+- Rift must have been started with a config source: `--configfile <file>` or `--datadir <dir>`.
+  Without one, reload is a **no-op** that returns `200`.
+- The new config is **validated before** the running imposters are torn down. If it fails to parse
+  or has duplicate ports / unsupported protocols, the running imposters are left untouched and the
+  call errors.
+- A successful reload **resets transient state**: recorded requests, scenario state, response
+  cyclers (`repeat`), and flow-state TTLs all start fresh.
+
+```bash
+rift --configfile ./imposters.json      # start with a config source
+
+# ...edit imposters.json...
+
+curl -X POST http://localhost:2525/admin/reload   # 200; new config now live
+```
+
+To reload from a directory of one-imposter-per-file configs, start with `--datadir ./mb-data`
+instead; `POST /admin/reload` re-reads the directory.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -58,6 +58,13 @@ Rift provides advanced features for service virtualization and chaos engineering
 
 - [Fault Injection]({{ site.baseurl }}/features/fault-injection/) - Latency and error simulation
 - [Scripting]({{ site.baseurl }}/features/scripting/) - Dynamic behavior with scripts
+- [Scenarios (FSM)]({{ site.baseurl }}/features/scenarios/) - Stateful stubs with declarative state machines
+- [Correlated Isolation (Spaces)]({{ site.baseurl }}/features/spaces/) - Per-flow stub and state partitioning
+- [Flow State]({{ site.baseurl }}/features/flow-state/) - Per-flow key/value store for stateful mocks
+- [Date Templates]({{ site.baseurl }}/features/date-templates/) - `{{NOW}}` / `{{DAYS±N}}` / `{{MONTHS±N}}` in responses
+- [Stub-by-ID]({{ site.baseurl }}/features/stub-by-id/) - Address stubs by stable id
+- [Single-Port Gateway]({{ site.baseurl }}/features/gateway/) - Reach every imposter through the admin port
+- [Hot Reload]({{ site.baseurl }}/features/hot-reload/) - Re-read config without restarting
 - [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) - Overlap detection and warnings
 - [Debug Mode]({{ site.baseurl }}/features/debug-mode/) - Request matching diagnostics
 - [TLS/HTTPS]({{ site.baseurl }}/features/tls/) - Secure connections

--- a/docs/features/scenarios.md
+++ b/docs/features/scenarios.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: Scenarios (FSM)
+parent: Features
+nav_order: 20
+---
+
+# Scenarios (Stateful FSM)
+
+Scenarios let a stub respond differently depending on where a flow is in a state machine — a
+WireMock/Mountebank-style FSM. Each stub can require a state to be eligible and can transition the
+state after it responds.
+
+---
+
+## Stub fields
+
+| Field | Meaning |
+|:------|:--------|
+| `scenarioName` | Names the scenario this stub belongs to. |
+| `requiredScenarioState` | The stub is only eligible when the scenario is in this state. |
+| `newScenarioState` | After the stub responds, the scenario transitions to this state. |
+
+The implicit initial state is **`Started`**. State is tracked per flow id (see
+[Spaces]({{ site.baseurl }}/features/spaces/)); by default that is the imposter port, so a single
+imposter has one scenario timeline.
+
+---
+
+## Example — pay-then-fulfil
+
+The first call to `/pay` returns `402` and moves the scenario to `paid`; subsequent calls match the
+second stub and return `200`.
+
+```json
+{
+  "port": 4602,
+  "protocol": "http",
+  "stubs": [
+    {
+      "scenarioName": "checkout",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "paid",
+      "predicates": [{ "equals": { "path": "/pay" } }],
+      "responses": [{ "is": { "statusCode": 402, "body": "payment required" } }]
+    },
+    {
+      "scenarioName": "checkout",
+      "requiredScenarioState": "paid",
+      "predicates": [{ "equals": { "path": "/pay" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "fulfilled" } }]
+    }
+  ]
+}
+```
+
+```bash
+curl -i http://localhost:4602/pay   # 402 payment required  (now in state "paid")
+curl -i http://localhost:4602/pay   # 200 fulfilled
+```
+
+---
+
+## Arranging and inspecting state
+
+Only scenarios declared on stubs are tracked; there is no upfront registration.
+
+```bash
+# List scenario states (optionally scoped to a flow with ?flowId=)
+curl http://localhost:2525/imposters/4602/scenarios
+# -> {"flowId":"4602","scenarios":[{"name":"checkout","state":"paid"}]}
+
+# Force a scenario into a state (body flowId optional)
+curl -X PUT http://localhost:2525/imposters/4602/scenarios/checkout/state \
+  -d '{"state":"paid"}'
+
+# Reset every scenario in a flow back to "Started"
+curl -X POST http://localhost:2525/imposters/4602/scenarios/reset -d '{}'
+```
+
+See the [API Reference]({{ site.baseurl }}/api/#scenarios) for the full endpoint contract.

--- a/docs/features/spaces.md
+++ b/docs/features/spaces.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Correlated Isolation (Spaces)
+parent: Features
+nav_order: 21
+---
+
+# Correlated Isolation (Spaces)
+
+A **space** partitions one imposter's stubs and state by a correlation id (the *flow id*), so
+parallel test runs sharing a port don't see each other's stubs, scenario state, or recorded
+requests.
+
+---
+
+## How a request's flow id is resolved
+
+`_rift.flowState.flowIdSource` decides which flow (space) a request belongs to:
+
+| `flowIdSource` | Resolution |
+|:---------------|:-----------|
+| `"imposter_port"` (default) | The imposter port — one shared space. |
+| `"header:X-Mock-Space"` | The value of that request header (case-insensitive); falls back to the port if the header is absent. |
+
+A stub's optional `space` field scopes it to one flow id. Stubs **without** a `space` are global and
+match any caller. Space-scoped stubs are considered only when the request's resolved flow id equals
+their `space`.
+
+---
+
+## Example — one port, isolated tenants
+
+```json
+{
+  "port": 4510,
+  "protocol": "http",
+  "recordRequests": true,
+  "_rift": {
+    "flowState": {
+      "backend": "inmemory",
+      "ttlSeconds": 300,
+      "flowIdSource": "header:X-Mock-Space"
+    }
+  },
+  "stubs": [
+    {
+      "space": "alice",
+      "predicates": [{ "equals": { "path": "/data" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice" } } }]
+    },
+    {
+      "space": "bob",
+      "predicates": [{ "equals": { "path": "/data" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "bob" } } }]
+    },
+    {
+      "predicates": [{ "equals": { "path": "/health" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "OK" } }]
+    }
+  ]
+}
+```
+
+```bash
+curl -H 'X-Mock-Space: alice' http://localhost:4510/data   # {"owner":"alice"}
+curl -H 'X-Mock-Space: bob'   http://localhost:4510/data   # {"owner":"bob"}
+curl http://localhost:4510/health                          # OK  (global stub)
+```
+
+---
+
+## Managing spaces at runtime
+
+Instead of declaring `space` inline, you can add stubs to a space through the admin API and tear the
+whole space down in one call (its scoped stubs, recorded requests, and scenario state):
+
+```bash
+curl -X POST http://localhost:2525/imposters/4510/spaces/alice/stubs \
+  -d '{"predicates":[{"equals":{"path":"/data"}}],"responses":[{"is":{"statusCode":200,"body":"scoped"}}]}'
+
+curl http://localhost:2525/imposters/4510/spaces/alice        # inspect the space
+curl -X DELETE http://localhost:2525/imposters/4510/spaces/alice   # teardown
+```
+
+Spaces build on the same store as [Flow State]({{ site.baseurl }}/features/flow-state/) and
+[Scenarios]({{ site.baseurl }}/features/scenarios/), which are likewise partitioned by flow id.

--- a/docs/features/stub-by-id.md
+++ b/docs/features/stub-by-id.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Stub-by-ID
+parent: Features
+nav_order: 24
+---
+
+# Stub-by-ID
+
+Stubs can be addressed by a stable `id` instead of by array index, so concurrent edits don't shift
+the stub you meant to change.
+
+---
+
+## The `id` field
+
+Give a stub an explicit `id` to address it by id. The id appears in stub listings
+(`GET /imposters/{port}/stubs`) and is accepted by the by-id endpoints below. A stub created without
+an `id` is addressable by array index only — so **set an `id`** on any stub you intend to manage
+by id.
+
+```json
+{
+  "port": 4545,
+  "protocol": "http",
+  "stubs": [{
+    "id": "greeting",
+    "predicates": [{ "equals": { "path": "/hi" } }],
+    "responses": [{ "is": { "statusCode": 200, "body": "hi" } }]
+  }]
+}
+```
+
+---
+
+## Endpoints
+
+| Method | Path | Action |
+|:-------|:-----|:-------|
+| `GET` | `/imposters/{port}/stubs/by-id/{id}` | Fetch the stub |
+| `PUT` | `/imposters/{port}/stubs/by-id/{id}` | Replace it **in place** (index preserved) |
+| `DELETE` | `/imposters/{port}/stubs/by-id/{id}` | Delete it |
+
+```bash
+curl http://localhost:2525/imposters/4545/stubs/by-id/greeting          # 200
+
+curl -X PUT http://localhost:2525/imposters/4545/stubs/by-id/greeting \
+  -d '{"id":"greeting","predicates":[{"equals":{"path":"/hi"}}],"responses":[{"is":{"statusCode":200,"body":"hello"}}]}'
+curl http://localhost:4545/hi                                           # hello
+
+curl -X DELETE http://localhost:2525/imposters/4545/stubs/by-id/greeting # 200
+curl -o /dev/null -w '%{http_code}\n' \
+  http://localhost:2525/imposters/4545/stubs/by-id/greeting             # 404
+```
+
+A `PUT` by id keeps the stub at its current position in the array; a `DELETE` compacts the list.


### PR DESCRIPTION
Delivers the **P0 "Undocumented headliners"** slice of #280 — dedicated, example-driven guide pages for seven previously undocumented user-facing features.

## New pages (`docs/features/`)
- **scenarios.md** — declarative FSM (`scenarioName` / `requiredScenarioState` / `newScenarioState`), initial state `Started`, arrange/reset via admin API.
- **spaces.md** — correlated isolation via `_rift.flowState.flowIdSource`; per-space stubs and one-call teardown.
- **flow-state.md** — per-flow KV store, the `flow_store` script API (Rhai/Lua), Redis backend, retry-then-succeed example, admin KV endpoints.
- **date-templates.md** — `{{NOW}}` / `{{DAYS±N}}` / `{{MONTHS±N}}` rendering to RFC 3339 in response bodies.
- **stub-by-id.md** — addressing stubs by stable `id` (GET/PUT/DELETE), PUT preserves position.
- **gateway.md** — `/__rift/{port}/{path}` single-port dispatch, api-key exemption.
- **hot-reload.md** — `POST /admin/reload` semantics, state reset, config-source requirement.

Each page is linked in `docs/features/index.md`.

## Verification
Every documented behavior was validated **end-to-end against a freshly built `rift` binary** (a gate spun up the server and asserted: date tokens render, scenario 402→200 + reset, space A/B isolation, flow-state 503/503/200 + 404-on-missing, gateway dispatch, stub-by-id get/put/delete, hot-reload picking up a file edit). A doc-vs-code accuracy review ran over all seven pages; the one finding (a stub-id auto-generation claim) was corrected.

## Scope
One slice of umbrella issue #280. Remaining: IA restructure (Concepts + Feature Gallery), reconciling `examples/`/`docs/demo/` with `rift-imposter-samples`, and validation CI.

Part of #280