### PR TITLE
chore: modernize to Rust 2024 edition, consolidate dependencies, add workspace lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,76 +230,17 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "boa_ast"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69ee3a749ea36d4e56d92941e7b25076b493d4917c3d155b6cf369e23547d9"
-dependencies = [
- "bitflags 2.13.0",
- "boa_interner 0.19.1",
- "boa_macros 0.19.1",
- "indexmap 2.12.0",
- "num-bigint",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_ast"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
 dependencies = [
  "bitflags 2.13.0",
- "boa_interner 0.20.0",
- "boa_macros 0.20.0",
- "boa_string 0.20.0",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
  "indexmap 2.12.0",
  "num-bigint",
  "rustc-hash",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4559b35b80ceb2e6328481c0eca9a24506663ea33ee1e279be6b5b618b25c"
-dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "boa_ast 0.19.1",
- "boa_gc 0.19.1",
- "boa_interner 0.19.1",
- "boa_macros 0.19.1",
- "boa_parser 0.19.1",
- "boa_profiler 0.19.1",
- "boa_string 0.19.1",
- "bytemuck",
- "cfg-if",
- "dashmap 5.5.3",
- "fast-float",
- "hashbrown 0.14.5",
- "icu_normalizer 1.5.0",
- "indexmap 2.12.0",
- "intrusive-collections",
- "itertools 0.13.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "num_enum",
- "once_cell",
- "pollster 0.3.0",
- "portable-atomic",
- "rand 0.8.5",
- "regress",
- "rustc-hash",
- "ryu-js",
- "serde",
- "serde_json",
- "sptr",
- "static_assertions",
- "tap",
- "thin-vec",
- "thiserror 1.0.69",
- "time",
 ]
 
 [[package]]
@@ -310,16 +251,16 @@ checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
- "boa_ast 0.20.0",
- "boa_gc 0.20.0",
- "boa_interner 0.20.0",
- "boa_macros 0.20.0",
- "boa_parser 0.20.0",
- "boa_profiler 0.20.0",
- "boa_string 0.20.0",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_profiler",
+ "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap 6.1.0",
+ "dashmap",
  "fast-float2",
  "hashbrown 0.15.5",
  "icu_normalizer 1.5.0",
@@ -331,7 +272,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "once_cell",
- "pollster 0.4.0",
+ "pollster",
  "portable-atomic",
  "rand 0.8.5",
  "regress",
@@ -349,44 +290,15 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716406f57d67bc3ac7fd227d5513b42df401dff14a3be22cbd8ee29817225363"
-dependencies = [
- "boa_macros 0.19.1",
- "boa_profiler 0.19.1",
- "boa_string 0.19.1",
- "hashbrown 0.14.5",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_gc"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
 dependencies = [
- "boa_macros 0.20.0",
- "boa_profiler 0.20.0",
- "boa_string 0.20.0",
+ "boa_macros",
+ "boa_profiler",
+ "boa_string",
  "hashbrown 0.15.5",
  "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e18df2272616e1ba0322a69333d37dbb78797f1aa0595aad9dc41e8ecd06ad9"
-dependencies = [
- "boa_gc 0.19.1",
- "boa_macros 0.19.1",
- "hashbrown 0.14.5",
- "indexmap 2.12.0",
- "once_cell",
- "phf",
- "rustc-hash",
- "static_assertions",
 ]
 
 [[package]]
@@ -395,26 +307,14 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
 dependencies = [
- "boa_gc 0.20.0",
- "boa_macros 0.20.0",
+ "boa_gc",
+ "boa_macros",
  "hashbrown 0.15.5",
  "indexmap 2.12.0",
  "once_cell",
  "phf",
  "rustc-hash",
  "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240f4126219a83519bad05c9a40bfc0303921eeb571fc2d7e44c17ffac99d3f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -431,34 +331,15 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b59dc05bf1dc019b11478a92986f590cff43fced4d20e866eefb913493e91c"
-dependencies = [
- "bitflags 2.13.0",
- "boa_ast 0.19.1",
- "boa_interner 0.19.1",
- "boa_macros 0.19.1",
- "boa_profiler 0.19.1",
- "fast-float",
- "icu_properties 1.5.1",
- "num-bigint",
- "num-traits",
- "regress",
- "rustc-hash",
-]
-
-[[package]]
-name = "boa_parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
 dependencies = [
  "bitflags 2.13.0",
- "boa_ast 0.20.0",
- "boa_interner 0.20.0",
- "boa_macros 0.20.0",
- "boa_profiler 0.20.0",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "boa_profiler",
  "fast-float2",
  "icu_properties 1.5.1",
  "num-bigint",
@@ -469,28 +350,9 @@ dependencies = [
 
 [[package]]
 name = "boa_profiler"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee0645509b3b91abd724f25072649d9e8e65653a78ff0b6e592788a58dd838"
-
-[[package]]
-name = "boa_profiler"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
-
-[[package]]
-name = "boa_string"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85205289bab1f2c7c8a30ddf0541cf89ba2ff7dbd144feef50bbfa664288d4"
-dependencies = [
- "fast-float",
- "paste",
- "rustc-hash",
- "sptr",
- "static_assertions",
-]
 
 [[package]]
 name = "boa_string"
@@ -1050,19 +912,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1204,15 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,12 +1095,6 @@ dependencies = [
  "home",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "fast-float"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fast-float2"
@@ -1354,21 +1188,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1546,9 +1365,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1721,22 +1537,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -2332,12 +2132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,23 +2196,6 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2620,48 +2397,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2878,12 +2617,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "pollster"
@@ -3350,20 +3083,15 @@ checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3374,7 +3102,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -3422,9 +3149,8 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
- "async-trait",
  "base64 0.22.1",
- "boa_engine 0.20.0",
+ "boa_engine",
  "bytes",
  "chrono",
  "crossbeam",
@@ -3438,7 +3164,6 @@ dependencies = [
  "matchit",
  "mlua",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "prometheus",
  "r2d2",
@@ -3489,7 +3214,6 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "assert-json-diff",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -3505,7 +3229,6 @@ dependencies = [
  "libc",
  "matchit",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "port_check",
  "prometheus",
@@ -3546,13 +3269,13 @@ dependencies = [
 name = "rift-lint"
 version = "0.1.0"
 dependencies = [
- "boa_engine 0.19.1",
+ "boa_engine",
  "clap",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3570,7 +3293,7 @@ dependencies = [
  "rift-lint",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tui-popup",
 ]
@@ -3662,7 +3385,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -3784,19 +3507,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
 
 [[package]]
 name = "security-framework"
@@ -4536,16 +4246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4444,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,12 +4463,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4898,6 +4611,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -4906,12 +4620,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ rust-version = "1.92"
 # sites. This table centralizes the existing policy and makes new crates inherit it.
 [workspace.lints.clippy]
 all = "warn"
+# Targeted idiom lints (not full pedantic): keep new code on modern idioms.
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+unnecessary_map_or = "warn"
 
 [workspace.dependencies]
 # Async runtime — version pinned here; each crate selects its own tokio features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Rift Contributors"]
 repository = "https://github.com/EtaCassiopeia/rift"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ rust-version = "1.92"
 all = "warn"
 
 [workspace.dependencies]
-# Async runtime
-tokio = { version = "1.35", features = ["full"] }
+# Async runtime — version pinned here; each crate selects its own tokio features
+tokio = { version = "1.41" }
 tokio-util = "0.7"
 
 # Serialization
@@ -41,25 +41,22 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 
-# Scripting
-rhai = { version = "1.16", features = ["sync", "serde", "no_optimize"] }
+# Scripting — pinned to =1.21.0 to match rift-core's deliberate exact pin
+rhai = { version = "=1.21.0", features = ["sync", "serde"] }
 
 # Faker
 fake = { version = "2.9", features = ["derive", "uuid", "http", "chrono"] }
 
-# CLI
-clap = { version = "4.4", features = ["derive", "cargo", "env"] }
-clap_complete = "4.4"
+# CLI — base features; crates add `env` where needed
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 
-# HTTP/gRPC
-reqwest = { version = "0.11", features = ["json"] }
-tonic = "0.11"
-tonic-build = "0.11"
-prost = "0.12"
+# HTTP client — rustls everywhere (the project pins the ring crypto provider)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Error handling
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 
 # Logging
 tracing = "0.1"
@@ -69,10 +66,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Misc utilities
-once_cell = "1.19"
 futures = "0.3"
-bytes = "1.5"
-uuid = { version = "1.6", features = ["v4", "serde"] }
+bytes = "1.7"
+uuid = { version = "1.8", features = ["v4", "serde"] }
 rand = "0.8"
 
 # Testing

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -16,9 +16,8 @@ workspace = true
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.41", features = ["full"] }
-async-trait = "0.1"
-futures = "0.3"
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
 
 # HTTP
 hyper = { version = "1.5", features = ["full"] }
@@ -32,15 +31,15 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rcgen = "0.13"
 
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-serde_json = "1.0"
+serde.workspace = true
+serde_yaml.workspace = true
+serde_json.workspace = true
 
 # Shared workspace types
 rift-types = { path = "../rift-types" }
 
 # Scripting engines
-rhai = { version = "=1.21.0", features = ["sync", "serde"] }
+rhai.workspace = true
 mlua = { version = "0.10", features = ["luajit", "serialize"], optional = true }
 boa_engine = { version = "0.20", optional = true }
 
@@ -49,26 +48,25 @@ redis = { version = "0.26", default-features = false, optional = true }
 r2d2 = { version = "0.8", optional = true }
 
 # Logging & Observability
-tracing = "0.1"
+tracing.workspace = true
 prometheus = "0.13"
 lazy_static = "1.4"
 
 # HTTP client (proxy forwarding)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest.workspace = true
 
 # Utils
-once_cell = "1.19"
-bytes = "1.7"
+bytes.workspace = true
 base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
+chrono.workspace = true
 regex = "1.11"
-rand = "0.8"
+rand.workspace = true
 urlencoding = "2.1"
 similar = "2.6"
 matchit = "0.9"
 aho-corasick = "1.1"
-anyhow = "1.0"
-thiserror = "2.0"
+anyhow.workspace = true
+thiserror.workspace = true
 socket2 = "0.5"
 num_cpus = "1.16"
 libc = "0.2"
@@ -84,11 +82,10 @@ serde_json_path = "0.7"
 
 [dev-dependencies]
 tempfile = "3.8"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest.workspace = true
 tokio-test = "0.4"
-uuid = { version = "1.8", features = ["v4"] }
+uuid.workspace = true
 serial_test = "3.0"
-once_cell = "1.19"
 
 [features]
 default = ["redis-backend", "lua", "javascript"]

--- a/crates/rift-core/src/backends/inmemory.rs
+++ b/crates/rift-core/src/backends/inmemory.rs
@@ -45,10 +45,10 @@ impl InMemoryFlowStore {
         key: &str,
         is_expired_fn: impl Fn(&Option<SystemTime>) -> bool,
     ) {
-        if let Some((_, expiry)) = data.get(key) {
-            if is_expired_fn(expiry) {
-                data.remove(key);
-            }
+        if let Some((_, expiry)) = data.get(key)
+            && is_expired_fn(expiry)
+        {
+            data.remove(key);
         }
     }
 }

--- a/crates/rift-core/src/behaviors/mod.rs
+++ b/crates/rift-core/src/behaviors/mod.rs
@@ -26,18 +26,18 @@ mod wait;
 
 // Re-export main types for library consumers
 #[allow(unused_imports)]
-pub use copy::{apply_copy_behaviors, CopyBehavior, CopySource};
+pub use copy::{CopyBehavior, CopySource, apply_copy_behaviors};
 pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
 #[allow(unused_imports)]
-pub use extraction::{extract_jsonpath, extract_xpath, extract_xpath_with_ns, ExtractionMethod};
+pub use extraction::{ExtractionMethod, extract_jsonpath, extract_xpath, extract_xpath_with_ns};
 #[allow(unused_imports)]
 pub use lookup::{
-    apply_lookup_behaviors, CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey,
+    CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey, apply_lookup_behaviors,
 };
-pub use request::{header_to_title_case, RequestContext};
+pub use request::{RequestContext, header_to_title_case};
 pub use transform::{
-    apply_decorate, apply_shell_transform, is_js_config_decorate, rewrite_js_config_to_rhai,
-    DecorateError,
+    DecorateError, apply_decorate, apply_shell_transform, is_js_config_decorate,
+    rewrite_js_config_to_rhai,
 };
 pub use types::ResponseBehaviors;
 #[allow(unused_imports)]

--- a/crates/rift-core/src/behaviors/transform.rs
+++ b/crates/rift-core/src/behaviors/transform.rs
@@ -157,32 +157,33 @@ pub fn apply_decorate(
     match engine.eval_with_scope::<Dynamic>(&mut scope, script) {
         Ok(_) => {
             // Extract modified response from scope
-            if let Some(response) = scope.get_value::<Map>("response") {
-                let new_body = response
-                    .get("body")
-                    .and_then(|v| v.clone().try_cast::<String>())
-                    .unwrap_or_else(|| response_body.to_string());
+            match scope.get_value::<Map>("response") {
+                Some(response) => {
+                    let new_body = response
+                        .get("body")
+                        .and_then(|v| v.clone().try_cast::<String>())
+                        .unwrap_or_else(|| response_body.to_string());
 
-                let new_status = response
-                    .get("statusCode")
-                    .and_then(|v| v.clone().try_cast::<i64>())
-                    .map(|s| s as u16)
-                    .unwrap_or(response_status);
+                    let new_status = response
+                        .get("statusCode")
+                        .and_then(|v| v.clone().try_cast::<i64>())
+                        .map(|s| s as u16)
+                        .unwrap_or(response_status);
 
-                // Update headers from response map
-                if let Some(headers) = response.get("headers") {
-                    if let Some(headers_map) = headers.clone().try_cast::<Map>() {
+                    // Update headers from response map
+                    if let Some(headers) = response.get("headers")
+                        && let Some(headers_map) = headers.clone().try_cast::<Map>()
+                    {
                         for (k, v) in headers_map {
                             if let Some(value) = v.try_cast::<String>() {
                                 response_headers.insert(k.to_string(), value);
                             }
                         }
                     }
-                }
 
-                Ok((new_body, new_status))
-            } else {
-                Ok((response_body.to_string(), response_status))
+                    Ok((new_body, new_status))
+                }
+                _ => Ok((response_body.to_string(), response_status)),
             }
         }
         Err(e) => Err(DecorateError::Rhai(e.to_string())),
@@ -347,10 +348,12 @@ mod tests {
 
         let result = apply_decorate(script, &request, "body", 200, &mut headers);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Decorate script error"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Decorate script error")
+        );
     }
 
     // Issue #191: JS `config =>` decorate convention detection + rewrite.

--- a/crates/rift-core/src/behaviors/wait.rs
+++ b/crates/rift-core/src/behaviors/wait.rs
@@ -182,8 +182,7 @@ mod tests {
             let duration = wait.get_duration_ms();
             assert!(
                 (50..=100).contains(&duration),
-                "Duration {} not in range 50-100",
-                duration
+                "Duration {duration} not in range 50-100"
             );
         }
     }
@@ -197,8 +196,7 @@ mod tests {
             let duration = wait.get_duration_ms();
             assert!(
                 (50..=150).contains(&duration),
-                "Duration {} not in range 50-150",
-                duration
+                "Duration {duration} not in range 50-150"
             );
         }
     }

--- a/crates/rift-core/src/extensions/fault.rs
+++ b/crates/rift-core/src/extensions/fault.rs
@@ -3,7 +3,7 @@ use crate::config::{FaultConfig, TcpFault};
 use crate::response::builder::ErrorResponseBuilder;
 use http_body_util::Full;
 use hyper::body::Bytes;
-use hyper::header::{HeaderName, CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING};
+use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderName, TRANSFER_ENCODING};
 use hyper::http::HeaderValue;
 use hyper::{HeaderMap, Response, StatusCode};
 use rand::Rng;
@@ -44,34 +44,34 @@ pub fn decide_fault(fault_config: &FaultConfig, rule_id: &str) -> FaultDecision 
     }
 
     // Check error fault (higher priority than latency)
-    if let Some(error_fault) = &fault_config.error {
-        if should_inject(error_fault.probability, &mut rng) {
-            return FaultDecision::Error {
-                status: error_fault.status,
-                body: error_fault.body.clone(),
-                rule_id: rule_id.to_string(),
-                headers: error_fault.headers.clone(),
-                behaviors: error_fault.behaviors.clone(),
-            };
-        }
+    if let Some(error_fault) = &fault_config.error
+        && should_inject(error_fault.probability, &mut rng)
+    {
+        return FaultDecision::Error {
+            status: error_fault.status,
+            body: error_fault.body.clone(),
+            rule_id: rule_id.to_string(),
+            headers: error_fault.headers.clone(),
+            behaviors: error_fault.behaviors.clone(),
+        };
     }
 
     // Check latency fault
-    if let Some(latency_fault) = &fault_config.latency {
-        if should_inject(latency_fault.probability, &mut rng) {
-            let duration_ms = rng.gen_range(latency_fault.min_ms..=latency_fault.max_ms);
-            return FaultDecision::Latency {
-                duration_ms,
-                rule_id: rule_id.to_string(),
-            };
-        }
+    if let Some(latency_fault) = &fault_config.latency
+        && should_inject(latency_fault.probability, &mut rng)
+    {
+        let duration_ms = rng.gen_range(latency_fault.min_ms..=latency_fault.max_ms);
+        return FaultDecision::Latency {
+            duration_ms,
+            rule_id: rule_id.to_string(),
+        };
     }
 
     FaultDecision::None
 }
 
 fn should_inject(probability: f64, rng: &mut impl Rng) -> bool {
-    rng.gen::<f64>() < probability
+    rng.r#gen::<f64>() < probability
 }
 
 pub async fn apply_latency(duration_ms: u64) {

--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -55,7 +55,9 @@ impl FlowStore for NoOpFlowStore {
     fn increment(&self, _flow_id: &str, _key: &str) -> Result<i64> {
         // Always return 1 for no-op store since we can't track state
         // Scripts using flow_store.increment() with NoOpFlowStore will always get 1
-        tracing::warn!("NoOpFlowStore: increment called but no state tracking available. Configure flow_state for stateful scripts.");
+        tracing::warn!(
+            "NoOpFlowStore: increment called but no state tracking available. Configure flow_state for stateful scripts."
+        );
         Ok(1)
     }
 
@@ -316,9 +318,11 @@ mod tests {
     #[test]
     fn test_noop_flow_store_with_object_value() {
         let store = NoOpFlowStore;
-        assert!(store
-            .set("flow", "key", json!({"nested": {"deep": "value"}}))
-            .is_ok());
+        assert!(
+            store
+                .set("flow", "key", json!({"nested": {"deep": "value"}}))
+                .is_ok()
+        );
     }
 
     // ============================================

--- a/crates/rift-core/src/extensions/matcher.rs
+++ b/crates/rift-core/src/extensions/matcher.rs
@@ -1,7 +1,7 @@
 use crate::config::{HeaderMatch, PathMatch, Rule};
 use crate::predicate::{
-    compile_header_matcher, compile_query_matcher, parse_query_string, CompiledBodyMatcher,
-    CompiledFieldMatcher,
+    CompiledBodyMatcher, CompiledFieldMatcher, compile_header_matcher, compile_query_matcher,
+    parse_query_string,
 };
 use hyper::{HeaderMap, Method, Uri};
 use regex::Regex;

--- a/crates/rift-core/src/extensions/matcher.rs
+++ b/crates/rift-core/src/extensions/matcher.rs
@@ -165,14 +165,12 @@ impl CompiledRule {
 
         // Match simple headers (backward compatible)
         for header_match in &self.match_config.headers {
-            let header_value = match headers.get(&header_match.name) {
-                Some(value) => value,
-                None => return false,
+            let Some(header_value) = headers.get(&header_match.name) else {
+                return false;
             };
 
-            let value_str = match header_value.to_str() {
-                Ok(s) => s,
-                Err(_) => return false,
+            let Ok(value_str) = header_value.to_str() else {
+                return false;
             };
 
             if value_str != header_match.value {

--- a/crates/rift-core/src/extensions/metrics.rs
+++ b/crates/rift-core/src/extensions/metrics.rs
@@ -5,8 +5,8 @@
 //! Tracks fault injection activity, script execution, and proxy performance.
 use lazy_static::lazy_static;
 use prometheus::{
-    register_counter_vec, register_gauge_vec, register_histogram_vec, CounterVec, Encoder,
-    GaugeVec, HistogramVec, TextEncoder,
+    CounterVec, Encoder, GaugeVec, HistogramVec, TextEncoder, register_counter_vec,
+    register_gauge_vec, register_histogram_vec,
 };
 
 lazy_static! {
@@ -146,12 +146,12 @@ pub fn record_script_execution(rule_id: &str, duration_ms: f64, result: &str) {
 pub fn record_script_fault(fault_type: &str, rule_id: &str, duration_ms: Option<u64>) {
     record_fault_injection(fault_type, rule_id, "script");
 
-    if fault_type == "latency" {
-        if let Some(ms) = duration_ms {
-            LATENCY_INJECTED_MS
-                .with_label_values(&[rule_id])
-                .observe(ms as f64);
-        }
+    if fault_type == "latency"
+        && let Some(ms) = duration_ms
+    {
+        LATENCY_INJECTED_MS
+            .with_label_values(&[rule_id])
+            .observe(ms as f64);
     }
 }
 

--- a/crates/rift-core/src/extensions/mod.rs
+++ b/crates/rift-core/src/extensions/mod.rs
@@ -24,9 +24,9 @@ pub mod template;
 
 // Re-export commonly used types for library consumers
 #[allow(unused_imports)]
-pub use fault::{create_error_response, decide_fault, FaultDecision};
+pub use fault::{FaultDecision, create_error_response, decide_fault};
 #[allow(unused_imports)]
-pub use flow_state::{create_flow_store, FlowStore, NoOpFlowStore};
+pub use flow_state::{FlowStore, NoOpFlowStore, create_flow_store};
 #[allow(unused_imports)]
 pub use matcher::{CompiledMatch, CompiledRule};
 #[allow(unused_imports)]
@@ -37,7 +37,7 @@ pub use routing::Router;
 pub use rule_index::{IndexedRule, RuleIndex};
 #[allow(unused_imports)]
 pub use stub_analysis::{
-    analyze_new_stub, analyze_stubs, StubAnalysisResult, StubWarning, WarningType,
+    StubAnalysisResult, StubWarning, WarningType, analyze_new_stub, analyze_stubs,
 };
 #[allow(unused_imports)]
-pub use template::{apply_date_templates, process_template, RequestData};
+pub use template::{RequestData, apply_date_templates, process_template};

--- a/crates/rift-core/src/extensions/routing.rs
+++ b/crates/rift-core/src/extensions/routing.rs
@@ -94,8 +94,8 @@ fn matches_route<B>(req: &Request<B>, route: &CompiledRoute) -> bool {
             .or_else(|| req.headers().get("host").and_then(|h| h.to_str().ok()));
 
         let matches = match (req_host, host_match) {
-            (Some(req_host), CompiledHost::Exact(ref pattern)) => req_host == pattern,
-            (Some(req_host), CompiledHost::Wildcard(ref pattern)) => {
+            (Some(req_host), CompiledHost::Exact(pattern)) => req_host == pattern,
+            (Some(req_host), CompiledHost::Wildcard(pattern)) => {
                 // Simple wildcard matching (*.example.com)
                 if let Some(suffix) = pattern.strip_prefix("*.") {
                     req_host.ends_with(suffix)
@@ -114,22 +114,22 @@ fn matches_route<B>(req: &Request<B>, route: &CompiledRoute) -> bool {
     // Check path
     let path = req.uri().path();
 
-    if let Some(ref exact) = route.path_exact {
-        if path != exact {
-            return false;
-        }
+    if let Some(ref exact) = route.path_exact
+        && path != exact
+    {
+        return false;
     }
 
-    if let Some(ref prefix) = route.path_prefix {
-        if !path.starts_with(prefix) {
-            return false;
-        }
+    if let Some(ref prefix) = route.path_prefix
+        && !path.starts_with(prefix)
+    {
+        return false;
     }
 
-    if let Some(ref regex) = route.path_regex {
-        if !regex.is_match(path) {
-            return false;
-        }
+    if let Some(ref regex) = route.path_regex
+        && !regex.is_match(path)
+    {
+        return false;
     }
 
     // Check headers

--- a/crates/rift-core/src/extensions/stub_analysis.rs
+++ b/crates/rift-core/src/extensions/stub_analysis.rs
@@ -165,20 +165,20 @@ pub fn analyze_stubs(stubs: &[Stub]) -> StubAnalysisResult {
     }
 
     // Warn if catch-all is not at the end
-    if let Some(&catch_all_idx) = catch_all_indices.first() {
-        if catch_all_idx < stubs.len() - 1 {
-            result.add_warning(StubWarning {
-                warning_type: WarningType::CatchAllNotLast,
-                message: format!(
-                    "Catch-all stub at index {} will shadow {} stub(s) after it",
-                    catch_all_idx,
-                    stubs.len() - catch_all_idx - 1
-                ),
-                stub_index: Some(catch_all_idx),
-                stub_id: stubs[catch_all_idx].id.clone(),
-                shadowed_by_index: None,
-            });
-        }
+    if let Some(&catch_all_idx) = catch_all_indices.first()
+        && catch_all_idx < stubs.len() - 1
+    {
+        result.add_warning(StubWarning {
+            warning_type: WarningType::CatchAllNotLast,
+            message: format!(
+                "Catch-all stub at index {} will shadow {} stub(s) after it",
+                catch_all_idx,
+                stubs.len() - catch_all_idx - 1
+            ),
+            stub_index: Some(catch_all_idx),
+            stub_id: stubs[catch_all_idx].id.clone(),
+            shadowed_by_index: None,
+        });
     }
 
     result
@@ -449,10 +449,12 @@ mod tests {
 
         let result = analyze_stubs(&stubs);
         assert!(result.has_warnings());
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::DuplicateId));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::DuplicateId)
+        );
     }
 
     #[test]
@@ -463,10 +465,12 @@ mod tests {
         ];
 
         let result = analyze_stubs(&stubs);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::CatchAll));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::CatchAll)
+        );
     }
 
     #[test]
@@ -477,14 +481,18 @@ mod tests {
         ];
 
         let result = analyze_stubs(&stubs);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::CatchAllNotLast));
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::PotentiallyShadowed));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::CatchAllNotLast)
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::PotentiallyShadowed)
+        );
     }
 
     #[test]
@@ -495,10 +503,12 @@ mod tests {
         ];
 
         let result = analyze_stubs(&stubs);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::ExactDuplicate));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate)
+        );
     }
 
     #[test]
@@ -510,14 +520,18 @@ mod tests {
 
         let result = analyze_stubs(&stubs);
         // May have warnings about different things, but not duplicates
-        assert!(!result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::DuplicateId));
-        assert!(!result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::ExactDuplicate));
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::DuplicateId)
+        );
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate)
+        );
     }
 
     #[test]
@@ -528,10 +542,12 @@ mod tests {
         ];
 
         let result = analyze_stubs(&stubs);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::PotentiallyShadowed));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::PotentiallyShadowed)
+        );
     }
 
     #[test]
@@ -544,10 +560,12 @@ mod tests {
             stub_with_id_and_predicates("stub1", vec![json!({"equals": {"path": "/b"}})]);
 
         let result = analyze_new_stub(&existing, &new_stub, 1);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::DuplicateId));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::DuplicateId)
+        );
     }
 
     #[test]
@@ -558,10 +576,12 @@ mod tests {
         let new_stub = stub_with_predicates(vec![json!({"equals": {"path": "/specific"}})]);
 
         let result = analyze_new_stub(&existing, &new_stub, 1);
-        assert!(result
-            .warnings
-            .iter()
-            .any(|w| w.warning_type == WarningType::PotentiallyShadowed));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::PotentiallyShadowed)
+        );
     }
 
     #[test]

--- a/crates/rift-core/src/extensions/template.rs
+++ b/crates/rift-core/src/extensions/template.rs
@@ -197,8 +197,8 @@ pub fn apply_date_templates(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderName, HeaderValue};
     use hyper::HeaderMap;
+    use hyper::header::{HeaderName, HeaderValue};
 
     fn create_test_request_data() -> RequestData {
         let mut headers = HeaderMap::new();

--- a/crates/rift-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-core/src/imposter/core/lifecycle.rs
@@ -19,10 +19,10 @@ impl Imposter {
     #[must_use]
     pub fn add_stub_unique(&self, stub: Stub, index: Option<usize>) -> bool {
         let mut stubs = self.stubs.write();
-        if let Some(id) = stub.id.as_deref() {
-            if stubs.iter().any(|s| s.stub.id.as_deref() == Some(id)) {
-                return false;
-            }
+        if let Some(id) = stub.id.as_deref()
+            && stubs.iter().any(|s| s.stub.id.as_deref() == Some(id))
+        {
+            return false;
         }
         let idx = index.unwrap_or(stubs.len()).min(stubs.len());
         stubs.insert(idx, StubState::new(stub));

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -42,10 +42,10 @@ impl Imposter {
             // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only
             // participates in matching when the request's resolved flow_id equals its space.
             // Unscoped stubs match any space (PerInstance default).
-            if let Some(space) = &stub.space {
-                if flow_id != *space {
-                    continue;
-                }
+            if let Some(space) = &stub.space
+                && flow_id != *space
+            {
+                continue;
             }
             // Scenario FSM eligibility gate (before predicate precedence): a stub guarded by
             // `requiredScenarioState` only participates in matching when the current
@@ -254,29 +254,29 @@ impl Imposter {
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
 
-        if content_type.contains("application/x-www-form-urlencoded") {
-            if let Some(body_str) = body {
-                let mut map = HashMap::new();
-                for pair in body_str.split('&').filter(|s| !s.is_empty()) {
-                    let mut parts = pair.splitn(2, '=');
-                    if let Some(raw_key) = parts.next() {
-                        let key = urlencoding::decode(raw_key)
-                            .unwrap_or_default()
-                            .into_owned();
-                        let value = parts
-                            .next()
-                            .map(|v| urlencoding::decode(v).unwrap_or_default().into_owned())
-                            .unwrap_or_default();
-                        map.entry(key)
-                            .and_modify(|existing: &mut String| {
-                                existing.push(',');
-                                existing.push_str(&value);
-                            })
-                            .or_insert(value);
-                    }
+        if content_type.contains("application/x-www-form-urlencoded")
+            && let Some(body_str) = body
+        {
+            let mut map = HashMap::new();
+            for pair in body_str.split('&').filter(|s| !s.is_empty()) {
+                let mut parts = pair.splitn(2, '=');
+                if let Some(raw_key) = parts.next() {
+                    let key = urlencoding::decode(raw_key)
+                        .unwrap_or_default()
+                        .into_owned();
+                    let value = parts
+                        .next()
+                        .map(|v| urlencoding::decode(v).unwrap_or_default().into_owned())
+                        .unwrap_or_default();
+                    map.entry(key)
+                        .and_modify(|existing: &mut String| {
+                            existing.push(',');
+                            existing.push_str(&value);
+                        })
+                        .or_insert(value);
                 }
-                return Some(map);
             }
+            return Some(map);
         }
         None
     }

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -27,8 +27,8 @@ use crate::recording::{ProxyMode, RecordedResponse, RecordingStore, RequestSigna
 use anyhow::Context;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
@@ -228,7 +228,9 @@ impl Imposter {
 
         #[cfg(not(feature = "redis-backend"))]
         {
-            error!("Redis backend not available (compile with --features redis-backend), falling back to NoOp");
+            error!(
+                "Redis backend not available (compile with --features redis-backend), falling back to NoOp"
+            );
             Arc::new(NoOpFlowStore)
         }
     }

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -17,8 +17,8 @@ impl Imposter {
     ) -> Vec<serde_json::Value> {
         let mut predicates = Vec::new();
 
-        for gen in generators {
-            let gen_obj = match gen.as_object() {
+        for r#gen in generators {
+            let gen_obj = match r#gen.as_object() {
                 Some(obj) => obj,
                 None => continue,
             };
@@ -28,7 +28,7 @@ impl Imposter {
             if let Some(inject_fn) = gen_obj.get("inject").and_then(|v| v.as_str()) {
                 #[cfg(feature = "javascript")]
                 {
-                    use crate::scripting::{execute_predicate_generator_inject, MountebankRequest};
+                    use crate::scripting::{MountebankRequest, execute_predicate_generator_inject};
                     let query_map = query
                         .map(crate::imposter::parse_query_string)
                         .unwrap_or_default();
@@ -45,7 +45,9 @@ impl Imposter {
                 }
                 #[cfg(not(feature = "javascript"))]
                 {
-                    tracing::warn!("predicateGenerator inject requires the 'javascript' feature; generator ignored");
+                    tracing::warn!(
+                        "predicateGenerator inject requires the 'javascript' feature; generator ignored"
+                    );
                     let _ = inject_fn;
                 }
                 continue;
@@ -79,10 +81,10 @@ impl Imposter {
             {
                 let mut path_val = path.to_string();
                 // Apply except pattern if present
-                if let Some(pattern) = except_pattern {
-                    if let Ok(re) = regex::Regex::new(pattern) {
-                        path_val = re.replace_all(&path_val, "").to_string();
-                    }
+                if let Some(pattern) = except_pattern
+                    && let Ok(re) = regex::Regex::new(pattern)
+                {
+                    path_val = re.replace_all(&path_val, "").to_string();
                 }
                 pred_values.insert("path".to_string(), serde_json::Value::String(path_val));
             }
@@ -94,10 +96,10 @@ impl Imposter {
                 .unwrap_or(false)
             {
                 let mut method_val = method.to_string();
-                if let Some(pattern) = except_pattern {
-                    if let Ok(re) = regex::Regex::new(pattern) {
-                        method_val = re.replace_all(&method_val, "").to_string();
-                    }
+                if let Some(pattern) = except_pattern
+                    && let Ok(re) = regex::Regex::new(pattern)
+                {
+                    method_val = re.replace_all(&method_val, "").to_string();
                 }
                 pred_values.insert("method".to_string(), serde_json::Value::String(method_val));
             }
@@ -107,17 +109,15 @@ impl Imposter {
                 .get("query")
                 .and_then(|q| q.as_bool())
                 .unwrap_or(false)
+                && let Some(query_str) = query
             {
-                if let Some(query_str) = query {
-                    let query_map = crate::imposter::parse_query_string(query_str);
-                    if !query_map.is_empty() {
-                        let query_json: serde_json::Map<String, serde_json::Value> = query_map
-                            .into_iter()
-                            .map(|(k, v)| (k, serde_json::Value::String(v)))
-                            .collect();
-                        pred_values
-                            .insert("query".to_string(), serde_json::Value::Object(query_json));
-                    }
+                let query_map = crate::imposter::parse_query_string(query_str);
+                if !query_map.is_empty() {
+                    let query_json: serde_json::Map<String, serde_json::Value> = query_map
+                        .into_iter()
+                        .map(|(k, v)| (k, serde_json::Value::String(v)))
+                        .collect();
+                    pred_values.insert("query".to_string(), serde_json::Value::Object(query_json));
                 }
             }
 
@@ -125,13 +125,13 @@ impl Imposter {
             if let Some(header_matches) = matches.get("headers").and_then(|h| h.as_object()) {
                 let mut header_preds = serde_json::Map::new();
                 for (header_name, should_match) in header_matches {
-                    if should_match.as_bool().unwrap_or(false) {
-                        if let Some(header_value) = headers.get(header_name) {
-                            header_preds.insert(
-                                header_name.clone(),
-                                serde_json::Value::String(header_value.clone()),
-                            );
-                        }
+                    if should_match.as_bool().unwrap_or(false)
+                        && let Some(header_value) = headers.get(header_name)
+                    {
+                        header_preds.insert(
+                            header_name.clone(),
+                            serde_json::Value::String(header_value.clone()),
+                        );
                     }
                 }
                 if !header_preds.is_empty() {
@@ -147,17 +147,16 @@ impl Imposter {
                 .get("body")
                 .and_then(|b| b.as_bool())
                 .unwrap_or(false)
+                && let Some(body_str) = body
             {
-                if let Some(body_str) = body {
-                    let mut body_val = body_str.to_string();
-                    // Apply except pattern if present
-                    if let Some(pattern) = except_pattern {
-                        if let Ok(re) = regex::Regex::new(pattern) {
-                            body_val = re.replace_all(&body_val, "").to_string();
-                        }
-                    }
-                    pred_values.insert("body".to_string(), serde_json::Value::String(body_val));
+                let mut body_val = body_str.to_string();
+                // Apply except pattern if present
+                if let Some(pattern) = except_pattern
+                    && let Ok(re) = regex::Regex::new(pattern)
+                {
+                    body_val = re.replace_all(&body_val, "").to_string();
                 }
+                pred_values.insert("body".to_string(), serde_json::Value::String(body_val));
             }
 
             if pred_values.is_empty() {
@@ -274,8 +273,12 @@ impl Imposter {
     ) -> anyhow::Result<(u16, Vec<(String, String)>, Vec<u8>, Option<u64>)> {
         let client = get_http_client();
 
-        info!("Proxy config - addDecorateBehavior: {:?}, addWaitBehavior: {}, predicateGenerators: {:?}",
-            proxy_config.add_decorate_behavior, proxy_config.add_wait_behavior, proxy_config.predicate_generators);
+        info!(
+            "Proxy config - addDecorateBehavior: {:?}, addWaitBehavior: {}, predicateGenerators: {:?}",
+            proxy_config.add_decorate_behavior,
+            proxy_config.add_wait_behavior,
+            proxy_config.predicate_generators
+        );
 
         // Build the proxy URL, applying path rewrite if configured
         let original_path = uri.path();
@@ -305,16 +308,16 @@ impl Imposter {
         let signature = RequestSignature::new(method, uri.path(), uri.query(), &[]);
 
         // Check if we should replay cached response (based on proxy mode)
-        if !self.recording_store.should_proxy(&signature) {
-            if let Some(recorded) = self.recording_store.get_recorded(&signature) {
-                debug!("Returning recorded proxy response (proxyOnce mode)");
-                return Ok((
-                    recorded.status,
-                    recorded.headers.clone(),
-                    recorded.body.clone(),
-                    recorded.latency_ms,
-                ));
-            }
+        if !self.recording_store.should_proxy(&signature)
+            && let Some(recorded) = self.recording_store.get_recorded(&signature)
+        {
+            debug!("Returning recorded proxy response (proxyOnce mode)");
+            return Ok((
+                recorded.status,
+                recorded.headers.clone(),
+                recorded.body.clone(),
+                recorded.latency_ms,
+            ));
         }
 
         // Forward the request
@@ -362,15 +365,15 @@ impl Imposter {
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
         // Check Content-Length before reading the full body to reject obviously oversized responses
-        if let Some(content_length) = response.content_length() {
-            if content_length as usize > MAX_PROXY_RESPONSE_BODY_SIZE {
-                anyhow::bail!(
-                    "Proxy response body from {} exceeds maximum size ({} > {} bytes)",
-                    target_url,
-                    content_length,
-                    MAX_PROXY_RESPONSE_BODY_SIZE
-                );
-            }
+        if let Some(content_length) = response.content_length()
+            && content_length as usize > MAX_PROXY_RESPONSE_BODY_SIZE
+        {
+            anyhow::bail!(
+                "Proxy response body from {} exceeds maximum size ({} > {} bytes)",
+                target_url,
+                content_length,
+                MAX_PROXY_RESPONSE_BODY_SIZE
+            );
         }
 
         let body_bytes = response

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -18,9 +18,8 @@ impl Imposter {
         let mut predicates = Vec::new();
 
         for r#gen in generators {
-            let gen_obj = match r#gen.as_object() {
-                Some(obj) => obj,
-                None => continue,
+            let Some(gen_obj) = r#gen.as_object() else {
+                continue;
             };
 
             // Handle inject predicateGenerator — calls a JS function with the request and
@@ -54,9 +53,8 @@ impl Imposter {
             }
 
             // Get the matches config
-            let matches = match gen_obj.get("matches").and_then(|m| m.as_object()) {
-                Some(m) => m,
-                None => continue,
+            let Some(matches) = gen_obj.get("matches").and_then(|m| m.as_object()) else {
+                continue;
             };
 
             // Get options
@@ -355,7 +353,7 @@ impl Imposter {
         let response = request
             .send()
             .await
-            .with_context(|| format!("Failed to send proxy request to {}", target_url))?;
+            .with_context(|| format!("Failed to send proxy request to {target_url}"))?;
         let latency_ms = start.elapsed().as_millis() as u64;
 
         let status = response.status().as_u16();
@@ -369,17 +367,14 @@ impl Imposter {
             && content_length as usize > MAX_PROXY_RESPONSE_BODY_SIZE
         {
             anyhow::bail!(
-                "Proxy response body from {} exceeds maximum size ({} > {} bytes)",
-                target_url,
-                content_length,
-                MAX_PROXY_RESPONSE_BODY_SIZE
+                "Proxy response body from {target_url} exceeds maximum size ({content_length} > {MAX_PROXY_RESPONSE_BODY_SIZE} bytes)"
             );
         }
 
         let body_bytes = response
             .bytes()
             .await
-            .with_context(|| format!("Failed to read response body from {}", target_url))?;
+            .with_context(|| format!("Failed to read response body from {target_url}"))?;
 
         if body_bytes.len() > MAX_PROXY_RESPONSE_BODY_SIZE {
             anyhow::bail!(

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -10,13 +10,13 @@ use super::types::{
     DebugMatchResult, DebugRequest, DebugResponse, ProxyResponse, RecordedRequest, ResponseMode,
 };
 use crate::behaviors::{
-    apply_copy_behaviors, apply_lookup_behaviors, apply_shell_transform, header_to_title_case,
-    CsvCache, RequestContext, ResponseBehaviors,
+    CsvCache, RequestContext, ResponseBehaviors, apply_copy_behaviors, apply_lookup_behaviors,
+    apply_shell_transform, header_to_title_case,
 };
-use crate::extensions::template::{has_template_variables, process_template, RequestData};
-#[cfg(feature = "javascript")]
-use crate::scripting::{execute_mountebank_inject, MountebankRequest};
+use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::scripting::{FaultDecision, ScriptEngine, ScriptRequest};
+#[cfg(feature = "javascript")]
+use crate::scripting::{MountebankRequest, execute_mountebank_inject};
 use crate::util::{build_response, build_response_with_headers};
 use base64::Engine;
 use bytes::Bytes;
@@ -459,14 +459,11 @@ async fn handle_request_inner(
             }
 
             // Apply _rift.fault extensions (probabilistic faults)
-            if let Some(ref rift) = rift_ext {
-                if let Some(ref fault_config) = rift.fault {
-                    if let Some(response) =
-                        apply_rift_fault(fault_config, &mut status, &mut body).await
-                    {
-                        return Ok(response);
-                    }
-                }
+            if let Some(ref rift) = rift_ext
+                && let Some(ref fault_config) = rift.fault
+                && let Some(response) = apply_rift_fault(fault_config, &mut status, &mut body).await
+            {
+                return Ok(response);
             }
 
             // Expand `${request.*}` request templates (issue #269) BEFORE behaviors — matching the
@@ -880,7 +877,7 @@ async fn apply_rift_fault(
     let (apply_latency, latency_delay_ms) = {
         let mut rng = rand::thread_rng();
         if let Some(ref latency) = fault_config.latency {
-            if rng.gen::<f64>() < latency.probability {
+            if rng.r#gen::<f64>() < latency.probability {
                 let delay_ms = if let Some(fixed_ms) = latency.ms {
                     fixed_ms
                 } else if latency.max_ms > latency.min_ms {
@@ -900,7 +897,7 @@ async fn apply_rift_fault(
     let apply_error = {
         let mut rng = rand::thread_rng();
         if let Some(ref error) = fault_config.error {
-            rng.gen::<f64>() < error.probability
+            rng.r#gen::<f64>() < error.probability
         } else {
             false
         }
@@ -937,29 +934,27 @@ async fn apply_rift_fault(
     }
 
     // Apply error fault
-    if apply_error {
-        if let Some(ref error) = fault_config.error {
-            debug!("Applying _rift.fault error: status {}", error.status);
+    if apply_error && let Some(ref error) = fault_config.error {
+        debug!("Applying _rift.fault error: status {}", error.status);
 
-            let mut response = Response::builder().status(error.status);
+        let mut response = Response::builder().status(error.status);
 
-            // Apply custom headers
-            for (k, v) in &error.headers {
-                response = response.header(k, v);
-            }
-
-            response = response.header("x-rift-imposter", "true");
-            response = response.header("x-rift-fault", "error");
-
-            let error_body = error.body.clone().unwrap_or_default();
-            return Some(
-                response
-                    .body(Full::new(Bytes::from(error_body)))
-                    .unwrap_or_else(|_| {
-                        build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
-                    }),
-            );
+        // Apply custom headers
+        for (k, v) in &error.headers {
+            response = response.header(k, v);
         }
+
+        response = response.header("x-rift-imposter", "true");
+        response = response.header("x-rift-fault", "error");
+
+        let error_body = error.body.clone().unwrap_or_default();
+        return Some(
+            response
+                .body(Full::new(Bytes::from(error_body)))
+                .unwrap_or_else(|_| {
+                    build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+                }),
+        );
     }
 
     None
@@ -969,7 +964,7 @@ async fn apply_rift_fault(
 mod fault_precedence_tests {
     use super::super::fault_io::TcpFaultKind;
     use super::super::types::{RiftErrorFault, RiftFaultConfig, RiftLatencyFault};
-    use super::{apply_rift_fault, Bytes, Full, Response};
+    use super::{Bytes, Full, Response, apply_rift_fault};
     use std::time::Instant;
 
     fn error_fault(status: u16) -> RiftErrorFault {

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -147,8 +147,7 @@ async fn handle_request_inner(
                 StatusCode::PAYLOAD_TOO_LARGE,
                 [("x-rift-imposter", "true")],
                 format!(
-                    r#"{{"error": "Request body exceeds maximum size of {} bytes"}}"#,
-                    MAX_REQUEST_BODY_SIZE
+                    r#"{{"error": "Request body exceeds maximum size of {MAX_REQUEST_BODY_SIZE} bytes"}}"#
                 ),
             ));
         }

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -535,9 +535,8 @@ impl ImposterManager {
         let Some(ref datadir) = self.datadir else {
             return Ok(());
         };
-        let port = match imposter.config.port {
-            Some(p) => p,
-            None => return Ok(()),
+        let Some(port) = imposter.config.port else {
+            return Ok(());
         };
         let mut snapshot = imposter.config.clone();
         snapshot.stubs = imposter.get_stubs();
@@ -558,9 +557,8 @@ impl ImposterManager {
         let Some(ref datadir) = self.datadir else {
             return;
         };
-        let port = match imposter.config.port {
-            Some(p) => p,
-            None => return,
+        let Some(port) = imposter.config.port else {
+            return;
         };
         let mut snapshot = imposter.config.clone();
         snapshot.stubs = imposter.get_stubs();

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -134,7 +134,7 @@ impl ImposterManager {
             _ => {
                 return Err(ImposterError::Tls(
                     "https imposter must provide both `cert` and `key`, or neither".to_string(),
-                ))
+                ));
             }
         }
         // Same both-or-neither rule for the server default: a half-configured default (e.g. only
@@ -148,7 +148,7 @@ impl ImposterManager {
             _ => {
                 return Err(ImposterError::Tls(
                     "server default TLS must provide both cert and key, or neither".to_string(),
-                ))
+                ));
             }
         }
         if self.tls_defaults.allow_self_signed {
@@ -414,10 +414,10 @@ impl ImposterManager {
                 "http" | "https" => {}
                 other => return Err(ImposterError::InvalidProtocol(other.to_string())),
             }
-            if let Some(port) = config.port {
-                if !seen.insert(port) {
-                    return Err(ImposterError::PortInUse(port));
-                }
+            if let Some(port) = config.port
+                && !seen.insert(port)
+            {
+                return Err(ImposterError::PortInUse(port));
             }
         }
 
@@ -587,13 +587,13 @@ impl ImposterManager {
         };
         let path = datadir.join(format!("{port}.json"));
         tokio::spawn(async move {
-            if path.exists() {
-                if let Err(e) = tokio::fs::remove_file(&path).await {
-                    error!(
-                        "Failed to remove persisted imposter {} at {:?}: {}",
-                        port, path, e
-                    );
-                }
+            if path.exists()
+                && let Err(e) = tokio::fs::remove_file(&path).await
+            {
+                error!(
+                    "Failed to remove persisted imposter {} at {:?}: {}",
+                    port, path, e
+                );
             }
         });
     }

--- a/crates/rift-core/src/imposter/predicates/fields.rs
+++ b/crates/rift-core/src/imposter/predicates/fields.rs
@@ -62,24 +62,24 @@ where
     };
 
     // Check method
-    if let Some(expected) = obj.get("method") {
-        if !check_string_field(expected, method) {
-            return false;
-        }
+    if let Some(expected) = obj.get("method")
+        && !check_string_field(expected, method)
+    {
+        return false;
     }
 
     // Check path
-    if let Some(expected) = obj.get("path") {
-        if !check_string_field(expected, path) {
-            return false;
-        }
+    if let Some(expected) = obj.get("path")
+        && !check_string_field(expected, path)
+    {
+        return false;
     }
 
     // Check body
-    if let Some(expected) = obj.get("body") {
-        if !check_string_field(expected, body) {
-            return false;
-        }
+    if let Some(expected) = obj.get("body")
+        && !check_string_field(expected, body)
+    {
+        return false;
     }
 
     // Check requestFrom (IP:port) - Mountebank compatible
@@ -99,84 +99,84 @@ where
     }
 
     // Check form fields (parsed from application/x-www-form-urlencoded) - Mountebank compatible
-    if let Some(expected_form) = obj.get("form") {
-        if let Some(expected_obj) = expected_form.as_object() {
-            let actual_form = form.cloned().unwrap_or_default();
+    if let Some(expected_form) = obj.get("form")
+        && let Some(expected_obj) = expected_form.as_object()
+    {
+        let actual_form = form.cloned().unwrap_or_default();
 
-            // For deepEquals, check exact match (same number of fields)
-            if deep_equals && expected_obj.len() != actual_form.len() {
-                return false;
-            }
+        // For deepEquals, check exact match (same number of fields)
+        if deep_equals && expected_obj.len() != actual_form.len() {
+            return false;
+        }
 
-            for (key, expected_val) in expected_obj {
-                // Find key using keyCaseSensitive option
-                let actual = actual_form
-                    .iter()
-                    .find(|(k, _)| key_matches(key, k))
-                    .map(|(_, v)| v.as_str());
+        for (key, expected_val) in expected_obj {
+            // Find key using keyCaseSensitive option
+            let actual = actual_form
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                match actual {
-                    Some(actual) => {
-                        if !check_string_field(expected_val, actual) {
-                            return false;
-                        }
+            match actual {
+                Some(actual) => {
+                    if !check_string_field(expected_val, actual) {
+                        return false;
                     }
-                    None => return false,
                 }
+                None => return false,
             }
         }
     }
 
     // Check query parameters
-    if let Some(expected_query) = obj.get("query") {
-        if let Some(expected_obj) = expected_query.as_object() {
-            // For deepEquals, check exact match (same number of params)
-            if deep_equals && expected_obj.len() != query.len() {
-                return false;
-            }
+    if let Some(expected_query) = obj.get("query")
+        && let Some(expected_obj) = expected_query.as_object()
+    {
+        // For deepEquals, check exact match (same number of params)
+        if deep_equals && expected_obj.len() != query.len() {
+            return false;
+        }
 
-            for (key, expected_val) in expected_obj {
-                // Find key using keyCaseSensitive option
-                let actual = query
-                    .iter()
-                    .find(|(k, _)| key_matches(key, k))
-                    .map(|(_, v)| v.as_str());
+        for (key, expected_val) in expected_obj {
+            // Find key using keyCaseSensitive option
+            let actual = query
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                match actual {
-                    Some(actual) => {
-                        if !check_string_field(expected_val, actual) {
-                            return false;
-                        }
+            match actual {
+                Some(actual) => {
+                    if !check_string_field(expected_val, actual) {
+                        return false;
                     }
-                    None => return false,
                 }
+                None => return false,
             }
         }
     }
 
     // Check headers
-    if let Some(expected_headers) = obj.get("headers") {
-        if let Some(expected_obj) = expected_headers.as_object() {
-            // For deepEquals, check exact match
-            if deep_equals && expected_obj.len() != headers.len() {
-                return false;
-            }
+    if let Some(expected_headers) = obj.get("headers")
+        && let Some(expected_obj) = expected_headers.as_object()
+    {
+        // For deepEquals, check exact match
+        if deep_equals && expected_obj.len() != headers.len() {
+            return false;
+        }
 
-            for (key, expected_val) in expected_obj {
-                // Headers use keyCaseSensitive option
-                let actual = headers
-                    .iter()
-                    .find(|(k, _)| key_matches(key, k))
-                    .map(|(_, v)| v.as_str());
+        for (key, expected_val) in expected_obj {
+            // Headers use keyCaseSensitive option
+            let actual = headers
+                .iter()
+                .find(|(k, _)| key_matches(key, k))
+                .map(|(_, v)| v.as_str());
 
-                match actual {
-                    Some(actual) => {
-                        if !check_string_field(expected_val, actual) {
-                            return false;
-                        }
+            match actual {
+                Some(actual) => {
+                    if !check_string_field(expected_val, actual) {
+                        return false;
                     }
-                    None => return false,
                 }
+                None => return false,
             }
         }
     }
@@ -258,38 +258,38 @@ pub(crate) fn check_predicate_fields_regex(
     };
 
     // Check method
-    if let Some(expected) = obj.get("method") {
-        if !check_regex_field(expected, method) {
-            return false;
-        }
+    if let Some(expected) = obj.get("method")
+        && !check_regex_field(expected, method)
+    {
+        return false;
     }
 
     // Check path
-    if let Some(expected) = obj.get("path") {
-        if !check_regex_field(expected, path) {
-            return false;
-        }
+    if let Some(expected) = obj.get("path")
+        && !check_regex_field(expected, path)
+    {
+        return false;
     }
 
     // Check body
-    if let Some(expected) = obj.get("body") {
-        if !check_regex_field(expected, body) {
-            return false;
-        }
+    if let Some(expected) = obj.get("body")
+        && !check_regex_field(expected, body)
+    {
+        return false;
     }
 
     // Check requestFrom
-    if let Some(expected) = obj.get("requestFrom") {
-        if !check_regex_field(expected, request_from.unwrap_or("")) {
-            return false;
-        }
+    if let Some(expected) = obj.get("requestFrom")
+        && !check_regex_field(expected, request_from.unwrap_or(""))
+    {
+        return false;
     }
 
     // Check ip
-    if let Some(expected) = obj.get("ip") {
-        if !check_regex_field(expected, client_ip.unwrap_or("")) {
-            return false;
-        }
+    if let Some(expected) = obj.get("ip")
+        && !check_regex_field(expected, client_ip.unwrap_or(""))
+    {
+        return false;
     }
 
     // Check form fields

--- a/crates/rift-core/src/imposter/predicates/json.rs
+++ b/crates/rift-core/src/imposter/predicates/json.rs
@@ -202,9 +202,8 @@ where
                 Err(_) => return false,
             };
 
-            let actual_obj = match actual_json.as_object() {
-                Some(obj) => obj,
-                None => return false,
+            let Some(actual_obj) = actual_json.as_object() else {
+                return false;
             };
 
             // For deepEquals, actual must have exactly the same keys
@@ -222,9 +221,8 @@ where
                         .map(|(_, v)| v)
                 };
 
-                let actual_val = match actual_val {
-                    Some(v) => v,
-                    None => return false,
+                let Some(actual_val) = actual_val else {
+                    return false;
                 };
 
                 let actual_val_str = json_value_to_string(actual_val);
@@ -247,9 +245,8 @@ where
                 Err(_) => return false,
             };
 
-            let actual_arr = match actual_json.as_array() {
-                Some(arr) => arr,
-                None => return false,
+            let Some(actual_arr) = actual_json.as_array() else {
+                return false;
             };
 
             if expected_arr.len() != actual_arr.len() {

--- a/crates/rift-core/src/imposter/predicates/json.rs
+++ b/crates/rift-core/src/imposter/predicates/json.rs
@@ -133,10 +133,10 @@ pub(crate) fn check_exists_predicate(
     }
 
     // Check body exists - supports both boolean and object values
-    if let Some(expected) = obj.get("body") {
-        if !check_exists_json_recursive(expected, body) {
-            return false;
-        }
+    if let Some(expected) = obj.get("body")
+        && !check_exists_json_recursive(expected, body)
+    {
+        return false;
     }
 
     // Check query parameters exist

--- a/crates/rift-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-core/src/imposter/predicates/mod.rs
@@ -80,10 +80,10 @@ pub fn predicate_matches(
 
     // Helper to apply except pattern
     let apply_except = |value: &str| -> String {
-        if let Some(pattern) = except_pattern {
-            if let Ok(re) = regex::Regex::new(pattern) {
-                return re.replace_all(value, "").to_string();
-            }
+        if let Some(pattern) = except_pattern
+            && let Ok(re) = regex::Regex::new(pattern)
+        {
+            return re.replace_all(value, "").to_string();
         }
         value.to_string()
     };
@@ -292,7 +292,7 @@ pub fn predicate_matches(
         PredicateOperation::Inject(inject_fn) => {
             #[cfg(feature = "javascript")]
             {
-                use crate::scripting::{execute_predicate_inject, MountebankRequest};
+                use crate::scripting::{MountebankRequest, execute_predicate_inject};
                 let query_map = parse_query(query);
                 let mb_request = MountebankRequest {
                     method: method.to_string(),

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -8,8 +8,8 @@ use super::types::{
     StubResponse,
 };
 use crate::behaviors::{
-    apply_decorate, is_js_config_decorate, rewrite_js_config_to_rhai, DecorateError,
-    HasRepeatBehavior, RequestContext,
+    DecorateError, HasRepeatBehavior, RequestContext, apply_decorate, is_js_config_decorate,
+    rewrite_js_config_to_rhai,
 };
 use crate::imposter::Predicate;
 use std::collections::HashMap;

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -2212,8 +2212,8 @@ fn test_exists_predicate_headers_key_case_sensitive() {
 
 #[test]
 fn test_header_map_to_hashmap_title_case() {
-    use hyper::header::HeaderValue;
     use hyper::HeaderMap;
+    use hyper::header::HeaderValue;
 
     let mut headers = HeaderMap::new();
     headers.insert("content-type", HeaderValue::from_static("application/json"));

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 /// `"k": ["v1", "v2"]` on the wire; serializes a single value back as a plain string and multiple
 /// values as an array, so existing single-value consumers are unaffected.
 pub(crate) mod multi_value_headers {
+    use serde::Deserialize;
     use serde::de::Deserializer;
     use serde::ser::{SerializeMap, Serializer};
-    use serde::Deserialize;
     use std::collections::HashMap;
 
     pub fn serialize<S: Serializer>(

--- a/crates/rift-core/src/predicate/body_matcher.rs
+++ b/crates/rift-core/src/predicate/body_matcher.rs
@@ -250,7 +250,7 @@ fn navigate_json<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a ser
 /// - `/root/element/text()` - text content
 pub fn extract_xpath(body: &str, path: &str) -> Option<String> {
     use sxd_document::parser;
-    use sxd_xpath::{evaluate_xpath, Value};
+    use sxd_xpath::{Value, evaluate_xpath};
 
     // Parse the XML document
     let package = parser::parse(body).ok()?;

--- a/crates/rift-core/src/predicate/deep_equals.rs
+++ b/crates/rift-core/src/predicate/deep_equals.rs
@@ -150,8 +150,8 @@ pub fn parse_query_string(query: Option<&str>) -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderName, HeaderValue};
     use hyper::HeaderMap;
+    use hyper::header::{HeaderName, HeaderValue};
 
     #[test]
     fn test_deep_equals_headers() {

--- a/crates/rift-core/src/predicate/field_matcher.rs
+++ b/crates/rift-core/src/predicate/field_matcher.rs
@@ -142,11 +142,7 @@ impl CompiledFieldMatcher {
                 .iter()
                 .any(|m| m.matches_with_except(value, self.case_sensitive, self.except.as_ref())),
         };
-        if self.not {
-            !result
-        } else {
-            result
-        }
+        if self.not { !result } else { result }
     }
 }
 

--- a/crates/rift-core/src/predicate/mod.rs
+++ b/crates/rift-core/src/predicate/mod.rs
@@ -39,13 +39,13 @@ mod string_matcher;
 // Re-export all public types for external consumers
 // Some are not yet used internally but are part of the public API
 #[allow(unused_imports)]
-pub use body_matcher::{extract_json_path, extract_xpath, BodyMatcher, CompiledBodyMatcher};
+pub use body_matcher::{BodyMatcher, CompiledBodyMatcher, extract_json_path, extract_xpath};
 #[allow(unused_imports)]
-pub use deep_equals::{parse_query_string, CompiledDeepEquals, DeepEquals};
+pub use deep_equals::{CompiledDeepEquals, DeepEquals, parse_query_string};
 #[allow(unused_imports)]
 pub use field_matcher::{
-    compile_header_matcher, compile_query_matcher, CompiledFieldMatcher, CompiledFieldMatcherInner,
-    CompiledHeaderMatcher, CompiledQueryMatcher, FieldMatcher, HeaderMatcher, QueryMatcher,
+    CompiledFieldMatcher, CompiledFieldMatcherInner, CompiledHeaderMatcher, CompiledQueryMatcher,
+    FieldMatcher, HeaderMatcher, QueryMatcher, compile_header_matcher, compile_query_matcher,
 };
 #[allow(unused_imports)]
 pub use logical::{CompiledLogicalMatcher, LogicalMatcher};

--- a/crates/rift-core/src/predicate/request.rs
+++ b/crates/rift-core/src/predicate/request.rs
@@ -1,7 +1,7 @@
 //! Unified request predicate for matching against request fields.
 
 use super::body_matcher::{BodyMatcher, CompiledBodyMatcher};
-use super::field_matcher::{compile_header_matcher, compile_query_matcher, FieldMatcher};
+use super::field_matcher::{FieldMatcher, compile_header_matcher, compile_query_matcher};
 use super::options::PredicateOptions;
 use super::path_matcher::{CompiledPathMatch, PathMatcher};
 use super::string_matcher::{CompiledStringMatcher, StringMatcher};

--- a/crates/rift-core/src/proxy/client.rs
+++ b/crates/rift-core/src/proxy/client.rs
@@ -40,7 +40,9 @@ pub fn create_http_client(config: &Config, skip_tls_verify: bool) -> HttpClient 
 
     // Build HTTPS connector for HTTP/1.1 only
     let https_connector = if skip_tls_verify {
-        warn!("TLS certificate verification DISABLED for one or more upstreams (development/testing only)");
+        warn!(
+            "TLS certificate verification DISABLED for one or more upstreams (development/testing only)"
+        );
         hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(
                 rustls::ClientConfig::builder()

--- a/crates/rift-core/src/proxy/handler.rs
+++ b/crates/rift-core/src/proxy/handler.rs
@@ -158,9 +158,8 @@ async fn handle_script_rules(
                 ) && rule_applies_to_upstream(rule_upstream, upstream.name.as_deref())
             });
 
-    let (compiled_script, compiled_rule, _) = match matching_script {
-        Some(m) => m,
-        None => return RuleHandlingResult::NoFault(req),
+    let Some((compiled_script, compiled_rule, _)) = matching_script else {
+        return RuleHandlingResult::NoFault(req);
     };
     info!("Request matched script rule: {}", compiled_rule.id);
 

--- a/crates/rift-core/src/proxy/handler.rs
+++ b/crates/rift-core/src/proxy/handler.rs
@@ -13,22 +13,22 @@ use super::headers::{
 };
 use super::response_ext::ResponseExt;
 use crate::behaviors::{
-    apply_copy_behaviors, apply_decorate, apply_lookup_behaviors, apply_shell_transform,
-    RequestContext,
+    RequestContext, apply_copy_behaviors, apply_decorate, apply_lookup_behaviors,
+    apply_shell_transform,
 };
 use crate::config::TcpFault;
-use crate::extensions::fault::{apply_latency, create_error_response, decide_fault, FaultDecision};
+use crate::extensions::fault::{FaultDecision, apply_latency, create_error_response, decide_fault};
 use crate::extensions::matcher::CompiledRule;
 use crate::extensions::metrics;
 use crate::extensions::routing::Router;
-use crate::extensions::template::{has_template_variables, process_template, RequestData};
+use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::proxy::context::{
     ForwardingContext, RequestHandlerContext, RequestInfo, ScriptingContext, UpstreamService,
 };
 use crate::scripting::{CacheKey, FaultDecision as ScriptFaultDecision, ScriptRequest};
 
-use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
+use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, Response};
 use std::collections::HashMap;
@@ -480,12 +480,12 @@ async fn handle_yaml_rule(
             warn!("Injecting error fault: status={}, rule={}", status, rule_id);
 
             // Apply wait behavior if present (Mountebank-compatible)
-            if let Some(ref bhvs) = behaviors {
-                if let Some(ref wait) = bhvs.wait {
-                    let wait_ms = wait.get_duration_ms();
-                    debug!("Applying wait behavior: {}ms", wait_ms);
-                    apply_latency(wait_ms).await;
-                }
+            if let Some(ref bhvs) = behaviors
+                && let Some(ref wait) = bhvs.wait
+            {
+                let wait_ms = wait.get_duration_ms();
+                debug!("Applying wait behavior: {}ms", wait_ms);
+                apply_latency(wait_ms).await;
             }
 
             // Record metrics
@@ -520,34 +520,33 @@ async fn handle_yaml_rule(
             // fault responses are single-value, so wrap losslessly for the substitution and fold
             // the (still single) result back for decorate / response building.
             let mut response_headers = fault_headers.clone();
-            if let Some(ref bhvs) = behaviors {
-                if !bhvs.copy.is_empty() || !bhvs.lookup.is_empty() {
-                    let mut multi: std::collections::HashMap<String, Vec<String>> =
-                        response_headers
-                            .drain()
-                            .map(|(k, v)| (k, vec![v]))
-                            .collect();
-                    if !bhvs.copy.is_empty() {
-                        debug!("Applying {} copy behaviors", bhvs.copy.len());
-                        processed_body = apply_copy_behaviors(
-                            &processed_body,
-                            &mut multi,
-                            &bhvs.copy,
-                            &request_context,
-                        );
-                    }
-                    if !bhvs.lookup.is_empty() {
-                        debug!("Applying {} lookup behaviors", bhvs.lookup.len());
-                        processed_body = apply_lookup_behaviors(
-                            &processed_body,
-                            &mut multi,
-                            &bhvs.lookup,
-                            &request_context,
-                            ctx.csv_cache,
-                        );
-                    }
-                    response_headers = multi.into_iter().map(|(k, v)| (k, v.join(", "))).collect();
+            if let Some(ref bhvs) = behaviors
+                && (!bhvs.copy.is_empty() || !bhvs.lookup.is_empty())
+            {
+                let mut multi: std::collections::HashMap<String, Vec<String>> = response_headers
+                    .drain()
+                    .map(|(k, v)| (k, vec![v]))
+                    .collect();
+                if !bhvs.copy.is_empty() {
+                    debug!("Applying {} copy behaviors", bhvs.copy.len());
+                    processed_body = apply_copy_behaviors(
+                        &processed_body,
+                        &mut multi,
+                        &bhvs.copy,
+                        &request_context,
+                    );
                 }
+                if !bhvs.lookup.is_empty() {
+                    debug!("Applying {} lookup behaviors", bhvs.lookup.len());
+                    processed_body = apply_lookup_behaviors(
+                        &processed_body,
+                        &mut multi,
+                        &bhvs.lookup,
+                        &request_context,
+                        ctx.csv_cache,
+                    );
+                }
+                response_headers = multi.into_iter().map(|(k, v)| (k, v.join(", "))).collect();
             }
 
             // Apply shell transform (Mountebank-compatible)
@@ -567,23 +566,23 @@ async fn handle_yaml_rule(
 
             // Apply decorate behavior (Mountebank-compatible Rhai script)
             let mut final_status = status;
-            if let Some(ref bhvs) = behaviors {
-                if let Some(ref script) = bhvs.decorate {
-                    debug!("Applying decorate behavior");
-                    match apply_decorate(
-                        script,
-                        &request_context,
-                        &processed_body,
-                        status,
-                        &mut response_headers,
-                    ) {
-                        Ok((new_body, new_status)) => {
-                            processed_body = new_body;
-                            final_status = new_status;
-                        }
-                        Err(e) => {
-                            warn!("Decorate behavior failed: {}", e);
-                        }
+            if let Some(ref bhvs) = behaviors
+                && let Some(ref script) = bhvs.decorate
+            {
+                debug!("Applying decorate behavior");
+                match apply_decorate(
+                    script,
+                    &request_context,
+                    &processed_body,
+                    status,
+                    &mut response_headers,
+                ) {
+                    Ok((new_body, new_status)) => {
+                        processed_body = new_body;
+                        final_status = new_status;
+                    }
+                    Err(e) => {
+                        warn!("Decorate behavior failed: {}", e);
                     }
                 }
             }

--- a/crates/rift-core/src/proxy/headers.rs
+++ b/crates/rift-core/src/proxy/headers.rs
@@ -7,9 +7,9 @@
 //! keeping call sites clean while the clones themselves are cheap (just copying
 //! a pointer for `from_static` headers).
 
+use hyper::Response;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::http::response::Parts;
-use hyper::Response;
 
 // Static header names for Rift custom headers
 pub static X_RIFT_FAULT: HeaderName = HeaderName::from_static("x-rift-fault");

--- a/crates/rift-core/src/proxy/response_ext.rs
+++ b/crates/rift-core/src/proxy/response_ext.rs
@@ -5,8 +5,8 @@
 
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
-use hyper::body::Bytes;
 use hyper::Response;
+use hyper::body::Bytes;
 use std::convert::Infallible;
 
 /// Extension trait for `Response<Full<Bytes>>` providing common transformations.

--- a/crates/rift-core/src/proxy/server.rs
+++ b/crates/rift-core/src/proxy/server.rs
@@ -3,22 +3,22 @@
 //! This module contains the ProxyServer struct which holds all state,
 //! and the main run loop that accepts connections and handles requests.
 
-use super::client::{create_http_client, should_skip_tls_verify, HttpClient};
+use super::client::{HttpClient, create_http_client, should_skip_tls_verify};
 use super::handler::handle_request;
 use super::network::create_reusable_listener;
 use super::tls::create_tls_acceptor;
 use crate::behaviors::{CsvCache, ResponseCycler};
 use crate::config::{Config, Protocol as RiftProtocol, Upstream};
-use crate::extensions::flow_state::{create_flow_store, FlowStore};
+use crate::extensions::flow_state::{FlowStore, create_flow_store};
 use crate::extensions::matcher::CompiledRule;
 use crate::extensions::routing::Router;
 use crate::proxy::context::RequestHandlerContext;
 use crate::recording::{ProxyMode, RecordingStore};
+use crate::scripting::RhaiEngine;
 #[cfg(feature = "javascript")]
 use crate::scripting::compile_js_to_bytecode;
 #[cfg(feature = "lua")]
 use crate::scripting::compile_to_bytecode;
-use crate::scripting::RhaiEngine;
 use crate::scripting::{
     CompiledScript, DecisionCache, DecisionCacheConfig, ScriptPool, ScriptPoolConfig,
 };
@@ -95,7 +95,9 @@ impl ProxyServer {
             // For reverse proxy mode, use first upstream as fallback
             config.upstreams[0].url.clone()
         } else {
-            anyhow::bail!("Config must specify either 'upstream' (sidecar mode) or 'upstreams' (reverse proxy mode)");
+            anyhow::bail!(
+                "Config must specify either 'upstream' (sidecar mode) or 'upstreams' (reverse proxy mode)"
+            );
         };
 
         // Create router for multi-upstream mode

--- a/crates/rift-core/src/proxy/tls.rs
+++ b/crates/rift-core/src/proxy/tls.rs
@@ -3,9 +3,9 @@
 //! This module provides TLS-related functionality including certificate loading
 //! and a no-op certificate verifier for development/testing.
 
+use rustls::DigitallySignedStruct;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::DigitallySignedStruct;
 use std::sync::Arc;
 use tokio_rustls::TlsAcceptor;
 

--- a/crates/rift-core/src/recording/stub_generator.rs
+++ b/crates/rift-core/src/recording/stub_generator.rs
@@ -30,15 +30,13 @@ pub fn generate_stub(
         );
     }
 
-    if include_query {
-        if let Some(ref query) = signature.query {
-            let query_map = parse_query_string(query);
-            if !query_map.is_empty() {
-                predicates.insert(
-                    "query".to_string(),
-                    serde_json::json!({ "equals": query_map }),
-                );
-            }
+    if include_query && let Some(ref query) = signature.query {
+        let query_map = parse_query_string(query);
+        if !query_map.is_empty() {
+            predicates.insert(
+                "query".to_string(),
+                serde_json::json!({ "equals": query_map }),
+            );
         }
     }
 

--- a/crates/rift-core/src/response/builder.rs
+++ b/crates/rift-core/src/response/builder.rs
@@ -77,8 +77,8 @@ impl ErrorResponseBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderValue, CONTENT_TYPE};
     use hyper::StatusCode;
+    use hyper::header::{CONTENT_TYPE, HeaderValue};
 
     #[test]
     fn test_builder_with_status() {

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,9 +1,9 @@
 use crate::extensions::flow_state::FlowStore;
 use crate::scripting::{FaultDecision, ScriptRequest};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use boa_engine::{
-    js_string, native_function::NativeFunction, object::builtins::JsArray, property::PropertyKey,
-    Context, JsNativeError, JsObject, JsResult, JsValue, Source,
+    Context, JsNativeError, JsObject, JsResult, JsValue, Source, js_string,
+    native_function::NativeFunction, object::builtins::JsArray, property::PropertyKey,
 };
 
 /// Create a JavaScript object with proper Object.prototype
@@ -559,28 +559,28 @@ fn parse_fault_decision(
 
             // Extract optional headers
             let mut headers = std::collections::HashMap::new();
-            if let Ok(headers_val) = obj.get(js_string!("headers"), context) {
-                if let Some(headers_obj) = headers_val.as_object() {
-                    // Get all enumerable properties
-                    if let Ok(keys) = headers_obj.own_property_keys(context) {
-                        for key in keys {
-                            let key_str = match &key {
-                                PropertyKey::String(s) => s.to_std_string_escaped(),
-                                PropertyKey::Index(i) => i.get().to_string(),
-                                PropertyKey::Symbol(_) => continue, // Skip symbols
+            if let Ok(headers_val) = obj.get(js_string!("headers"), context)
+                && let Some(headers_obj) = headers_val.as_object()
+            {
+                // Get all enumerable properties
+                if let Ok(keys) = headers_obj.own_property_keys(context) {
+                    for key in keys {
+                        let key_str = match &key {
+                            PropertyKey::String(s) => s.to_std_string_escaped(),
+                            PropertyKey::Index(i) => i.get().to_string(),
+                            PropertyKey::Symbol(_) => continue, // Skip symbols
+                        };
+                        if let Ok(val) = headers_obj.get(key.clone(), context) {
+                            let val_str = if let Some(s) = val.as_string() {
+                                s.to_std_string_escaped()
+                            } else if let Some(n) = val.as_number() {
+                                n.to_string()
+                            } else if let Some(b) = val.as_boolean() {
+                                b.to_string()
+                            } else {
+                                continue;
                             };
-                            if let Ok(val) = headers_obj.get(key.clone(), context) {
-                                let val_str = if let Some(s) = val.as_string() {
-                                    s.to_std_string_escaped()
-                                } else if let Some(n) = val.as_number() {
-                                    n.to_string()
-                                } else if let Some(b) = val.as_boolean() {
-                                    b.to_string()
-                                } else {
-                                    continue;
-                                };
-                                headers.insert(key_str, val_str);
-                            }
+                            headers.insert(key_str, val_str);
                         }
                     }
                 }
@@ -860,10 +860,10 @@ pub fn execute_predicate_inject(
     };
 
     // Update state
-    if let Ok(updated_state) = global.get(js_string!("__state"), &mut context) {
-        if let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state) {
-            save_imposter_state(imposter_port, map);
-        }
+    if let Ok(updated_state) = global.get(js_string!("__state"), &mut context)
+        && let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state)
+    {
+        save_imposter_state(imposter_port, map);
     }
 
     result.to_boolean()
@@ -1046,21 +1046,20 @@ fn parse_mountebank_response(
 
     // Get headers (optional)
     let mut headers = std::collections::HashMap::new();
-    if let Ok(headers_val) = obj.get(js_string!("headers"), context) {
-        if let Some(headers_obj) = headers_val.as_object() {
-            if let Ok(keys) = headers_obj.own_property_keys(context) {
-                for key in keys {
-                    let key_str = match &key {
-                        PropertyKey::String(s) => s.to_std_string_escaped(),
-                        PropertyKey::Index(i) => i.get().to_string(),
-                        PropertyKey::Symbol(_) => continue,
-                    };
-                    if let Ok(val) = headers_obj.get(key.clone(), context) {
-                        if let Some(s) = val.as_string() {
-                            headers.insert(key_str, s.to_std_string_escaped());
-                        }
-                    }
-                }
+    if let Ok(headers_val) = obj.get(js_string!("headers"), context)
+        && let Some(headers_obj) = headers_val.as_object()
+        && let Ok(keys) = headers_obj.own_property_keys(context)
+    {
+        for key in keys {
+            let key_str = match &key {
+                PropertyKey::String(s) => s.to_std_string_escaped(),
+                PropertyKey::Index(i) => i.get().to_string(),
+                PropertyKey::Symbol(_) => continue,
+            };
+            if let Ok(val) = headers_obj.get(key.clone(), context)
+                && let Some(s) = val.as_string()
+            {
+                headers.insert(key_str, s.to_std_string_escaped());
             }
         }
     }
@@ -1202,21 +1201,20 @@ pub fn execute_mountebank_decorate(
 
     // Get headers
     let mut headers = response_headers.clone();
-    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut context) {
-        if let Some(headers_obj) = headers_val.as_object() {
-            if let Ok(keys) = headers_obj.own_property_keys(&mut context) {
-                for key in keys {
-                    let key_str = match &key {
-                        PropertyKey::String(s) => s.to_std_string_escaped(),
-                        PropertyKey::Index(i) => i.get().to_string(),
-                        PropertyKey::Symbol(_) => continue,
-                    };
-                    if let Ok(val) = headers_obj.get(key.clone(), &mut context) {
-                        if let Some(s) = val.as_string() {
-                            headers.insert(key_str, s.to_std_string_escaped());
-                        }
-                    }
-                }
+    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut context)
+        && let Some(headers_obj) = headers_val.as_object()
+        && let Ok(keys) = headers_obj.own_property_keys(&mut context)
+    {
+        for key in keys {
+            let key_str = match &key {
+                PropertyKey::String(s) => s.to_std_string_escaped(),
+                PropertyKey::Index(i) => i.get().to_string(),
+                PropertyKey::Symbol(_) => continue,
+            };
+            if let Ok(val) = headers_obj.get(key.clone(), &mut context)
+                && let Some(s) = val.as_string()
+            {
+                headers.insert(key_str, s.to_std_string_escaped());
             }
         }
     }

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -705,11 +705,11 @@ pub struct MountebankInjectResponse {
 
 /// Per-imposter state storage for inject functions
 /// This is used to share state between inject function calls
-use once_cell::sync::Lazy;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-static IMPOSTER_STATE: Lazy<Mutex<std::collections::HashMap<u16, serde_json::Map<String, Value>>>> =
-    Lazy::new(|| Mutex::new(std::collections::HashMap::new()));
+static IMPOSTER_STATE: LazyLock<
+    Mutex<std::collections::HashMap<u16, serde_json::Map<String, Value>>>,
+> = LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
 /// Get or create state for an imposter
 fn get_imposter_state(port: u16) -> serde_json::Map<String, Value> {

--- a/crates/rift-core/src/scripting/js_validator.rs
+++ b/crates/rift-core/src/scripting/js_validator.rs
@@ -1,5 +1,5 @@
 use super::validator::{ScriptValidationError, ScriptValidator};
-use boa_engine::{js_string, Context, Source};
+use boa_engine::{Context, Source, js_string};
 use std::error::Error;
 use std::fmt;
 

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1,6 +1,6 @@
 use crate::extensions::flow_state::FlowStore;
 use crate::scripting::{FaultDecision, ScriptRequest};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use mlua::prelude::*;
 use serde_json::Value;
 use std::sync::Arc;

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -1,5 +1,5 @@
 use crate::extensions::flow_state::FlowStore;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use rhai::Dynamic;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,19 +20,19 @@ pub use decision_cache::{CacheKey, DecisionCache, DecisionCacheConfig};
 #[cfg(feature = "lua")]
 mod lua_engine;
 #[cfg(feature = "lua")]
-pub use lua_engine::{compile_to_bytecode, LuaEngine};
+pub use lua_engine::{LuaEngine, compile_to_bytecode};
 
 #[cfg(feature = "javascript")]
 mod js_engine;
 #[cfg(feature = "javascript")]
 pub use js_engine::{
-    clear_imposter_state, compile_js_to_bytecode, execute_mountebank_decorate,
-    execute_mountebank_inject, execute_predicate_generator_inject, execute_predicate_inject,
-    JsEngine, MountebankRequest,
+    JsEngine, MountebankRequest, clear_imposter_state, compile_js_to_bytecode,
+    execute_mountebank_decorate, execute_mountebank_inject, execute_predicate_generator_inject,
+    execute_predicate_inject,
 };
 #[cfg(feature = "javascript")]
 #[allow(unused_imports)]
-pub use js_engine::{execute_js_bytecode, MountebankDecorateResponse, MountebankInjectResponse};
+pub use js_engine::{MountebankDecorateResponse, MountebankInjectResponse, execute_js_bytecode};
 
 // Validator trait and unified error types
 mod validator;

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -1,6 +1,6 @@
 use crate::extensions::flow_state::FlowStore;
-use anyhow::{anyhow, Result};
-use rhai::{Dynamic, Engine, Map, Scope, AST};
+use anyhow::{Result, anyhow};
+use rhai::{AST, Dynamic, Engine, Map, Scope};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -315,29 +315,34 @@ impl RhaiEngine {
                     .map(|v| {
                         if let Some(s) = v.clone().try_cast::<String>() {
                             s
-                        } else if let Some(m) = v.clone().try_cast::<Map>() {
-                            // Convert map to JSON string
-                            serde_json::to_string(&dynamic_to_json(Dynamic::from(m)))
-                                .unwrap_or_else(|_| "{}".to_string())
                         } else {
-                            format!("{v}")
+                            match v.clone().try_cast::<Map>() {
+                                Some(m) => {
+                                    // Convert map to JSON string
+                                    serde_json::to_string(&dynamic_to_json(Dynamic::from(m)))
+                                        .unwrap_or_else(|_| "{}".to_string())
+                                }
+                                _ => {
+                                    format!("{v}")
+                                }
+                            }
                         }
                     })
                     .unwrap_or_else(|| "{}".to_string());
 
                 // Extract optional headers map
                 let mut headers = std::collections::HashMap::new();
-                if let Some(headers_value) = map.get("headers") {
-                    if let Some(headers_map) = headers_value.clone().try_cast::<Map>() {
-                        for (key, value) in headers_map {
-                            // Try to convert value to string
-                            let value_str = if let Some(s) = value.clone().try_cast::<String>() {
-                                s
-                            } else {
-                                format!("{value}")
-                            };
-                            headers.insert(key.to_string(), value_str);
-                        }
+                if let Some(headers_value) = map.get("headers")
+                    && let Some(headers_map) = headers_value.clone().try_cast::<Map>()
+                {
+                    for (key, value) in headers_map {
+                        // Try to convert value to string
+                        let value_str = if let Some(s) = value.clone().try_cast::<String>() {
+                            s
+                        } else {
+                            format!("{value}")
+                        };
+                        headers.insert(key.to_string(), value_str);
                     }
                 }
 
@@ -438,29 +443,34 @@ fn parse_fault_decision_with_rule_id(result: Dynamic, rule_id: &str) -> Result<F
                 .map(|v| {
                     if let Some(s) = v.clone().try_cast::<String>() {
                         s
-                    } else if let Some(m) = v.clone().try_cast::<Map>() {
-                        // Convert map to JSON string
-                        serde_json::to_string(&dynamic_to_json(Dynamic::from(m)))
-                            .unwrap_or_else(|_| "{}".to_string())
                     } else {
-                        format!("{v}")
+                        match v.clone().try_cast::<Map>() {
+                            Some(m) => {
+                                // Convert map to JSON string
+                                serde_json::to_string(&dynamic_to_json(Dynamic::from(m)))
+                                    .unwrap_or_else(|_| "{}".to_string())
+                            }
+                            _ => {
+                                format!("{v}")
+                            }
+                        }
                     }
                 })
                 .unwrap_or_else(|| "{}".to_string());
 
             // Extract optional headers map
             let mut headers = std::collections::HashMap::new();
-            if let Some(headers_value) = map.get("headers") {
-                if let Some(headers_map) = headers_value.clone().try_cast::<Map>() {
-                    for (key, value) in headers_map {
-                        // Try to convert value to string
-                        let value_str = if let Some(s) = value.clone().try_cast::<String>() {
-                            s
-                        } else {
-                            format!("{value}")
-                        };
-                        headers.insert(key.to_string(), value_str);
-                    }
+            if let Some(headers_value) = map.get("headers")
+                && let Some(headers_map) = headers_value.clone().try_cast::<Map>()
+            {
+                for (key, value) in headers_map {
+                    // Try to convert value to string
+                    let value_str = if let Some(s) = value.clone().try_cast::<String>() {
+                        s
+                    } else {
+                        format!("{value}")
+                    };
+                    headers.insert(key.to_string(), value_str);
                 }
             }
 
@@ -516,16 +526,20 @@ pub(super) fn dynamic_to_json(value: Dynamic) -> Value {
         Value::Number(serde_json::Number::from_f64(f).unwrap_or(0.into()))
     } else if let Some(s) = value.clone().try_cast::<String>() {
         Value::String(s)
-    } else if let Some(arr) = value.clone().try_cast::<Vec<Dynamic>>() {
-        Value::Array(arr.into_iter().map(dynamic_to_json).collect())
-    } else if let Some(map) = value.clone().try_cast::<Map>() {
-        let mut obj = serde_json::Map::new();
-        for (k, v) in map {
-            obj.insert(k.to_string(), dynamic_to_json(v));
-        }
-        Value::Object(obj)
     } else {
-        Value::String(format!("{value}"))
+        match value.clone().try_cast::<Vec<Dynamic>>() {
+            Some(arr) => Value::Array(arr.into_iter().map(dynamic_to_json).collect()),
+            _ => match value.clone().try_cast::<Map>() {
+                Some(map) => {
+                    let mut obj = serde_json::Map::new();
+                    for (k, v) in map {
+                        obj.insert(k.to_string(), dynamic_to_json(v));
+                    }
+                    Value::Object(obj)
+                }
+                _ => Value::String(format!("{value}")),
+            },
+        }
     }
 }
 

--- a/crates/rift-core/src/scripting/rhai_validator.rs
+++ b/crates/rift-core/src/scripting/rhai_validator.rs
@@ -1,5 +1,5 @@
 use super::validator::{ScriptValidationError, ScriptValidator};
-use rhai::{Engine, AST};
+use rhai::{AST, Engine};
 use std::error::Error;
 use std::fmt;
 

--- a/crates/rift-core/src/scripting/script_pool.rs
+++ b/crates/rift-core/src/scripting/script_pool.rs
@@ -1,10 +1,10 @@
 use crate::extensions::flow_state::FlowStore;
 use crate::scripting::{FaultDecision, ScriptRequest};
-use anyhow::{anyhow, Result};
-use crossbeam::channel::{bounded, Receiver, Sender};
+use anyhow::{Result, anyhow};
+use crossbeam::channel::{Receiver, Sender, bounded};
 use rhai::AST;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tokio::sync::oneshot;

--- a/crates/rift-core/src/scripting/stub_validator.rs
+++ b/crates/rift-core/src/scripting/stub_validator.rs
@@ -119,7 +119,7 @@ fn validate_response(
         }
         // Is responses with optional _rift extension
         StubResponse::Is { rift, .. } => {
-            if let Some(ref rift_ext) = rift {
+            if let Some(rift_ext) = rift {
                 if let Some(ref script_config) = rift_ext.script {
                     validate_rift_script(
                         &script_config.engine,

--- a/crates/rift-core/src/scripting/stub_validator.rs
+++ b/crates/rift-core/src/scripting/stub_validator.rs
@@ -67,7 +67,7 @@ pub fn validate_stubs(stubs: &[Stub]) -> StubValidationResult {
         let stub_id = stub
             .id
             .clone()
-            .unwrap_or_else(|| format!("stub[{}]", stub_idx));
+            .unwrap_or_else(|| format!("stub[{stub_idx}]"));
 
         for (resp_idx, response) in stub.responses.iter().enumerate() {
             if let Some(err) = validate_response(response, &stub_id, resp_idx) {
@@ -86,7 +86,7 @@ pub fn validate_stub(stub: &Stub, stub_index: usize) -> StubValidationResult {
     let stub_id = stub
         .id
         .clone()
-        .unwrap_or_else(|| format!("stub[{}]", stub_index));
+        .unwrap_or_else(|| format!("stub[{stub_index}]"));
 
     for (resp_idx, response) in stub.responses.iter().enumerate() {
         if let Some(err) = validate_response(response, &stub_id, resp_idx) {

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -23,14 +23,14 @@ workspace = true
 # Features are forwarded (not hard-coded) so the per-platform cdylib build can drop engines that
 # can't cross-compile for a given target (e.g. LuaJIT for x86_64-apple-darwin) — issue #205.
 rift-core = { path = "../rift-core", default-features = false }
-tokio = { version = "1.41", features = ["rt-multi-thread"] }
-serde_json = "1.0"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+serde_json.workspace = true
 # Emit a diagnostic before collapsing a typed error into a C sentinel; the embedding host
 # installs the subscriber (no-op if none is set).
-tracing = "0.1"
+tracing.workspace = true
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest.workspace = true
 
 [features]
 default = ["redis-backend", "lua", "javascript"]

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -18,7 +18,7 @@
 //! and emits a `tracing` event with the dropped error so the reason is not lost.
 
 use rift_core::imposter::{ImposterConfig, ImposterManager, Stub};
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::warn;
@@ -34,7 +34,7 @@ pub struct RiftHandle {
 /// # Safety
 /// `h` must be null or a pointer returned by [`rift_start`] and not yet passed to [`rift_stop`].
 unsafe fn handle<'a>(h: *mut RiftHandle) -> Option<&'a RiftHandle> {
-    h.as_ref()
+    unsafe { h.as_ref() }
 }
 
 /// Read a borrowed UTF-8 string from a C string pointer, or `None` if null/invalid.
@@ -42,10 +42,12 @@ unsafe fn handle<'a>(h: *mut RiftHandle) -> Option<&'a RiftHandle> {
 /// # Safety
 /// `p` must be null or a valid NUL-terminated C string that outlives the borrow.
 unsafe fn c_str<'a>(p: *const c_char) -> Option<&'a str> {
-    if p.is_null() {
-        return None;
+    unsafe {
+        if p.is_null() {
+            return None;
+        }
+        CStr::from_ptr(p).to_str().ok()
     }
-    CStr::from_ptr(p).to_str().ok()
 }
 
 /// Move a `String` across the boundary as an owned `*mut c_char` the caller frees with
@@ -58,7 +60,7 @@ fn into_c_string(s: String) -> *mut c_char {
 }
 
 /// Start the engine. Returns an opaque handle, or null if the runtime could not be created.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rift_start() -> *mut RiftHandle {
     match Runtime::new() {
         Ok(runtime) => Box::into_raw(Box::new(RiftHandle {
@@ -74,57 +76,61 @@ pub extern "C" fn rift_start() -> *mut RiftHandle {
 ///
 /// # Safety
 /// `h` must be a live handle and `json` a valid C string (or null).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_create_imposter(h: *mut RiftHandle, json: *const c_char) -> u16 {
-    let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
-        warn!("rift_create_imposter: null handle or config pointer");
-        return 0;
-    };
-    let config = match serde_json::from_str::<ImposterConfig>(s) {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(error = %e, "rift_create_imposter: invalid config JSON");
+    unsafe {
+        let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+            warn!("rift_create_imposter: null handle or config pointer");
             return 0;
-        }
-    };
-    handle
-        .runtime
-        .block_on(handle.manager.create_imposter(config))
-        .unwrap_or_else(|e| {
-            warn!(error = %e, "rift_create_imposter failed");
-            0
-        })
+        };
+        let config = match serde_json::from_str::<ImposterConfig>(s) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "rift_create_imposter: invalid config JSON");
+                return 0;
+            }
+        };
+        handle
+            .runtime
+            .block_on(handle.manager.create_imposter(config))
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "rift_create_imposter failed");
+                0
+            })
+    }
 }
 
 /// Replace all stubs on `port` from a JSON array. Returns `0` on success, `-1` on any error.
 ///
 /// # Safety
 /// `h` must be a live handle and `json` a valid C string (or null).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_replace_stubs(
     h: *mut RiftHandle,
     port: u16,
     json: *const c_char,
 ) -> i32 {
-    let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
-        warn!("rift_replace_stubs: null handle or stubs pointer");
-        return -1;
-    };
-    let stubs = match serde_json::from_str::<Vec<Stub>>(s) {
-        Ok(v) => v,
-        Err(e) => {
-            warn!(error = %e, "rift_replace_stubs: invalid stubs JSON");
+    unsafe {
+        let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+            warn!("rift_replace_stubs: null handle or stubs pointer");
             return -1;
-        }
-    };
-    match handle
-        .runtime
-        .block_on(handle.manager.replace_stubs(port, stubs))
-    {
-        Ok(()) => 0,
-        Err(e) => {
-            warn!(error = %e, port, "rift_replace_stubs failed");
-            -1
+        };
+        let stubs = match serde_json::from_str::<Vec<Stub>>(s) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "rift_replace_stubs: invalid stubs JSON");
+                return -1;
+            }
+        };
+        match handle
+            .runtime
+            .block_on(handle.manager.replace_stubs(port, stubs))
+        {
+            Ok(()) => 0,
+            Err(e) => {
+                warn!(error = %e, port, "rift_replace_stubs failed");
+                -1
+            }
         }
     }
 }
@@ -133,13 +139,15 @@ pub unsafe extern "C" fn rift_replace_stubs(
 ///
 /// # Safety
 /// `h` must be a live handle (or null).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_delete_all(h: *mut RiftHandle) -> i32 {
-    let Some(handle) = handle(h) else {
-        return -1;
-    };
-    handle.runtime.block_on(handle.manager.delete_all());
-    0
+    unsafe {
+        let Some(handle) = handle(h) else {
+            return -1;
+        };
+        handle.runtime.block_on(handle.manager.delete_all());
+        0
+    }
 }
 
 /// Return the recorded requests for `port` as a JSON array string the caller must free with
@@ -147,23 +155,25 @@ pub unsafe extern "C" fn rift_delete_all(h: *mut RiftHandle) -> i32 {
 ///
 /// # Safety
 /// `h` must be a live handle (or null).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_char {
-    let Some(handle) = handle(h) else {
-        return std::ptr::null_mut();
-    };
-    let imposter = match handle.manager.get_imposter(port) {
-        Ok(i) => i,
-        Err(e) => {
-            warn!(error = %e, port, "rift_recorded: no such imposter");
+    unsafe {
+        let Some(handle) = handle(h) else {
             return std::ptr::null_mut();
-        }
-    };
-    match serde_json::to_string(&imposter.get_recorded_requests()) {
-        Ok(json) => into_c_string(json),
-        Err(e) => {
-            warn!(error = %e, port, "rift_recorded: failed to encode recorded requests");
-            std::ptr::null_mut()
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                warn!(error = %e, port, "rift_recorded: no such imposter");
+                return std::ptr::null_mut();
+            }
+        };
+        match serde_json::to_string(&imposter.get_recorded_requests()) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                warn!(error = %e, port, "rift_recorded: failed to encode recorded requests");
+                std::ptr::null_mut()
+            }
         }
     }
 }
@@ -172,10 +182,12 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
 ///
 /// # Safety
 /// `p` must be null or a pointer returned by a `rift-ffi` function and not yet freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_free(p: *mut c_char) {
-    if !p.is_null() {
-        drop(CString::from_raw(p));
+    unsafe {
+        if !p.is_null() {
+            drop(CString::from_raw(p));
+        }
     }
 }
 
@@ -184,11 +196,13 @@ pub unsafe extern "C" fn rift_free(p: *mut c_char) {
 ///
 /// # Safety
 /// `h` must be null or a pointer returned by [`rift_start`] and not previously stopped.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
-    if h.is_null() {
-        return;
+    unsafe {
+        if h.is_null() {
+            return;
+        }
+        let handle = Box::from_raw(h);
+        handle.runtime.block_on(handle.manager.shutdown());
     }
-    let handle = Box::from_raw(h);
-    handle.runtime.block_on(handle.manager.shutdown());
 }

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -4,17 +4,19 @@
 //! use-after-free are undefined behaviour, so they belong under Miri/ASan, not a normal test.)
 
 use rift_ffi::*;
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 
 fn cstr(s: &str) -> CString {
     CString::new(s).expect("no interior NUL in test input")
 }
 
 unsafe fn take_json(p: *mut c_char) -> String {
-    assert!(!p.is_null(), "expected JSON, got null");
-    let s = CStr::from_ptr(p).to_str().expect("utf8").to_owned();
-    rift_free(p);
-    s
+    unsafe {
+        assert!(!p.is_null(), "expected JSON, got null");
+        let s = CStr::from_ptr(p).to_str().expect("utf8").to_owned();
+        rift_free(p);
+        s
+    }
 }
 
 #[test]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -19,9 +19,8 @@ workspace = true
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.41", features = ["full"] }
-async-trait = "0.1"
-futures = "0.3"
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
 
 # HTTP
 hyper = { version = "1.5", features = ["full"] }
@@ -38,43 +37,42 @@ rustls-pemfile = "2.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-serde_json = "1.0"
+serde.workspace = true
+serde_yaml.workspace = true
+serde_json.workspace = true
 
 # Shared workspace types + CLI-free engine (issue #203)
 rift-types = { path = "../rift-types" }
 rift-core = { path = "../rift-core", default-features = false }
 
 # Stable stub id generation for id-addressed stub ops (issue #202)
-uuid = { version = "1.8", features = ["v4"] }
+uuid.workspace = true
 
 # Logging & Observability
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 tracing-appender = "0.2"
 prometheus = "0.13"
 lazy_static = "1.4"
 
 # CLI
-clap = { version = "4.5", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 
 # HTTP client (for save command)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest.workspace = true
 
 # Utils
-once_cell = "1.19"
-bytes = "1.7"
+bytes.workspace = true
 base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
+chrono.workspace = true
 regex = "1.11"
-rand = "0.8"
+rand.workspace = true
 urlencoding = "2.1"
 similar = "2.6"
 matchit = "0.9"
 aho-corasick = "1.1"
-anyhow = "1.0"
-thiserror = "2.0"
+anyhow.workspace = true
+thiserror.workspace = true
 socket2 = "0.5"
 num_cpus = "1.16"
 libc = "0.2"
@@ -94,14 +92,13 @@ rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Integration testing
-reqwest = { version = "0.12", features = ["json"] }
+reqwest.workspace = true
 tokio-test = "0.4"
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["redis"] }
 assert-json-diff = "2.0"
 serial_test = "3.0"
 tracing-test = "0.2"
-once_cell = "1.19"
 port_check = "0.2"
 
 [features]

--- a/crates/rift-http-proxy/benches/matcher_bench.rs
+++ b/crates/rift-http-proxy/benches/matcher_bench.rs
@@ -1,7 +1,7 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use hyper::{HeaderMap, Method, Uri};
 use rift_http_proxy::config::{FaultConfig, LatencyFault, MatchConfig, PathMatch, Rule};
-use rift_http_proxy::matcher::{find_matching_rule, CompiledRule};
+use rift_http_proxy::matcher::{CompiledRule, find_matching_rule};
 use rift_http_proxy::predicate::{PathMatcher, PredicateOptions, RequestPredicate, StringMatcher};
 use rift_http_proxy::rule_index::RuleIndex;
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -2,9 +2,9 @@
 
 use crate::admin_api::request_filter::{parse_match_clauses, request_matches};
 use crate::admin_api::types::{
-    collect_body, error_response, json_response, make_imposter_links, make_stub_links,
     ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
-    RiftImposterExtensions, StubWithLinks,
+    RiftImposterExtensions, StubWithLinks, collect_body, error_response, json_response,
+    make_imposter_links, make_stub_links,
 };
 use crate::extensions::stub_analysis::analyze_stubs;
 use crate::imposter::{
@@ -36,7 +36,7 @@ pub async fn handle_create(
             return error_response(
                 StatusCode::BAD_REQUEST,
                 &format!("Invalid imposter JSON: {e}"),
-            )
+            );
         }
     };
 
@@ -144,7 +144,7 @@ pub async fn handle_replace_all(
     let batch: BatchRequest = match serde_json::from_slice(&body) {
         Ok(b) => b,
         Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid batch JSON: {e}"))
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid batch JSON: {e}"));
         }
     };
 
@@ -560,12 +560,13 @@ mod requests_filter_tests {
         let resp = handle_get_requests(19732, Some("match=header:X-Mock-Space=A"), m.clone()).await;
         let got = requests(resp).await;
         assert_eq!(got.len(), 2, "only the two X-Mock-Space=A requests");
-        assert!(got.iter().all(|r| r
-            .headers
-            .get("X-Mock-Space")
-            .and_then(|v| v.first())
-            .map(String::as_str)
-            == Some("A")));
+        assert!(got.iter().all(|r| {
+            r.headers
+                .get("X-Mock-Space")
+                .and_then(|v| v.first())
+                .map(String::as_str)
+                == Some("A")
+        }));
         let _ = m.delete_imposter(19732).await;
     }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -115,7 +115,7 @@ pub async fn handle_reset_scenarios(
         match serde_json::from_slice::<serde_json::Value>(&body) {
             Ok(v) => v.get("flowId").and_then(|v| v.as_str()).map(String::from),
             Err(e) => {
-                return error_response(StatusCode::BAD_REQUEST, &format!("Invalid JSON: {e}"))
+                return error_response(StatusCode::BAD_REQUEST, &format!("Invalid JSON: {e}"));
             }
         }
     };

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -2,8 +2,8 @@
 
 use crate::admin_api::handlers::imposters::handle_get as handle_get_imposter;
 use crate::admin_api::types::{
-    collect_body, error_response, json_response, make_stub_links, AddStubRequest,
-    ReplaceStubsRequest, StubWithLinks,
+    AddStubRequest, ReplaceStubsRequest, StubWithLinks, collect_body, error_response,
+    json_response, make_stub_links,
 };
 use crate::extensions::stub_analysis::{analyze_new_stub, analyze_stubs};
 use crate::imposter::{ImposterManager, Stub};
@@ -30,7 +30,7 @@ pub async fn handle_add(
     let mut add_req: AddStubRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"))
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
 
@@ -103,7 +103,7 @@ pub async fn handle_replace_all(
     let replace_req: ReplaceStubsRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stubs JSON: {e}"))
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stubs JSON: {e}"));
         }
     };
 
@@ -198,7 +198,7 @@ pub async fn handle_replace(
     let stub: Stub = match serde_json::from_slice(&body) {
         Ok(s) => s,
         Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"))
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
 
@@ -262,7 +262,7 @@ pub async fn handle_replace_by_id(
     let stub: Stub = match serde_json::from_slice(&body) {
         Ok(s) => s,
         Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"))
+            return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
     let validation_result = validate_stub(&stub, 0);

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -139,7 +139,7 @@ pub async fn handle_reload(
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Reload failed (imposters unchanged): {e}"),
-            )
+            );
         }
     };
 

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -110,14 +110,11 @@ async fn handle_gateway(
             &format!("invalid gateway target '{port_str}' (expected /__rift/<port>/<path>)"),
         );
     };
-    let imposter = match manager.get_imposter(port) {
-        Ok(imposter) => imposter,
-        Err(_) => {
-            return error_response(
-                StatusCode::NOT_FOUND,
-                &format!("no imposter on port {port}"),
-            );
-        }
+    let Ok(imposter) = manager.get_imposter(port) else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            &format!("no imposter on port {port}"),
+        );
     };
 
     let target = match query {
@@ -249,9 +246,8 @@ async fn route_imposter(
     };
 
     // Parse remaining route
-    let route = match ImposterRoute::parse(&segments[1..]) {
-        Some(r) => r,
-        None => return not_found(),
+    let Some(route) = ImposterRoute::parse(&segments[1..]) else {
+        return not_found();
     };
 
     // Dispatch based on method and route

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -116,7 +116,7 @@ async fn handle_gateway(
             return error_response(
                 StatusCode::NOT_FOUND,
                 &format!("no imposter on port {port}"),
-            )
+            );
         }
     };
 
@@ -168,7 +168,7 @@ async fn route_by_path(
         (&Method::GET, "/config") => return system::handle_config(),
         (&Method::GET, "/logs") => return system::handle_logs(query),
         (&Method::POST, "/admin/reload") => {
-            return system::handle_reload(manager, config_source).await
+            return system::handle_reload(manager, config_source).await;
         }
         (&Method::GET, "/metrics") => return system::handle_metrics(manager).await,
         _ => {}

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -72,16 +72,16 @@ impl AdminApiServer {
                         // (which would otherwise force app-under-test traffic to carry the admin
                         // key and would leak that Authorization header into imposter predicates).
                         let is_gateway = req.uri().path().starts_with("/__rift/");
-                        if let Some(ref key) = api_key {
-                            if !is_gateway {
-                                let auth = req
-                                    .headers()
-                                    .get("authorization")
-                                    .and_then(|v| v.to_str().ok())
-                                    .unwrap_or("");
-                                if auth != key.as_str() {
-                                    return Ok::<_, hyper::Error>(unauthorized_response());
-                                }
+                        if let Some(ref key) = api_key
+                            && !is_gateway
+                        {
+                            let auth = req
+                                .headers()
+                                .get("authorization")
+                                .and_then(|v| v.to_str().ok())
+                                .unwrap_or("");
+                            if auth != key.as_str() {
+                                return Ok::<_, hyper::Error>(unauthorized_response());
                             }
                         }
                         route_request(req, manager, config_source).await

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -162,7 +162,7 @@ fn base_url_from_headers(headers: &hyper::HeaderMap) -> String {
         && !host_str.contains('/')
         && !host_str.contains("://")
     {
-        return format!("http://{}", host_str);
+        return format!("http://{host_str}");
     }
     format!("http://localhost:{}", super::DEFAULT_ADMIN_PORT)
 }
@@ -171,10 +171,10 @@ fn base_url_from_headers(headers: &hyper::HeaderMap) -> String {
 pub fn make_imposter_links(base_url: &str, port: u16) -> ImposterLinks {
     ImposterLinks {
         self_link: Link {
-            href: format!("{}/imposters/{}", base_url, port),
+            href: format!("{base_url}/imposters/{port}"),
         },
         stubs: Link {
-            href: format!("{}/imposters/{}/stubs", base_url, port),
+            href: format!("{base_url}/imposters/{port}/stubs"),
         },
     }
 }
@@ -183,7 +183,7 @@ pub fn make_imposter_links(base_url: &str, port: u16) -> ImposterLinks {
 pub fn make_stub_links(base_url: &str, port: u16, index: usize) -> StubLinks {
     StubLinks {
         self_link: Link {
-            href: format!("{}/imposters/{}/stubs/{}", base_url, port, index),
+            href: format!("{base_url}/imposters/{port}/stubs/{index}"),
         },
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -157,12 +157,12 @@ pub fn get_base_url(req: &Request<Incoming>) -> String {
 /// Rejects Host header values containing `/` or `://` to prevent link-injection via a
 /// malformed Host header (e.g. `attacker.com/evil`).
 fn base_url_from_headers(headers: &hyper::HeaderMap) -> String {
-    if let Some(host) = headers.get("host") {
-        if let Ok(host_str) = host.to_str() {
-            if !host_str.contains('/') && !host_str.contains("://") {
-                return format!("http://{}", host_str);
-            }
-        }
+    if let Some(host) = headers.get("host")
+        && let Ok(host_str) = host.to_str()
+        && !host_str.contains('/')
+        && !host_str.contains("://")
+    {
+        return format!("http://{}", host_str);
     }
     format!("http://localhost:{}", super::DEFAULT_ADMIN_PORT)
 }

--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -259,18 +259,30 @@ impl FailureReason {
                     format!("Hint: HTTP request failed - {err}")
                 }
             }
-            FailureReason::StatusMismatch { expected, actual } => {
-                match *actual {
-                    404 => format!("Hint: Got 404 instead of {expected}. The stub predicate may not match the test request path/method."),
-                    500 => format!("Hint: Got 500 instead of {expected}. Check server logs for errors."),
-                    _ => format!("Hint: Expected status {expected} but got {actual}. Verify the stub response configuration."),
+            FailureReason::StatusMismatch { expected, actual } => match *actual {
+                404 => format!(
+                    "Hint: Got 404 instead of {expected}. The stub predicate may not match the test request path/method."
+                ),
+                500 => {
+                    format!("Hint: Got 500 instead of {expected}. Check server logs for errors.")
                 }
-            }
+                _ => format!(
+                    "Hint: Expected status {expected} but got {actual}. Verify the stub response configuration."
+                ),
+            },
             FailureReason::HeaderMissing { header_name } => {
-                format!("Hint: Expected header '{header_name}' is missing from the response. Add it to the stub's response headers.")
+                format!(
+                    "Hint: Expected header '{header_name}' is missing from the response. Add it to the stub's response headers."
+                )
             }
-            FailureReason::HeaderMismatch { header_name, expected, actual } => {
-                format!("Hint: Header '{header_name}' has wrong value.\n       Expected: \"{expected}\"\n       Actual:   \"{actual}\"")
+            FailureReason::HeaderMismatch {
+                header_name,
+                expected,
+                actual,
+            } => {
+                format!(
+                    "Hint: Header '{header_name}' has wrong value.\n       Expected: \"{expected}\"\n       Actual:   \"{actual}\""
+                )
             }
             FailureReason::BodyMismatch { .. } => {
                 "Hint: Response body doesn't match. See diff below for details.".to_string()
@@ -279,7 +291,9 @@ impl FailureReason {
                 "Hint: Expected a response body but got an empty response.".to_string()
             }
             FailureReason::TransportResetExpected { actual } => {
-                format!("Hint: This stub injects a _rift.fault.tcp reset, so the connection should drop; instead it answered HTTP {actual}. The fault did not fire.")
+                format!(
+                    "Hint: This stub injects a _rift.fault.tcp reset, so the connection should drop; instead it answered HTTP {actual}. The fault did not fire."
+                )
             }
         }
     }
@@ -637,10 +651,10 @@ async fn fetch_imposters(
     let mut imposters = Vec::new();
 
     for link in imposter_links {
-        if let Some(port) = filter_port {
-            if link.port != port {
-                continue;
-            }
+        if let Some(port) = filter_port
+            && link.port != port
+        {
+            continue;
         }
 
         // Fetch full imposter details
@@ -880,10 +894,11 @@ fn check_if_dynamic(responses: &[serde_json::Value]) -> (bool, Option<String>) {
 
     // Only treat as proxy if it's a real proxy config (object with "to" field)
     // Many stubs have "proxy": null which should not be treated as dynamic
-    if let Some(proxy) = first.get("proxy") {
-        if proxy.is_object() && proxy.get("to").is_some() {
-            return (true, Some("proxy response".to_string()));
-        }
+    if let Some(proxy) = first.get("proxy")
+        && proxy.is_object()
+        && proxy.get("to").is_some()
+    {
+        return (true, Some("proxy response".to_string()));
     }
 
     if first.get("fault").is_some() {
@@ -1051,13 +1066,11 @@ fn extract_expected_response(
     let has_is_response = first.get("is").is_some();
 
     // Handle proxy response - only if it's a real proxy config (not null) and there's no "is" response
-    if !has_is_response {
-        if let Some(proxy) = first.get("proxy") {
-            // proxy must be an object with a "to" field to be a real proxy
-            if proxy.is_object() && proxy.get("to").is_some() {
-                // For proxy, we just verify connectivity - any 2xx is fine, no specific body expected
-                return (200, HashMap::new(), None);
-            }
+    if !has_is_response && let Some(proxy) = first.get("proxy") {
+        // proxy must be an object with a "to" field to be a real proxy
+        if proxy.is_object() && proxy.get("to").is_some() {
+            // For proxy, we just verify connectivity - any 2xx is fine, no specific body expected
+            return (200, HashMap::new(), None);
         }
     }
 
@@ -1153,51 +1166,48 @@ fn parse_predicates(
 
     // First pass: extract startsWith to set base path (regardless of predicate order)
     for predicate in predicates {
-        if let Some(starts_with) = predicate.get("startsWith") {
-            if let Some(p) = starts_with.get("path").and_then(|v| v.as_str()) {
-                path = p.to_string();
-            }
+        if let Some(starts_with) = predicate.get("startsWith")
+            && let Some(p) = starts_with.get("path").and_then(|v| v.as_str())
+        {
+            path = p.to_string();
         }
     }
 
     // Second pass: process all other predicates
     for predicate in predicates {
         // Handle jsonpath predicates - build a JSON body based on the selector
-        if let Some(jsonpath) = predicate.get("jsonpath") {
-            if let Some(selector) = jsonpath.get("selector").and_then(|v| v.as_str()) {
-                // Get the expected value from equals.body
-                if let Some(equals) = predicate.get("equals") {
-                    if let Some(value) = equals.get("body") {
-                        let json_value = if let Some(s) = value.as_str() {
-                            serde_json::Value::String(s.to_string())
-                        } else {
-                            value.clone()
-                        };
+        if let Some(jsonpath) = predicate.get("jsonpath")
+            && let Some(selector) = jsonpath.get("selector").and_then(|v| v.as_str())
+        {
+            // Get the expected value from equals.body
+            if let Some(equals) = predicate.get("equals")
+                && let Some(value) = equals.get("body")
+            {
+                let json_value = if let Some(s) = value.as_str() {
+                    serde_json::Value::String(s.to_string())
+                } else {
+                    value.clone()
+                };
 
-                        // Build or merge into jsonpath_body
-                        let new_obj = build_json_from_jsonpath(selector, json_value);
-                        jsonpath_body = Some(match jsonpath_body {
-                            Some(existing) => merge_json_objects(existing, new_obj),
-                            None => new_obj,
-                        });
-                    }
-                }
+                // Build or merge into jsonpath_body
+                let new_obj = build_json_from_jsonpath(selector, json_value);
+                jsonpath_body = Some(match jsonpath_body {
+                    Some(existing) => merge_json_objects(existing, new_obj),
+                    None => new_obj,
+                });
             }
         }
         // Handle xpath predicates - build a matching XML body from the selector and the
         // expected `equals.body` value (mirrors the jsonpath handling above). Issue #249 finding #1.
-        if let Some(xpath) = predicate.get("xpath") {
-            if let Some(selector) = xpath.get("selector").and_then(|v| v.as_str()) {
-                if let Some(value) = predicate
-                    .get("equals")
-                    .and_then(|e| e.get("body"))
-                    .and_then(|v| v.as_str())
-                {
-                    if let Some(xml) = build_xml_from_xpath(selector, value) {
-                        body = Some(xml);
-                    }
-                }
-            }
+        if let Some(xpath) = predicate.get("xpath")
+            && let Some(selector) = xpath.get("selector").and_then(|v| v.as_str())
+            && let Some(value) = predicate
+                .get("equals")
+                .and_then(|e| e.get("body"))
+                .and_then(|v| v.as_str())
+            && let Some(xml) = build_xml_from_xpath(selector, value)
+        {
+            body = Some(xml);
         }
 
         // Handle various predicate formats
@@ -1274,17 +1284,17 @@ fn parse_predicates(
         }
 
         // "endsWith" predicate - append to path if needed
-        if let Some(ends_with) = predicate.get("endsWith") {
-            if let Some(p) = ends_with.get("path").and_then(|v| v.as_str()) {
-                // If path doesn't end with the required suffix, append it
-                if !path.ends_with(p) {
-                    if path == "/" {
-                        path = format!("/prefix{p}");
-                    } else if !path.ends_with('/') && !p.starts_with('/') {
-                        path = format!("{path}/{p}");
-                    } else {
-                        path = format!("{path}{p}");
-                    }
+        if let Some(ends_with) = predicate.get("endsWith")
+            && let Some(p) = ends_with.get("path").and_then(|v| v.as_str())
+        {
+            // If path doesn't end with the required suffix, append it
+            if !path.ends_with(p) {
+                if path == "/" {
+                    path = format!("/prefix{p}");
+                } else if !path.ends_with('/') && !p.starts_with('/') {
+                    path = format!("{path}/{p}");
+                } else {
+                    path = format!("{path}{p}");
                 }
             }
         }
@@ -1307,21 +1317,21 @@ fn parse_predicates(
         }
 
         // "or" predicate - use first inner predicate
-        if let Some(or_predicates) = predicate.get("or").and_then(|v| v.as_array()) {
-            if let Some(first) = or_predicates.first() {
-                let inner = vec![first.clone()];
-                let (m, p, h, q, b) = parse_predicates(&inner);
-                if m != "GET" {
-                    method = m;
-                }
-                if p != "/" {
-                    path = p;
-                }
-                headers.extend(h);
-                query_params.extend(q);
-                if b.is_some() {
-                    body = b;
-                }
+        if let Some(or_predicates) = predicate.get("or").and_then(|v| v.as_array())
+            && let Some(first) = or_predicates.first()
+        {
+            let inner = vec![first.clone()];
+            let (m, p, h, q, b) = parse_predicates(&inner);
+            if m != "GET" {
+                method = m;
+            }
+            if p != "/" {
+                path = p;
+            }
+            headers.extend(h);
+            query_params.extend(q);
+            if b.is_some() {
+                body = b;
             }
         }
 
@@ -1378,14 +1388,13 @@ fn predicate_mentions_field(value: &serde_json::Value, field: &str) -> bool {
 fn unwrap_xpath_function(selector: &str) -> &str {
     let s = selector.trim();
     for func in ["string", "boolean", "number", "normalize-space"] {
-        if let Some(rest) = s.strip_prefix(func) {
-            if let Some(inner) = rest
+        if let Some(rest) = s.strip_prefix(func)
+            && let Some(inner) = rest
                 .trim_start()
                 .strip_prefix('(')
                 .and_then(|r| r.strip_suffix(')'))
-            {
-                return inner.trim();
-            }
+        {
+            return inner.trim();
         }
     }
     s
@@ -1471,10 +1480,11 @@ fn unsynthesizable_xpath(predicates: &[serde_json::Value]) -> Option<String> {
             .get("equals")
             .and_then(|e| e.get("body"))
             .is_some();
-        if let Some(selector) = selector {
-            if has_body && build_xml_from_xpath(selector, "probe").is_none() {
-                return Some(selector.to_string());
-            }
+        if let Some(selector) = selector
+            && has_body
+            && build_xml_from_xpath(selector, "probe").is_none()
+        {
+            return Some(selector.to_string());
         }
     }
     None
@@ -1577,16 +1587,14 @@ fn parse_equals_predicate(
     }
 
     // Skip body if it's being handled by jsonpath
-    if !skip_body {
-        if let Some(b) = equals.get("body") {
-            if let Some(s) = b.as_str() {
-                // Don't set body if it's an empty string (means "body should be absent")
-                if !s.is_empty() {
-                    *body = Some(s.to_string());
-                }
-            } else {
-                *body = Some(serde_json::to_string(b).unwrap_or_default());
+    if !skip_body && let Some(b) = equals.get("body") {
+        if let Some(s) = b.as_str() {
+            // Don't set body if it's an empty string (means "body should be absent")
+            if !s.is_empty() {
+                *body = Some(s.to_string());
             }
+        } else {
+            *body = Some(serde_json::to_string(b).unwrap_or_default());
         }
     }
 }
@@ -1650,12 +1658,12 @@ fn parse_contains_predicate(
 /// can be sampled into a literal — the global flags don't change the generated sample. A scoped
 /// group such as `(?:...)` or `(?i:...)` (flags followed by `:`) is left intact.
 fn strip_leading_inline_flags(pattern: &str) -> &str {
-    if let Some(rest) = pattern.strip_prefix("(?") {
-        if let Some(close) = rest.find(')') {
-            let flags = &rest[..close];
-            if !flags.is_empty() && flags.chars().all(|c| c.is_ascii_alphabetic()) {
-                return &rest[close + 1..];
-            }
+    if let Some(rest) = pattern.strip_prefix("(?")
+        && let Some(close) = rest.find(')')
+    {
+        let flags = &rest[..close];
+        if !flags.is_empty() && flags.chars().all(|c| c.is_ascii_alphabetic()) {
+            return &rest[close + 1..];
         }
     }
     pattern
@@ -2125,10 +2133,8 @@ fn print_summary(summary: &VerificationSummary, show_curl: bool) {
             println!("   Expected: {}", failure.expected);
             println!("   {}Actual:   {}{}", RED, failure.actual, RESET);
 
-            if show_curl {
-                if let Some(ref curl) = failure.curl_command {
-                    println!("   Curl:     {curl}");
-                }
+            if show_curl && let Some(ref curl) = failure.curl_command {
+                println!("   Curl:     {curl}");
             }
 
             // Print failure reasons with hints
@@ -2158,7 +2164,9 @@ fn print_summary(summary: &VerificationSummary, show_curl: bool) {
 fn print_failure_reason(reason: &FailureReason) {
     match reason {
         FailureReason::StatusMismatch { expected, actual } => {
-            println!("   - {YELLOW}Status mismatch:{RESET} expected {GREEN}{expected}{RESET}, got {RED}{actual}{RESET}");
+            println!(
+                "   - {YELLOW}Status mismatch:{RESET} expected {GREEN}{expected}{RESET}, got {RED}{actual}{RESET}"
+            );
             println!("     {DIM}{}{RESET}", reason.hint());
         }
         FailureReason::HeaderMissing { header_name } => {
@@ -2198,7 +2206,9 @@ fn print_failure_reason(reason: &FailureReason) {
             println!("     {DIM}{}{RESET}", reason.hint());
         }
         FailureReason::TransportResetExpected { actual } => {
-            println!("   - {YELLOW}Fault not triggered:{RESET} expected connection reset, got HTTP {actual}");
+            println!(
+                "   - {YELLOW}Fault not triggered:{RESET} expected connection reset, got HTTP {actual}"
+            );
             println!("     {DIM}{}{RESET}", reason.hint());
         }
     }
@@ -2794,11 +2804,13 @@ mod verify_tests {
         .unwrap();
         // No flow header resolved → the space-gated stub is a visible SKIP, not a silent degraded run.
         let cases = generate_test_cases(0, &stub, false, "http", None);
-        assert!(cases[0]
-            .skip_reason
-            .as_deref()
-            .unwrap_or("")
-            .contains("flowIdSource"));
+        assert!(
+            cases[0]
+                .skip_reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("flowIdSource")
+        );
         // With a header resolved, it is verified normally (no skip).
         let cases = generate_test_cases(0, &stub, false, "http", Some("X-Mock-Space"));
         assert!(cases[0].skip_reason.is_none());

--- a/crates/rift-http-proxy/src/bin/verify/dynamic.rs
+++ b/crates/rift-http-proxy/src/bin/verify/dynamic.rs
@@ -140,29 +140,29 @@ pub enum ExpectMismatch {
 /// Check an observed (status, body) against a declared expectation. Returns `Ok(())` on a match
 /// or `Err` describing the first mismatch.
 pub fn check_expect(expect: &VerifyExpect, status: u16, body: &str) -> Result<(), ExpectMismatch> {
-    if let Some(want) = expect.status {
-        if status != want {
-            return Err(ExpectMismatch::Status {
-                actual: status,
-                expected: want,
-            });
-        }
+    if let Some(want) = expect.status
+        && status != want
+    {
+        return Err(ExpectMismatch::Status {
+            actual: status,
+            expected: want,
+        });
     }
-    if let Some(want) = &expect.body_equals {
-        if body != want {
-            return Err(ExpectMismatch::BodyEquals {
-                actual: body.to_string(),
-                expected: want.clone(),
-            });
-        }
+    if let Some(want) = &expect.body_equals
+        && body != want
+    {
+        return Err(ExpectMismatch::BodyEquals {
+            actual: body.to_string(),
+            expected: want.clone(),
+        });
     }
-    if let Some(want) = &expect.body_contains {
-        if !body.contains(want.as_str()) {
-            return Err(ExpectMismatch::BodyContains {
-                actual: body.to_string(),
-                expected: want.clone(),
-            });
-        }
+    if let Some(want) = &expect.body_contains
+        && !body.contains(want.as_str())
+    {
+        return Err(ExpectMismatch::BodyContains {
+            actual: body.to_string(),
+            expected: want.clone(),
+        });
     }
     Ok(())
 }
@@ -190,17 +190,17 @@ pub fn fault_expectation(response: &serde_json::Value) -> Option<FaultExpectatio
     if fault.get("tcp").is_some() {
         return Some(FaultExpectation::TransportReset);
     }
-    if let Some(latency) = fault.get("latency") {
-        if is_certain(latency) {
-            let ms = latency.get("ms").and_then(|v| v.as_u64())?;
-            return Some(FaultExpectation::Latency { ms });
-        }
+    if let Some(latency) = fault.get("latency")
+        && is_certain(latency)
+    {
+        let ms = latency.get("ms").and_then(|v| v.as_u64())?;
+        return Some(FaultExpectation::Latency { ms });
     }
-    if let Some(error) = fault.get("error") {
-        if is_certain(error) {
-            let status = error.get("status").and_then(|v| v.as_u64())? as u16;
-            return Some(FaultExpectation::ErrorStatus { status });
-        }
+    if let Some(error) = fault.get("error")
+        && is_certain(error)
+    {
+        let status = error.get("status").and_then(|v| v.as_u64())? as u16;
+        return Some(FaultExpectation::ErrorStatus { status });
     }
     None
 }
@@ -455,7 +455,9 @@ impl<'a> DynamicVerifier<'a> {
                             }
                             Ok(_) => DynCheck::fail(
                                 format!("{label} latency"),
-                                format!("{elapsed}ms over {baseline_ms}ms baseline does not show the configured {ms}ms delay"),
+                                format!(
+                                    "{elapsed}ms over {baseline_ms}ms baseline does not show the configured {ms}ms delay"
+                                ),
                             ),
                         }
                     }
@@ -475,7 +477,9 @@ impl<'a> DynamicVerifier<'a> {
                 if base_status == Some(want) {
                     DynCheck::skip(
                         format!("stub #{stub_idx} fault"),
-                        format!("error-fault status {want} equals the base response status; cannot prove the fault fired"),
+                        format!(
+                            "error-fault status {want} equals the base response status; cannot prove the fault fired"
+                        ),
                     )
                 } else {
                     match self.drive_step(port, &get_request(path)).await {

--- a/crates/rift-http-proxy/src/bin/verify/dynamic.rs
+++ b/crates/rift-http-proxy/src/bin/verify/dynamic.rs
@@ -291,9 +291,8 @@ impl<'a> DynamicVerifier<'a> {
             Ok(s) => s,
             Err(e) => return vec![DynCheck::fail(label, e)],
         };
-        let port = match free_port() {
-            Some(p) => p,
-            None => return vec![DynCheck::fail(label, "no free port".to_string())],
+        let Some(port) = free_port() else {
+            return vec![DynCheck::fail(label, "no free port".to_string())];
         };
         let mut config = imposter.clone();
         config["port"] = port.into();
@@ -331,9 +330,8 @@ impl<'a> DynamicVerifier<'a> {
             Ok(m) => m,
             Err(e) => return vec![DynCheck::fail(label, e)],
         };
-        let port = match free_port() {
-            Some(p) => p,
-            None => return vec![DynCheck::fail(label, "no free port".to_string())],
+        let Some(port) = free_port() else {
+            return vec![DynCheck::fail(label, "no free port".to_string())];
         };
 
         let mut proxy_cfg = serde_json::json!({ "to": mock.url(), "mode": mode });
@@ -394,9 +392,8 @@ impl<'a> DynamicVerifier<'a> {
         expectation: FaultExpectation,
     ) -> Vec<DynCheck> {
         let label = format!("stub #{stub_idx} fault");
-        let port = match free_port() {
-            Some(p) => p,
-            None => return vec![DynCheck::fail(label, "no free port".to_string())],
+        let Some(port) = free_port() else {
+            return vec![DynCheck::fail(label, "no free port".to_string())];
         };
         let path = "/__rift_verify_fault";
         let config = serde_json::json!({

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -215,11 +215,13 @@ mod tests {
     fn parse_error_is_returned_not_panicked() {
         let dir = tempfile::tempdir().unwrap();
         let bad = write(dir.path(), "bad.json", "{ not valid json");
-        assert!(load_configs(&ConfigSource::File {
-            path: bad,
-            no_parse: false
-        })
-        .is_err());
+        assert!(
+            load_configs(&ConfigSource::File {
+                path: bad,
+                no_parse: false
+            })
+            .is_err()
+        );
     }
 
     // EJS configfile pre-processing (relocated from main.rs with preprocess_ejs in issue #197)
@@ -233,17 +235,20 @@ mod tests {
 
     #[test]
     fn test_ejs_env_var_substitution() {
-        std::env::set_var("RIFT_TEST_HOST", "myhost");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("RIFT_TEST_HOST", "myhost") };
         let content = r#"{"body": "<%= process.env.RIFT_TEST_HOST %>"}"#;
         let path = PathBuf::from("config.json");
         let result = preprocess_ejs(content, &path).unwrap();
         assert_eq!(result, r#"{"body": "myhost"}"#);
-        std::env::remove_var("RIFT_TEST_HOST");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RIFT_TEST_HOST") };
     }
 
     #[test]
     fn test_ejs_env_var_with_default() {
-        std::env::remove_var("RIFT_TEST_UNSET_VAR");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RIFT_TEST_UNSET_VAR") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_UNSET_VAR || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
         let result = preprocess_ejs(content, &path).unwrap();
@@ -252,12 +257,14 @@ mod tests {
 
     #[test]
     fn test_ejs_env_var_present_overrides_default() {
-        std::env::set_var("RIFT_TEST_PORT", "8080");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("RIFT_TEST_PORT", "8080") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_PORT || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
         let result = preprocess_ejs(content, &path).unwrap();
         assert_eq!(result, r#"{"port": "8080"}"#);
-        std::env::remove_var("RIFT_TEST_PORT");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RIFT_TEST_PORT") };
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -235,19 +235,16 @@ mod tests {
 
     #[test]
     fn test_ejs_env_var_substitution() {
-        // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { std::env::set_var("RIFT_TEST_HOST", "myhost") };
         let content = r#"{"body": "<%= process.env.RIFT_TEST_HOST %>"}"#;
         let path = PathBuf::from("config.json");
         let result = preprocess_ejs(content, &path).unwrap();
         assert_eq!(result, r#"{"body": "myhost"}"#);
-        // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { std::env::remove_var("RIFT_TEST_HOST") };
     }
 
     #[test]
     fn test_ejs_env_var_with_default() {
-        // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { std::env::remove_var("RIFT_TEST_UNSET_VAR") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_UNSET_VAR || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
@@ -257,13 +254,11 @@ mod tests {
 
     #[test]
     fn test_ejs_env_var_present_overrides_default() {
-        // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { std::env::set_var("RIFT_TEST_PORT", "8080") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_PORT || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
         let result = preprocess_ejs(content, &path).unwrap();
         assert_eq!(result, r#"{"port": "8080"}"#);
-        // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { std::env::remove_var("RIFT_TEST_PORT") };
     }
 

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -195,7 +195,7 @@ fn main() -> Result<(), anyhow::Error> {
     if let Some(ref rcfile) = cli.rcfile.clone() {
         match apply_rcfile_defaults(&mut cli, rcfile) {
             Ok(()) => {}
-            Err(e) => eprintln!("Warning: failed to load --rcfile {:?}: {}", rcfile, e),
+            Err(e) => eprintln!("Warning: failed to load --rcfile {rcfile:?}: {e}"),
         }
     }
 

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -38,7 +38,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info, warn};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
 
 use admin_api::DEFAULT_ADMIN_PORT;
 
@@ -475,24 +475,24 @@ fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &std::path::Path) -> Result<(), 
     for (key, val) in map {
         match key.as_str() {
             "port" => {
-                if cli.port == DEFAULT_ADMIN_PORT {
-                    if let Some(p) = val.as_u64() {
-                        cli.port = p as u16;
-                    }
+                if cli.port == DEFAULT_ADMIN_PORT
+                    && let Some(p) = val.as_u64()
+                {
+                    cli.port = p as u16;
                 }
             }
             "host" => {
-                if cli.host == "0.0.0.0" {
-                    if let Some(h) = val.as_str() {
-                        cli.host = h.to_string();
-                    }
+                if cli.host == "0.0.0.0"
+                    && let Some(h) = val.as_str()
+                {
+                    cli.host = h.to_string();
                 }
             }
             "logLevel" | "loglevel" => {
-                if cli.loglevel == "info" {
-                    if let Some(l) = val.as_str() {
-                        cli.loglevel = l.to_string();
-                    }
+                if cli.loglevel == "info"
+                    && let Some(l) = val.as_str()
+                {
+                    cli.loglevel = l.to_string();
                 }
             }
             "allowInjection" | "allow_injection" => {
@@ -506,17 +506,17 @@ fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &std::path::Path) -> Result<(), 
                 }
             }
             "datadir" => {
-                if cli.datadir.is_none() {
-                    if let Some(d) = val.as_str() {
-                        cli.datadir = Some(std::path::PathBuf::from(d));
-                    }
+                if cli.datadir.is_none()
+                    && let Some(d) = val.as_str()
+                {
+                    cli.datadir = Some(std::path::PathBuf::from(d));
                 }
             }
             "configfile" => {
-                if cli.configfile.is_none() {
-                    if let Some(f) = val.as_str() {
-                        cli.configfile = Some(std::path::PathBuf::from(f));
-                    }
+                if cli.configfile.is_none()
+                    && let Some(f) = val.as_str()
+                {
+                    cli.configfile = Some(std::path::PathBuf::from(f));
                 }
             }
             other => {
@@ -557,7 +557,7 @@ fn save_imposters(
 async fn run_metrics_server(port: u16) -> anyhow::Result<()> {
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
-    use hyper::{body::Incoming, Request, Response};
+    use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
     use std::convert::Infallible;
     use tokio::net::TcpListener;

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -685,7 +685,10 @@ mod https {
             .create_imposter(serde_json::from_value(stub_config(19847, "https", None)).unwrap())
             .await;
         assert!(
-            matches!(result, Err(rift_http_proxy::imposter::ImposterError::Tls(_))),
+            matches!(
+                result,
+                Err(rift_http_proxy::imposter::ImposterError::Tls(_))
+            ),
             "half-configured server default must error, not downgrade to self-signed, got {result:?}"
         );
     }
@@ -960,7 +963,7 @@ mod multi_value_headers {
 // Issue #197: POST /admin/reload re-reads the config source and replaces imposters.
 mod reload {
     use super::*;
-    use rift_http_proxy::config_loader::{load_configs, ConfigSource};
+    use rift_http_proxy::config_loader::{ConfigSource, load_configs};
 
     fn cfg(port: u16, body: &str) -> String {
         format!(

--- a/crates/rift-lint/Cargo.toml
+++ b/crates/rift-lint/Cargo.toml
@@ -18,20 +18,20 @@ workspace = true
 
 [dependencies]
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 
 # Regex for pattern validation
 regex = "1"
 
 # Structured error types
-thiserror = "1.0"
+thiserror.workspace = true
 
 # CLI argument parsing (only needed for binary)
-clap = { version = "4", features = ["derive"], optional = true }
+clap = { workspace = true, optional = true }
 
-# JavaScript validation (optional)
-boa_engine = { version = "0.19", optional = true }
+# JavaScript validation (optional) — aligned with rift-core's boa_engine pin
+boa_engine = { version = "0.20", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rift-lint/src/main.rs
+++ b/crates/rift-lint/src/main.rs
@@ -7,7 +7,7 @@
 //!   rift-lint <directory_or_file> [OPTIONS]
 
 use clap::Parser;
-use rift_lint::{lint_file, LintIssue, LintOptions, LintResult, Severity};
+use rift_lint::{LintIssue, LintOptions, LintResult, Severity, lint_file};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -136,13 +136,13 @@ fn collect_imposter_files(path: &Path) -> Vec<PathBuf> {
         if path.extension().is_some_and(|ext| ext == "json") {
             files.push(path.to_path_buf());
         }
-    } else if path.is_dir() {
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
-                let entry_path = entry.path();
-                if entry_path.is_file() && entry_path.extension().is_some_and(|ext| ext == "json") {
-                    files.push(entry_path);
-                }
+    } else if path.is_dir()
+        && let Ok(entries) = std::fs::read_dir(path)
+    {
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_file() && entry_path.extension().is_some_and(|ext| ext == "json") {
+                files.push(entry_path);
             }
         }
     }
@@ -368,40 +368,39 @@ fn apply_fixes(imposters: &[(PathBuf, Value)]) {
             for stub in stubs {
                 if let Some(responses) = stub.get_mut("responses").and_then(|v| v.as_array_mut()) {
                     for response in responses {
-                        if let Some(is_response) = response.get_mut("is") {
-                            if let Some(headers) = is_response
+                        if let Some(is_response) = response.get_mut("is")
+                            && let Some(headers) = is_response
                                 .get_mut("headers")
                                 .and_then(|v| v.as_object_mut())
-                            {
-                                for (name, value) in headers.iter_mut() {
-                                    if value.is_array() {
-                                        // Convert array to comma-separated string
-                                        if let Some(arr) = value.as_array() {
-                                            let joined: Vec<String> = arr
-                                                .iter()
-                                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                                                .collect();
-                                            *value = Value::String(joined.join(", "));
-                                            file_fixed = true;
-                                            fixes_applied += 1;
-                                            println!("  Fixed header '{name}' array -> string");
-                                        }
-                                    } else if value.is_number() {
-                                        *value = Value::String(value.to_string());
+                        {
+                            for (name, value) in headers.iter_mut() {
+                                if value.is_array() {
+                                    // Convert array to comma-separated string
+                                    if let Some(arr) = value.as_array() {
+                                        let joined: Vec<String> = arr
+                                            .iter()
+                                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                            .collect();
+                                        *value = Value::String(joined.join(", "));
                                         file_fixed = true;
                                         fixes_applied += 1;
-                                        println!("  Fixed header '{name}' number -> string");
-                                    } else if value.is_boolean() {
-                                        let bool_str = if value.as_bool().unwrap_or(false) {
-                                            "true"
-                                        } else {
-                                            "false"
-                                        };
-                                        *value = Value::String(bool_str.to_string());
-                                        file_fixed = true;
-                                        fixes_applied += 1;
-                                        println!("  Fixed header '{name}' boolean -> string");
+                                        println!("  Fixed header '{name}' array -> string");
                                     }
+                                } else if value.is_number() {
+                                    *value = Value::String(value.to_string());
+                                    file_fixed = true;
+                                    fixes_applied += 1;
+                                    println!("  Fixed header '{name}' number -> string");
+                                } else if value.is_boolean() {
+                                    let bool_str = if value.as_bool().unwrap_or(false) {
+                                        "true"
+                                    } else {
+                                        "false"
+                                    };
+                                    *value = Value::String(bool_str.to_string());
+                                    file_fixed = true;
+                                    fixes_applied += 1;
+                                    println!("  Fixed header '{name}' boolean -> string");
                                 }
                             }
                         }

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -209,15 +209,12 @@ pub fn validate_predicate(
         "inject",
     ];
 
-    let pred_obj = match predicate.as_object() {
-        Some(obj) => obj,
-        None => {
-            result.add_issue(
-                LintIssue::error("E007", "Predicate must be an object", file.to_path_buf())
-                    .with_location(location),
-            );
-            return;
-        }
+    let Some(pred_obj) = predicate.as_object() else {
+        result.add_issue(
+            LintIssue::error("E007", "Predicate must be an object", file.to_path_buf())
+                .with_location(location),
+        );
+        return;
     };
 
     let modifier_keys: HashSet<&str> =
@@ -564,7 +561,7 @@ pub fn validate_headers(file: &Path, headers: &Value, location: &str, result: &m
                     file.to_path_buf(),
                 )
                 .with_location(format!("{location}.{name}"))
-                .with_suggestion(format!("Change to: \"{name}\": \"{}\"", value)),
+                .with_suggestion(format!("Change to: \"{name}\": \"{value}\"")),
             );
         } else if value.is_boolean() {
             result.add_issue(
@@ -574,7 +571,7 @@ pub fn validate_headers(file: &Path, headers: &Value, location: &str, result: &m
                     file.to_path_buf(),
                 )
                 .with_location(format!("{location}.{name}"))
-                .with_suggestion(format!("Change to: \"{name}\": \"{}\"", value)),
+                .with_suggestion(format!("Change to: \"{name}\": \"{value}\"")),
             );
         } else if value.is_null() {
             result.add_issue(

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -257,8 +257,9 @@ pub fn validate_predicate(
             .collect::<Vec<_>>();
         let sub_predicates = serde_json::json!(sub_predicates);
         let and_predicate = serde_json::json!({"and": sub_predicates});
-        let suggestion =
-            format!("Split into separate predicates, combined with and, like: {and_predicate} (or just {sub_predicates} if at the top level)");
+        let suggestion = format!(
+            "Split into separate predicates, combined with and, like: {and_predicate} (or just {sub_predicates} if at the top level)"
+        );
         result.add_issue(
             LintIssue::error("E034", "Only one predicate operation", file.to_path_buf())
                 .with_location(location)
@@ -345,18 +346,18 @@ fn validate_regex_patterns(
 ) {
     if let Some(obj) = matches.as_object() {
         for (field, pattern) in obj {
-            if let Some(pattern_str) = pattern.as_str() {
-                if let Err(e) = Regex::new(pattern_str) {
-                    result.add_issue(
-                        LintIssue::error(
-                            "E013",
-                            format!("Invalid regex pattern in '{field}': {e}"),
-                            file.to_path_buf(),
-                        )
-                        .with_location(format!("{location}.matches.{field}"))
-                        .with_suggestion("Check regex syntax"),
-                    );
-                }
+            if let Some(pattern_str) = pattern.as_str()
+                && let Err(e) = Regex::new(pattern_str)
+            {
+                result.add_issue(
+                    LintIssue::error(
+                        "E013",
+                        format!("Invalid regex pattern in '{field}': {e}"),
+                        file.to_path_buf(),
+                    )
+                    .with_location(format!("{location}.matches.{field}"))
+                    .with_suggestion("Check regex syntax"),
+                );
             }
         }
     }
@@ -424,10 +425,10 @@ pub fn validate_response(
         validate_is_response(file, is_response, &format!("{location}.is"), result);
     }
 
-    if let Some(proxy) = response.get("proxy") {
-        if !proxy.is_null() {
-            validate_proxy_response(file, proxy, &format!("{location}.proxy"), result);
-        }
+    if let Some(proxy) = response.get("proxy")
+        && !proxy.is_null()
+    {
+        validate_proxy_response(file, proxy, &format!("{location}.proxy"), result);
     }
 
     // Rift/Mountebank write behaviors as `_behaviors: { wait, repeat, ... }` (object).
@@ -493,31 +494,29 @@ pub fn validate_is_response(
     }
 
     // Check if body is valid JSON when Content-Type is application/json
-    if let Some(body) = is_response.get("body") {
-        if let Some(headers) = is_response.get("headers").and_then(|h| h.as_object()) {
-            let content_type = headers
-                .iter()
-                .find(|(k, _)| k.to_lowercase() == "content-type")
-                .and_then(|(_, v)| v.as_str());
+    if let Some(body) = is_response.get("body")
+        && let Some(headers) = is_response.get("headers").and_then(|h| h.as_object())
+    {
+        let content_type = headers
+            .iter()
+            .find(|(k, _)| k.to_lowercase() == "content-type")
+            .and_then(|(_, v)| v.as_str());
 
-            if content_type
-                .map(|ct| ct.contains("application/json"))
-                .unwrap_or(false)
-            {
-                if let Some(body_str) = body.as_str() {
-                    if serde_json::from_str::<Value>(body_str).is_err() {
-                        result.add_issue(
-                            LintIssue::warning(
-                                "W004",
-                                "Body is not valid JSON but Content-Type is application/json",
-                                file.to_path_buf(),
-                            )
-                            .with_location(format!("{location}.body"))
-                            .with_suggestion("Verify the body is valid JSON"),
-                        );
-                    }
-                }
-            }
+        if content_type
+            .map(|ct| ct.contains("application/json"))
+            .unwrap_or(false)
+            && let Some(body_str) = body.as_str()
+            && serde_json::from_str::<Value>(body_str).is_err()
+        {
+            result.add_issue(
+                LintIssue::warning(
+                    "W004",
+                    "Body is not valid JSON but Content-Type is application/json",
+                    file.to_path_buf(),
+                )
+                .with_location(format!("{location}.body"))
+                .with_suggestion("Verify the body is valid JSON"),
+            );
         }
     }
 }
@@ -589,22 +588,20 @@ pub fn validate_headers(file: &Path, headers: &Value, location: &str, result: &m
             );
         }
 
-        if name.to_lowercase() == "content-length" {
-            if let Some(len_str) = value.as_str() {
-                if let Ok(len) = len_str.parse::<u64>() {
-                    if len < 10 {
-                        result.add_issue(
-                            LintIssue::warning(
-                                "W006",
-                                format!("Content-Length is very small ({len}), may cause issues"),
-                                file.to_path_buf(),
-                            )
-                            .with_location(format!("{location}.{name}"))
-                            .with_suggestion("Verify Content-Length matches actual body length"),
-                        );
-                    }
-                }
-            }
+        if name.to_lowercase() == "content-length"
+            && let Some(len_str) = value.as_str()
+            && let Ok(len) = len_str.parse::<u64>()
+            && len < 10
+        {
+            result.add_issue(
+                LintIssue::warning(
+                    "W006",
+                    format!("Content-Length is very small ({len}), may cause issues"),
+                    file.to_path_buf(),
+                )
+                .with_location(format!("{location}.{name}"))
+                .with_suggestion("Verify Content-Length matches actual body length"),
+            );
         }
     }
 }
@@ -631,20 +628,19 @@ pub fn validate_proxy_response(
 
             if url.contains("localhost:") || url.contains("127.0.0.1:") {
                 let port_re = Regex::new(r":(\d+)").unwrap();
-                if let Some(captures) = port_re.captures(url) {
-                    if let Ok(port) = captures[1].parse::<u16>() {
-                        if port > 10000 {
-                            result.add_issue(
-                                LintIssue::info(
-                                    "I002",
-                                    format!("Proxy targets localhost:{port}"),
-                                    file.to_path_buf(),
-                                )
-                                .with_location(format!("{location}.to"))
-                                .with_suggestion("Ensure upstream service is running on this port"),
-                            );
-                        }
-                    }
+                if let Some(captures) = port_re.captures(url)
+                    && let Ok(port) = captures[1].parse::<u16>()
+                    && port > 10000
+                {
+                    result.add_issue(
+                        LintIssue::info(
+                            "I002",
+                            format!("Proxy targets localhost:{port}"),
+                            file.to_path_buf(),
+                        )
+                        .with_location(format!("{location}.to"))
+                        .with_suggestion("Ensure upstream service is running on this port"),
+                    );
                 }
             }
         } else {
@@ -738,36 +734,34 @@ pub fn validate_behavior(
         }
     }
 
-    if let Some(decorate) = obj.get("decorate") {
-        if let Some(script) = decorate.as_str() {
-            validate_javascript_behavior(
-                file,
-                script,
-                &format!("{location}.decorate"),
-                result,
-                options,
-                true,
-            );
-        }
+    if let Some(decorate) = obj.get("decorate")
+        && let Some(script) = decorate.as_str()
+    {
+        validate_javascript_behavior(
+            file,
+            script,
+            &format!("{location}.decorate"),
+            result,
+            options,
+            true,
+        );
     }
 
-    if let Some(shell) = obj.get("shellTransform") {
-        if let Some(cmd) = shell.as_str() {
-            let dangerous_patterns = ["rm ", "rm -", "sudo ", "chmod ", "dd ", "> /dev/"];
-            for pattern in dangerous_patterns {
-                if cmd.contains(pattern) {
-                    result.add_issue(
-                        LintIssue::warning(
-                            "W008",
-                            format!(
-                                "shellTransform contains potentially dangerous command: {pattern}"
-                            ),
-                            file.to_path_buf(),
-                        )
-                        .with_location(format!("{location}.shellTransform"))
-                        .with_suggestion("Review this command for safety"),
-                    );
-                }
+    if let Some(shell) = obj.get("shellTransform")
+        && let Some(cmd) = shell.as_str()
+    {
+        let dangerous_patterns = ["rm ", "rm -", "sudo ", "chmod ", "dd ", "> /dev/"];
+        for pattern in dangerous_patterns {
+            if cmd.contains(pattern) {
+                result.add_issue(
+                    LintIssue::warning(
+                        "W008",
+                        format!("shellTransform contains potentially dangerous command: {pattern}"),
+                        file.to_path_buf(),
+                    )
+                    .with_location(format!("{location}.shellTransform"))
+                    .with_suggestion("Review this command for safety"),
+                );
             }
         }
     }

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -1,9 +1,9 @@
 use rift_lint::{
-    lint_directory, lint_json, lint_value, validate_behavior, validate_imposter,
-    validate_is_response, validate_predicate, validate_proxy_response, validate_response,
-    validate_stub, LintOptions, LintResult,
+    LintOptions, LintResult, lint_directory, lint_json, lint_value, validate_behavior,
+    validate_imposter, validate_is_response, validate_predicate, validate_proxy_response,
+    validate_response, validate_stub,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::path::Path;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/crates/rift-tui/Cargo.toml
+++ b/crates/rift-tui/Cargo.toml
@@ -32,21 +32,21 @@ arboard = "3.4"
 dirs = "5.0"
 
 # Async runtime
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 # HTTP client for Admin API
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest.workspace = true
 
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 
 # CLI argument parsing
-clap = { version = "4", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 
 # Error handling
-anyhow = "1.0"
-thiserror = "1.0"
+anyhow.workspace = true
+thiserror.workspace = true
 
 # Validation
 rift-lint = { path = "../rift-lint", default-features = false }

--- a/crates/rift-tui/src/api.rs
+++ b/crates/rift-tui/src/api.rs
@@ -521,7 +521,7 @@ impl ApiClient {
         }
         Err(ApiError::Server {
             code: status.as_str().to_string(),
-            message: format!("Request failed with status {}", status),
+            message: format!("Request failed with status {status}"),
         })
     }
 }

--- a/crates/rift-tui/src/api.rs
+++ b/crates/rift-tui/src/api.rs
@@ -511,13 +511,13 @@ impl ApiClient {
     /// Handle error responses
     async fn handle_error<T>(&self, resp: reqwest::Response) -> Result<T, ApiError> {
         let status = resp.status();
-        if let Ok(error_body) = resp.json::<ErrorResponse>().await {
-            if let Some(err) = error_body.errors.first() {
-                return Err(ApiError::Server {
-                    code: err.code.clone(),
-                    message: err.message.clone(),
-                });
-            }
+        if let Ok(error_body) = resp.json::<ErrorResponse>().await
+            && let Some(err) = error_body.errors.first()
+        {
+            return Err(ApiError::Server {
+                code: err.code.clone(),
+                message: err.message.clone(),
+            });
         }
         Err(ApiError::Server {
             code: status.as_str().to_string(),
@@ -537,31 +537,30 @@ fn parse_prometheus_metrics(text: &str) -> MetricsData {
         }
 
         // Parse rift_imposters_total
-        if line.starts_with("rift_imposters_total") {
-            if let Some(value) = line.split_whitespace().last() {
-                data.imposter_count = value.parse().unwrap_or(0);
-            }
+        if line.starts_with("rift_imposters_total")
+            && let Some(value) = line.split_whitespace().last()
+        {
+            data.imposter_count = value.parse().unwrap_or(0);
         }
 
         // Parse rift_imposter_requests_total{port="..."} VALUE
-        if line.starts_with("rift_imposter_requests_total") {
-            if let Some(port_start) = line.find("port=\"") {
-                let port_str = &line[port_start + 6..];
-                if let Some(port_end) = port_str.find('"') {
-                    if let Ok(port) = port_str[..port_end].parse::<u16>() {
-                        if let Some(value) = line.split_whitespace().last() {
-                            let count: u64 = value.parse().unwrap_or(0);
-                            data.total_requests += count;
-                            data.per_imposter.insert(
-                                port,
-                                ImposterMetrics {
-                                    request_count: count,
-                                    requests_per_second: 0.0,
-                                },
-                            );
-                        }
-                    }
-                }
+        if line.starts_with("rift_imposter_requests_total")
+            && let Some(port_start) = line.find("port=\"")
+        {
+            let port_str = &line[port_start + 6..];
+            if let Some(port_end) = port_str.find('"')
+                && let Ok(port) = port_str[..port_end].parse::<u16>()
+                && let Some(value) = line.split_whitespace().last()
+            {
+                let count: u64 = value.parse().unwrap_or(0);
+                data.total_requests += count;
+                data.per_imposter.insert(
+                    port,
+                    ImposterMetrics {
+                        request_count: count,
+                        requests_per_second: 0.0,
+                    },
+                );
             }
         }
     }

--- a/crates/rift-tui/src/app/commands/curl.rs
+++ b/crates/rift-tui/src/app/commands/curl.rs
@@ -33,7 +33,7 @@ impl App {
 
         // Add method if not GET
         if method != "GET" {
-            parts.push(format!("-X {}", method));
+            parts.push(format!("-X {method}"));
         }
 
         // Add Content-Type header if we have a body and it looks like JSON
@@ -51,7 +51,7 @@ impl App {
 
         // Add headers
         for (key, value) in &headers {
-            parts.push(format!("-H '{}: {}'", key, value));
+            parts.push(format!("-H '{key}: {value}'"));
         }
 
         // Add body if present
@@ -60,16 +60,16 @@ impl App {
         }
 
         // Build URL with query params
-        let mut url = format!("http://localhost:{}{}", port, path);
+        let mut url = format!("http://localhost:{port}{path}");
         if !query_params.is_empty() {
             let query_string: Vec<String> = query_params
                 .iter()
-                .map(|(k, v)| format!("{}={}", k, v))
+                .map(|(k, v)| format!("{k}={v}"))
                 .collect();
             url = format!("{}?{}", url, query_string.join("&"));
         }
 
-        parts.push(format!("'{}'", url));
+        parts.push(format!("'{url}'"));
 
         parts.join(" \\\n  ")
     }
@@ -121,7 +121,7 @@ impl App {
                                 if p.starts_with('/') {
                                     p.to_string()
                                 } else {
-                                    format!("/{}", p)
+                                    format!("/{p}")
                                 }
                             }
                             _ => {
@@ -129,7 +129,7 @@ impl App {
                                 if p.starts_with('/') {
                                     p.to_string()
                                 } else {
-                                    format!("/{}", p)
+                                    format!("/{p}")
                                 }
                             }
                         };
@@ -189,7 +189,7 @@ impl App {
         // Replace [^/]+ patterns with numbered placeholders
         let mut counter = 1;
         while path.contains("[^/]+") {
-            path = path.replacen("[^/]+", &format!("{{{}}}", counter), 1);
+            path = path.replacen("[^/]+", &format!("{{{counter}}}"), 1);
             counter += 1;
         }
 
@@ -205,7 +205,7 @@ impl App {
         path = path.replace(")", "");
 
         if !path.starts_with('/') {
-            path = format!("/{}", path);
+            path = format!("/{path}");
         }
 
         path

--- a/crates/rift-tui/src/app/commands/curl.rs
+++ b/crates/rift-tui/src/app/commands/curl.rs
@@ -41,12 +41,11 @@ impl App {
             let has_content_type = headers
                 .iter()
                 .any(|(k, _)| k.to_lowercase() == "content-type");
-            if !has_content_type {
-                if let Some(ref b) = body {
-                    if b.trim_start().starts_with('{') || b.trim_start().starts_with('[') {
-                        parts.push("-H 'Content-Type: application/json'".to_string());
-                    }
-                }
+            if !has_content_type
+                && let Some(ref b) = body
+                && (b.trim_start().starts_with('{') || b.trim_start().starts_with('['))
+            {
+                parts.push("-H 'Content-Type: application/json'".to_string());
             }
         }
 
@@ -296,10 +295,10 @@ impl App {
                 }
                 (Some(serde_json::Value::Array(t)), serde_json::Value::Array(s)) => {
                     // Merge array contents - for arrays of objects, merge first elements
-                    if let Some(serde_json::Value::Object(t_obj)) = t.first_mut() {
-                        if let Some(serde_json::Value::Object(s_obj)) = s.into_iter().next() {
-                            self.deep_merge(t_obj, s_obj);
-                        }
+                    if let Some(serde_json::Value::Object(t_obj)) = t.first_mut()
+                        && let Some(serde_json::Value::Object(s_obj)) = s.into_iter().next()
+                    {
+                        self.deep_merge(t_obj, s_obj);
                     }
                 }
                 (_, v) => {
@@ -323,17 +322,16 @@ impl App {
             _ => None,
         };
 
-        if let Some(idx) = stub_index {
-            if let Some(imp) = &self.current_imposter {
-                if let Some(stub) = imp.stubs.get(idx) {
-                    let curl_cmd = self.generate_curl_command(stub, port);
-                    self.copy_to_clipboard(&curl_cmd);
-                    self.set_status(
-                        "Curl command copied to clipboard".to_string(),
-                        StatusLevel::Success,
-                    );
-                }
-            }
+        if let Some(idx) = stub_index
+            && let Some(imp) = &self.current_imposter
+            && let Some(stub) = imp.stubs.get(idx)
+        {
+            let curl_cmd = self.generate_curl_command(stub, port);
+            self.copy_to_clipboard(&curl_cmd);
+            self.set_status(
+                "Curl command copied to clipboard".to_string(),
+                StatusLevel::Success,
+            );
         }
     }
 }

--- a/crates/rift-tui/src/app/commands/imposters.rs
+++ b/crates/rift-tui/src/app/commands/imposters.rs
@@ -16,7 +16,7 @@ impl App {
                 }
                 _ => {
                     self.set_status(
-                        format!("Failed to load imposter :{}", port),
+                        format!("Failed to load imposter :{port}"),
                         StatusLevel::Error,
                     );
                 }
@@ -54,15 +54,12 @@ impl App {
                     } else {
                         "enabled"
                     };
-                    self.set_status(
-                        format!("Imposter :{} {}", port, action),
-                        StatusLevel::Success,
-                    );
+                    self.set_status(format!("Imposter :{port} {action}"), StatusLevel::Success);
                     self.refresh().await;
                 }
                 Err(e) => {
                     self.set_status(
-                        format!("Failed to toggle imposter: {}", e),
+                        format!("Failed to toggle imposter: {e}"),
                         StatusLevel::Error,
                     );
                 }
@@ -79,7 +76,7 @@ impl App {
                     imp.port,
                     imp.name
                         .as_ref()
-                        .map(|n| format!(" ({})", n))
+                        .map(|n| format!(" ({n})"))
                         .unwrap_or_default()
                 ),
                 action: PendingAction::DeleteImposter { port: imp.port },
@@ -92,14 +89,14 @@ impl App {
         self.is_loading = true;
         match self.client.delete_imposter(port).await {
             Ok(_) => {
-                self.set_status(format!("Deleted imposter :{}", port), StatusLevel::Success);
+                self.set_status(format!("Deleted imposter :{port}"), StatusLevel::Success);
                 self.refresh().await;
                 if matches!(self.view, View::ImposterDetail { port: p } if p == port) {
                     self.view = View::ImposterList;
                 }
             }
             Err(e) => {
-                self.set_status(format!("Failed to delete: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to delete: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;
@@ -153,12 +150,12 @@ impl App {
         self.is_loading = true;
         match self.client.create_imposter(request).await {
             Ok(port) => {
-                self.set_status(format!("Created imposter :{}", port), StatusLevel::Success);
+                self.set_status(format!("Created imposter :{port}"), StatusLevel::Success);
                 self.overlay = Overlay::None;
                 self.refresh().await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to create: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to create: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;

--- a/crates/rift-tui/src/app/commands/imposters.rs
+++ b/crates/rift-tui/src/app/commands/imposters.rs
@@ -8,15 +8,18 @@ impl App {
         if let Some(imp) = self.selected_imposter() {
             let port = imp.port;
             self.is_loading = true;
-            if let Ok(detail) = self.client.get_imposter(port).await {
-                self.current_imposter = Some(detail);
-                self.stub_list_state.select(Some(0));
-                self.navigate(View::ImposterDetail { port });
-            } else {
-                self.set_status(
-                    format!("Failed to load imposter :{}", port),
-                    StatusLevel::Error,
-                );
+            match self.client.get_imposter(port).await {
+                Ok(detail) => {
+                    self.current_imposter = Some(detail);
+                    self.stub_list_state.select(Some(0));
+                    self.navigate(View::ImposterDetail { port });
+                }
+                _ => {
+                    self.set_status(
+                        format!("Failed to load imposter :{}", port),
+                        StatusLevel::Error,
+                    );
+                }
             }
             self.is_loading = false;
         }

--- a/crates/rift-tui/src/app/commands/io.rs
+++ b/crates/rift-tui/src/app/commands/io.rs
@@ -85,10 +85,10 @@ impl App {
             if let Some(home) = dirs::home_dir() {
                 return home.join(rest).to_string_lossy().to_string();
             }
-        } else if path == "~" {
-            if let Some(home) = dirs::home_dir() {
-                return home.to_string_lossy().to_string();
-            }
+        } else if path == "~"
+            && let Some(home) = dirs::home_dir()
+        {
+            return home.to_string_lossy().to_string();
         }
         path.to_string()
     }
@@ -230,20 +230,20 @@ impl App {
         if let Ok(entries) = std::fs::read_dir(path) {
             for entry in entries.flatten() {
                 let file_path = entry.path();
-                if file_path.extension().map(|e| e == "json").unwrap_or(false) {
-                    if let Ok(content) = std::fs::read_to_string(&file_path) {
-                        if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
-                            let url = format!("{}/imposters", self.client.base_url());
-                            let resp = self.client.client().post(url).json(&config).send().await;
+                if file_path.extension().map(|e| e == "json").unwrap_or(false)
+                    && let Ok(content) = std::fs::read_to_string(&file_path)
+                {
+                    if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
+                        let url = format!("{}/imposters", self.client.base_url());
+                        let resp = self.client.client().post(url).json(&config).send().await;
 
-                            if resp.map(|r| r.status().is_success()).unwrap_or(false) {
-                                imported += 1;
-                            } else {
-                                failed += 1;
-                            }
+                        if resp.map(|r| r.status().is_success()).unwrap_or(false) {
+                            imported += 1;
                         } else {
                             failed += 1;
                         }
+                    } else {
+                        failed += 1;
                     }
                 }
             }

--- a/crates/rift-tui/src/app/commands/io.rs
+++ b/crates/rift-tui/src/app/commands/io.rs
@@ -14,15 +14,9 @@ impl App {
         match self.client.export_imposter(port, remove_proxies).await {
             Ok(json) => {
                 let title = if remove_proxies {
-                    format!(
-                        "Exported Stubs (Port :{}) - [s]ave [c]opy [A]pply [Esc]close",
-                        port
-                    )
+                    format!("Exported Stubs (Port :{port}) - [s]ave [c]opy [A]pply [Esc]close")
                 } else {
-                    format!(
-                        "Exported Config (Port :{}) - [s]ave [c]opy [Esc]close",
-                        port
-                    )
+                    format!("Exported Config (Port :{port}) - [s]ave [c]opy [Esc]close")
                 };
                 self.overlay = Overlay::Export {
                     title,
@@ -31,7 +25,7 @@ impl App {
                 };
             }
             Err(e) => {
-                self.set_status(format!("Failed to export: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to export: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;
@@ -42,16 +36,13 @@ impl App {
         match arboard::Clipboard::new() {
             Ok(mut clipboard) => {
                 if let Err(e) = clipboard.set_text(content.to_string()) {
-                    self.set_status(format!("Failed to copy: {}", e), StatusLevel::Error);
+                    self.set_status(format!("Failed to copy: {e}"), StatusLevel::Error);
                 } else {
                     self.set_status("Copied to clipboard".to_string(), StatusLevel::Success);
                 }
             }
             Err(e) => {
-                self.set_status(
-                    format!("Clipboard not available: {}", e),
-                    StatusLevel::Error,
-                );
+                self.set_status(format!("Clipboard not available: {e}"), StatusLevel::Error);
             }
         }
     }
@@ -67,14 +58,14 @@ impl App {
     pub fn show_save_dialog(&mut self, content: String, port: u16) {
         // Generate default filename
         let default_path = dirs::home_dir()
-            .map(|h| h.join(format!("imposter-{}.json", port)))
-            .unwrap_or_else(|| std::path::PathBuf::from(format!("imposter-{}.json", port)));
+            .map(|h| h.join(format!("imposter-{port}.json")))
+            .unwrap_or_else(|| std::path::PathBuf::from(format!("imposter-{port}.json")));
 
         let path_str = default_path.to_string_lossy().to_string();
         self.input_state.cursor_pos = path_str.len();
         self.input_state.file_path = path_str;
         self.overlay = Overlay::FilePathInput {
-            prompt: format!("Save imposter :{} to file", port),
+            prompt: format!("Save imposter :{port} to file"),
             action: FileAction::SaveExport { content, port },
         };
     }
@@ -98,11 +89,11 @@ impl App {
         let expanded_path = Self::expand_path(path);
         match std::fs::write(&expanded_path, content) {
             Ok(_) => {
-                self.set_status(format!("Saved to {}", expanded_path), StatusLevel::Success);
+                self.set_status(format!("Saved to {expanded_path}"), StatusLevel::Success);
                 self.overlay = Overlay::None;
             }
             Err(e) => {
-                self.set_status(format!("Failed to save: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to save: {e}"), StatusLevel::Error);
             }
         }
     }
@@ -174,7 +165,7 @@ impl App {
                 self.do_import(&content).await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to read file: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to read file: {e}"), StatusLevel::Error);
             }
         }
 
@@ -196,15 +187,15 @@ impl App {
                     }
                     Ok(r) => {
                         let body = r.text().await.unwrap_or_default();
-                        self.set_status(format!("Failed to import: {}", body), StatusLevel::Error);
+                        self.set_status(format!("Failed to import: {body}"), StatusLevel::Error);
                     }
                     Err(e) => {
-                        self.set_status(format!("Failed to import: {}", e), StatusLevel::Error);
+                        self.set_status(format!("Failed to import: {e}"), StatusLevel::Error);
                     }
                 }
             }
             Err(e) => {
-                self.set_status(format!("Invalid JSON: {}", e), StatusLevel::Error);
+                self.set_status(format!("Invalid JSON: {e}"), StatusLevel::Error);
             }
         }
     }
@@ -217,7 +208,7 @@ impl App {
         let path = std::path::Path::new(&expanded_folder);
         if !path.is_dir() {
             self.set_status(
-                format!("{} is not a directory", expanded_folder),
+                format!("{expanded_folder} is not a directory"),
                 StatusLevel::Error,
             );
             self.is_loading = false;
@@ -251,12 +242,12 @@ impl App {
 
         if failed > 0 {
             self.set_status(
-                format!("Imported {} imposters, {} failed", imported, failed),
+                format!("Imported {imported} imposters, {failed} failed"),
                 StatusLevel::Warning,
             );
         } else {
             self.set_status(
-                format!("Imported {} imposters", imported),
+                format!("Imported {imported} imposters"),
                 StatusLevel::Success,
             );
         }
@@ -304,18 +295,15 @@ impl App {
         match self.client.export_all_imposters().await {
             Ok(json) => match std::fs::write(&expanded_path, &json) {
                 Ok(_) => {
-                    self.set_status(
-                        format!("Exported to {}", expanded_path),
-                        StatusLevel::Success,
-                    );
+                    self.set_status(format!("Exported to {expanded_path}"), StatusLevel::Success);
                     self.overlay = Overlay::None;
                 }
                 Err(e) => {
-                    self.set_status(format!("Failed to write: {}", e), StatusLevel::Error);
+                    self.set_status(format!("Failed to write: {e}"), StatusLevel::Error);
                 }
             },
             Err(e) => {
-                self.set_status(format!("Failed to export: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to export: {e}"), StatusLevel::Error);
             }
         }
 
@@ -331,10 +319,7 @@ impl App {
 
         // Create folder if it doesn't exist
         if let Err(e) = std::fs::create_dir_all(path) {
-            self.set_status(
-                format!("Failed to create folder: {}", e),
-                StatusLevel::Error,
-            );
+            self.set_status(format!("Failed to create folder: {e}"), StatusLevel::Error);
             self.is_loading = false;
             return;
         }
@@ -365,12 +350,12 @@ impl App {
 
         if failed > 0 {
             self.set_status(
-                format!("Exported {} imposters, {} failed", exported, failed),
+                format!("Exported {exported} imposters, {failed} failed"),
                 StatusLevel::Warning,
             );
         } else {
             self.set_status(
-                format!("Exported {} imposters to {}", exported, folder),
+                format!("Exported {exported} imposters to {folder}"),
                 StatusLevel::Success,
             );
         }

--- a/crates/rift-tui/src/app/commands/proxy.rs
+++ b/crates/rift-tui/src/app/commands/proxy.rs
@@ -59,14 +59,14 @@ impl App {
         {
             Ok(port) => {
                 self.set_status(
-                    format!("Created proxy imposter :{}", port),
+                    format!("Created proxy imposter :{port}"),
                     StatusLevel::Success,
                 );
                 self.overlay = Overlay::None;
                 self.refresh().await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to create: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to create: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;
@@ -81,8 +81,7 @@ impl App {
 
         self.overlay = Overlay::Confirm {
             message: format!(
-                "Apply recorded stubs to :{}?\nThis will remove proxy stubs and replace with recorded responses.",
-                port
+                "Apply recorded stubs to :{port}?\nThis will remove proxy stubs and replace with recorded responses."
             ),
             action: PendingAction::ApplyRecordedStubs { port },
         };
@@ -108,7 +107,7 @@ impl App {
 
                         // Delete and recreate imposter with new stubs
                         if let Err(e) = self.client.delete_imposter(port).await {
-                            self.set_status(format!("Failed to apply: {}", e), StatusLevel::Error);
+                            self.set_status(format!("Failed to apply: {e}"), StatusLevel::Error);
                             self.is_loading = false;
                             self.overlay = Overlay::None;
                             return;
@@ -121,7 +120,7 @@ impl App {
                         match resp {
                             Ok(r) if r.status().is_success() => {
                                 self.set_status(
-                                    format!("Applied recorded stubs to :{}", port),
+                                    format!("Applied recorded stubs to :{port}"),
                                     StatusLevel::Success,
                                 );
                                 self.refresh().await;
@@ -134,22 +133,19 @@ impl App {
                             }
                             Err(e) => {
                                 self.set_status(
-                                    format!("Failed to apply: {}", e),
+                                    format!("Failed to apply: {e}"),
                                     StatusLevel::Error,
                                 );
                             }
                         }
                     }
                     Err(e) => {
-                        self.set_status(
-                            format!("Failed to parse config: {}", e),
-                            StatusLevel::Error,
-                        );
+                        self.set_status(format!("Failed to parse config: {e}"), StatusLevel::Error);
                     }
                 }
             }
             Err(e) => {
-                self.set_status(format!("Failed to export: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to export: {e}"), StatusLevel::Error);
             }
         }
 
@@ -166,7 +162,7 @@ impl App {
 
         if let Some(port) = port {
             self.overlay = Overlay::Confirm {
-                message: format!("Clear all proxy recordings for :{}?", port),
+                message: format!("Clear all proxy recordings for :{port}?"),
                 action: PendingAction::ClearProxyResponses { port },
             };
         }
@@ -181,7 +177,7 @@ impl App {
                 self.refresh().await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to clear: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to clear: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;
@@ -197,7 +193,7 @@ impl App {
 
         if let Some(port) = port {
             self.overlay = Overlay::Confirm {
-                message: format!("Clear all recorded requests for :{}?", port),
+                message: format!("Clear all recorded requests for :{port}?"),
                 action: PendingAction::ClearRequests { port },
             };
         }
@@ -215,7 +211,7 @@ impl App {
                 self.refresh().await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to clear: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to clear: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;

--- a/crates/rift-tui/src/app/commands/stubs.rs
+++ b/crates/rift-tui/src/app/commands/stubs.rs
@@ -70,7 +70,7 @@ impl App {
                         self.refresh().await;
                     }
                     Err(e) => {
-                        self.set_status(format!("Failed to save: {}", e), StatusLevel::Error);
+                        self.set_status(format!("Failed to save: {e}"), StatusLevel::Error);
                     }
                 }
                 self.is_loading = false;
@@ -115,7 +115,7 @@ impl App {
             && let Some(idx) = self.stub_list_state.selected()
         {
             self.overlay = Overlay::Confirm {
-                message: format!("Delete stub #{} from :{}?", idx, port),
+                message: format!("Delete stub #{idx} from :{port}?"),
                 action: PendingAction::DeleteStub { port, index: idx },
             };
         }
@@ -130,7 +130,7 @@ impl App {
                 self.refresh().await;
             }
             Err(e) => {
-                self.set_status(format!("Failed to delete: {}", e), StatusLevel::Error);
+                self.set_status(format!("Failed to delete: {e}"), StatusLevel::Error);
             }
         }
         self.is_loading = false;
@@ -138,9 +138,8 @@ impl App {
     }
 
     pub(in super::super) async fn reorder_stub(&mut self, direction: i32) {
-        let port = match self.view {
-            View::ImposterDetail { port } => port,
-            _ => return,
+        let View::ImposterDetail { port } = self.view else {
+            return;
         };
         if let Some(idx) = self.stub_list_state.selected() {
             let new_idx = idx as i32 + direction;
@@ -164,7 +163,7 @@ impl App {
                         self.refresh().await;
                     }
                     Err(e) => {
-                        self.set_status(format!("Failed to reorder: {}", e), StatusLevel::Error);
+                        self.set_status(format!("Failed to reorder: {e}"), StatusLevel::Error);
                         // Refresh to restore correct order
                         self.refresh().await;
                     }
@@ -197,9 +196,7 @@ impl App {
                     self.set_status("Stub duplicated".to_string(), StatusLevel::Success);
                     self.refresh().await;
                 }
-                Err(e) => {
-                    self.set_status(format!("Failed to duplicate: {}", e), StatusLevel::Error)
-                }
+                Err(e) => self.set_status(format!("Failed to duplicate: {e}"), StatusLevel::Error),
             }
             self.is_loading = false;
         }

--- a/crates/rift-tui/src/app/commands/stubs.rs
+++ b/crates/rift-tui/src/app/commands/stubs.rs
@@ -17,15 +17,15 @@ impl App {
             _ => return,
         };
 
-        if let Some(imp) = &self.current_imposter {
-            if let Some(stub) = imp.stubs.get(idx) {
-                let json = serde_json::to_string_pretty(stub).unwrap_or_default();
-                self.stub_editor = Some(StubEditor::new(&json));
-                self.navigate(View::StubEdit {
-                    port,
-                    index: Some(idx),
-                });
-            }
+        if let Some(imp) = &self.current_imposter
+            && let Some(stub) = imp.stubs.get(idx)
+        {
+            let json = serde_json::to_string_pretty(stub).unwrap_or_default();
+            self.stub_editor = Some(StubEditor::new(&json));
+            self.navigate(View::StubEdit {
+                port,
+                index: Some(idx),
+            });
         }
     }
 
@@ -52,28 +52,28 @@ impl App {
                 return;
             }
 
-            if let Some(stub) = editor.get_stub() {
-                if let View::StubEdit { port, index } = self.view {
-                    self.is_loading = true;
-                    let result = if let Some(idx) = index {
-                        self.client.update_stub(port, idx, stub).await
-                    } else {
-                        self.client.add_stub(port, stub, None).await
-                    };
+            if let Some(stub) = editor.get_stub()
+                && let View::StubEdit { port, index } = self.view
+            {
+                self.is_loading = true;
+                let result = if let Some(idx) = index {
+                    self.client.update_stub(port, idx, stub).await
+                } else {
+                    self.client.add_stub(port, stub, None).await
+                };
 
-                    match result {
-                        Ok(_) => {
-                            self.set_status("Stub saved".to_string(), StatusLevel::Success);
-                            self.stub_editor = None;
-                            self.go_back();
-                            self.refresh().await;
-                        }
-                        Err(e) => {
-                            self.set_status(format!("Failed to save: {}", e), StatusLevel::Error);
-                        }
+                match result {
+                    Ok(_) => {
+                        self.set_status("Stub saved".to_string(), StatusLevel::Success);
+                        self.stub_editor = None;
+                        self.go_back();
+                        self.refresh().await;
                     }
-                    self.is_loading = false;
+                    Err(e) => {
+                        self.set_status(format!("Failed to save: {}", e), StatusLevel::Error);
+                    }
                 }
+                self.is_loading = false;
             }
         }
     }
@@ -111,13 +111,13 @@ impl App {
 
     /// Confirm delete stub
     pub fn confirm_delete_stub(&mut self) {
-        if let View::ImposterDetail { port } = self.view {
-            if let Some(idx) = self.stub_list_state.selected() {
-                self.overlay = Overlay::Confirm {
-                    message: format!("Delete stub #{} from :{}?", idx, port),
-                    action: PendingAction::DeleteStub { port, index: idx },
-                };
-            }
+        if let View::ImposterDetail { port } = self.view
+            && let Some(idx) = self.stub_list_state.selected()
+        {
+            self.overlay = Overlay::Confirm {
+                message: format!("Delete stub #{} from :{}?", idx, port),
+                action: PendingAction::DeleteStub { port, index: idx },
+            };
         }
     }
 
@@ -184,25 +184,24 @@ impl App {
             View::ImposterDetail { .. } => self.stub_list_state.selected(),
             _ => None,
         };
-        if let Some(idx) = idx {
-            if let Some(stub) = self
+        if let Some(idx) = idx
+            && let Some(stub) = self
                 .current_imposter
                 .as_ref()
                 .and_then(|imp| imp.stubs.get(idx))
                 .cloned()
-            {
-                self.is_loading = true;
-                match self.client.add_stub(port, stub, None).await {
-                    Ok(_) => {
-                        self.set_status("Stub duplicated".to_string(), StatusLevel::Success);
-                        self.refresh().await;
-                    }
-                    Err(e) => {
-                        self.set_status(format!("Failed to duplicate: {}", e), StatusLevel::Error)
-                    }
+        {
+            self.is_loading = true;
+            match self.client.add_stub(port, stub, None).await {
+                Ok(_) => {
+                    self.set_status("Stub duplicated".to_string(), StatusLevel::Success);
+                    self.refresh().await;
                 }
-                self.is_loading = false;
+                Err(e) => {
+                    self.set_status(format!("Failed to duplicate: {}", e), StatusLevel::Error)
+                }
             }
+            self.is_loading = false;
         }
     }
 }

--- a/crates/rift-tui/src/app/events.rs
+++ b/crates/rift-tui/src/app/events.rs
@@ -178,7 +178,7 @@ impl App {
                     self.set_status("Config refreshed".to_string(), StatusLevel::Success);
                 }
                 Err(e) => {
-                    self.set_status(format!("Failed to load config: {}", e), StatusLevel::Error)
+                    self.set_status(format!("Failed to load config: {e}"), StatusLevel::Error)
                 }
             }
         }
@@ -210,7 +210,7 @@ impl App {
                 self.server_config = Some(cfg);
                 self.navigate(View::Config);
             }
-            Err(e) => self.set_status(format!("Failed to load config: {}", e), StatusLevel::Error),
+            Err(e) => self.set_status(format!("Failed to load config: {e}"), StatusLevel::Error),
         }
         self.is_loading = false;
     }

--- a/crates/rift-tui/src/app/events.rs
+++ b/crates/rift-tui/src/app/events.rs
@@ -303,16 +303,16 @@ impl App {
                         self.copy_to_clipboard(&text);
                     }
                     Some(EditorAction::PasteRequest) => {
-                        if let Some(text) = self.paste_from_clipboard() {
-                            if let Some(editor) = &mut self.stub_editor {
-                                editor.editor.set_yank_text(text.clone());
-                                editor.editor.input(ratatui_textarea::Input {
-                                    key: ratatui_textarea::Key::Char('y'),
-                                    ctrl: true,
-                                    alt: false,
-                                    shift: false,
-                                });
-                            }
+                        if let Some(text) = self.paste_from_clipboard()
+                            && let Some(editor) = &mut self.stub_editor
+                        {
+                            editor.editor.set_yank_text(text.clone());
+                            editor.editor.input(ratatui_textarea::Input {
+                                key: ratatui_textarea::Key::Char('y'),
+                                ctrl: true,
+                                alt: false,
+                                shift: false,
+                            });
                         }
                     }
                     None => {}

--- a/crates/rift-tui/src/app/mod.rs
+++ b/crates/rift-tui/src/app/mod.rs
@@ -202,7 +202,7 @@ impl StubEditor {
                 true
             }
             Err(e) => {
-                self.validation_error = Some(format!("JSON error: {}", e));
+                self.validation_error = Some(format!("JSON error: {e}"));
                 self.validation_report = None;
                 false
             }
@@ -478,10 +478,7 @@ impl App {
                 }
             }
             Err(e) => {
-                self.set_status(
-                    format!("Failed to load imposters: {}", e),
-                    StatusLevel::Error,
-                );
+                self.set_status(format!("Failed to load imposters: {e}"), StatusLevel::Error);
             }
         }
 

--- a/crates/rift-tui/src/app/mod.rs
+++ b/crates/rift-tui/src/app/mod.rs
@@ -4,7 +4,7 @@ use crate::api::{
     ApiClient, CreateImposterRequest, ImposterDetail, ImposterSummary, MetricsData, Stub,
 };
 use crate::theme::Theme;
-use crate::validation::{validate_imposter_json, validate_stub_json, ValidationReport};
+use crate::validation::{ValidationReport, validate_imposter_json, validate_stub_json};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::ListState;
 use std::collections::{HashMap, VecDeque};
@@ -218,21 +218,21 @@ impl StubEditor {
     /// Format the JSON content
     pub fn format(&mut self) {
         let content = self.editor.lines().join("\n");
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Ok(pretty) = serde_json::to_string_pretty(&val) {
-                let lines: Vec<String> = pretty.lines().map(String::from).collect();
-                self.editor = ratatui_textarea::TextArea::new(lines);
-                self.editor.set_line_number_style(
-                    ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
-                );
-                self.editor
-                    .set_cursor_line_style(ratatui::style::Style::default());
-                self.editor.set_block(
-                    ratatui::widgets::Block::default()
-                        .borders(ratatui::widgets::Borders::ALL)
-                        .title(" Edit Stub (Ctrl+S save, Ctrl+F format, Ctrl+L lint, Esc cancel) "),
-                );
-            }
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Ok(pretty) = serde_json::to_string_pretty(&val)
+        {
+            let lines: Vec<String> = pretty.lines().map(String::from).collect();
+            self.editor = ratatui_textarea::TextArea::new(lines);
+            self.editor.set_line_number_style(
+                ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray),
+            );
+            self.editor
+                .set_cursor_line_style(ratatui::style::Style::default());
+            self.editor.set_block(
+                ratatui::widgets::Block::default()
+                    .borders(ratatui::widgets::Borders::ALL)
+                    .title(" Edit Stub (Ctrl+S save, Ctrl+F format, Ctrl+L lint, Esc cancel) "),
+            );
         }
     }
 
@@ -291,7 +291,7 @@ pub(super) fn crossterm_key_to_input(key: KeyEvent) -> ratatui_textarea::Input {
                 ctrl,
                 alt,
                 shift: true,
-            }
+            };
         }
         KeyCode::Delete => Key::Delete,
         KeyCode::Home => Key::Home,
@@ -469,11 +469,11 @@ impl App {
                 if !self.imposters.is_empty() {
                     if self.imposter_list_state.selected().is_none() {
                         self.imposter_list_state.select(Some(0));
-                    } else if let Some(idx) = self.imposter_list_state.selected() {
-                        if idx >= self.imposters.len() {
-                            self.imposter_list_state
-                                .select(Some(self.imposters.len() - 1));
-                        }
+                    } else if let Some(idx) = self.imposter_list_state.selected()
+                        && idx >= self.imposters.len()
+                    {
+                        self.imposter_list_state
+                            .select(Some(self.imposters.len() - 1));
                     }
                 }
             }
@@ -506,10 +506,10 @@ impl App {
         }
 
         // Refresh current imposter if viewing detail
-        if let View::ImposterDetail { port } | View::StubDetail { port, .. } = self.view {
-            if let Ok(detail) = self.client.get_imposter(port).await {
-                self.current_imposter = Some(detail);
-            }
+        if let View::ImposterDetail { port } | View::StubDetail { port, .. } = self.view
+            && let Ok(detail) = self.client.get_imposter(port).await
+        {
+            self.current_imposter = Some(detail);
         }
 
         self.is_loading = false;
@@ -523,10 +523,10 @@ impl App {
 
     /// Clear status if expired
     pub fn clear_expired_status(&mut self) {
-        if let Some((_, _, time)) = &self.status_message {
-            if time.elapsed() > Duration::from_secs(5) {
-                self.status_message = None;
-            }
+        if let Some((_, _, time)) = &self.status_message
+            && time.elapsed() > Duration::from_secs(5)
+        {
+            self.status_message = None;
         }
     }
 

--- a/crates/rift-tui/src/app/search.rs
+++ b/crates/rift-tui/src/app/search.rs
@@ -194,11 +194,10 @@ impl App {
                 let filtered = self.filtered_imposters();
                 if !filtered.is_empty() {
                     // Find the index of the first matching imposter in the original list
-                    if let Some(first) = filtered.first() {
-                        if let Some(idx) = self.imposters.iter().position(|i| i.port == first.port)
-                        {
-                            self.imposter_list_state.select(Some(idx));
-                        }
+                    if let Some(first) = filtered.first()
+                        && let Some(idx) = self.imposters.iter().position(|i| i.port == first.port)
+                    {
+                        self.imposter_list_state.select(Some(idx));
                     }
                 }
             }

--- a/crates/rift-tui/src/event.rs
+++ b/crates/rift-tui/src/event.rs
@@ -39,20 +39,18 @@ impl EventHandler {
                     }
                     _ = tokio::time::sleep(Duration::from_millis(50)) => {
                         // Poll for crossterm events
-                        if event::poll(Duration::from_millis(0)).unwrap_or(false) {
-                            if let Ok(evt) = event::read() {
+                        if event::poll(Duration::from_millis(0)).unwrap_or(false)
+                            && let Ok(evt) = event::read() {
                                 let event = match evt {
                                     CrosstermEvent::Key(key) => Some(Event::Key(key)),
                                     CrosstermEvent::Resize(w, h) => Some(Event::Resize(w, h)),
                                     _ => None,
                                 };
-                                if let Some(e) = event {
-                                    if tx_clone.send(e).is_err() {
+                                if let Some(e) = event
+                                    && tx_clone.send(e).is_err() {
                                         break;
                                     }
-                                }
                             }
-                        }
                     }
                 }
             }

--- a/crates/rift-tui/src/lib.rs
+++ b/crates/rift-tui/src/lib.rs
@@ -39,9 +39,9 @@ pub use theme::Theme;
 use crossterm::{
     event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
 
 /// Run the TUI application with the given app state.

--- a/crates/rift-tui/src/theme.rs
+++ b/crates/rift-tui/src/theme.rs
@@ -192,8 +192,7 @@ mod tests {
         for preset in ThemePreset::ALL {
             assert!(
                 !preset.name().is_empty(),
-                "preset {:?} has empty name",
-                preset
+                "preset {preset:?} has empty name"
             );
         }
     }

--- a/crates/rift-tui/src/ui/config.rs
+++ b/crates/rift-tui/src/ui/config.rs
@@ -2,11 +2,11 @@
 
 use crate::app::App;
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-    Frame,
 };
 
 /// Draw the server configuration view

--- a/crates/rift-tui/src/ui/config.rs
+++ b/crates/rift-tui/src/ui/config.rs
@@ -77,7 +77,7 @@ fn render_json_as_lines<'a>(value: &serde_json::Value, app: &'a App) -> Vec<Line
                 Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
-                        format!("{:<24}", k),
+                        format!("{k:<24}"),
                         Style::default()
                             .fg(app.theme.key_fg)
                             .add_modifier(Modifier::BOLD),

--- a/crates/rift-tui/src/ui/dialogs.rs
+++ b/crates/rift-tui/src/ui/dialogs.rs
@@ -80,7 +80,7 @@ pub fn draw_confirm(frame: &mut Frame, message: &str) {
 
 /// Draw an error dialog using tui-popup
 pub fn draw_error(frame: &mut Frame, message: &str) {
-    let content = format!("\n{}\n\nPress Esc to close", message);
+    let content = format!("\n{message}\n\nPress Esc to close");
 
     let popup = Popup::new(content)
         .title(" Error ")
@@ -92,7 +92,7 @@ pub fn draw_error(frame: &mut Frame, message: &str) {
 
 /// Draw a success message dialog using tui-popup
 pub fn draw_success(frame: &mut Frame, message: &str) {
-    let content = format!("\n{}\n\nPress any key to continue", message);
+    let content = format!("\n{message}\n\nPress any key to continue");
 
     let popup = Popup::new(content)
         .title(" Success ")
@@ -127,9 +127,9 @@ fn draw_input_field(
     };
 
     let title = if focused {
-        format!(" ▶ {} ", label)
+        format!(" ▶ {label} ")
     } else {
-        format!("   {} ", label)
+        format!("   {label} ")
     };
 
     let block = Block::default()
@@ -197,7 +197,7 @@ fn draw_create_imposter_input(frame: &mut Frame, app: &App, prompt: &str) {
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(format!(" {} ", prompt))
+        .title(format!(" {prompt} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
@@ -276,7 +276,7 @@ fn draw_create_proxy_input(frame: &mut Frame, app: &App, prompt: &str) {
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(format!(" {} ", prompt))
+        .title(format!(" {prompt} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
@@ -411,7 +411,7 @@ pub fn draw_export(
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(format!(" {} ", title))
+        .title(format!(" {title} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Green))
@@ -489,7 +489,7 @@ pub fn draw_file_path_input(frame: &mut Frame, app: &App, prompt: &str) {
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(format!(" {} ", prompt))
+        .title(format!(" {prompt} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))

--- a/crates/rift-tui/src/ui/dialogs.rs
+++ b/crates/rift-tui/src/ui/dialogs.rs
@@ -3,13 +3,13 @@
 use crate::app::{App, InputAction, ValidationAction};
 use crate::validation::{IssueSeverity, ValidationReport};
 use ratatui::{
+    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
         Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
     },
-    Frame,
 };
 use tui_popup::Popup;
 

--- a/crates/rift-tui/src/ui/help.rs
+++ b/crates/rift-tui/src/ui/help.rs
@@ -1,11 +1,11 @@
 //! Help overlay with scroll support
 
 use ratatui::{
+    Frame,
     layout::Alignment,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
-    Frame,
 };
 
 /// Draw the help overlay with scrolling

--- a/crates/rift-tui/src/ui/help.rs
+++ b/crates/rift-tui/src/ui/help.rs
@@ -144,7 +144,7 @@ fn build_help_text() -> Vec<Line<'static>> {
 
 fn section_header(title: &'static str) -> Line<'static> {
     Line::from(Span::styled(
-        format!("  {}", title),
+        format!("  {title}"),
         Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
     ))
 }
@@ -152,7 +152,7 @@ fn section_header(title: &'static str) -> Line<'static> {
 fn help_line(key: &'static str, desc: &'static str) -> Line<'static> {
     Line::from(vec![
         Span::styled(
-            format!("  {:<16}", key),
+            format!("  {key:<16}"),
             Style::default().add_modifier(Modifier::BOLD),
         ),
         Span::raw(desc),

--- a/crates/rift-tui/src/ui/imposter_detail.rs
+++ b/crates/rift-tui/src/ui/imposter_detail.rs
@@ -105,7 +105,7 @@ fn draw_info_panel(frame: &mut Frame, app: &App, port: u16, area: Rect) {
     };
 
     let block = Block::default()
-        .title(format!(" Imposter :{} ", port))
+        .title(format!(" Imposter :{port} "))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(app.theme.border));
 
@@ -134,11 +134,11 @@ fn build_stub_summary(stubs: &[crate::api::Stub], max_width: usize) -> String {
     let mut summary = format!("{} total", stubs.len());
 
     if scenario_count > 0 {
-        summary.push_str(&format!(", {} scenarios", scenario_count));
+        summary.push_str(&format!(", {scenario_count} scenarios"));
     }
 
     if proxy_count > 0 {
-        summary.push_str(&format!(", {} proxy", proxy_count));
+        summary.push_str(&format!(", {proxy_count} proxy"));
     }
 
     // Add first few scenario names if there's space
@@ -221,7 +221,7 @@ fn draw_stubs_panel(frame: &mut Frame, app: &App, area: Rect) {
 
             let pred_count = stub.predicates.len();
             let resp_count = stub.responses.len();
-            let counts = format!(" {}p {}r", pred_count, resp_count);
+            let counts = format!(" {pred_count}p {resp_count}r");
 
             let line = Line::from(vec![
                 Span::styled(
@@ -240,9 +240,9 @@ fn draw_stubs_panel(frame: &mut Frame, app: &App, area: Rect) {
                     format!("#{:<2}", i + 1),
                     Style::default().fg(app.theme.muted),
                 ),
-                Span::styled(format!(" {} ", display_name), Style::default().fg(fg_color)),
+                Span::styled(format!(" {display_name} "), Style::default().fg(fg_color)),
                 Span::styled(
-                    format!("[{}]", response_type),
+                    format!("[{response_type}]"),
                     Style::default().fg(response_color),
                 ),
                 Span::styled(counts, Style::default().fg(app.theme.muted)),
@@ -523,7 +523,7 @@ fn summarize_predicates(predicates: &[serde_json::Value]) -> String {
                     }
                 }
                 "contains" | "startsWith" | "endsWith" | "matches" => {
-                    return format!("{} ...", key);
+                    return format!("{key} ...");
                 }
                 "and" | "or" => {
                     if let Some(arr) = value.as_array() {

--- a/crates/rift-tui/src/ui/imposter_detail.rs
+++ b/crates/rift-tui/src/ui/imposter_detail.rs
@@ -2,11 +2,11 @@
 
 use crate::app::{App, FocusArea};
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph},
-    Frame,
 };
 
 /// Draw the imposter detail view

--- a/crates/rift-tui/src/ui/imposters.rs
+++ b/crates/rift-tui/src/ui/imposters.rs
@@ -2,11 +2,11 @@
 
 use crate::app::App;
 use ratatui::{
+    Frame,
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem},
-    Frame,
 };
 
 /// Draw the imposter list view

--- a/crates/rift-tui/src/ui/imposters.rs
+++ b/crates/rift-tui/src/ui/imposters.rs
@@ -50,7 +50,7 @@ pub fn draw_list(frame: &mut Frame, app: &App, area: Rect) {
                         app.theme.highlight_bg
                     }),
                 ),
-                Span::styled(format!("{} ", status), Style::default().fg(status_color)),
+                Span::styled(format!("{status} "), Style::default().fg(status_color)),
                 Span::styled(
                     format!(":{:<5}", imp.port),
                     Style::default().fg(fg_color).add_modifier(if dim {

--- a/crates/rift-tui/src/ui/metrics.rs
+++ b/crates/rift-tui/src/ui/metrics.rs
@@ -2,11 +2,11 @@
 
 use crate::app::App;
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Bar, BarChart, BarGroup, Block, Borders, Paragraph, Sparkline},
-    Frame,
 };
 
 /// Draw the metrics view

--- a/crates/rift-tui/src/ui/metrics.rs
+++ b/crates/rift-tui/src/ui/metrics.rs
@@ -51,7 +51,7 @@ fn draw_summary(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("    │    ", Style::default().fg(app.theme.border)),
             Span::styled("Rate: ", Style::default().fg(app.theme.muted)),
             Span::styled(
-                format!("{:.1} req/s", total_rate),
+                format!("{total_rate:.1} req/s"),
                 Style::default().fg(app.theme.success),
             ),
         ]),
@@ -182,7 +182,7 @@ fn draw_sparklines(frame: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             )),
             Line::from(Span::styled(
-                format!("{:.1}/s", rate),
+                format!("{rate:.1}/s"),
                 Style::default().fg(if rate > 0.0 {
                     app.theme.success
                 } else {

--- a/crates/rift-tui/src/ui/mod.rs
+++ b/crates/rift-tui/src/ui/mod.rs
@@ -138,12 +138,9 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             StatusLevel::Warning => app.theme.warning,
             StatusLevel::Error => app.theme.error,
         };
-        let paragraph = Paragraph::new(Span::styled(
-            format!(" {}", msg),
-            Style::default().fg(color),
-        ))
-        .block(block)
-        .alignment(Alignment::Left);
+        let paragraph = Paragraph::new(Span::styled(format!(" {msg}"), Style::default().fg(color)))
+            .block(block)
+            .alignment(Alignment::Left);
         frame.render_widget(paragraph, area);
     } else {
         let (commands1, commands2) = get_commands(&app.view);
@@ -174,14 +171,14 @@ fn build_command_line(commands: &[Command], app: &App) -> Line<'static> {
         }
         // Key in brackets with accent color
         spans.push(Span::styled(
-            format!("[{}]", key),
+            format!("[{key}]"),
             Style::default()
                 .fg(app.theme.key_fg)
                 .add_modifier(Modifier::BOLD),
         ));
         // Label in muted color
         spans.push(Span::styled(
-            format!(" {}", label),
+            format!(" {label}"),
             Style::default().fg(app.theme.cmd_fg),
         ));
     }
@@ -362,11 +359,11 @@ pub fn format_uptime(duration: std::time::Duration) -> String {
     let secs = secs % 60;
 
     if hours > 0 {
-        format!("{}h {}m {}s", hours, mins, secs)
+        format!("{hours}h {mins}m {secs}s")
     } else if mins > 0 {
-        format!("{}m {}s", mins, secs)
+        format!("{mins}m {secs}s")
     } else {
-        format!("{}s", secs)
+        format!("{secs}s")
     }
 }
 

--- a/crates/rift-tui/src/ui/mod.rs
+++ b/crates/rift-tui/src/ui/mod.rs
@@ -11,11 +11,11 @@ mod stubs;
 
 use crate::app::{App, Overlay, StatusLevel, View};
 use ratatui::{
+    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-    Frame,
 };
 
 /// Main draw function
@@ -374,7 +374,7 @@ pub fn format_uptime(duration: std::time::Duration) -> String {
 mod tests {
     use super::*;
     use crate::app::tests::{make_imposter, make_test_app};
-    use ratatui::{backend::TestBackend, Terminal};
+    use ratatui::{Terminal, backend::TestBackend};
 
     // ─── format_number ────────────────────────────────────────────────────────
 

--- a/crates/rift-tui/src/ui/request_detail.rs
+++ b/crates/rift-tui/src/ui/request_detail.rs
@@ -2,11 +2,11 @@
 
 use crate::app::App;
 use ratatui::{
+    Frame,
     layout::Rect,
     style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
-    Frame,
 };
 
 /// Draw the full request detail for a single recorded request

--- a/crates/rift-tui/src/ui/stubs.rs
+++ b/crates/rift-tui/src/ui/stubs.rs
@@ -2,11 +2,11 @@
 
 use crate::app::App;
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
-    Frame,
 };
 
 /// Draw stub detail view

--- a/crates/rift-tui/src/validation.rs
+++ b/crates/rift-tui/src/validation.rs
@@ -3,7 +3,7 @@
 //! This module provides validation capabilities using the `rift-lint` library
 //! to validate configurations before importing or saving them.
 
-use rift_lint::{lint_json, lint_value, validate_stub, LintOptions, LintResult, Severity};
+use rift_lint::{LintOptions, LintResult, Severity, lint_json, lint_value, validate_stub};
 use std::path::PathBuf;
 
 /// Validate an imposter configuration from a JSON string.

--- a/crates/rift-types/Cargo.toml
+++ b/crates/rift-types/Cargo.toml
@@ -13,5 +13,5 @@ description = "Shared core types for the Rift workspace (imposters, stubs, predi
 workspace = true
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/rift-types/src/predicate.rs
+++ b/crates/rift-types/src/predicate.rs
@@ -146,10 +146,12 @@ mod tests {
         // empty `except` is omitted from the wire form (skip_serializing_if)
         let empty: Predicate =
             serde_json::from_value(json!({ "matches": { "path": "/x" } })).unwrap();
-        assert!(serde_json::to_value(&empty)
-            .unwrap()
-            .get("except")
-            .is_none());
+        assert!(
+            serde_json::to_value(&empty)
+                .unwrap()
+                .get("except")
+                .is_none()
+        );
     }
 
     #[test]

--- a/tests/compatibility/Cargo.toml
+++ b/tests/compatibility/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rift-compatibility-tests"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Modernizes the workspace in three independently-reviewable/revertible commits (each maps to a phase in the issue):

- **Edition 2024** (`cargo fix --edition` + `edition = "2024"`): `#[unsafe(no_mangle)]`, `unsafe{}` around test `env::set_var`, let-chains unlocked (collapsed nested ifs).
- **Dependency consolidation**: `[workspace.dependencies]` is now the single source of truth (crates use `<dep>.workspace = true`); pins bumped to reality (thiserror 2.0, tokio 1.41, reqwest 0.12, clap 4.5, bytes 1.7, uuid 1.8, rhai =1.21.0), unifying the thiserror 1↔2 / clap splits. Dropped dead deps (async-trait, tonic, tonic-build, prost); migrated the last `once_cell::sync::Lazy` → `std::sync::LazyLock`; aligned rift-lint boa_engine 0.19→0.20.
- **Workspace idiom lints**: added `uninlined_format_args`, `manual_let_else`, `unnecessary_map_or` = "warn"; swept the code to those idioms (format-arg inlining + match→let-else, hand-done where machine-unsafe with side effects preserved).

Verification: `cargo fmt` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, tests pass (the 4 `redis_backend` tests require a Docker daemon). Out of scope: `rust-toolchain.toml`/`deny.toml`, `serde_yaml` fork, full `clippy::pedantic`, and the opportunistic `is_some_and` sweep.

Closes #285

Milestone: standalone chore (own PR + release)