### PR TITLE
Incremental apply_config + imposter change events + stable stub keys; use in /admin/reload

### DIFF
--- a/crates/rift-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-core/src/imposter/core/lifecycle.rs
@@ -3,8 +3,29 @@
 //! Part of the `Imposter` implementation; see `core/mod.rs` for the struct definition.
 
 use super::*;
+use crate::imposter::reconcile::{StubReconcile, reconcile_stub_states};
 
 impl Imposter {
+    /// Move the stub at `from` to position `to`, carrying its cycling state with it
+    /// (issue #316). Stub order is match priority, so this changes matching precedence.
+    pub fn move_stub(&self, from: usize, to: usize) -> Result<(), ImposterError> {
+        let mut stubs = self.stubs.write();
+        if from >= stubs.len() {
+            return Err(ImposterError::StubIndexOutOfBounds(from));
+        }
+        if to >= stubs.len() {
+            return Err(ImposterError::StubIndexOutOfBounds(to));
+        }
+        let state = stubs.remove(from);
+        stubs.insert(to, state);
+        Ok(())
+    }
+
+    /// Reconcile live stubs toward `desired` under one write lock (issue #316).
+    pub(crate) fn reconcile_stubs(&self, desired: Vec<Stub>) -> StubReconcile {
+        reconcile_stub_states(&mut self.stubs.write(), desired)
+    }
+
     /// Add a stub at a specific index
     pub fn add_stub(&self, stub: Stub, index: Option<usize>) {
         let mut stubs = self.stubs.write();

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -6,6 +6,7 @@
 use super::core::Imposter;
 use super::fault_io::{FaultCell, FaultIo, TcpFaultKind};
 use super::handler::handle_imposter_request;
+use super::reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, StubReconcile};
 use super::types::{ImposterConfig, ImposterError, Stub};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -92,6 +93,8 @@ pub struct ImposterManager {
     datadir: Option<Arc<PathBuf>>,
     /// TLS defaults for HTTPS imposters (issue #206)
     tls_defaults: TlsDefaults,
+    /// Observer for config mutations (issue #316)
+    event_listener: Option<Arc<dyn ImposterEventListener>>,
 }
 
 impl ImposterManager {
@@ -108,6 +111,7 @@ impl ImposterManager {
             shutdown_tx,
             datadir: datadir.map(Arc::new),
             tls_defaults: TlsDefaults::default(),
+            event_listener: None,
         }
     }
 
@@ -116,6 +120,21 @@ impl ImposterManager {
     pub fn with_tls_defaults(mut self, tls_defaults: TlsDefaults) -> Self {
         self.tls_defaults = tls_defaults;
         self
+    }
+
+    /// Register an observer for config mutations (issue #316). Events are delivered
+    /// synchronously on the mutating call; the in-memory change has already been applied
+    /// when the listener runs (persistence may still be pending or fail afterwards).
+    #[must_use]
+    pub fn with_event_listener(mut self, listener: Arc<dyn ImposterEventListener>) -> Self {
+        self.event_listener = Some(listener);
+        self
+    }
+
+    fn emit(&self, event: ImposterEvent) {
+        if let Some(listener) = &self.event_listener {
+            listener.on_event(&event);
+        }
     }
 
     /// Resolve the TLS acceptor for an HTTPS imposter by precedence: inline imposter cert/key →
@@ -163,7 +182,18 @@ impl ImposterManager {
 
     /// Create and start an imposter
     /// Returns the assigned port (which may have been auto-assigned if not specified)
-    pub async fn create_imposter(&self, mut config: ImposterConfig) -> Result<u16, ImposterError> {
+    pub async fn create_imposter(&self, config: ImposterConfig) -> Result<u16, ImposterError> {
+        let port = self.create_imposter_inner(config).await?;
+        self.emit(ImposterEvent::Created(port));
+        Ok(port)
+    }
+
+    /// Create without emitting an event, so composite operations (wholesale replace in
+    /// `apply_config`) can report a single higher-level event instead of Deleted+Created.
+    async fn create_imposter_inner(
+        &self,
+        mut config: ImposterConfig,
+    ) -> Result<u16, ImposterError> {
         // Validate protocol first
         match config.protocol.as_str() {
             "http" | "https" => {}
@@ -345,6 +375,13 @@ impl ImposterManager {
 
     /// Delete an imposter
     pub async fn delete_imposter(&self, port: u16) -> Result<ImposterConfig, ImposterError> {
+        let config = self.delete_imposter_inner(port).await?;
+        self.emit(ImposterEvent::Deleted(port));
+        Ok(config)
+    }
+
+    /// Delete without emitting an event (see `create_imposter_inner`).
+    async fn delete_imposter_inner(&self, port: u16) -> Result<ImposterConfig, ImposterError> {
         let imposter = {
             let mut imposters = self.imposters.write();
             imposters
@@ -381,7 +418,8 @@ impl ImposterManager {
         imposters.values().cloned().collect()
     }
 
-    /// Delete all imposters
+    /// Delete all imposters. Emits a single `AllDeleted` event rather than one `Deleted`
+    /// per port.
     pub async fn delete_all(&self) -> Vec<ImposterConfig> {
         let ports: Vec<u16> = {
             let imposters = self.imposters.read();
@@ -390,11 +428,14 @@ impl ImposterManager {
 
         let mut configs = Vec::new();
         for port in ports {
-            if let Ok(config) = self.delete_imposter(port).await {
-                configs.push(config);
+            match self.delete_imposter_inner(port).await {
+                Ok(config) => configs.push(config),
+                // Only realizable as a concurrent-delete race (NotFound) — already gone.
+                Err(e) => debug!("delete_all: imposter on port {} not deleted: {}", port, e),
             }
         }
 
+        self.emit(ImposterEvent::AllDeleted);
         configs
     }
 
@@ -407,9 +448,26 @@ impl ImposterManager {
     /// after teardown (e.g. a port grabbed by an external process) is returned and may leave a
     /// partial set — the caller surfaces it as a 5xx. Reload resets all imposter state (recorded
     /// requests, scenario state, response cyclers).
+    #[deprecated(
+        note = "use `apply_config`, which reconciles incrementally and preserves unchanged imposters' runtime state"
+    )]
     pub async fn reload(&self, configs: Vec<ImposterConfig>) -> Result<(), ImposterError> {
+        Self::validate_config_set(&configs)?;
+
+        self.delete_all().await;
+        for config in configs {
+            self.create_imposter(config).await?;
+        }
+        Ok(())
+    }
+
+    /// Full-set validation shared by `reload` and `apply_config`: protocol validity, no
+    /// duplicate explicit ports, and no duplicate explicit stub ids within an imposter
+    /// (the invariant `add_stub_unique` enforces incrementally, issue #202 — duplicate ids
+    /// would silently corrupt the stub-key diff). Runs before anything mutates.
+    fn validate_config_set(configs: &[ImposterConfig]) -> Result<(), ImposterError> {
         let mut seen = std::collections::HashSet::new();
-        for config in &configs {
+        for config in configs {
             match config.protocol.as_str() {
                 "http" | "https" => {}
                 other => return Err(ImposterError::InvalidProtocol(other.to_string())),
@@ -419,13 +477,139 @@ impl ImposterManager {
             {
                 return Err(ImposterError::PortInUse(port));
             }
-        }
-
-        self.delete_all().await;
-        for config in configs {
-            self.create_imposter(config).await?;
+            let mut ids = std::collections::HashSet::new();
+            for stub in &config.stubs {
+                if let Some(id) = stub.id.as_deref()
+                    && !ids.insert(id)
+                {
+                    return Err(ImposterError::StubIdConflict(id.to_string()));
+                }
+            }
         }
         Ok(())
+    }
+
+    /// Reconcile the running imposters toward `desired` incrementally (issue #316): per-port
+    /// diff, then an order-aware per-stub edit (stub identity = explicit id or content key,
+    /// see [`super::stub_key`]) applied in place. Unlike [`reload`](Self::reload), untouched
+    /// imposters keep all runtime state (recorded requests, scenario state, response cyclers)
+    /// and their listeners are never torn down.
+    ///
+    /// Semantics per desired port: new port → create; missing port → delete; identical
+    /// config → untouched; imposter-level field change or a degenerate stub diff (> 50 % of
+    /// stubs changing) → wholesale replace (PUT semantics, state resets); otherwise the stub
+    /// set is patched in place and untouched slots keep their cycling state.
+    ///
+    /// The whole set is validated up front — `Err` means nothing was mutated. Per-port apply
+    /// failures after that (e.g. a bind failure on a freed port) land in
+    /// [`ApplyReport::failed`] while the remaining ports are still applied. Configs without
+    /// an explicit port are never reconciled — each apply creates them fresh on an
+    /// auto-assigned port (and reports their failures under port `0`).
+    pub async fn apply_config(
+        &self,
+        desired: Vec<ImposterConfig>,
+    ) -> Result<ApplyReport, ImposterError> {
+        Self::validate_config_set(&desired)?;
+
+        let mut report = ApplyReport::default();
+
+        // Deletes first, so ports freed here can be re-bound by creates below.
+        let desired_ports: std::collections::HashSet<u16> =
+            desired.iter().filter_map(|c| c.port).collect();
+        let removed_ports: Vec<u16> = {
+            let imposters = self.imposters.read();
+            let mut ports: Vec<u16> = imposters
+                .keys()
+                .copied()
+                .filter(|port| !desired_ports.contains(port))
+                .collect();
+            ports.sort_unstable();
+            ports
+        };
+        for port in removed_ports {
+            match self.delete_imposter_inner(port).await {
+                Ok(_) => {
+                    report.deleted.push(port);
+                    self.emit(ImposterEvent::Deleted(port));
+                }
+                Err(e) => report.failed.push((port, e)),
+            }
+        }
+
+        for config in desired {
+            let Some(port) = config.port else {
+                // No explicit port → nothing to reconcile against; always an auto-assigned create.
+                self.create_for_apply(config, 0, &mut report).await;
+                continue;
+            };
+
+            let Ok(existing) = self.get_imposter(port) else {
+                self.create_for_apply(config, port, &mut report).await;
+                continue;
+            };
+
+            if imposter_level_differs(&existing.config, &config) {
+                self.replace_imposter(port, config, &mut report).await;
+                continue;
+            }
+
+            match existing.reconcile_stubs(config.stubs.clone()) {
+                StubReconcile::Unchanged => {}
+                StubReconcile::Patched => {
+                    report.stub_patched.push(port);
+                    self.emit(ImposterEvent::StubsChanged(port));
+                    // The in-memory patch stands either way; a datadir write failure must
+                    // still be observable (issue #173), not silently lost until restart.
+                    if let Err(e) = self.persist_imposter_checked(&existing).await {
+                        report.failed.push((port, e));
+                    }
+                }
+                StubReconcile::Degenerate => {
+                    self.replace_imposter(port, config, &mut report).await;
+                }
+            }
+        }
+
+        Ok(report)
+    }
+
+    /// Create for `apply_config`: record the assigned port + Created event, or a failure
+    /// under `fail_port` (the sentinel `0` for port-less, auto-assigned configs).
+    async fn create_for_apply(
+        &self,
+        config: ImposterConfig,
+        fail_port: u16,
+        report: &mut ApplyReport,
+    ) {
+        match self.create_imposter_inner(config).await {
+            Ok(assigned) => {
+                report.created.push(assigned);
+                self.emit(ImposterEvent::Created(assigned));
+            }
+            Err(e) => report.failed.push((fail_port, e)),
+        }
+    }
+
+    /// Wholesale replace (PUT semantics): tear down, then recreate; all runtime state resets.
+    /// When the recreate fails after a successful teardown, the imposter is genuinely gone —
+    /// that is reported as deleted (list + event) alongside the failure, so listeners and the
+    /// report never track a phantom imposter.
+    async fn replace_imposter(&self, port: u16, config: ImposterConfig, report: &mut ApplyReport) {
+        if let Err(e) = self.delete_imposter_inner(port).await {
+            report.failed.push((port, e));
+            return;
+        }
+        match self.create_imposter_inner(config).await {
+            Ok(_) => {
+                report.replaced.push(port);
+                self.emit(ImposterEvent::Replaced(port));
+            }
+            Err(e) => {
+                report.deleted.push(port);
+                self.emit(ImposterEvent::Deleted(port));
+                report.failed.push((port, e));
+            }
+        }
     }
 
     /// Get imposter count (for future metrics)
@@ -446,6 +630,7 @@ impl ImposterManager {
         if !imposter.add_stub_unique(stub, index) {
             return Err(ImposterError::StubIdConflict(id.unwrap_or_default()));
         }
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -460,6 +645,7 @@ impl ImposterManager {
         if !imposter.replace_stub_by_id(id, stub) {
             return Err(ImposterError::StubNotFound(id.to_string()));
         }
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -469,6 +655,7 @@ impl ImposterManager {
         if !imposter.delete_stub_by_id(id) {
             return Err(ImposterError::StubNotFound(id.to_string()));
         }
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -497,6 +684,7 @@ impl ImposterManager {
     ) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.replace_stub(index, stub)?;
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -504,6 +692,7 @@ impl ImposterManager {
     pub async fn delete_stub(&self, port: u16, index: usize) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.delete_stub(index)?;
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -511,6 +700,16 @@ impl ImposterManager {
     pub async fn replace_stubs(&self, port: u16, stubs: Vec<Stub>) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.replace_stubs(stubs);
+        self.emit(ImposterEvent::StubsChanged(port));
+        self.persist_imposter_checked(&imposter).await
+    }
+
+    /// Move the stub at `from` to position `to` (issue #316), preserving the slot's
+    /// cycling state. Stub order is match priority.
+    pub async fn move_stub(&self, port: u16, from: usize, to: usize) -> Result<(), ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        imposter.move_stub(from, to)?;
+        self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
 
@@ -600,6 +799,29 @@ impl ImposterManager {
 impl Default for ImposterManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Imposter-level diff for `apply_config`, comparing the configs with stubs stripped: any
+/// difference (protocol, TLS, recordRequests, name, …) replaces wholesale. A serialization
+/// failure on either side counts as "differs" — the conservative direction (worst case an
+/// unnecessary replace, never a silently skipped change).
+fn imposter_level_differs(a: &ImposterConfig, b: &ImposterConfig) -> bool {
+    let flatten = |config: &ImposterConfig| {
+        let mut flat = config.clone();
+        flat.stubs = Vec::new();
+        serde_json::to_value(&flat)
+    };
+    match (flatten(a), flatten(b)) {
+        (Ok(va), Ok(vb)) => va != vb,
+        (ra, rb) => {
+            error!(
+                "imposter config serialization failed during reconcile; treating as changed: {:?} {:?}",
+                ra.err(),
+                rb.err()
+            );
+            true
+        }
     }
 }
 
@@ -833,5 +1055,457 @@ mod tests {
                 );
             }
         }
+    }
+
+    // =========================================================================
+    // Issue #316: incremental apply_config, move_stub, and imposter change events
+    // =========================================================================
+
+    use super::super::core::StubState;
+    use super::super::reconcile::{ImposterEvent, ImposterEventListener};
+    use super::super::types::RecordedRequest;
+    use serde_json::json;
+
+    fn imposter_cfg(v: serde_json::Value) -> ImposterConfig {
+        serde_json::from_value(v).expect("test imposter config")
+    }
+
+    fn stub_json(body: &str) -> serde_json::Value {
+        json!({
+            "predicates": [{"equals": {"path": format!("/{body}")}}],
+            "responses": [{"is": {"statusCode": 200, "body": body}}]
+        })
+    }
+
+    fn cycled_stub_json(first: &str, second: &str) -> serde_json::Value {
+        json!({
+            "predicates": [{"equals": {"path": "/cycled"}}],
+            "responses": [
+                {"is": {"statusCode": 200, "body": first}},
+                {"is": {"statusCode": 200, "body": second}}
+            ]
+        })
+    }
+
+    /// Serve the state's next response and return its body (advances the cycler).
+    fn next_body(state: &StubState) -> String {
+        let resp = state.get_next_response().expect("stub has responses");
+        serde_json::to_value(resp).expect("serialize response")["is"]["body"]
+            .as_str()
+            .expect("string body")
+            .to_string()
+    }
+
+    fn recorded(path: &str) -> RecordedRequest {
+        RecordedRequest {
+            request_from: "127.0.0.1".to_string(),
+            method: "GET".to_string(),
+            path: path.to_string(),
+            query: std::collections::HashMap::new(),
+            headers: std::collections::HashMap::new(),
+            body: None,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    // AC1: an unchanged imposter keeps recorded requests and cycler position
+    // while a sibling port is modified.
+    #[tokio::test]
+    async fn apply_config_preserves_untouched_imposter_state() {
+        let manager = ImposterManager::new();
+        let p1 = imposter_cfg(json!({
+            "protocol": "http", "port": 19410, "recordRequests": true,
+            "stubs": [cycled_stub_json("a1", "a2"), stub_json("b"), stub_json("c")]
+        }));
+        let p2 = imposter_cfg(json!({
+            "protocol": "http", "port": 19411,
+            "stubs": [stub_json("x"), stub_json("y"), stub_json("z")]
+        }));
+        let report = manager
+            .apply_config(vec![p1.clone(), p2])
+            .await
+            .expect("initial apply");
+        assert_eq!(report.created, vec![19410, 19411]);
+        assert!(report.failed.is_empty());
+
+        let untouched = manager.get_imposter(19410).unwrap();
+        untouched.record_request(&recorded("/cycled"));
+        assert_eq!(next_body(&untouched.stubs.read()[0]), "a1");
+
+        let p2_changed = imposter_cfg(json!({
+            "protocol": "http", "port": 19411,
+            "stubs": [stub_json("x"), stub_json("y"), stub_json("z2")]
+        }));
+        let report = manager
+            .apply_config(vec![p1, p2_changed])
+            .await
+            .expect("second apply");
+        assert!(report.created.is_empty());
+        assert!(report.deleted.is_empty());
+        assert!(report.replaced.is_empty());
+        assert_eq!(report.stub_patched, vec![19411]);
+
+        let after = manager.get_imposter(19410).unwrap();
+        assert!(
+            Arc::ptr_eq(&untouched, &after),
+            "untouched imposter must not be recreated"
+        );
+        assert_eq!(after.get_recorded_requests().len(), 1);
+        assert_eq!(
+            next_body(&after.stubs.read()[0]),
+            "a2",
+            "cycler position survives a sibling patch"
+        );
+
+        let patched = manager.get_imposter(19411).unwrap();
+        let stubs = patched.get_stubs();
+        let last = serde_json::to_value(&stubs[2]).unwrap();
+        assert_eq!(last["responses"][0]["is"]["body"], "z2");
+
+        manager.delete_all().await;
+    }
+
+    // AC2d: imposter-level field changes always replace wholesale.
+    #[tokio::test]
+    async fn apply_config_imposter_level_change_replaces_wholesale() {
+        let manager = ImposterManager::new();
+        let initial = imposter_cfg(json!({
+            "protocol": "http", "port": 19420, "recordRequests": true,
+            "stubs": [stub_json("a")]
+        }));
+        manager.apply_config(vec![initial]).await.expect("create");
+        let before = manager.get_imposter(19420).unwrap();
+        before.record_request(&recorded("/a"));
+
+        let renamed = imposter_cfg(json!({
+            "protocol": "http", "port": 19420, "recordRequests": true, "name": "renamed",
+            "stubs": [stub_json("a")]
+        }));
+        let report = manager.apply_config(vec![renamed]).await.expect("apply");
+        assert_eq!(report.replaced, vec![19420]);
+        assert!(report.stub_patched.is_empty());
+
+        let after = manager.get_imposter(19420).unwrap();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "imposter-level change recreates the imposter"
+        );
+        assert_eq!(after.config.name.as_deref(), Some("renamed"));
+        assert!(
+            after.get_recorded_requests().is_empty(),
+            "wholesale replace resets runtime state"
+        );
+
+        manager.delete_all().await;
+    }
+
+    // AC2c: > 50 % of stubs changing falls back to whole-imposter replace.
+    #[tokio::test]
+    async fn apply_config_degenerate_stub_change_replaces_imposter() {
+        let manager = ImposterManager::new();
+        let initial = imposter_cfg(json!({
+            "protocol": "http", "port": 19421,
+            "stubs": [stub_json("a"), stub_json("b")]
+        }));
+        manager.apply_config(vec![initial]).await.expect("create");
+        let before = manager.get_imposter(19421).unwrap();
+
+        let rewritten = imposter_cfg(json!({
+            "protocol": "http", "port": 19421,
+            "stubs": [stub_json("x"), stub_json("y")]
+        }));
+        let report = manager.apply_config(vec![rewritten]).await.expect("apply");
+        assert_eq!(report.replaced, vec![19421]);
+        assert!(report.stub_patched.is_empty());
+        let after = manager.get_imposter(19421).unwrap();
+        assert!(!Arc::ptr_eq(&before, &after));
+
+        manager.delete_all().await;
+    }
+
+    // AC6: full-set validation up front — nothing mutates on validation failure.
+    #[tokio::test]
+    async fn apply_config_validation_failure_mutates_nothing() {
+        let manager = ImposterManager::new();
+        let initial = imposter_cfg(json!({
+            "protocol": "http", "port": 19422,
+            "stubs": [stub_json("a")]
+        }));
+        manager.apply_config(vec![initial]).await.expect("create");
+        let before = manager.get_imposter(19422).unwrap();
+
+        let would_change = imposter_cfg(json!({
+            "protocol": "http", "port": 19422,
+            "stubs": [stub_json("x")]
+        }));
+        let invalid = imposter_cfg(json!({
+            "protocol": "tcp", "port": 19423,
+            "stubs": []
+        }));
+        let result = manager.apply_config(vec![would_change, invalid]).await;
+        assert!(
+            matches!(result, Err(ImposterError::InvalidProtocol(ref p)) if p == "tcp"),
+            "got: {result:?}"
+        );
+        let after = manager.get_imposter(19422).unwrap();
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "validation failure must not touch any imposter"
+        );
+        let stubs = after.get_stubs();
+        assert_eq!(
+            serde_json::to_value(&stubs[0]).unwrap()["responses"][0]["is"]["body"],
+            "a"
+        );
+        assert!(manager.get_imposter(19423).is_err());
+
+        let dup_a = imposter_cfg(json!({"protocol": "http", "port": 19424, "stubs": []}));
+        let dup_b = imposter_cfg(json!({"protocol": "http", "port": 19424, "stubs": []}));
+        let result = manager.apply_config(vec![dup_a, dup_b]).await;
+        assert!(matches!(result, Err(ImposterError::PortInUse(19424))));
+        assert!(manager.get_imposter(19424).is_err());
+
+        manager.delete_all().await;
+    }
+
+    #[tokio::test]
+    async fn apply_config_creates_new_and_deletes_missing_ports() {
+        let manager = ImposterManager::new();
+        let first = imposter_cfg(json!({"protocol": "http", "port": 19425, "stubs": []}));
+        let report = manager.apply_config(vec![first]).await.expect("apply");
+        assert_eq!(report.created, vec![19425]);
+
+        let second = imposter_cfg(json!({"protocol": "http", "port": 19426, "stubs": []}));
+        let report = manager.apply_config(vec![second]).await.expect("apply");
+        assert_eq!(report.created, vec![19426]);
+        assert_eq!(report.deleted, vec![19425]);
+        assert!(manager.get_imposter(19425).is_err());
+        assert!(manager.get_imposter(19426).is_ok());
+
+        manager.delete_all().await;
+    }
+
+    #[derive(Default)]
+    struct RecordingListener(Mutex<Vec<ImposterEvent>>);
+
+    impl ImposterEventListener for RecordingListener {
+        fn on_event(&self, event: &ImposterEvent) {
+            self.0.lock().push(event.clone());
+        }
+    }
+
+    // AC4: events fired per mutation kind.
+    #[tokio::test]
+    async fn events_fired_per_mutation_kind() {
+        let listener = Arc::new(RecordingListener::default());
+        let manager = ImposterManager::new().with_event_listener(listener.clone());
+
+        manager
+            .create_imposter(imposter_cfg(json!({
+                "protocol": "http", "port": 19430,
+                "stubs": [stub_json("a"), stub_json("b"), stub_json("c")]
+            })))
+            .await
+            .expect("create");
+        let stub_d: Stub = serde_json::from_value(stub_json("d")).unwrap();
+        manager.add_stub(19430, stub_d, None).await.expect("add");
+        manager.move_stub(19430, 0, 1).await.expect("move");
+        // live stubs now [b, a, c, d]; patch one of four (below the degenerate threshold)
+        // and create a sibling in the same apply.
+        let patched_cfg = imposter_cfg(json!({
+            "protocol": "http", "port": 19430,
+            "stubs": [stub_json("b"), stub_json("a"), stub_json("c"), stub_json("e")]
+        }));
+        let sibling = imposter_cfg(json!({"protocol": "http", "port": 19431, "stubs": []}));
+        manager
+            .apply_config(vec![patched_cfg, sibling.clone()])
+            .await
+            .expect("apply patch+create");
+        // drop 19430, keep 19431 unchanged
+        manager
+            .apply_config(vec![sibling])
+            .await
+            .expect("apply delete");
+        // imposter-level change on 19431
+        let renamed = imposter_cfg(json!({
+            "protocol": "http", "port": 19431, "name": "renamed", "stubs": []
+        }));
+        manager
+            .apply_config(vec![renamed])
+            .await
+            .expect("apply replace");
+        manager.delete_imposter(19431).await.expect("delete");
+        manager.delete_all().await;
+
+        let events = listener.0.lock().clone();
+        assert_eq!(
+            events,
+            vec![
+                ImposterEvent::Created(19430),
+                ImposterEvent::StubsChanged(19430), // add_stub
+                ImposterEvent::StubsChanged(19430), // move_stub
+                ImposterEvent::StubsChanged(19430), // apply_config stub patch
+                ImposterEvent::Created(19431),      // apply_config create
+                ImposterEvent::Deleted(19430),      // apply_config delete
+                ImposterEvent::Replaced(19431),     // apply_config imposter-level change
+                ImposterEvent::Deleted(19431),      // delete_imposter
+                ImposterEvent::AllDeleted,          // delete_all
+            ]
+        );
+    }
+
+    // Per-port apply failures land in `failed` while sibling ports still apply.
+    #[tokio::test]
+    async fn apply_config_partial_failure_reports_failed_port() {
+        let manager = ImposterManager::new();
+        let good = imposter_cfg(json!({"protocol": "http", "port": 19450, "stubs": []}));
+        let bad_tls = imposter_cfg(json!({
+            "protocol": "https", "port": 19451,
+            "cert": "not a pem", "key": "not a pem",
+            "stubs": []
+        }));
+        let report = manager
+            .apply_config(vec![good, bad_tls])
+            .await
+            .expect("apply");
+        assert_eq!(report.created, vec![19450], "sibling still applied");
+        assert_eq!(report.failed.len(), 1);
+        assert!(
+            matches!(report.failed[0], (19451, ImposterError::Tls(_))),
+            "got: {:?}",
+            report.failed
+        );
+        assert!(manager.get_imposter(19450).is_ok());
+        assert!(manager.get_imposter(19451).is_err());
+
+        manager.delete_all().await;
+    }
+
+    // A replace whose recreate fails after teardown is honestly reported: the port lands in
+    // both `deleted` and `failed`, and a Deleted event fires so listeners don't track a
+    // phantom imposter.
+    #[tokio::test]
+    async fn apply_config_failed_replace_reports_deletion_and_event() {
+        let listener = Arc::new(RecordingListener::default());
+        let manager = ImposterManager::new().with_event_listener(listener.clone());
+        manager
+            .create_imposter(imposter_cfg(json!({
+                "protocol": "http", "port": 19452, "stubs": [stub_json("a")]
+            })))
+            .await
+            .expect("create");
+
+        // Imposter-level change (protocol + TLS) whose create fails: bad PEM material.
+        let bad_tls = imposter_cfg(json!({
+            "protocol": "https", "port": 19452,
+            "cert": "not a pem", "key": "not a pem",
+            "stubs": [stub_json("a")]
+        }));
+        let report = manager.apply_config(vec![bad_tls]).await.expect("apply");
+        assert!(report.replaced.is_empty());
+        assert_eq!(report.deleted, vec![19452], "teardown really happened");
+        assert!(matches!(report.failed[0], (19452, ImposterError::Tls(_))));
+        assert!(manager.get_imposter(19452).is_err());
+        assert_eq!(
+            listener.0.lock().clone(),
+            vec![ImposterEvent::Created(19452), ImposterEvent::Deleted(19452),],
+            "listener must learn the imposter is gone"
+        );
+    }
+
+    // Duplicate explicit stub ids are rejected up front (issue #202 invariant) — they would
+    // otherwise silently corrupt the stub-key diff.
+    #[tokio::test]
+    async fn apply_config_rejects_duplicate_stub_ids() {
+        let manager = ImposterManager::new();
+        let mut stub_a = stub_json("a");
+        stub_a["id"] = json!("dup");
+        let mut stub_b = stub_json("b");
+        stub_b["id"] = json!("dup");
+        let config = imposter_cfg(json!({
+            "protocol": "http", "port": 19454, "stubs": [stub_a, stub_b]
+        }));
+        let result = manager.apply_config(vec![config]).await;
+        assert!(
+            matches!(result, Err(ImposterError::StubIdConflict(ref id)) if id == "dup"),
+            "got: {result:?}"
+        );
+        assert_eq!(manager.count(), 0, "nothing mutated");
+    }
+
+    // A datadir write failure on the patched path is observable in `failed` (issue #173),
+    // while the in-memory patch stands.
+    #[tokio::test]
+    async fn apply_config_patch_persist_failure_lands_in_failed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = ImposterManager::with_datadir(Some(dir.path().join("does_not_exist_subdir")));
+        manager
+            .create_imposter(imposter_cfg(json!({
+                "protocol": "http", "port": 19453,
+                "stubs": [stub_json("a"), stub_json("b"), stub_json("c")]
+            })))
+            .await
+            .expect("create succeeds in memory");
+
+        let patched = imposter_cfg(json!({
+            "protocol": "http", "port": 19453,
+            "stubs": [stub_json("a"), stub_json("b"), stub_json("c2")]
+        }));
+        let report = manager.apply_config(vec![patched]).await.expect("apply");
+        assert_eq!(report.stub_patched, vec![19453], "in-memory patch applied");
+        assert!(
+            matches!(report.failed[0], (19453, ImposterError::PersistError(_))),
+            "persist failure must be observable, got: {:?}",
+            report.failed
+        );
+        let stubs = manager.get_imposter(19453).unwrap().get_stubs();
+        assert_eq!(
+            serde_json::to_value(&stubs[2]).unwrap()["responses"][0]["is"]["body"],
+            "c2"
+        );
+
+        manager.delete_all().await;
+    }
+
+    // move_stub is a positional move that preserves the moved slot's cycling state.
+    #[tokio::test]
+    async fn move_stub_repositions_and_preserves_cursor() {
+        let manager = ImposterManager::new();
+        manager
+            .create_imposter(imposter_cfg(json!({
+                "protocol": "http", "port": 19440,
+                "stubs": [cycled_stub_json("a1", "a2"), stub_json("b"), stub_json("c")]
+            })))
+            .await
+            .expect("create");
+        let imposter = manager.get_imposter(19440).unwrap();
+        assert_eq!(next_body(&imposter.stubs.read()[0]), "a1");
+
+        manager.move_stub(19440, 0, 2).await.expect("move");
+        {
+            let stubs = imposter.stubs.read();
+            let first = serde_json::to_value(&stubs[0].stub).unwrap();
+            assert_eq!(first["responses"][0]["is"]["body"], "b");
+            assert_eq!(
+                next_body(&stubs[2]),
+                "a2",
+                "moved stub keeps its cycling position"
+            );
+        }
+
+        assert!(matches!(
+            manager.move_stub(19440, 5, 0).await,
+            Err(ImposterError::StubIndexOutOfBounds(5))
+        ));
+        assert!(matches!(
+            manager.move_stub(19440, 0, 5).await,
+            Err(ImposterError::StubIndexOutOfBounds(5))
+        ));
+        assert!(matches!(
+            manager.move_stub(19441, 0, 0).await,
+            Err(ImposterError::NotFound(19441))
+        ));
+
+        manager.delete_all().await;
     }
 }

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -21,6 +21,7 @@ mod fault_io;
 mod handler;
 mod manager;
 mod predicates;
+mod reconcile;
 mod response;
 mod types;
 
@@ -48,6 +49,9 @@ pub use handler::handle_imposter_request;
 
 // Re-export manager
 pub use manager::{ImposterManager, TlsDefaults};
+
+// Re-export incremental reconciliation types (issue #316)
+pub use reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, stub_key};
 
 // Re-export predicate utilities (used in tests and for external consumers)
 #[allow(unused_imports)]

--- a/crates/rift-core/src/imposter/reconcile.rs
+++ b/crates/rift-core/src/imposter/reconcile.rs
@@ -1,0 +1,374 @@
+//! Incremental config reconciliation (issue #316): stable stub identity, the order-aware
+//! stub edit script, apply reports, and imposter change events.
+
+use super::core::StubState;
+use super::types::{ImposterError, Stub};
+use std::collections::{HashMap, HashSet};
+use tracing::error;
+
+/// Outcome of [`ImposterManager::apply_config`](super::ImposterManager::apply_config):
+/// which ports were created, replaced wholesale, stub-patched in place, deleted, or
+/// failed to apply. Untouched imposters appear in none of the lists. A port may appear
+/// in more than one list when that is the truth — e.g. a wholesale replace whose recreate
+/// fails after teardown lands in both `deleted` and `failed`, and a patched imposter whose
+/// datadir write fails lands in both `stub_patched` and `failed`. Failures for configs
+/// without an explicit port (auto-assign creates) are reported under port `0`.
+#[derive(Debug, Default)]
+pub struct ApplyReport {
+    pub created: Vec<u16>,
+    pub replaced: Vec<u16>,
+    pub stub_patched: Vec<u16>,
+    pub deleted: Vec<u16>,
+    pub failed: Vec<(u16, ImposterError)>,
+}
+
+/// A config mutation observed on the manager (issue #316), for embedders that need to
+/// react to config changes (audit logging, persistence hooks, webhooks).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImposterEvent {
+    Created(u16),
+    Replaced(u16),
+    StubsChanged(u16),
+    Deleted(u16),
+    AllDeleted,
+}
+
+/// Observer for [`ImposterEvent`]s; register via
+/// [`ImposterManager::with_event_listener`](super::ImposterManager::with_event_listener).
+/// Called synchronously on the mutating path — keep implementations fast and non-blocking.
+pub trait ImposterEventListener: Send + Sync {
+    fn on_event(&self, event: &ImposterEvent);
+}
+
+/// Stable stub identity: the explicit `id` (issue #202) if set, else
+/// `"~" + <16-hex content hash> + "#" + <occurrence among byte-identical siblings>`.
+/// The `~` prefix keeps generated keys disjoint from user-supplied ids.
+pub fn stub_key(stub: &Stub, occurrence: usize) -> String {
+    match &stub.id {
+        Some(id) => id.clone(),
+        None => format!("~{:016x}#{occurrence}", content_hash(stub)),
+    }
+}
+
+/// FNV-1a 64 over the stub's serialized JSON. Deterministic: struct field order is fixed
+/// and serde_json maps are sorted (the `preserve_order` feature is off workspace-wide).
+fn content_hash(stub: &Stub) -> u64 {
+    let canonical = serde_json::to_string(stub).unwrap_or_else(|e| {
+        // Debug output is content-distinguishing but not canonical across processes —
+        // keys built from it may churn between reloads, so make the degradation visible.
+        error!("stub serialization failed while keying; falling back to Debug format: {e}");
+        format!("{stub:?}")
+    });
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    canonical.bytes().fold(FNV_OFFSET, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME)
+    })
+}
+
+/// Keys for a stub sequence; occurrence is counted per content hash so byte-identical
+/// id-less siblings get distinct keys and stay individually addressable in the diff.
+pub(crate) fn stub_keys(stubs: &[Stub]) -> Vec<String> {
+    stub_keys_iter(stubs.iter())
+}
+
+fn stub_keys_iter<'a>(stubs: impl Iterator<Item = &'a Stub>) -> Vec<String> {
+    let mut seen: HashMap<u64, usize> = HashMap::new();
+    stubs
+        .map(|stub| match &stub.id {
+            Some(id) => id.clone(),
+            None => {
+                let hash = content_hash(stub);
+                let occurrence = seen.entry(hash).or_insert(0);
+                let key = format!("~{hash:016x}#{occurrence}");
+                *occurrence += 1;
+                key
+            }
+        })
+        .collect()
+}
+
+/// Outcome of a stub-level reconcile.
+#[derive(Debug)]
+pub(crate) enum StubReconcile {
+    /// Same stubs, same order — nothing touched.
+    Unchanged,
+    /// Edited in place; untouched slots kept their cycling state.
+    Patched,
+    /// More than half the stubs would change — the caller should replace the imposter
+    /// wholesale instead of thrashing the stub set in place.
+    Degenerate,
+}
+
+/// Reconcile a live `StubState` vector toward `desired`, preserving per-slot cycling
+/// state for every stub whose key survives. Pure moves (reorder) preserve everything;
+/// a same-key content change (explicit id) swaps the stub in place like
+/// `replace_stub_by_id`. Returns `Degenerate` — without mutating — when the changed
+/// fraction exceeds 1/2 (pure moves cost nothing in that metric).
+pub(crate) fn reconcile_stub_states(
+    states: &mut Vec<StubState>,
+    desired: Vec<Stub>,
+) -> StubReconcile {
+    let old_keys = stub_keys_iter(states.iter().map(|s| &s.stub));
+    let new_keys = stub_keys(&desired);
+
+    let old_index: HashMap<&String, usize> =
+        old_keys.iter().enumerate().map(|(i, k)| (k, i)).collect();
+    let new_set: HashSet<&String> = new_keys.iter().collect();
+
+    let deletes = old_keys.iter().filter(|k| !new_set.contains(*k)).count();
+    let mut inserts = 0usize;
+    let mut content_replaced = 0usize;
+    for (i, key) in new_keys.iter().enumerate() {
+        match old_index.get(key) {
+            None => inserts += 1,
+            // Same key, different content — explicit-id stubs (or a hash collision).
+            Some(&j) if stubs_differ(&desired[i], &states[j].stub) => {
+                content_replaced += 1;
+            }
+            Some(_) => {}
+        }
+    }
+
+    if old_keys == new_keys && content_replaced == 0 {
+        return StubReconcile::Unchanged;
+    }
+    // Changed fraction over both sides: a content replace touches one slot on each side.
+    let changed_slots = deletes + inserts + 2 * content_replaced;
+    if changed_slots * 2 > states.len() + desired.len() {
+        return StubReconcile::Degenerate;
+    }
+
+    let mut by_key: HashMap<String, StubState> =
+        old_keys.into_iter().zip(states.drain(..)).collect();
+    *states = new_keys
+        .into_iter()
+        .zip(desired)
+        .map(|(key, stub)| match by_key.remove(&key) {
+            Some(mut state) => {
+                if stubs_differ(&state.stub, &stub) {
+                    state.stub = stub;
+                }
+                state
+            }
+            None => StubState::new(stub),
+        })
+        .collect();
+    StubReconcile::Patched
+}
+
+/// Content inequality via canonical JSON. A serialization failure on either side counts
+/// as "differs" — the conservative direction for a diff (worst case an unneeded replace,
+/// never a silently dropped change) — and is logged.
+fn stubs_differ(a: &Stub, b: &Stub) -> bool {
+    match (serde_json::to_value(a), serde_json::to_value(b)) {
+        (Ok(va), Ok(vb)) => va != vb,
+        (ra, rb) => {
+            error!(
+                "stub serialization failed during reconcile; treating as changed: {:?} {:?}",
+                ra.err(),
+                rb.err()
+            );
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imposter::core::StubState;
+    use crate::imposter::types::Stub;
+    use serde_json::json;
+
+    fn stub(v: serde_json::Value) -> Stub {
+        serde_json::from_value(v).expect("test stub json")
+    }
+
+    fn one_resp(body: &str) -> Stub {
+        stub(json!({
+            "predicates": [{"equals": {"path": format!("/{body}")}}],
+            "responses": [{"is": {"statusCode": 200, "body": body}}]
+        }))
+    }
+
+    fn two_resp(first: &str, second: &str) -> Stub {
+        stub(json!({
+            "predicates": [{"equals": {"path": "/cycled"}}],
+            "responses": [
+                {"is": {"statusCode": 200, "body": first}},
+                {"is": {"statusCode": 200, "body": second}}
+            ]
+        }))
+    }
+
+    /// Serve the state's next response and return its body (advances the cycler).
+    fn next_body(state: &StubState) -> String {
+        let resp = state.get_next_response().expect("stub has responses");
+        serde_json::to_value(resp).expect("serialize response")["is"]["body"]
+            .as_str()
+            .expect("string body")
+            .to_string()
+    }
+
+    // AC3: determinism, occurrence suffixes, "~" disjointness from user ids.
+
+    #[test]
+    fn stub_key_is_deterministic_and_prefixed() {
+        let a = one_resp("a");
+        let b = one_resp("a");
+        let key = stub_key(&a, 0);
+        assert_eq!(
+            key,
+            stub_key(&b, 0),
+            "same content must hash to the same key"
+        );
+        assert!(key.starts_with('~'), "generated keys carry the ~ prefix");
+        assert!(key.ends_with("#0"));
+        assert_eq!(
+            key.len(),
+            "~".len() + 16 + "#0".len(),
+            "16-hex content hash"
+        );
+    }
+
+    #[test]
+    fn stub_key_uses_explicit_id_verbatim() {
+        let mut s = one_resp("a");
+        s.id = Some("checkout-flow".into());
+        assert_eq!(stub_key(&s, 0), "checkout-flow");
+        assert_eq!(
+            stub_key(&s, 3),
+            "checkout-flow",
+            "occurrence is irrelevant for explicit ids"
+        );
+    }
+
+    #[test]
+    fn stub_key_occurrence_suffix_disambiguates_identical_siblings() {
+        let s = one_resp("dup");
+        let keys = stub_keys(&[s.clone(), s.clone(), one_resp("other")]);
+        assert_eq!(keys.len(), 3);
+        assert_ne!(
+            keys[0], keys[1],
+            "byte-identical siblings get distinct keys"
+        );
+        assert!(keys[0].ends_with("#0"));
+        assert!(keys[1].ends_with("#1"));
+        assert!(keys[2].ends_with("#0"));
+        assert_ne!(keys[0], keys[2]);
+    }
+
+    #[test]
+    fn stub_key_content_change_changes_key() {
+        assert_ne!(stub_key(&one_resp("a"), 0), stub_key(&one_resp("b"), 0));
+    }
+
+    // AC2a: a stub-level patch preserves untouched stubs' cursors.
+
+    #[test]
+    fn patch_preserves_untouched_stub_cursors() {
+        let mut states = vec![
+            StubState::new(two_resp("a1", "a2")),
+            StubState::new(one_resp("b")),
+            StubState::new(one_resp("c")),
+        ];
+        assert_eq!(next_body(&states[0]), "a1");
+
+        let desired = vec![two_resp("a1", "a2"), one_resp("b"), one_resp("c2")];
+        let outcome = reconcile_stub_states(&mut states, desired);
+        assert!(matches!(outcome, StubReconcile::Patched));
+        assert_eq!(states.len(), 3);
+        assert_eq!(
+            next_body(&states[0]),
+            "a2",
+            "untouched stub keeps its cursor"
+        );
+        assert_eq!(next_body(&states[2]), "c2", "changed stub swapped in");
+    }
+
+    // AC2b: a pure reorder converges without resetting any cursor.
+
+    #[test]
+    fn pure_reorder_preserves_all_cursors() {
+        let mut states = vec![
+            StubState::new(two_resp("a1", "a2")),
+            StubState::new(two_resp("b1", "b2")),
+        ];
+        assert_eq!(next_body(&states[0]), "a1");
+        assert_eq!(next_body(&states[1]), "b1");
+
+        let desired = vec![two_resp("b1", "b2"), two_resp("a1", "a2")];
+        let outcome = reconcile_stub_states(&mut states, desired);
+        assert!(matches!(outcome, StubReconcile::Patched));
+        assert_eq!(next_body(&states[0]), "b2", "moved stub keeps its cursor");
+        assert_eq!(next_body(&states[1]), "a2", "moved stub keeps its cursor");
+    }
+
+    // AC2c: > 50 % of stubs changing is degenerate — no in-place mutation.
+
+    #[test]
+    fn degenerate_ratio_falls_back_without_mutating() {
+        let mut states = vec![StubState::new(one_resp("a")), StubState::new(one_resp("b"))];
+        let outcome = reconcile_stub_states(&mut states, vec![one_resp("x"), one_resp("y")]);
+        assert!(matches!(outcome, StubReconcile::Degenerate));
+        assert_eq!(
+            next_body(&states[0]),
+            "a",
+            "a degenerate outcome must not mutate the live stubs"
+        );
+        assert_eq!(next_body(&states[1]), "b");
+    }
+
+    #[test]
+    fn identical_stubs_are_unchanged() {
+        let mut states = vec![StubState::new(one_resp("a")), StubState::new(one_resp("b"))];
+        let outcome = reconcile_stub_states(&mut states, vec![one_resp("a"), one_resp("b")]);
+        assert!(matches!(outcome, StubReconcile::Unchanged));
+    }
+
+    #[test]
+    fn same_id_content_change_patches_in_place_keeping_cursor() {
+        let mut with_id = two_resp("v1a", "v1b");
+        with_id.id = Some("s1".into());
+        let mut states = vec![
+            StubState::new(with_id),
+            StubState::new(one_resp("b")),
+            StubState::new(one_resp("c")),
+        ];
+        assert_eq!(next_body(&states[0]), "v1a");
+
+        let mut updated = two_resp("v2a", "v2b");
+        updated.id = Some("s1".into());
+        let outcome =
+            reconcile_stub_states(&mut states, vec![updated, one_resp("b"), one_resp("c")]);
+        assert!(matches!(outcome, StubReconcile::Patched));
+        assert_eq!(
+            next_body(&states[0]),
+            "v2b",
+            "in-place id replace keeps the slot's cursor"
+        );
+    }
+
+    #[test]
+    fn insertion_below_threshold_patches() {
+        let mut states = vec![
+            StubState::new(two_resp("a1", "a2")),
+            StubState::new(one_resp("b")),
+            StubState::new(one_resp("c")),
+        ];
+        assert_eq!(next_body(&states[0]), "a1");
+
+        let desired = vec![
+            two_resp("a1", "a2"),
+            one_resp("new"),
+            one_resp("b"),
+            one_resp("c"),
+        ];
+        let outcome = reconcile_stub_states(&mut states, desired);
+        assert!(matches!(outcome, StubReconcile::Patched));
+        assert_eq!(states.len(), 4);
+        assert_eq!(next_body(&states[0]), "a2");
+        assert_eq!(next_body(&states[1]), "new");
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -116,11 +116,12 @@ pub fn handle_logs(query: Option<&str>) -> Response<Full<Bytes>> {
     json_response(StatusCode::OK, &logs)
 }
 
-/// POST /admin/reload - re-read the startup config source and replace all imposters (issue #197,
-/// Rift extension). No-op (200) when no `--configfile`/`--datadir` was given. The new set is
-/// validated before the running imposters are touched, so a parse or semantic error (bad
-/// protocol, duplicate port) returns 500 with the running imposters left unchanged. Reload resets
-/// all imposter state (recorded requests, scenario state, response cyclers).
+/// POST /admin/reload - re-read the startup config source and reconcile the running imposters
+/// toward it incrementally (issues #197/#316, Rift extension). No-op (200) when no
+/// `--configfile`/`--datadir` was given. The new set is validated before the running imposters
+/// are touched, so a parse or semantic error (bad protocol, duplicate port) returns 500 with the
+/// running imposters left unchanged. Unchanged imposters keep all runtime state (recorded
+/// requests, scenario state, response cyclers); only changed ports are patched or replaced.
 pub async fn handle_reload(
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<crate::config_loader::ConfigSource>>,
@@ -144,17 +145,51 @@ pub async fn handle_reload(
     };
 
     let count = configs.len();
-    match manager.reload(configs).await {
-        Ok(()) => json_response(
+    match manager.apply_config(configs).await {
+        Ok(report) if report.failed.is_empty() => json_response(
             StatusCode::OK,
-            &serde_json::json!({ "message": format!("Reloaded {count} imposter(s)") }),
+            &serde_json::json!({
+                "message": format!("Reloaded {count} imposter(s)"),
+                "created": report.created,
+                "replaced": report.replaced,
+                "stubPatched": report.stub_patched,
+                "deleted": report.deleted,
+            }),
         ),
         // A reload failure is a server-side config problem, not a bad client request — report 5xx.
-        // Protocol/duplicate-port errors are caught before teardown (running imposters intact); a
-        // residual error here is a post-teardown bind failure.
+        // Validation errors are caught before anything mutates (running imposters intact, Err
+        // below); per-port failures here are residual apply errors (e.g. a bind failure on a
+        // freed port) with the other ports already reconciled — so the body carries the full
+        // report: a partial failure is exactly when the client needs to know what did apply.
+        Ok(report) => {
+            let failures: Vec<String> = report
+                .failed
+                .iter()
+                .map(|(port, e)| match port {
+                    // Port 0 is the ApplyReport sentinel for auto-assigned (port-less) configs.
+                    0 => format!("auto-assign: {e}"),
+                    port => format!("{port}: {e}"),
+                })
+                .collect();
+            // Mountebank error envelope (like `error_response`) plus the apply report.
+            json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &serde_json::json!({
+                    "errors": [{
+                        "code": "500",
+                        "message": format!("Reload partially failed: {}", failures.join("; ")),
+                    }],
+                    "failed": failures,
+                    "created": report.created,
+                    "replaced": report.replaced,
+                    "stubPatched": report.stub_patched,
+                    "deleted": report.deleted,
+                }),
+            )
+        }
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Reload failed: {e}"),
+            &format!("Reload failed (imposters unchanged): {e}"),
         ),
     }
 }
@@ -186,6 +221,51 @@ mod tests {
         let manager = Arc::new(ImposterManager::new());
         let resp = handle_reload(manager, None).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Issue #316: a partial apply failure returns 500 with the full report, so the client
+    // can tell what state the server is now in.
+    #[tokio::test]
+    async fn test_handle_reload_partial_failure_returns_report() {
+        use http_body_util::BodyExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(
+            &path,
+            r#"{"imposters":[
+                {"port":19477,"protocol":"http","stubs":[]},
+                {"port":19478,"protocol":"https","cert":"not a pem","key":"not a pem","stubs":[]}
+            ]}"#,
+        )
+        .expect("write config");
+        let source = Arc::new(crate::config_loader::ConfigSource::File {
+            path,
+            no_parse: false,
+        });
+
+        let manager = Arc::new(ImposterManager::new());
+        let resp = handle_reload(manager.clone(), Some(source)).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert!(
+            body["errors"][0]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("Reload partially failed: 19478:"),
+            "got: {body}"
+        );
+        assert_eq!(
+            body["created"],
+            serde_json::json!([19477]),
+            "sibling applied"
+        );
+        assert!(manager.get_imposter(19477).is_ok());
+        assert!(manager.get_imposter(19478).is_err());
+
+        manager.delete_all().await;
     }
 
     #[test]

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -961,6 +961,9 @@ mod multi_value_headers {
 }
 
 // Issue #197: POST /admin/reload re-reads the config source and replaces imposters.
+// Several tests still seed state through the deprecated `reload()` on purpose — it is
+// kept working alongside `apply_config` (issue #316).
+#[allow(deprecated)]
 mod reload {
     use super::*;
     use rift_http_proxy::config_loader::{ConfigSource, load_configs};
@@ -1109,6 +1112,84 @@ mod reload {
         );
 
         let _ = manager.delete_imposter(19791).await;
+    }
+
+    fn two_imposter_cfg(keep_body: &str, sibling_body: &str) -> String {
+        format!(
+            r#"{{"imposters":[
+                {{"port":19475,"protocol":"http","recordRequests":true,"stubs":[
+                    {{"predicates":[{{"equals":{{"path":"/p"}}}}],
+                     "responses":[{{"is":{{"statusCode":200,"body":"{keep_body}"}}}}]}}]}},
+                {{"port":19476,"protocol":"http","stubs":[
+                    {{"predicates":[{{"equals":{{"path":"/p"}}}}],
+                     "responses":[{{"is":{{"statusCode":200,"body":"{sibling_body}"}}}}]}}]}}]}}"#
+        )
+    }
+
+    // Issue #316: reload reconciles incrementally — an untouched imposter keeps its
+    // runtime state (recorded requests, listener) while a sibling is modified.
+    #[tokio::test]
+    async fn reload_preserves_untouched_imposter_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, two_imposter_cfg("keep", "v1")).unwrap();
+        let source = ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        };
+
+        let manager = start(12601, Some(source.clone())).await;
+        manager
+            .apply_config(load_configs(&source).unwrap())
+            .await
+            .unwrap();
+
+        // Drive the untouched imposter so it accrues runtime state.
+        let served = reqwest::get("http://127.0.0.1:19475/p")
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert_eq!(served, "keep");
+        let before = manager.get_imposter(19475).unwrap();
+        assert_eq!(before.get_recorded_requests().len(), 1);
+
+        // Change only the sibling on disk, then reload via the admin endpoint.
+        std::fs::write(&path, two_imposter_cfg("keep", "v2")).unwrap();
+        let resp = reqwest::Client::new()
+            .post("http://127.0.0.1:12601/admin/reload")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(
+            body["message"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("Reloaded"),
+            "message stays backward-compatible, got: {body}"
+        );
+        assert_eq!(
+            body["replaced"],
+            serde_json::json!([19476]),
+            "single-stub rewrite is a degenerate patch, so the sibling is replaced wholesale"
+        );
+
+        let after = manager.get_imposter(19475).unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&before, &after),
+            "reload must not recreate an unchanged imposter"
+        );
+        assert_eq!(
+            after.get_recorded_requests().len(),
+            1,
+            "reload must not reset an unchanged imposter's recorded requests"
+        );
+        assert_eq!(stub_body(&manager, 19476), "v2");
+
+        manager.delete_all().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds `ImposterManager::apply_config` — an incremental per-port + per-stub reconcile (stable stub identity via explicit id or `~<content-hash>#<occurrence>` keys) that preserves untouched imposters' and stub slots' runtime state, plus `ImposterEvent`/`ImposterEventListener` for embedders and a state-preserving `move_stub`. `POST /admin/reload` now reconciles instead of destroying all state; `reload()` is deprecated but kept. Full-set validation runs before anything mutates; per-port failures are reported (500 carries the full apply report).

Closes #316
Part of #310 (no milestone assigned)