### PR TITLE
Typed BackendUnavailable error, per-request op annotations, and a ResponseDecorator hook

### DIFF
--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -92,3 +92,5 @@ default = ["redis-backend", "lua", "javascript"]
 redis-backend = ["redis", "r2d2"]
 lua = ["mlua"]
 javascript = ["boa_engine"]
+# Deliberately failing flow-store backend for backend-outage tests (issue #318)
+test-backend = []

--- a/crates/rift-core/src/backends/redis.rs
+++ b/crates/rift-core/src/backends/redis.rs
@@ -101,19 +101,30 @@ impl RedisFlowStore {
     }
 }
 
+/// Wrap a Redis op failure so response boundaries map it to a structured 503 (issue
+/// #318): annotate the failed op, then attach `BackendUnavailable`. Serde failures are
+/// NOT wrapped — malformed stored data is corruption, not backend unavailability.
+fn backend_err(op: &'static str, err: impl std::fmt::Display) -> anyhow::Error {
+    crate::extensions::decorate::annotate(op, err.to_string());
+    anyhow::Error::new(crate::extensions::decorate::BackendUnavailable {
+        feature: "flowState",
+        detail: format!("{op}: {err}"),
+    })
+}
+
 impl FlowStore for RedisFlowStore {
     fn get(&self, flow_id: &str, key: &str) -> Result<Option<Value>> {
         let key_str = self.make_key(flow_id, key);
         let conn = self
             .pool
             .get()
-            .context("Failed to get Redis connection from pool")?;
+            .map_err(|e| backend_err("flowStore.pool", e))?;
 
         let value: Option<String> = conn
             .lock()
             .unwrap()
             .get(&key_str)
-            .context("Redis GET failed")?;
+            .map_err(|e| backend_err("flowStore.get", e))?;
 
         if let Some(json_str) = value {
             let val = serde_json::from_str(&json_str).context("Failed to parse JSON from Redis")?;
@@ -131,7 +142,7 @@ impl FlowStore for RedisFlowStore {
         let conn = self
             .pool
             .get()
-            .context("Failed to get Redis connection from pool")?;
+            .map_err(|e| backend_err("flowStore.pool", e))?;
 
         // SET with TTL using SETEX
         let _: () = redis::cmd("SETEX")
@@ -139,7 +150,7 @@ impl FlowStore for RedisFlowStore {
             .arg(self.default_ttl_seconds)
             .arg(json_str)
             .query(&mut *conn.lock().unwrap())
-            .context("Redis SETEX failed")?;
+            .map_err(|e| backend_err("flowStore.set", e))?;
 
         Ok(())
     }
@@ -149,13 +160,13 @@ impl FlowStore for RedisFlowStore {
         let conn = self
             .pool
             .get()
-            .context("Failed to get Redis connection from pool")?;
+            .map_err(|e| backend_err("flowStore.pool", e))?;
 
         let count: i64 = conn
             .lock()
             .unwrap()
             .exists(&key_str)
-            .context("Redis EXISTS failed")?;
+            .map_err(|e| backend_err("flowStore.exists", e))?;
 
         Ok(count > 0)
     }
@@ -165,13 +176,13 @@ impl FlowStore for RedisFlowStore {
         let conn = self
             .pool
             .get()
-            .context("Failed to get Redis connection from pool")?;
+            .map_err(|e| backend_err("flowStore.pool", e))?;
 
         let _: () = conn
             .lock()
             .unwrap()
             .del(&key_str)
-            .context("Redis DEL failed")?;
+            .map_err(|e| backend_err("flowStore.delete", e))?;
 
         Ok(())
     }
@@ -181,18 +192,20 @@ impl FlowStore for RedisFlowStore {
         let conn = self
             .pool
             .get()
-            .context("Failed to get Redis connection from pool")?;
+            .map_err(|e| backend_err("flowStore.pool", e))?;
         let mut conn_guard = conn.lock().unwrap();
 
         // INCR returns the new value
-        let new_value: i64 = conn_guard.incr(&key_str, 1).context("Redis INCR failed")?;
+        let new_value: i64 = conn_guard
+            .incr(&key_str, 1)
+            .map_err(|e| backend_err("flowStore.increment", e))?;
 
         // Set TTL on the key (INCR doesn't reset TTL)
         let _: () = redis::cmd("EXPIRE")
             .arg(&key_str)
             .arg(self.default_ttl_seconds)
             .query(&mut *conn_guard)
-            .context("Redis EXPIRE failed")?;
+            .map_err(|e| backend_err("flowStore.expire", e))?;
 
         Ok(new_value)
     }
@@ -224,5 +237,23 @@ pub(crate) fn health_check(pool: &r2d2::Pool<RedisConnectionManager>) -> Result<
             tracing::warn!("Redis health check failed: {}", e);
             Ok(false)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Every Redis op failure funnels through backend_err, so this pins the whole file's
+    // error shape: typed, downcastable, structured-503-able (issue #318).
+    #[test]
+    fn backend_err_is_downcastable_to_backend_unavailable() {
+        let err = backend_err("flowStore.get", "connection refused");
+        let unavailable = err
+            .downcast_ref::<crate::extensions::decorate::BackendUnavailable>()
+            .expect("typed error");
+        assert_eq!(unavailable.feature, "flowState");
+        assert!(unavailable.detail.contains("flowStore.get"));
+        assert!(unavailable.detail.contains("connection refused"));
     }
 }

--- a/crates/rift-core/src/extensions/decorate.rs
+++ b/crates/rift-core/src/extensions/decorate.rs
@@ -1,0 +1,181 @@
+//! Typed backend errors, per-request op annotations, and the response-decorator hook
+//! (issue #318).
+//!
+//! Backends attach [`BackendUnavailable`] to a failed op (as the source of their
+//! `anyhow::Error`); response boundaries map it to a structured 503 via
+//! [`backend_error_response`]. Operational metadata travels per request through a tokio
+//! task-local annotation scope: the server opens one per request task, backends call
+//! [`annotate`] from sync code inside that task, and the server hands the collected
+//! annotations to the configured [`ResponseDecorator`] before the response is written.
+//! Annotations from other threads (e.g. script-pool workers) are best-effort: outside a
+//! scope, [`annotate`] is an infallible no-op.
+
+use crate::util::build_response_with_headers;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Response, StatusCode};
+use std::cell::RefCell;
+
+/// Attached by backends to a failed op; response boundaries map it to a structured 503.
+#[derive(Debug, thiserror::Error)]
+#[error("backend unavailable: {feature}: {detail}")]
+pub struct BackendUnavailable {
+    pub feature: &'static str,
+    pub detail: String,
+}
+
+tokio::task_local! {
+    static ANNOTATIONS: RefCell<Vec<(&'static str, String)>>;
+}
+
+/// Append a per-request operation annotation. Cheap and infallible; a no-op when no
+/// annotation scope is open on the current task (documented best-effort for calls from
+/// non-request threads).
+pub fn annotate(key: &'static str, value: String) {
+    let _ = ANNOTATIONS.try_with(|a| a.borrow_mut().push((key, value)));
+}
+
+/// Run `fut` inside a fresh annotation scope and return its output together with the
+/// annotations collected while it ran. Task-locals follow the task across `.await`s, so
+/// synchronous backend calls made anywhere inside the request task land in this scope.
+pub async fn with_annotation_scope<F: Future>(fut: F) -> (F::Output, Vec<(&'static str, String)>) {
+    ANNOTATIONS
+        .scope(RefCell::new(Vec::new()), async move {
+            let out = fut.await;
+            let collected = ANNOTATIONS.with(|a| a.borrow_mut().drain(..).collect());
+            (out, collected)
+        })
+        .await
+}
+
+/// Which response surface a decorator is being invoked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponsePhase {
+    /// A response served by an imposter (per-imposter port traffic).
+    DataPlane,
+    /// A response served by the admin API (including the `/__rift/` gateway, which rides
+    /// the admin listener).
+    Admin,
+}
+
+/// Inspect/annotate an outgoing response (headers only; the body is untouched). Invoked
+/// synchronously on the response path — keep implementations fast and non-blocking, and
+/// never panic: a panic tears down the connection serving the request.
+pub trait ResponseDecorator: Send + Sync {
+    fn decorate(
+        &self,
+        phase: ResponsePhase,
+        req_port: Option<u16>,
+        annotations: &[(&'static str, String)],
+        headers: &mut hyper::HeaderMap,
+    );
+}
+
+/// Map a backend/handler error to its response: [`BackendUnavailable`] anywhere in the
+/// chain → `503 {"error":"backendUnavailable",...}`; anything else → `500
+/// {"error":"internalError",...}`. Never a silent fallback.
+pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
+    let (status, body) = match err.downcast_ref::<BackendUnavailable>() {
+        Some(b) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "error": "backendUnavailable",
+                "feature": b.feature,
+                "detail": b.detail,
+            }),
+        ),
+        None => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            serde_json::json!({
+                "error": "internalError",
+                // "{err:#}" keeps the whole context chain — the outermost message alone
+                // rarely says why ("Redis GET failed" without the refused connection).
+                "detail": format!("{err:#}"),
+            }),
+        ),
+    };
+    // The response body is otherwise the only record of this failure — keep operators
+    // in the loop without requiring a client bug report.
+    tracing::warn!("backend error surfaced as {}: {err:#}", status.as_u16());
+    build_response_with_headers(
+        status,
+        [("content-type", "application/json")],
+        body.to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    // AC1: annotate inside a scope is collected (and follows the task across awaits).
+    #[tokio::test]
+    async fn annotations_collected_inside_scope_across_awaits() {
+        let ((), notes) = with_annotation_scope(async {
+            annotate("first", "1".to_string());
+            tokio::task::yield_now().await;
+            annotate("second", "2".to_string());
+        })
+        .await;
+        assert_eq!(
+            notes,
+            vec![("first", "1".to_string()), ("second", "2".to_string()),]
+        );
+    }
+
+    // AC1: annotate outside any scope is an infallible no-op.
+    #[test]
+    fn annotate_outside_scope_is_noop() {
+        annotate("orphan", "x".to_string());
+    }
+
+    #[tokio::test]
+    async fn scopes_start_empty_and_do_not_leak() {
+        annotate("orphan", "x".to_string());
+        let ((), notes) = with_annotation_scope(async {}).await;
+        assert!(
+            notes.is_empty(),
+            "a fresh scope must not see outside writes"
+        );
+    }
+
+    // The error mapper: BackendUnavailable → structured 503; anything else → 500.
+    #[tokio::test]
+    async fn backend_unavailable_maps_to_structured_503() {
+        let err = anyhow::Error::new(BackendUnavailable {
+            feature: "flowState",
+            detail: "redis connection refused".to_string(),
+        });
+        let resp = backend_error_response(&err);
+        assert_eq!(resp.status(), hyper::StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert_eq!(json["error"], "backendUnavailable");
+        assert_eq!(json["feature"], "flowState");
+        assert_eq!(json["detail"], "redis connection refused");
+    }
+
+    #[tokio::test]
+    async fn other_errors_map_to_500() {
+        let resp = backend_error_response(&anyhow::anyhow!("boom"));
+        assert_eq!(resp.status(), hyper::StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert_eq!(json["error"], "internalError");
+    }
+
+    // BackendUnavailable survives an anyhow context chain (backends wrap with .context()).
+    #[tokio::test]
+    async fn downcast_works_through_context_chain() {
+        use anyhow::Context;
+        let err = Err::<(), _>(anyhow::Error::new(BackendUnavailable {
+            feature: "flowState",
+            detail: "down".to_string(),
+        }))
+        .context("while reading scenario state")
+        .expect_err("err");
+        let resp = backend_error_response(&err);
+        assert_eq!(resp.status(), hyper::StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -361,3 +361,56 @@ mod tests {
         assert!(store.set(flow_id, key, json!("データ")).is_ok());
     }
 }
+
+/// Log-and-fallback for the script-facing flow-store wrappers: scripts keep their legacy
+/// fallback values on a backend failure (changing that is a breaking script contract),
+/// but the dropped error is no longer invisible (issue #318).
+pub fn log_flow_err<T>(op: &str, fallback: T, result: Result<T>) -> T {
+    result.unwrap_or_else(|e| {
+        tracing::warn!("script flow_store.{op} failed; returning fallback: {e:#}");
+        fallback
+    })
+}
+
+/// A deliberately failing flow store (feature `test-backend`): every operation annotates
+/// the op via `decorate::annotate`, then fails with a `BackendUnavailable` source —
+/// selected with `_rift.flowState.backend = "failing"` to exercise backend-outage paths
+/// (issue #318) without a real unreachable backend.
+#[cfg(feature = "test-backend")]
+#[derive(Debug)]
+pub struct FailingFlowStore;
+
+#[cfg(feature = "test-backend")]
+impl FailingFlowStore {
+    fn fail<T>(&self, op: &'static str, flow_id: &str, key: &str) -> Result<T> {
+        crate::extensions::decorate::annotate(op, format!("{flow_id}/{key}"));
+        Err(anyhow::Error::new(
+            crate::extensions::decorate::BackendUnavailable {
+                feature: "flowState",
+                detail: format!("failing test backend: {op} {flow_id}/{key}"),
+            },
+        ))
+    }
+}
+
+#[cfg(feature = "test-backend")]
+impl FlowStore for FailingFlowStore {
+    fn get(&self, flow_id: &str, key: &str) -> Result<Option<Value>> {
+        self.fail("flowStore.get", flow_id, key)
+    }
+    fn set(&self, flow_id: &str, key: &str, _value: Value) -> Result<()> {
+        self.fail("flowStore.set", flow_id, key)
+    }
+    fn exists(&self, flow_id: &str, key: &str) -> Result<bool> {
+        self.fail("flowStore.exists", flow_id, key)
+    }
+    fn delete(&self, flow_id: &str, key: &str) -> Result<()> {
+        self.fail("flowStore.delete", flow_id, key)
+    }
+    fn increment(&self, flow_id: &str, key: &str) -> Result<i64> {
+        self.fail("flowStore.increment", flow_id, key)
+    }
+    fn set_ttl(&self, flow_id: &str, _ttl_seconds: i64) -> Result<()> {
+        self.fail("flowStore.setTtl", flow_id, "")
+    }
+}

--- a/crates/rift-core/src/extensions/mod.rs
+++ b/crates/rift-core/src/extensions/mod.rs
@@ -13,6 +13,7 @@
 //! - **Template** (`template`): Response body templating with request data
 //! - **Routing** (`routing`): Multi-upstream routing for reverse proxy mode
 
+pub mod decorate;
 pub mod fault;
 pub mod flow_state;
 pub mod matcher;

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -5,7 +5,9 @@
 use super::*;
 
 impl Imposter {
-    /// Find a matching stub for a request and return a cloned copy with its index
+    /// Find a matching stub for a request and return a cloned copy with its index.
+    /// `Err` means a backend consulted during matching failed (issue #318) — the caller
+    /// must surface it, never treat it as "no match".
     pub fn find_matching_stub(
         &self,
         method: &str,
@@ -13,7 +15,7 @@ impl Imposter {
         headers: &hyper::HeaderMap,
         query: Option<&str>,
         body: Option<&str>,
-    ) -> Option<(StubState, usize)> {
+    ) -> anyhow::Result<Option<(StubState, usize)>> {
         // Call the extended version with no client info (backward compatible)
         self.find_matching_stub_with_client(method, path, headers, query, body, None, None)
     }
@@ -29,7 +31,7 @@ impl Imposter {
         body: Option<&str>,
         request_from: Option<&str>,
         client_ip: Option<&str>,
-    ) -> Option<(StubState, usize)> {
+    ) -> anyhow::Result<Option<(StubState, usize)>> {
         let stubs = self.stubs.read();
         let headers_map = Self::header_map_to_hashmap(headers);
         // Parse form data if Content-Type is application/x-www-form-urlencoded
@@ -52,7 +54,7 @@ impl Imposter {
             // (flow_id, scenario) state equals it.
             if let Some(required) = &stub.required_scenario_state {
                 let scenario = stub.scenario_name.as_deref().unwrap_or("");
-                if self.scenario_state(&flow_id, scenario) != *required {
+                if self.scenario_state(&flow_id, scenario)? != *required {
                     continue;
                 }
             }
@@ -80,10 +82,10 @@ impl Imposter {
                 // clone cleanly would mean making `StubState.stub` an `Arc<Stub>` — a broader field
                 // retype across every `.stub` access/mutation site, deferred out of this
                 // behavior-preserving pass.
-                return Some((stub_state.clone(), index));
+                return Ok(Some((stub_state.clone(), index)));
             }
         }
-        None
+        Ok(None)
     }
 
     /// The configured `flow_id_source` (`"imposter_port"` or `"header:<Name>"`),
@@ -137,18 +139,19 @@ impl Imposter {
     }
 
     /// Current scenario state for `(flow_id, scenario)`, or the initial state if absent.
-    /// A backend read error degrades to the initial state but is logged — it must not be
-    /// silently mistaken for "no state yet", which would mis-gate matching.
-    pub fn scenario_state(&self, flow_id: &str, scenario: &str) -> String {
-        match self.flow_store.get(flow_id, scenario) {
-            Ok(Some(v)) => v.as_str().unwrap_or(INITIAL_SCENARIO_STATE).to_string(),
-            Ok(None) => INITIAL_SCENARIO_STATE.to_string(),
-            Err(e) => {
-                warn!(
-                    "scenario state read failed ({flow_id}/{scenario}); using initial '{INITIAL_SCENARIO_STATE}': {e}"
-                );
-                INITIAL_SCENARIO_STATE.to_string()
-            }
+    /// A backend read error propagates (issue #318): defaulting to the initial state on a
+    /// failing store would mis-gate matching into a silent wrong match.
+    pub fn scenario_state(&self, flow_id: &str, scenario: &str) -> anyhow::Result<String> {
+        match self.flow_store.get(flow_id, scenario)? {
+            // A non-string here means the key was overwritten out-of-band (raw flow-state
+            // PUT): coercing it to the initial state would silently mis-gate matching.
+            Some(v) => match v.as_str() {
+                Some(state) => Ok(state.to_string()),
+                None => {
+                    anyhow::bail!("scenario state for {flow_id}/{scenario} is not a string: {v}")
+                }
+            },
+            None => Ok(INITIAL_SCENARIO_STATE.to_string()),
         }
     }
 
@@ -171,14 +174,15 @@ impl Imposter {
         self.flow_store.delete(flow_id, scenario)
     }
 
-    /// Apply a matched stub's `newScenarioState` transition after it responds (no-op if unset).
-    pub fn apply_scenario_transition(&self, flow_id: &str, stub: &Stub) {
+    /// Apply a matched stub's `newScenarioState` transition (no-op if unset). A backend
+    /// write error propagates (issue #318): a lost transition would silently desync the
+    /// FSM, so the request must fail loudly instead.
+    pub fn apply_scenario_transition(&self, flow_id: &str, stub: &Stub) -> anyhow::Result<()> {
         if let Some(next) = &stub.new_scenario_state {
             let scenario = stub.scenario_name.as_deref().unwrap_or("");
-            if let Err(e) = self.set_scenario_state(flow_id, scenario, next) {
-                warn!("scenario transition failed ({flow_id}/{scenario} -> {next}): {e}");
-            }
+            self.set_scenario_state(flow_id, scenario, next)?;
         }
+        Ok(())
     }
 
     /// Read a raw flow-state value (admin flow-state inspection).
@@ -226,7 +230,7 @@ impl Imposter {
 
     /// Tear down a correlation space (issue #223): remove its scoped stubs, drop its recorded
     /// requests, and reset its named scenario states. Other spaces and the port are untouched.
-    pub fn teardown_space(&self, space: &str) {
+    pub fn teardown_space(&self, space: &str) -> anyhow::Result<()> {
         // Snapshot scenario names BEFORE pruning stubs: a scenario declared only on this space's
         // stubs would otherwise vanish from scenario_names() and its state would never be reset.
         let scenarios = self.scenario_names();
@@ -237,10 +241,19 @@ impl Imposter {
         self.recorded_requests.write().retain(|r| {
             Self::flow_id_for(&source, &r.headers, self.config.port.unwrap_or(0)) != space
         });
+        // Best-effort across scenarios so one bad key doesn't leave later scenarios stale,
+        // but the first failure still surfaces (issue #318) — never report a clean teardown
+        // while stale scenario state persists in the backend.
+        let mut first_err = None;
         for scenario in scenarios {
             if let Err(e) = self.delete_scenario_state(space, &scenario) {
                 warn!("space teardown: failed to reset scenario '{scenario}' for '{space}': {e}");
+                first_err.get_or_insert(e);
             }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
         }
     }
 

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -168,6 +168,11 @@ impl Imposter {
                     Arc::new(InMemoryFlowStore::new(flow_state_config.ttl_seconds as u64))
                 }
                 "redis" => Self::create_redis_flow_store(flow_state_config),
+                #[cfg(feature = "test-backend")]
+                "failing" => {
+                    info!("Creating deliberately failing FlowStore (test-backend feature)");
+                    Arc::new(crate::extensions::flow_state::FailingFlowStore)
+                }
                 other => {
                     warn!("Unknown flow state backend '{}', using NoOp", other);
                     Arc::new(NoOpFlowStore)

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -13,6 +13,9 @@ use crate::behaviors::{
     CsvCache, RequestContext, ResponseBehaviors, apply_copy_behaviors, apply_lookup_behaviors,
     apply_shell_transform, header_to_title_case,
 };
+use crate::extensions::decorate::{
+    ResponseDecorator, ResponsePhase, backend_error_response, with_annotation_scope,
+};
 use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::scripting::{FaultDecision, ScriptEngine, ScriptRequest};
 #[cfg(feature = "javascript")]
@@ -40,6 +43,32 @@ const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
 fn csv_cache() -> &'static CsvCache {
     static CSV_CACHE: std::sync::OnceLock<CsvCache> = std::sync::OnceLock::new();
     CSV_CACHE.get_or_init(CsvCache::new)
+}
+
+/// [`handle_imposter_request`] inside a per-request annotation scope, with the configured
+/// [`ResponseDecorator`](crate::extensions::decorate::ResponseDecorator) applied (phase
+/// `DataPlane`, the imposter's `port`) before the response is written (issue #318). This
+/// is the serve-loop wrapper; it is public so custom listeners can reuse the exact
+/// production wiring.
+pub async fn handle_imposter_request_decorated(
+    req: Request<Incoming>,
+    imposter: Arc<Imposter>,
+    client_addr: SocketAddr,
+    port: u16,
+    decorator: Option<Arc<dyn ResponseDecorator>>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let (response, annotations) =
+        with_annotation_scope(handle_imposter_request(req, imposter, client_addr)).await;
+    let mut response = response?;
+    if let Some(decorator) = decorator {
+        decorator.decorate(
+            ResponsePhase::DataPlane,
+            Some(port),
+            &annotations,
+            response.headers_mut(),
+        );
+    }
+    Ok(response)
 }
 
 /// Handle a request to an imposter
@@ -215,7 +244,7 @@ async fn handle_request_inner(
     // Get client address info for requestFrom, ip predicates
     let request_from = client_addr.to_string();
     let client_ip = client_addr.ip().to_string();
-    if let Some((stub_state, stub_index)) = imposter.find_matching_stub_with_client(
+    let matched = match imposter.find_matching_stub_with_client(
         method_str,
         path_str,
         &headers_for_context,
@@ -224,12 +253,20 @@ async fn handle_request_inner(
         Some(&request_from),
         Some(&client_ip),
     ) {
+        Ok(matched) => matched,
+        // A backend consulted during matching failed (issue #318): surface it, never
+        // fall through to "no match" (which would serve the wrong response).
+        Err(e) => return Ok(backend_error_response(&e)),
+    };
+    if let Some((stub_state, stub_index)) = matched {
         // Scenario FSM: apply the matched stub's newScenarioState transition (no-op unless set).
         // Resolve flow_id from the same header map the eligibility gate used (headers_for_context)
         // so the transition writes the exact key the gate read.
         let scenario_flow_id =
             imposter.resolve_flow_id(&Imposter::header_map_to_hashmap(&headers_for_context));
-        imposter.apply_scenario_transition(&scenario_flow_id, &stub_state.stub);
+        if let Err(e) = imposter.apply_scenario_transition(&scenario_flow_id, &stub_state.stub) {
+            return Ok(backend_error_response(&e));
+        }
 
         // Check if this is a proxy response
         if let Some(proxy_config) = imposter.get_proxy_response(&stub_state) {
@@ -781,16 +818,19 @@ fn handle_debug_request(
         Some(query_str)
     };
 
-    let match_result = if let Some((stub_state, stub_index)) = imposter
-        .find_matching_stub_with_client(
-            method,
-            path,
-            headers_for_context,
-            query_opt,
-            body_string.as_deref(),
-            Some(&request_from),
-            Some(&client_ip),
-        ) {
+    let matched = match imposter.find_matching_stub_with_client(
+        method,
+        path,
+        headers_for_context,
+        query_opt,
+        body_string.as_deref(),
+        Some(&request_from),
+        Some(&client_ip),
+    ) {
+        Ok(matched) => matched,
+        Err(e) => return Ok(backend_error_response(&e)),
+    };
+    let match_result = if let Some((stub_state, stub_index)) = matched {
         // Match found
         let response_preview = imposter.get_response_preview(&stub_state);
         DebugMatchResult {

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -5,9 +5,10 @@
 
 use super::core::Imposter;
 use super::fault_io::{FaultCell, FaultIo, TcpFaultKind};
-use super::handler::handle_imposter_request;
+use super::handler::handle_imposter_request_decorated;
 use super::reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, StubReconcile};
 use super::types::{ImposterConfig, ImposterError, Stub};
+use crate::extensions::decorate::ResponseDecorator;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
@@ -50,14 +51,17 @@ async fn run_http1<I>(
     fault_cell: FaultCell,
     mut conn_shutdown_rx: broadcast::Receiver<()>,
     port: u16,
+    decorator: Option<Arc<dyn ResponseDecorator>>,
 ) where
     I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
 {
     let service = service_fn(move |req| {
         let imposter = Arc::clone(&imposter);
         let fault_cell = Arc::clone(&fault_cell);
+        let decorator = decorator.clone();
         async move {
-            let response = handle_imposter_request(req, imposter, addr).await?;
+            let response =
+                handle_imposter_request_decorated(req, imposter, addr, port, decorator).await?;
             if let Some(kind) = response.extensions().get::<TcpFaultKind>().copied() {
                 *fault_cell.lock() = Some(kind);
             }
@@ -95,6 +99,8 @@ pub struct ImposterManager {
     tls_defaults: TlsDefaults,
     /// Observer for config mutations (issue #316)
     event_listener: Option<Arc<dyn ImposterEventListener>>,
+    /// Outgoing-response hook for imposter traffic (issue #318)
+    response_decorator: Option<Arc<dyn ResponseDecorator>>,
 }
 
 impl ImposterManager {
@@ -112,6 +118,7 @@ impl ImposterManager {
             datadir: datadir.map(Arc::new),
             tls_defaults: TlsDefaults::default(),
             event_listener: None,
+            response_decorator: None,
         }
     }
 
@@ -129,6 +136,22 @@ impl ImposterManager {
     pub fn with_event_listener(mut self, listener: Arc<dyn ImposterEventListener>) -> Self {
         self.event_listener = Some(listener);
         self
+    }
+
+    /// Register an outgoing-response decorator (issue #318). Invoked for every response an
+    /// imposter serves (phase `DataPlane`, the imposter's port), with the annotations
+    /// collected during the request. The admin server applies the same decorator with
+    /// phase `Admin` via [`Self::response_decorator`].
+    #[must_use]
+    pub fn with_response_decorator(mut self, decorator: Arc<dyn ResponseDecorator>) -> Self {
+        self.response_decorator = Some(decorator);
+        self
+    }
+
+    /// The configured response decorator, if any — public so admin/embedder listeners can
+    /// apply the same hook to their own responses.
+    pub fn response_decorator(&self) -> Option<Arc<dyn ResponseDecorator>> {
+        self.response_decorator.clone()
     }
 
     fn emit(&self, event: ImposterEvent) {
@@ -248,6 +271,7 @@ impl ImposterManager {
         let imposter_clone = Arc::clone(&imposter);
         let conn_shutdown_tx = shutdown_tx.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
+        let response_decorator = self.response_decorator.clone();
 
         let _handle = tokio::spawn(async move {
             loop {
@@ -262,6 +286,7 @@ impl ImposterManager {
                                 let conn_shutdown_rx = conn_shutdown_tx.subscribe();
                                 // Per-imposter TLS acceptor is cheap to clone (Arc-backed).
                                 let tls_acceptor = tls_acceptor.clone();
+                                let decorator = response_decorator.clone();
                                 tokio::spawn(async move {
                                     // Per-connection slot for a real transport fault (issue #239);
                                     // armed by the handler, applied by FaultIo on the response write.
@@ -286,6 +311,7 @@ impl ImposterManager {
                                                     fault_cell,
                                                     conn_shutdown_rx,
                                                     port,
+                                                    decorator,
                                                 )
                                                 .await
                                             }
@@ -304,6 +330,7 @@ impl ImposterManager {
                                                 fault_cell,
                                                 conn_shutdown_rx,
                                                 port,
+                                                decorator,
                                             )
                                             .await
                                         }
@@ -671,7 +698,9 @@ impl ImposterManager {
     /// and scenario state, then persist the updated stub set.
     pub async fn teardown_space(&self, port: u16, space: &str) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
-        imposter.teardown_space(space);
+        imposter
+            .teardown_space(space)
+            .map_err(ImposterError::Backend)?;
         self.persist_imposter_checked(&imposter).await
     }
 

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -45,7 +45,7 @@ pub use types::{
 pub use core::Imposter;
 
 // Re-export the imposter request handler (single-port gateway dispatch, issue #212)
-pub use handler::handle_imposter_request;
+pub use handler::{handle_imposter_request, handle_imposter_request_decorated};
 
 // Re-export manager
 pub use manager::{ImposterManager, TlsDefaults};

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -2799,6 +2799,7 @@ mod scenario_fsm_tests {
         // Started ⇒ first eligible (index 0)
         let (_, idx) = imp
             .find_matching_stub("GET", "/s", &hdrs, None, None)
+            .expect("store is infallible")
             .expect("match in Started");
         assert_eq!(idx, 0);
 
@@ -2806,6 +2807,7 @@ mod scenario_fsm_tests {
         imp.set_scenario_state("7001", "order", "paid").unwrap();
         let (_, idx) = imp
             .find_matching_stub("GET", "/s", &hdrs, None, None)
+            .expect("store is infallible")
             .expect("match in paid");
         assert_eq!(idx, 1);
     }
@@ -3340,5 +3342,257 @@ mod id_addressed_stub_tests {
             assert_eq!(present, i % 2 == 1, "only odd ids survive ({i})");
         }
         let _ = manager.delete_imposter(19813).await;
+    }
+}
+
+// =========================================================================
+// Issue #318: backend error propagation + per-request annotations + decorator
+// =========================================================================
+mod backend_errors {
+    use super::*;
+    use crate::extensions::decorate::{
+        BackendUnavailable, ResponseDecorator, ResponsePhase, annotate,
+    };
+    use crate::extensions::flow_state::FlowStore;
+    use crate::imposter::core::Imposter;
+    use crate::imposter::handler::handle_imposter_request_decorated;
+    use parking_lot::Mutex;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    /// A backend whose reads and writes fail with `BackendUnavailable`, annotating each op.
+    struct FailingStore;
+
+    impl FlowStore for FailingStore {
+        fn get(&self, _flow_id: &str, _key: &str) -> anyhow::Result<Option<Value>> {
+            annotate("flowStore.get", "induced-failure".to_string());
+            Err(anyhow::Error::new(BackendUnavailable {
+                feature: "flowState",
+                detail: "induced get failure".to_string(),
+            }))
+        }
+        fn set(&self, _flow_id: &str, _key: &str, _value: Value) -> anyhow::Result<()> {
+            annotate("flowStore.set", "induced-failure".to_string());
+            Err(anyhow::Error::new(BackendUnavailable {
+                feature: "flowState",
+                detail: "induced set failure".to_string(),
+            }))
+        }
+        fn exists(&self, _flow_id: &str, _key: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn delete(&self, _flow_id: &str, _key: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn increment(&self, _flow_id: &str, _key: &str) -> anyhow::Result<i64> {
+            Ok(1)
+        }
+        fn set_ttl(&self, _flow_id: &str, _ttl_seconds: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn gated_imposter() -> Arc<Imposter> {
+        let config: ImposterConfig = serde_json::from_value(json!({
+            "protocol": "http", "port": 19490,
+            "stubs": [{
+                "scenarioName": "order",
+                "requiredScenarioState": "Started",
+                "predicates": [{"equals": {"path": "/gated"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "ok"}}]
+            }]
+        }))
+        .expect("config");
+        let mut imposter = Imposter::new(config);
+        imposter.flow_store = Arc::new(FailingStore);
+        Arc::new(imposter)
+    }
+
+    // AC3 (propagation): the scenario eligibility gate no longer swallows store errors.
+    #[test]
+    fn scenario_gate_propagates_store_error() {
+        let imposter = gated_imposter();
+        let err = imposter
+            .find_matching_stub("GET", "/gated", &hyper::HeaderMap::new(), None, None)
+            .expect_err("store failure must propagate, not default to initial state");
+        assert!(
+            err.downcast_ref::<BackendUnavailable>().is_some(),
+            "typed error must survive: {err:?}"
+        );
+    }
+
+    // A non-string value stored on a scenario key (out-of-band raw flow-state PUT) is an
+    // error, never silently coerced to the initial state.
+    #[test]
+    fn scenario_state_non_string_value_errors() {
+        let config: ImposterConfig = serde_json::from_value(json!({
+            "protocol": "http", "port": 19492,
+            "stubs": [{
+                "scenarioName": "order",
+                "requiredScenarioState": "Started",
+                "predicates": [{"equals": {"path": "/gated"}}],
+                "responses": [{"is": {"statusCode": 200}}]
+            }]
+        }))
+        .expect("config");
+        let imposter = Imposter::new(config);
+        imposter
+            .flow_set("f", "order", json!(42))
+            .expect("in-memory set");
+        let err = imposter
+            .scenario_state("f", "order")
+            .expect_err("non-string state must error");
+        assert!(err.to_string().contains("not a string"), "got: {err}");
+    }
+
+    // AC3 (propagation): a failed newScenarioState write propagates too.
+    #[test]
+    fn scenario_transition_error_propagates() {
+        let imposter = gated_imposter();
+        let stub: Stub = serde_json::from_value(json!({
+            "scenarioName": "order",
+            "newScenarioState": "paid",
+            "predicates": [],
+            "responses": [{"is": {"statusCode": 200}}]
+        }))
+        .expect("stub");
+        let err = imposter
+            .apply_scenario_transition("flow", &stub)
+            .expect_err("transition write failure must propagate");
+        assert!(err.downcast_ref::<BackendUnavailable>().is_some());
+    }
+
+    type DecoratorCall = (ResponsePhase, Option<u16>, Vec<(&'static str, String)>);
+
+    #[derive(Default)]
+    struct RecordingDecorator {
+        calls: Mutex<Vec<DecoratorCall>>,
+    }
+
+    impl ResponseDecorator for RecordingDecorator {
+        fn decorate(
+            &self,
+            phase: ResponsePhase,
+            req_port: Option<u16>,
+            annotations: &[(&'static str, String)],
+            headers: &mut hyper::HeaderMap,
+        ) {
+            self.calls
+                .lock()
+                .push((phase, req_port, annotations.to_vec()));
+            headers.insert("x-test-decorated", "1".parse().expect("header"));
+        }
+    }
+
+    // AC2 + AC3 end-to-end on the data plane: a bare listener serving the decorated
+    // entrypoint returns the structured 503, and the decorator sees the phase, the
+    // imposter port, and the annotations the failing backend attached.
+    #[tokio::test]
+    async fn decorated_data_plane_serves_503_and_annotations() {
+        use hyper::server::conn::http1;
+        use hyper::service::service_fn;
+        use hyper_util::rt::TokioIo;
+
+        let imposter = gated_imposter();
+        let recorder = Arc::new(RecordingDecorator::default());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:12617")
+            .await
+            .expect("bind");
+        let imp = imposter.clone();
+        let rec = recorder.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, addr)) = listener.accept().await else {
+                    break;
+                };
+                let imp = imp.clone();
+                let rec = rec.clone();
+                tokio::spawn(async move {
+                    let service = service_fn(move |req| {
+                        let imp = imp.clone();
+                        let rec = rec.clone();
+                        async move {
+                            handle_imposter_request_decorated(
+                                req,
+                                imp,
+                                addr,
+                                19490,
+                                Some(rec as Arc<dyn ResponseDecorator>),
+                            )
+                            .await
+                        }
+                    });
+                    let _ = http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let resp = reqwest::get("http://127.0.0.1:12617/gated")
+            .await
+            .expect("request");
+        assert_eq!(resp.status(), 503, "backend failure is a structured 503");
+        assert_eq!(
+            resp.headers()
+                .get("x-test-decorated")
+                .and_then(|v| v.to_str().ok()),
+            Some("1"),
+            "decorator header must land on the wire"
+        );
+        let body: serde_json::Value = resp.json().await.expect("json");
+        assert_eq!(body["error"], "backendUnavailable");
+        assert_eq!(body["feature"], "flowState");
+
+        let calls = recorder.calls.lock().clone();
+        assert_eq!(calls.len(), 1);
+        let (phase, port, annotations) = &calls[0];
+        assert_eq!(*phase, ResponsePhase::DataPlane);
+        assert_eq!(*port, Some(19490));
+        assert!(
+            annotations
+                .iter()
+                .any(|(k, v)| *k == "flowStore.get" && v == "induced-failure"),
+            "backend annotation must reach the decorator: {annotations:?}"
+        );
+    }
+
+    // AC2: the manager's builder wires the decorator into the real serve loop.
+    #[tokio::test]
+    async fn manager_with_decorator_decorates_normal_response() {
+        let recorder = Arc::new(RecordingDecorator::default());
+        let manager = ImposterManager::new()
+            .with_response_decorator(recorder.clone() as Arc<dyn ResponseDecorator>);
+        let config: ImposterConfig = serde_json::from_value(json!({
+            "protocol": "http", "port": 19491,
+            "stubs": [{
+                "predicates": [{"equals": {"path": "/ping"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "pong"}}]
+            }]
+        }))
+        .expect("config");
+        manager.create_imposter(config).await.expect("create");
+
+        let resp = reqwest::get("http://127.0.0.1:19491/ping")
+            .await
+            .expect("request");
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get("x-test-decorated")
+                .and_then(|v| v.to_str().ok()),
+            Some("1")
+        );
+
+        let calls = recorder.calls.lock().clone();
+        assert_eq!(calls.len(), 1);
+        let (phase, port, annotations) = &calls[0];
+        assert_eq!(*phase, ResponsePhase::DataPlane);
+        assert_eq!(*port, Some(19491));
+        assert!(annotations.is_empty(), "plain stub produces no annotations");
+
+        manager.delete_all().await;
     }
 }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -1023,6 +1023,8 @@ pub enum ImposterError {
     PersistError(String),
     #[error("TLS configuration error: {0}")]
     Tls(String),
+    #[error("backend error: {0:#}")]
+    Backend(anyhow::Error),
 }
 
 #[cfg(test)]

--- a/crates/rift-core/src/response/mod.rs
+++ b/crates/rift-core/src/response/mod.rs
@@ -72,6 +72,7 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 StatusCode::BAD_REQUEST,
                 &format!("TLS configuration error: {msg}"),
             ),
+            ImposterError::Backend(e) => crate::extensions::decorate::backend_error_response(&e),
         }
     }
 }

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{FlowStore, log_flow_err};
 use crate::scripting::{FaultDecision, ScriptRequest};
 use anyhow::{Result, anyhow};
 use boa_engine::{
@@ -355,8 +355,11 @@ fn flow_store_get(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsRes
     let result = with_current_flow_store(|store| store.get(&flow_id, &key));
 
     match result {
-        Some(Ok(Some(value))) => json_to_js_result(ctx, &value),
-        _ => Ok(JsValue::null()),
+        Some(store_result) => match log_flow_err("get", None, store_result) {
+            Some(value) => json_to_js_result(ctx, &value),
+            None => Ok(JsValue::null()),
+        },
+        None => Ok(JsValue::null()),
     }
 }
 
@@ -374,8 +377,14 @@ fn flow_store_set(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsRes
     let value = args.get(2).cloned().unwrap_or(JsValue::null());
 
     let json_value = js_to_json(ctx, &value)?;
-    let result = with_current_flow_store(|store| store.set(&flow_id, &key, json_value).is_ok())
-        .unwrap_or(false);
+    let result = with_current_flow_store(|store| {
+        log_flow_err(
+            "set",
+            false,
+            store.set(&flow_id, &key, json_value).map(|()| true),
+        )
+    })
+    .unwrap_or(false);
 
     Ok(JsValue::from(result))
 }
@@ -392,8 +401,10 @@ fn flow_store_exists(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> J
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result = with_current_flow_store(|store| store.exists(&flow_id, &key).unwrap_or(false))
-        .unwrap_or(false);
+    let result = with_current_flow_store(|store| {
+        log_flow_err("exists", false, store.exists(&flow_id, &key))
+    })
+    .unwrap_or(false);
 
     Ok(JsValue::from(result))
 }
@@ -410,8 +421,10 @@ fn flow_store_delete(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> J
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result =
-        with_current_flow_store(|store| store.delete(&flow_id, &key).is_ok()).unwrap_or(false);
+    let result = with_current_flow_store(|store| {
+        log_flow_err("delete", false, store.delete(&flow_id, &key).map(|()| true))
+    })
+    .unwrap_or(false);
 
     Ok(JsValue::from(result))
 }
@@ -432,8 +445,10 @@ fn flow_store_increment(
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result =
-        with_current_flow_store(|store| store.increment(&flow_id, &key).unwrap_or(0)).unwrap_or(0);
+    let result = with_current_flow_store(|store| {
+        log_flow_err("increment", 0, store.increment(&flow_id, &key))
+    })
+    .unwrap_or(0);
 
     Ok(JsValue::from(result))
 }
@@ -450,8 +465,14 @@ fn flow_store_set_ttl(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> 
         .map(|n| n as i64)
         .ok_or_else(|| JsNativeError::typ().with_message("ttl_seconds must be a number"))?;
 
-    let result = with_current_flow_store(|store| store.set_ttl(&flow_id, ttl_seconds).is_ok())
-        .unwrap_or(false);
+    let result = with_current_flow_store(|store| {
+        log_flow_err(
+            "setTtl",
+            false,
+            store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
+        )
+    })
+    .unwrap_or(false);
 
     Ok(JsValue::from(result))
 }

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{FlowStore, log_flow_err};
 use crate::scripting::{FaultDecision, ScriptRequest};
 use anyhow::{Result, anyhow};
 use mlua::prelude::*;
@@ -611,9 +611,9 @@ impl LuaFlowStore {
         let store = Arc::clone(&self.store);
 
         // Direct synchronous call - no async bridging needed
-        match store.get(&flow_id, &key) {
-            Ok(Some(value)) => json_to_lua(lua, &value),
-            _ => Ok(LuaValue::Nil),
+        match log_flow_err("get", None, store.get(&flow_id, &key)) {
+            Some(value) => json_to_lua(lua, &value),
+            None => Ok(LuaValue::Nil),
         }
     }
 
@@ -624,47 +624,45 @@ impl LuaFlowStore {
 
         let store = Arc::clone(&self.store);
 
-        let result = store.set(&flow_id, &key, json_value);
+        let result = store.set(&flow_id, &key, json_value).map(|()| true);
 
-        Ok(result.is_ok())
+        Ok(log_flow_err("set", false, result))
     }
 
     /// Check if a key exists
     fn exists(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        match store.exists(&flow_id, &key) {
-            Ok(exists) => Ok(exists),
-            Err(_) => Ok(false),
-        }
+        Ok(log_flow_err("exists", false, store.exists(&flow_id, &key)))
     }
 
     /// Delete a key
     fn delete(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        let result = store.delete(&flow_id, &key);
+        let result = store.delete(&flow_id, &key).map(|()| true);
 
-        Ok(result.is_ok())
+        Ok(log_flow_err("delete", false, result))
     }
 
     /// Increment a counter
     fn increment(&self, flow_id: String, key: String) -> LuaResult<i64> {
         let store = Arc::clone(&self.store);
 
-        match store.increment(&flow_id, &key) {
-            Ok(value) => Ok(value),
-            Err(_) => Ok(0),
-        }
+        Ok(log_flow_err(
+            "increment",
+            0,
+            store.increment(&flow_id, &key),
+        ))
     }
 
     /// Set TTL for a flow
     fn set_ttl(&self, flow_id: String, ttl_seconds: i64) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        let result = store.set_ttl(&flow_id, ttl_seconds);
+        let result = store.set_ttl(&flow_id, ttl_seconds).map(|()| true);
 
-        Ok(result.is_ok())
+        Ok(log_flow_err("setTtl", false, result))
     }
 }
 

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{FlowStore, log_flow_err};
 use anyhow::{Result, anyhow};
 use rhai::Dynamic;
 use serde_json::Value;
@@ -160,36 +160,48 @@ impl ScriptFlowStore {
 
     /// Get a value from flow state
     pub fn get(&mut self, flow_id: String, key: String) -> Dynamic {
-        match self.store.get(&flow_id, &key) {
-            Ok(Some(val)) => rhai_engine::json_to_dynamic(val),
-            _ => Dynamic::UNIT,
+        match log_flow_err("get", None, self.store.get(&flow_id, &key)) {
+            Some(val) => rhai_engine::json_to_dynamic(val),
+            None => Dynamic::UNIT,
         }
     }
 
     /// Set a value in flow state
     pub fn set(&mut self, flow_id: String, key: String, value: Dynamic) -> bool {
         let json_val = rhai_engine::dynamic_to_json(value);
-        self.store.set(&flow_id, &key, json_val).is_ok()
+        log_flow_err(
+            "set",
+            false,
+            self.store.set(&flow_id, &key, json_val).map(|()| true),
+        )
     }
 
     /// Check if a key exists
     pub fn exists(&mut self, flow_id: String, key: String) -> bool {
-        self.store.exists(&flow_id, &key).unwrap_or(false)
+        log_flow_err("exists", false, self.store.exists(&flow_id, &key))
     }
 
     /// Delete a key
     pub fn delete(&mut self, flow_id: String, key: String) -> bool {
-        self.store.delete(&flow_id, &key).is_ok()
+        log_flow_err(
+            "delete",
+            false,
+            self.store.delete(&flow_id, &key).map(|()| true),
+        )
     }
 
     /// Increment a counter
     pub fn increment(&mut self, flow_id: String, key: String) -> i64 {
-        self.store.increment(&flow_id, &key).unwrap_or(0)
+        log_flow_err("increment", 0, self.store.increment(&flow_id, &key))
     }
 
     /// Set TTL for a flow
     pub fn set_ttl(&mut self, flow_id: String, ttl_seconds: i64) -> bool {
-        self.store.set_ttl(&flow_id, ttl_seconds).is_ok()
+        log_flow_err(
+            "setTtl",
+            false,
+            self.store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
+        )
     }
 }
 

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -87,6 +87,8 @@ sxd-xpath = "0.4"
 serde_json_path = "0.7"
 
 [dev-dependencies]
+# Turn on the failing flow-store backend for backend-outage tests (issue #318)
+rift-core = { path = "../rift-core", default-features = false, features = ["test-backend"] }
 tempfile = "3.8"
 rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -5,6 +5,7 @@
 //! flow (`resolve_flow_id` with no headers ⇒ the `imposter_port` flow) is used.
 
 use crate::admin_api::types::{collect_body, error_response, json_response};
+use crate::extensions::decorate::backend_error_response;
 use crate::imposter::{Imposter, ImposterManager, Stub};
 use bytes::Bytes;
 use http_body_util::Full;
@@ -49,14 +50,15 @@ pub async fn handle_list_scenarios(
     match manager.get_imposter(port) {
         Ok(imposter) => {
             let flow_id = flow_id_from_query(query).unwrap_or_else(|| default_flow_id(&imposter));
-            let scenarios: Vec<_> = imposter
-                .scenario_names()
-                .into_iter()
-                .map(|name| {
-                    let state = imposter.scenario_state(&flow_id, &name);
-                    serde_json::json!({ "name": name, "state": state })
-                })
-                .collect();
+            let mut scenarios = Vec::new();
+            for name in imposter.scenario_names() {
+                match imposter.scenario_state(&flow_id, &name) {
+                    Ok(state) => {
+                        scenarios.push(serde_json::json!({ "name": name, "state": state }))
+                    }
+                    Err(e) => return backend_error_response(&e),
+                }
+            }
             json_response(
                 StatusCode::OK,
                 &serde_json::json!({ "flowId": flow_id, "scenarios": scenarios }),
@@ -92,7 +94,7 @@ pub async fn handle_set_scenario_state(
                     StatusCode::OK,
                     &serde_json::json!({ "flowId": flow_id, "name": name, "state": state }),
                 ),
-                Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+                Err(e) => backend_error_response(&e),
             }
         }
         Err(e) => e.into(),
@@ -124,7 +126,7 @@ pub async fn handle_reset_scenarios(
             let flow_id = flow_id_opt.unwrap_or_else(|| default_flow_id(&imposter));
             for name in imposter.scenario_names() {
                 if let Err(e) = imposter.delete_scenario_state(&flow_id, &name) {
-                    return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
+                    return backend_error_response(&e);
                 }
             }
             json_response(
@@ -150,7 +152,7 @@ pub async fn handle_get_flow_state(
                 &serde_json::json!({ "flowId": flow_id, "key": key, "value": value }),
             ),
             Ok(None) => error_response(StatusCode::NOT_FOUND, "flow-state key not found"),
-            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+            Err(e) => backend_error_response(&e),
         },
         Err(e) => e.into(),
     }
@@ -177,7 +179,7 @@ pub async fn handle_put_flow_state(
                 StatusCode::OK,
                 &serde_json::json!({ "flowId": flow_id, "key": key, "value": value }),
             ),
-            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+            Err(e) => backend_error_response(&e),
         },
         Err(e) => e.into(),
     }
@@ -196,7 +198,7 @@ pub async fn handle_delete_flow_state(
                 StatusCode::OK,
                 &serde_json::json!({ "flowId": flow_id, "key": key, "deleted": true }),
             ),
-            Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+            Err(e) => backend_error_response(&e),
         },
         Err(e) => e.into(),
     }
@@ -256,14 +258,15 @@ pub async fn handle_get_space(
 ) -> Response<Full<Bytes>> {
     match manager.get_imposter(port) {
         Ok(imposter) => {
-            let scenarios: Vec<_> = imposter
-                .scenario_names()
-                .into_iter()
-                .map(|name| {
-                    let state = imposter.scenario_state(flow_id, &name);
-                    serde_json::json!({ "name": name, "state": state })
-                })
-                .collect();
+            let mut scenarios = Vec::new();
+            for name in imposter.scenario_names() {
+                match imposter.scenario_state(flow_id, &name) {
+                    Ok(state) => {
+                        scenarios.push(serde_json::json!({ "name": name, "state": state }))
+                    }
+                    Err(e) => return backend_error_response(&e),
+                }
+            }
             let number_of_requests = imposter
                 .get_recorded_requests()
                 .iter()

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -2,6 +2,7 @@
 
 use crate::admin_api::router::route_request;
 use crate::config_loader::ConfigSource;
+use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -66,25 +67,42 @@ impl AdminApiServer {
                     let api_key = api_key.clone();
                     let config_source = config_source.clone();
                     async move {
-                        // The single-port gateway (`/__rift/...`, issue #212) is data-plane
-                        // imposter traffic, not the admin control plane — it mirrors direct
-                        // per-imposter-port access and so is NOT gated by the admin `--apikey`
-                        // (which would otherwise force app-under-test traffic to carry the admin
-                        // key and would leak that Authorization header into imposter predicates).
-                        let is_gateway = req.uri().path().starts_with("/__rift/");
-                        if let Some(ref key) = api_key
-                            && !is_gateway
-                        {
-                            let auth = req
-                                .headers()
-                                .get("authorization")
-                                .and_then(|v| v.to_str().ok())
-                                .unwrap_or("");
-                            if auth != key.as_str() {
-                                return Ok::<_, hyper::Error>(unauthorized_response());
+                        // Per-request annotation scope + response decorator (issue #318):
+                        // every response through this listener — including the `/__rift/`
+                        // gateway — is decorated with phase `Admin`.
+                        let decorator = manager.response_decorator();
+                        let (result, annotations) = with_annotation_scope(async move {
+                            // The single-port gateway (`/__rift/...`, issue #212) is data-plane
+                            // imposter traffic, not the admin control plane — it mirrors direct
+                            // per-imposter-port access and so is NOT gated by the admin `--apikey`
+                            // (which would otherwise force app-under-test traffic to carry the admin
+                            // key and would leak that Authorization header into imposter predicates).
+                            let is_gateway = req.uri().path().starts_with("/__rift/");
+                            if let Some(ref key) = api_key
+                                && !is_gateway
+                            {
+                                let auth = req
+                                    .headers()
+                                    .get("authorization")
+                                    .and_then(|v| v.to_str().ok())
+                                    .unwrap_or("");
+                                if auth != key.as_str() {
+                                    return Ok::<_, hyper::Error>(unauthorized_response());
+                                }
                             }
+                            route_request(req, manager, config_source).await
+                        })
+                        .await;
+                        let mut response = result?;
+                        if let Some(decorator) = decorator {
+                            decorator.decorate(
+                                ResponsePhase::Admin,
+                                None,
+                                &annotations,
+                                response.headers_mut(),
+                            );
                         }
-                        route_request(req, manager, config_source).await
+                        Ok::<_, hyper::Error>(response)
                     }
                 });
 

--- a/crates/rift-http-proxy/tests/backend_decorate.rs
+++ b/crates/rift-http-proxy/tests/backend_decorate.rs
@@ -1,0 +1,386 @@
+//! Issue #318: typed BackendUnavailable errors surface as structured 503s (data plane and
+//! admin), the ResponseDecorator hook fires on both phases, and no-decorator responses are
+//! byte-identical to before.
+//!
+//! The failing backend comes from rift-core's `test-backend` feature (dev-dependency):
+//! `_rift.flowState.backend = "failing"` installs a store whose ops annotate then fail
+//! with `BackendUnavailable`.
+
+use parking_lot::Mutex;
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::extensions::decorate::{ResponseDecorator, ResponsePhase};
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::sync::Arc;
+
+fn imposter_cfg(v: serde_json::Value) -> ImposterConfig {
+    serde_json::from_value(v).expect("test imposter config")
+}
+
+fn failing_backend_cfg(port: u16) -> ImposterConfig {
+    imposter_cfg(serde_json::json!({
+        "protocol": "http", "port": port,
+        "_rift": {"flowState": {"backend": "failing"}},
+        "stubs": [{
+            "scenarioName": "order",
+            "requiredScenarioState": "Started",
+            "predicates": [{"equals": {"path": "/gated"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "ok"}}]
+        }]
+    }))
+}
+
+async fn start_admin(admin_port: u16, manager: Arc<ImposterManager>) {
+    let server = AdminApiServer::new(
+        format!("127.0.0.1:{admin_port}").parse().expect("addr"),
+        manager,
+        None,
+    );
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+}
+
+type DecoratorCall = (ResponsePhase, Option<u16>, Vec<(String, String)>);
+
+#[derive(Default)]
+struct RecordingDecorator {
+    calls: Mutex<Vec<DecoratorCall>>,
+}
+
+impl ResponseDecorator for RecordingDecorator {
+    fn decorate(
+        &self,
+        phase: ResponsePhase,
+        req_port: Option<u16>,
+        annotations: &[(&'static str, String)],
+        headers: &mut hyper::HeaderMap,
+    ) {
+        let owned = annotations
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect();
+        self.calls.lock().push((phase, req_port, owned));
+        headers.insert("x-test-decorated", "1".parse().expect("header"));
+    }
+}
+
+// AC2 (admin half): every admin response passes through the decorator with phase Admin.
+#[tokio::test]
+async fn admin_responses_are_decorated() {
+    let recorder = Arc::new(RecordingDecorator::default());
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_response_decorator(recorder.clone() as Arc<dyn ResponseDecorator>),
+    );
+    start_admin(12618, manager).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12618/health")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("x-test-decorated")
+            .and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "admin response must be decorated"
+    );
+    let calls = recorder.calls.lock().clone();
+    assert!(
+        calls
+            .iter()
+            .any(|(p, port, _)| *p == ResponsePhase::Admin && port.is_none()),
+        "decorator must see phase Admin with no port: {calls:?}"
+    );
+}
+
+// AC3 (data plane, e2e through the manager): a failing backend on a scenario-gated
+// request is a structured 503 — never a silent wrong match.
+#[tokio::test]
+async fn data_plane_scenario_gate_returns_structured_503() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(failing_backend_cfg(19493))
+        .await
+        .expect("create");
+
+    let resp = reqwest::get("http://127.0.0.1:19493/gated")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 503);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"], "backendUnavailable");
+    assert_eq!(body["feature"], "flowState");
+
+    manager.delete_all().await;
+}
+
+// AC3 (admin half): a failing backend behind an admin flow-state endpoint is the same
+// structured 503, not an opaque 500.
+#[tokio::test]
+async fn flow_state_admin_endpoint_returns_structured_503() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(failing_backend_cfg(19494))
+        .await
+        .expect("create");
+    start_admin(12620, manager.clone()).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12620/admin/imposters/19494/flow-state/f/k")
+        .await
+        .expect("request");
+    assert_eq!(
+        resp.status(),
+        503,
+        "backend failure must be a structured 503"
+    );
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"], "backendUnavailable");
+
+    manager.delete_all().await;
+}
+
+// AC3 (admin half): the scenario inspection endpoint maps the store error too.
+#[tokio::test]
+async fn scenario_list_maps_backend_error_to_503() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(failing_backend_cfg(19495))
+        .await
+        .expect("create");
+    start_admin(12621, manager.clone()).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12621/imposters/19495/scenarios")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 503);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"], "backendUnavailable");
+
+    manager.delete_all().await;
+}
+
+// AC4: with no decorator and infallible built-ins, the response is byte-identical to
+// before this change — pinned as the exact ordered header-name list captured from the
+// pre-#318 binary for this stub.
+#[tokio::test]
+async fn no_decorator_response_headers_unchanged() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(imposter_cfg(serde_json::json!({
+            "protocol": "http", "port": 19496,
+            "stubs": [{
+                "predicates": [{"equals": {"path": "/ping"}}],
+                "responses": [{"is": {
+                    "statusCode": 200, "body": "pong",
+                    "headers": {"content-type": "text/plain"}
+                }}]
+            }]
+        })))
+        .await
+        .expect("create");
+
+    let resp = reqwest::get("http://127.0.0.1:19496/ping")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 200);
+    let names: Vec<&str> = resp.headers().keys().map(|k| k.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["content-type", "x-rift-imposter", "content-length", "date"],
+        "no-decorator header set must be byte-identical to the pre-#318 baseline"
+    );
+    assert_eq!(resp.text().await.expect("body"), "pong");
+
+    manager.delete_all().await;
+}
+
+// The transition-WRITE path end-to-end: no gate read (no requiredScenarioState), so the
+// match succeeds and the 503 comes from the failed newScenarioState write — the "lost
+// FSM transition" the issue exists to prevent.
+#[tokio::test]
+async fn transition_write_failure_returns_structured_503() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(imposter_cfg(serde_json::json!({
+            "protocol": "http", "port": 19497,
+            "_rift": {"flowState": {"backend": "failing"}},
+            "stubs": [{
+                "scenarioName": "order",
+                "newScenarioState": "paid",
+                "predicates": [{"equals": {"path": "/transition"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "ok"}}]
+            }]
+        })))
+        .await
+        .expect("create");
+
+    let resp = reqwest::get("http://127.0.0.1:19497/transition")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 503, "a lost transition must fail loudly");
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"], "backendUnavailable");
+
+    manager.delete_all().await;
+}
+
+// Annotations produced by a backend during an ADMIN request reach the Admin decorator —
+// proving the with_annotation_scope wiring in server.rs, not just the decorator call.
+#[tokio::test]
+async fn admin_decorator_receives_backend_annotations() {
+    let recorder = Arc::new(RecordingDecorator::default());
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_response_decorator(recorder.clone() as Arc<dyn ResponseDecorator>),
+    );
+    manager
+        .create_imposter(failing_backend_cfg(19498))
+        .await
+        .expect("create");
+    start_admin(12623, manager.clone()).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12623/admin/imposters/19498/flow-state/f/k")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 503);
+    let calls = recorder.calls.lock().clone();
+    let admin_call = calls
+        .iter()
+        .find(|(p, _, _)| *p == ResponsePhase::Admin)
+        .expect("admin call recorded");
+    assert!(admin_call.1.is_none());
+    assert!(
+        admin_call.2.iter().any(|(k, _)| k == "flowStore.get"),
+        "backend annotation must reach the admin decorator: {calls:?}"
+    );
+
+    manager.delete_all().await;
+}
+
+// The /__rift/ gateway rides the admin listener: decorated with phase Admin (documented
+// design decision), and a failing backend through it is the same structured 503.
+#[tokio::test]
+async fn gateway_503_is_decorated_with_admin_phase() {
+    let recorder = Arc::new(RecordingDecorator::default());
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_response_decorator(recorder.clone() as Arc<dyn ResponseDecorator>),
+    );
+    manager
+        .create_imposter(failing_backend_cfg(19499))
+        .await
+        .expect("create");
+    start_admin(12624, manager.clone()).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12624/__rift/19499/gated")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 503);
+    assert_eq!(
+        resp.headers()
+            .get("x-test-decorated")
+            .and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "gateway responses are decorated"
+    );
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"], "backendUnavailable");
+
+    let calls = recorder.calls.lock().clone();
+    let call = calls
+        .iter()
+        .find(|(_, _, notes)| notes.iter().any(|(k, _)| k == "flowStore.get"))
+        .expect("gateway call recorded with the backend annotation");
+    assert_eq!(
+        call.0,
+        ResponsePhase::Admin,
+        "gateway rides the admin phase"
+    );
+    assert!(call.1.is_none());
+
+    manager.delete_all().await;
+}
+
+// The --apikey 401 is produced inside the scope and decorated like any other admin
+// response (the decorator sees it; nothing internal leaks since no route ran).
+#[tokio::test]
+async fn unauthorized_response_is_decorated() {
+    let recorder = Arc::new(RecordingDecorator::default());
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_response_decorator(recorder.clone() as Arc<dyn ResponseDecorator>),
+    );
+    let server = AdminApiServer::new(
+        "127.0.0.1:12625".parse().expect("addr"),
+        manager,
+        Some("secret-token".to_string()),
+    );
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let resp = reqwest::get("http://127.0.0.1:12625/health")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 401);
+    assert_eq!(
+        resp.headers()
+            .get("x-test-decorated")
+            .and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "401s are decorated too"
+    );
+    let calls = recorder.calls.lock().clone();
+    assert!(
+        calls
+            .iter()
+            .any(|(p, port, notes)| *p == ResponsePhase::Admin
+                && port.is_none()
+                && notes.is_empty()),
+        "auth reject collects no annotations: {calls:?}"
+    );
+}
+
+// The write-side admin endpoints (PUT/DELETE flow-state, PUT scenario state, POST reset)
+// all map a failing backend to the structured 503 — they switched from opaque 500s.
+#[tokio::test]
+async fn flow_state_write_endpoints_map_backend_error_to_503() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(failing_backend_cfg(19504))
+        .await
+        .expect("create");
+    start_admin(12622, manager.clone()).await;
+    let client = reqwest::Client::new();
+
+    let put = client
+        .put("http://127.0.0.1:12622/admin/imposters/19504/flow-state/f/k")
+        .json(&serde_json::json!({"value": 1}))
+        .send()
+        .await
+        .expect("put");
+    assert_eq!(put.status(), 503, "PUT flow-state");
+
+    let del = client
+        .delete("http://127.0.0.1:12622/admin/imposters/19504/flow-state/f/k")
+        .send()
+        .await
+        .expect("delete");
+    assert_eq!(del.status(), 503, "DELETE flow-state");
+
+    let set_state = client
+        .put("http://127.0.0.1:12622/imposters/19504/scenarios/order/state")
+        .json(&serde_json::json!({"state": "paid"}))
+        .send()
+        .await
+        .expect("set state");
+    assert_eq!(set_state.status(), 503, "PUT scenario state");
+
+    let reset = client
+        .post("http://127.0.0.1:12622/imposters/19504/scenarios/reset")
+        .send()
+        .await
+        .expect("reset");
+    assert_eq!(reset.status(), 503, "POST scenarios reset");
+
+    manager.delete_all().await;
+}


### PR DESCRIPTION
Gives pluggable backends (#310) an error shape and a per-request metadata channel, and stops the scenario FSM path from silently swallowing `FlowStore` errors.

**New `rift-core` `extensions::decorate`:**
- `BackendUnavailable` typed error → structured `503 {error:backendUnavailable,feature,detail}` (survives an anyhow context chain); non-backend errors → 500 with the full chain. Both logged server-side.
- `annotate`/`with_annotation_scope` — per-request op annotations in a tokio task-local (infallible no-op outside a scope).
- `ResponsePhase` + `ResponseDecorator` + `ImposterManager::with_response_decorator` — outgoing-response header hook, invoked on the data plane (`DataPlane`, imposter port) and admin API (`Admin`).

**Scenario-path fix:** `scenario_state` / `apply_scenario_transition` / `find_matching_stub*` / `teardown_space` now propagate; a failing backend is a 503, never a silent wrong match. `RedisFlowStore` wraps its op failures so a real Redis outage produces the structured 503. Script-engine flow-store wrappers keep their fallback values but now log the dropped error.

**Compatibility:** built-in stores are infallible, so with no decorator responses are byte-identical (pinned by a header-baseline test).

**Notes for reviewers:**
- 503 blast radius: an imposter owning any scenario-gated stub returns 503 for *all* its requests while its store is down — intended fail-loud behavior.
- Adds an off-by-default `test-backend` feature (a deliberately failing flow store) to exercise outage paths; enabled only via dev-dependencies.

22 new tests. Closes #318. Part of #310 (no milestone assigned).