### PR TITLE
Add compare_and_set to FlowStore; use it for scenario transitions

### DIFF
--- a/crates/rift-core/src/backends/inmemory.rs
+++ b/crates/rift-core/src/backends/inmemory.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{CasOutcome, FlowStore};
 use anyhow::Result;
 use parking_lot::RwLock;
 use serde_json::Value;
@@ -125,6 +125,29 @@ impl FlowStore for InMemoryFlowStore {
         }
 
         Ok(())
+    }
+
+    /// Atomic under the single write lock (issue #311): compare and write happen with no
+    /// interleaving window, unlike the trait's get-then-set default.
+    fn compare_and_set(
+        &self,
+        flow_id: &str,
+        key: &str,
+        expected: Option<&Value>,
+        new: Value,
+    ) -> Result<CasOutcome> {
+        let key_str = self.make_key(flow_id, key);
+        let mut data = self.data.write();
+        Self::cleanup_on_write(&mut data, &key_str, |exp| self.is_expired(exp));
+
+        let current = data.get(&key_str).map(|(value, _)| value);
+        if current == expected {
+            let expiry = SystemTime::now() + self.default_ttl;
+            data.insert(key_str, (new, Some(expiry)));
+            Ok(CasOutcome::Applied)
+        } else {
+            Ok(CasOutcome::Conflict(current.cloned()))
+        }
     }
 }
 
@@ -289,5 +312,94 @@ mod tests {
             Some(json!(expected)),
             "Concurrent increments lost updates: expected {expected}, got {final_value:?}"
         );
+    }
+
+    // ===== compare_and_set (issue #311) =====
+
+    #[test]
+    fn cas_expected_absent_applies() {
+        let store = InMemoryFlowStore::new(300);
+        let outcome = store
+            .compare_and_set("f", "state", None, json!("paid"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert_eq!(store.get("f", "state").expect("get"), Some(json!("paid")));
+    }
+
+    #[test]
+    fn cas_expected_present_applies() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f", "state", json!("Started")).expect("set");
+        let outcome = store
+            .compare_and_set("f", "state", Some(&json!("Started")), json!("paid"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert_eq!(store.get("f", "state").expect("get"), Some(json!("paid")));
+    }
+
+    #[test]
+    fn cas_conflict_returns_current() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f", "state", json!("shipped")).expect("set");
+        let outcome = store
+            .compare_and_set("f", "state", Some(&json!("Started")), json!("paid"))
+            .expect("cas");
+        match outcome {
+            CasOutcome::Conflict(current) => assert_eq!(current, Some(json!("shipped"))),
+            CasOutcome::Applied => panic!("must conflict"),
+        }
+        assert_eq!(
+            store.get("f", "state").expect("get"),
+            Some(json!("shipped")),
+            "conflict must not write"
+        );
+
+        let outcome = store
+            .compare_and_set("f", "absent", Some(&json!("Started")), json!("paid"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Conflict(None)));
+    }
+
+    // AC1: N racers, one CAS each on the same expected state — exactly one Applied,
+    // the rest Conflict, final state legal.
+    #[test]
+    fn cas_race_exactly_one_winner() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let store = Arc::new(InMemoryFlowStore::new(300));
+        store.set("f", "state", json!("Started")).expect("seed");
+        let racers = 64;
+        let barrier = Arc::new(Barrier::new(racers));
+
+        let handles: Vec<_> = (0..racers)
+            .map(|i| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let outcome = store
+                        .compare_and_set(
+                            "f",
+                            "state",
+                            Some(&json!("Started")),
+                            json!(format!("paid-by-{i}")),
+                        )
+                        .expect("cas");
+                    matches!(outcome, CasOutcome::Applied)
+                })
+            })
+            .collect();
+
+        let applied = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread"))
+            .filter(|won| *won)
+            .count();
+        assert_eq!(applied, 1, "exactly one racer must win the CAS");
+
+        let final_state = store.get("f", "state").expect("get").expect("present");
+        let s = final_state.as_str().expect("string state");
+        assert!(s.starts_with("paid-by-"), "final state legal, got {s}");
     }
 }

--- a/crates/rift-core/src/backends/redis.rs
+++ b/crates/rift-core/src/backends/redis.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{CasOutcome, FlowStore};
 use anyhow::{Context, Result};
 use redis::{Commands, Connection};
 use serde_json::Value;
@@ -208,6 +208,67 @@ impl FlowStore for RedisFlowStore {
             .map_err(|e| backend_err("flowStore.expire", e))?;
 
         Ok(new_value)
+    }
+
+    /// Single-round-trip atomic CAS via a server-side Lua script (issue #311): compare
+    /// and SETEX happen inside one EVAL, so no WATCH/MULTI and no interleaving window.
+    /// Values compare as their canonical JSON strings — the same encoding `set` writes.
+    fn compare_and_set(
+        &self,
+        flow_id: &str,
+        key: &str,
+        expected: Option<&Value>,
+        new: Value,
+    ) -> Result<CasOutcome> {
+        // Lua false/nil TERMINATES a Redis table reply, so absence is encoded as '' —
+        // unambiguous because stored payloads are always JSON (never the empty string).
+        const CAS_SCRIPT: &str = r#"
+local current = redis.call('GET', KEYS[1])
+local matches
+if ARGV[1] == '0' then
+  matches = (current == false)
+else
+  matches = (current == ARGV[2])
+end
+if matches then
+  redis.call('SETEX', KEYS[1], tonumber(ARGV[4]), ARGV[3])
+  return {1, current or ''}
+else
+  return {0, current or ''}
+end
+"#;
+        let key_str = self.make_key(flow_id, key);
+        let expected_json = expected
+            .map(|v| serde_json::to_string(v).context("Failed to serialize expected to JSON"))
+            .transpose()?
+            .unwrap_or_default();
+        let new_json = serde_json::to_string(&new).context("Failed to serialize value to JSON")?;
+
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| backend_err("flowStore.pool", e))?;
+        let (applied, current): (i64, String) = redis::cmd("EVAL")
+            .arg(CAS_SCRIPT)
+            .arg(1)
+            .arg(&key_str)
+            .arg(if expected.is_some() { "1" } else { "0" })
+            .arg(&expected_json)
+            .arg(&new_json)
+            .arg(self.default_ttl_seconds)
+            .query(&mut *conn.lock().unwrap())
+            .map_err(|e| backend_err("flowStore.compareAndSet", e))?;
+
+        if applied == 1 {
+            Ok(CasOutcome::Applied)
+        } else {
+            let current = if current.is_empty() {
+                None
+            } else {
+                Some(serde_json::from_str(&current).context("Failed to parse JSON from Redis")?)
+            };
+            Ok(CasOutcome::Conflict(current))
+        }
     }
 
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()> {

--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -2,6 +2,14 @@ use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
 use std::sync::Arc;
 
+/// Outcome of [`FlowStore::compare_and_set`]: either the write applied, or the key's
+/// current value (at decision time) is returned so the caller can react to who won.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CasOutcome {
+    Applied,
+    Conflict(Option<Value>),
+}
+
 /// Backend-agnostic trait for flow state storage
 ///
 /// This trait is intentionally synchronous to avoid async bridging issues
@@ -25,6 +33,31 @@ pub trait FlowStore: Send + Sync {
 
     /// Set TTL for all keys under a flow_id
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()>;
+
+    /// Atomically set `key` to `new` iff its current value equals `expected`
+    /// (`None` = "not present"). Returns the winning current value on conflict.
+    ///
+    /// Backends may compare by canonical JSON serialization rather than structurally
+    /// (the two agree for anything this crate writes; `preserve_order` is off).
+    ///
+    /// The provided default is a NON-ATOMIC get-then-set fallback kept so existing
+    /// third-party impls keep compiling (issue #311); real backends should override
+    /// with a genuinely atomic implementation.
+    fn compare_and_set(
+        &self,
+        flow_id: &str,
+        key: &str,
+        expected: Option<&Value>,
+        new: Value,
+    ) -> Result<CasOutcome> {
+        let current = self.get(flow_id, key)?;
+        if current.as_ref() == expected {
+            self.set(flow_id, key, new)?;
+            Ok(CasOutcome::Applied)
+        } else {
+            Ok(CasOutcome::Conflict(current))
+        }
+    }
 }
 
 /// No-op flow store that does nothing
@@ -412,5 +445,100 @@ impl FlowStore for FailingFlowStore {
     }
     fn set_ttl(&self, flow_id: &str, _ttl_seconds: i64) -> Result<()> {
         self.fail("flowStore.setTtl", flow_id, "")
+    }
+}
+
+#[cfg(test)]
+mod cas_tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// A third-party-style store that does NOT override compare_and_set — proves the
+    /// provided default keeps existing impls compiling and gives get-then-set semantics.
+    struct MinimalStore {
+        data: Mutex<std::collections::HashMap<String, Value>>,
+    }
+
+    impl MinimalStore {
+        fn new() -> Self {
+            Self {
+                data: Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+    }
+
+    impl FlowStore for MinimalStore {
+        fn get(&self, flow_id: &str, key: &str) -> Result<Option<Value>> {
+            Ok(self
+                .data
+                .lock()
+                .expect("test lock")
+                .get(&format!("{flow_id}:{key}"))
+                .cloned())
+        }
+        fn set(&self, flow_id: &str, key: &str, value: Value) -> Result<()> {
+            self.data
+                .lock()
+                .expect("test lock")
+                .insert(format!("{flow_id}:{key}"), value);
+            Ok(())
+        }
+        fn exists(&self, flow_id: &str, key: &str) -> Result<bool> {
+            Ok(self.get(flow_id, key)?.is_some())
+        }
+        fn delete(&self, flow_id: &str, key: &str) -> Result<()> {
+            self.data
+                .lock()
+                .expect("test lock")
+                .remove(&format!("{flow_id}:{key}"));
+            Ok(())
+        }
+        fn increment(&self, _flow_id: &str, _key: &str) -> Result<i64> {
+            Ok(1)
+        }
+        fn set_ttl(&self, _flow_id: &str, _ttl_seconds: i64) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn default_cas_applies_when_expected_matches() {
+        let store = MinimalStore::new();
+        let outcome = store
+            .compare_and_set("f", "k", None, json!("v1"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert_eq!(store.get("f", "k").expect("get"), Some(json!("v1")));
+
+        let outcome = store
+            .compare_and_set("f", "k", Some(&json!("v1")), json!("v2"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert_eq!(store.get("f", "k").expect("get"), Some(json!("v2")));
+    }
+
+    #[test]
+    fn default_cas_conflicts_with_current_value() {
+        let store = MinimalStore::new();
+        store.set("f", "k", json!("actual")).expect("set");
+
+        let outcome = store
+            .compare_and_set("f", "k", Some(&json!("expected")), json!("new"))
+            .expect("cas");
+        match outcome {
+            CasOutcome::Conflict(current) => assert_eq!(current, Some(json!("actual"))),
+            CasOutcome::Applied => panic!("must conflict"),
+        }
+        assert_eq!(
+            store.get("f", "k").expect("get"),
+            Some(json!("actual")),
+            "conflict must not write"
+        );
+
+        let outcome = store
+            .compare_and_set("f", "k", None, json!("new"))
+            .expect("cas");
+        assert!(matches!(outcome, CasOutcome::Conflict(Some(_))));
     }
 }

--- a/crates/rift-core/src/extensions/mod.rs
+++ b/crates/rift-core/src/extensions/mod.rs
@@ -27,7 +27,7 @@ pub mod template;
 #[allow(unused_imports)]
 pub use fault::{FaultDecision, create_error_response, decide_fault};
 #[allow(unused_imports)]
-pub use flow_state::{FlowStore, NoOpFlowStore, create_flow_store};
+pub use flow_state::{CasOutcome, FlowStore, NoOpFlowStore, create_flow_store};
 #[allow(unused_imports)]
 pub use matcher::{CompiledMatch, CompiledRule};
 #[allow(unused_imports)]

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -177,12 +177,66 @@ impl Imposter {
     /// Apply a matched stub's `newScenarioState` transition (no-op if unset). A backend
     /// write error propagates (issue #318): a lost transition would silently desync the
     /// FSM, so the request must fail loudly instead.
+    ///
+    /// A gated stub (`requiredScenarioState`) transitions via compare-and-set expecting
+    /// the state its gate observed (issue #311): if the state moved underneath — a
+    /// concurrent request won — the stale write is dropped rather than clobbering the
+    /// newer state. Conflict is normal concurrency, not an error. Ungated stubs keep
+    /// today's unconditional overwrite (there is no gate read to race against).
     pub fn apply_scenario_transition(&self, flow_id: &str, stub: &Stub) -> anyhow::Result<()> {
-        if let Some(next) = &stub.new_scenario_state {
-            let scenario = stub.scenario_name.as_deref().unwrap_or("");
-            self.set_scenario_state(flow_id, scenario, next)?;
+        use crate::extensions::flow_state::CasOutcome;
+
+        let Some(next) = &stub.new_scenario_state else {
+            return Ok(());
+        };
+        let scenario = stub.scenario_name.as_deref().unwrap_or("");
+        let Some(required) = &stub.required_scenario_state else {
+            return self.set_scenario_state(flow_id, scenario, next);
+        };
+
+        let new_value = serde_json::Value::String(next.to_string());
+        let expected = serde_json::Value::String(required.to_string());
+        match self.flow_store.compare_and_set(
+            flow_id,
+            scenario,
+            Some(&expected),
+            new_value.clone(),
+        )? {
+            CasOutcome::Applied => Ok(()),
+            // The initial state is normally stored as ABSENCE — retry expecting that
+            // representation before concluding the state moved.
+            CasOutcome::Conflict(None) if required == INITIAL_SCENARIO_STATE => {
+                match self
+                    .flow_store
+                    .compare_and_set(flow_id, scenario, None, new_value)?
+                {
+                    CasOutcome::Applied => Ok(()),
+                    CasOutcome::Conflict(current) => {
+                        Self::log_dropped_transition(flow_id, scenario, required, next, &current);
+                        Ok(())
+                    }
+                }
+            }
+            CasOutcome::Conflict(current) => {
+                Self::log_dropped_transition(flow_id, scenario, required, next, &current);
+                Ok(())
+            }
         }
-        Ok(())
+    }
+
+    /// A dropped transition is correct behavior but must not be invisible: without this,
+    /// "my scenario stopped advancing" under concurrency has zero diagnostic signal.
+    fn log_dropped_transition(
+        flow_id: &str,
+        scenario: &str,
+        required: &str,
+        next: &str,
+        current: &Option<serde_json::Value>,
+    ) {
+        debug!(
+            "scenario transition dropped ({flow_id}/{scenario} {required} -> {next}): \
+             state moved underneath, current {current:?}"
+        );
     }
 
     /// Read a raw flow-state value (admin flow-state inspection).

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -3596,3 +3596,173 @@ mod backend_errors {
         manager.delete_all().await;
     }
 }
+
+// =========================================================================
+// Issue #311: scenario transitions are compare-and-set, not get-then-set
+// =========================================================================
+mod cas_transitions {
+    use super::*;
+    use crate::imposter::core::Imposter;
+    use serde_json::json;
+
+    fn imposter_with(stub: serde_json::Value) -> Imposter {
+        let config: ImposterConfig = serde_json::from_value(json!({
+            "protocol": "http", "port": 19506,
+            "stubs": [stub]
+        }))
+        .expect("config");
+        Imposter::new(config)
+    }
+
+    fn gated_stub() -> serde_json::Value {
+        json!({
+            "scenarioName": "order",
+            "requiredScenarioState": "Started",
+            "newScenarioState": "paid",
+            "predicates": [{"equals": {"path": "/pay"}}],
+            "responses": [{"is": {"statusCode": 200}}]
+        })
+    }
+
+    // The deterministic red for the lost-update class: a transition whose gate state has
+    // moved underneath must NOT clobber the newer state (old code overwrote it).
+    #[test]
+    fn transition_conflict_does_not_clobber() {
+        let imposter = imposter_with(gated_stub());
+        let stub: Stub = serde_json::from_value(gated_stub()).expect("stub");
+        imposter
+            .set_scenario_state("f", "order", "shipped")
+            .expect("seed moved state");
+
+        imposter
+            .apply_scenario_transition("f", &stub)
+            .expect("conflict is not an error");
+        assert_eq!(
+            imposter.scenario_state("f", "order").expect("state"),
+            "shipped",
+            "a stale transition must not overwrite a state that moved underneath"
+        );
+    }
+
+    #[test]
+    fn transition_from_stored_initial_state_applies() {
+        let imposter = imposter_with(gated_stub());
+        let stub: Stub = serde_json::from_value(gated_stub()).expect("stub");
+        imposter
+            .set_scenario_state("f", "order", "Started")
+            .expect("seed explicit initial");
+
+        imposter
+            .apply_scenario_transition("f", &stub)
+            .expect("transition");
+        assert_eq!(
+            imposter.scenario_state("f", "order").expect("state"),
+            "paid"
+        );
+    }
+
+    #[test]
+    fn transition_from_absent_initial_applies() {
+        let imposter = imposter_with(gated_stub());
+        let stub: Stub = serde_json::from_value(gated_stub()).expect("stub");
+
+        imposter
+            .apply_scenario_transition("f", &stub)
+            .expect("transition");
+        assert_eq!(
+            imposter.scenario_state("f", "order").expect("state"),
+            "paid",
+            "initial state stored as absence must satisfy the gate expectation"
+        );
+    }
+
+    // The retry-then-lose sub-arm: a racer writes between the two CAS calls of the
+    // absent-initial path. Losing must be a silent no-write Ok, never an error or a set.
+    #[test]
+    fn losing_the_initial_state_retry_is_a_silent_no_write() {
+        use crate::extensions::flow_state::{CasOutcome, FlowStore};
+        use serde_json::Value;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Default)]
+        struct RetryLoserStore {
+            writes: AtomicUsize,
+        }
+
+        impl FlowStore for RetryLoserStore {
+            fn get(&self, _f: &str, _k: &str) -> anyhow::Result<Option<Value>> {
+                Ok(None)
+            }
+            fn set(&self, _f: &str, _k: &str, _v: Value) -> anyhow::Result<()> {
+                self.writes.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            fn exists(&self, _f: &str, _k: &str) -> anyhow::Result<bool> {
+                Ok(false)
+            }
+            fn delete(&self, _f: &str, _k: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn increment(&self, _f: &str, _k: &str) -> anyhow::Result<i64> {
+                Ok(1)
+            }
+            fn set_ttl(&self, _f: &str, _t: i64) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn compare_and_set(
+                &self,
+                _f: &str,
+                _k: &str,
+                expected: Option<&Value>,
+                _new: Value,
+            ) -> anyhow::Result<CasOutcome> {
+                match expected {
+                    // First CAS (expecting "Started"): key looks absent.
+                    Some(_) => Ok(CasOutcome::Conflict(None)),
+                    // Retry (expecting absent): a racer won in between.
+                    None => Ok(CasOutcome::Conflict(Some(serde_json::json!(
+                        "paid-elsewhere"
+                    )))),
+                }
+            }
+        }
+
+        let mut imposter = imposter_with(gated_stub());
+        let store = std::sync::Arc::new(RetryLoserStore::default());
+        imposter.flow_store = store.clone();
+        let stub: Stub = serde_json::from_value(gated_stub()).expect("stub");
+
+        imposter
+            .apply_scenario_transition("f", &stub)
+            .expect("losing the retry is not an error");
+        assert_eq!(
+            store.writes.load(Ordering::SeqCst),
+            0,
+            "the losing retry must not write"
+        );
+    }
+
+    #[test]
+    fn ungated_transition_still_unconditional() {
+        let stub_json = json!({
+            "scenarioName": "order",
+            "newScenarioState": "paid",
+            "predicates": [{"equals": {"path": "/pay"}}],
+            "responses": [{"is": {"statusCode": 200}}]
+        });
+        let imposter = imposter_with(stub_json.clone());
+        let stub: Stub = serde_json::from_value(stub_json).expect("stub");
+        imposter
+            .set_scenario_state("f", "order", "shipped")
+            .expect("seed");
+
+        imposter
+            .apply_scenario_transition("f", &stub)
+            .expect("transition");
+        assert_eq!(
+            imposter.scenario_state("f", "order").expect("state"),
+            "paid",
+            "an ungated transition keeps today's unconditional overwrite semantics"
+        );
+    }
+}

--- a/crates/rift-http-proxy/tests/redis_backend.rs
+++ b/crates/rift-http-proxy/tests/redis_backend.rs
@@ -74,4 +74,74 @@ mod tests {
         store.delete("flow1", "key1").unwrap();
         assert!(!store.exists("flow1", "key1").unwrap());
     }
+
+    // ===== compare_and_set (issue #311) — single-round-trip Lua CAS =====
+
+    use rift_http_proxy::flow_state::CasOutcome;
+
+    #[tokio::test]
+    async fn test_redis_cas_expected_absent_applies() {
+        let (_container, store) = setup(300).await;
+
+        let outcome = store
+            .compare_and_set("casf", "state", None, json!("paid"))
+            .unwrap();
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert_eq!(store.get("casf", "state").unwrap(), Some(json!("paid")));
+
+        store.delete("casf", "state").unwrap();
+    }
+
+    // SETEX inside the CAS script must carry the store TTL: a CAS-applied key expires
+    // like a set() key (a dropped TTL arg would mean unbounded key growth in Redis).
+    #[tokio::test]
+    async fn test_redis_cas_applied_key_expires() {
+        let (_container, store) = setup(2).await;
+
+        let outcome = store
+            .compare_and_set("casttl", "state", None, json!("paid"))
+            .unwrap();
+        assert!(matches!(outcome, CasOutcome::Applied));
+        assert!(store.exists("casttl", "state").unwrap());
+
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        assert_eq!(
+            store.get("casttl", "state").unwrap(),
+            None,
+            "CAS-applied key must expire with the store TTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redis_cas_expected_present_and_conflict() {
+        let (_container, store) = setup(300).await;
+        store.set("casf2", "state", json!("Started")).unwrap();
+
+        let outcome = store
+            .compare_and_set("casf2", "state", Some(&json!("Started")), json!("paid"))
+            .unwrap();
+        assert!(matches!(outcome, CasOutcome::Applied));
+
+        // Now the state is "paid": expecting "Started" must conflict and return "paid".
+        let outcome = store
+            .compare_and_set("casf2", "state", Some(&json!("Started")), json!("shipped"))
+            .unwrap();
+        match outcome {
+            CasOutcome::Conflict(current) => assert_eq!(current, Some(json!("paid"))),
+            CasOutcome::Applied => panic!("must conflict"),
+        }
+        assert_eq!(
+            store.get("casf2", "state").unwrap(),
+            Some(json!("paid")),
+            "conflict must not write"
+        );
+
+        // Expecting absent while present also conflicts.
+        let outcome = store
+            .compare_and_set("casf2", "state", None, json!("shipped"))
+            .unwrap();
+        assert!(matches!(outcome, CasOutcome::Conflict(Some(_))));
+
+        store.delete("casf2", "state").unwrap();
+    }
 }


### PR DESCRIPTION
Fixes the single-node get-then-set race in scenario FSM transitions: two concurrent requests in the same flow could interleave between the state read and the write, losing an update or making an illegal transition.

**New primitive:** `FlowStore::compare_and_set` + `CasOutcome{Applied, Conflict(Option<Value>)}`. The trait default is a documented **non-atomic** get-then-set fallback so third-party impls keep compiling; real backends override:
- `InMemoryFlowStore` — atomic under its single write lock.
- `RedisFlowStore` — one server-side Lua `EVAL` (GET-compare-SETEX, no WATCH/MULTI), single round trip.

**Scenario transitions** switch to CAS: a gated stub transitions expecting the state its gate observed (retrying against the absent representation for the initial state). If the state moved underneath, the stale write is dropped instead of clobbering the newer state — normal concurrency, not an error, logged at `debug!`. Ungated stubs keep today's unconditional overwrite.

**Compatibility:** non-concurrent behavior unchanged; concurrent scenario traffic becomes correct instead of racy.

**Tests:** 64-thread CAS race (exactly one winner), a deterministic clobber-regression (verified red against the old code), default-impl compile/behavior proof, retry-then-lose no-write, and Redis CAS + TTL-expiry tests (Docker-gated, CI Redis job).

Closes #311. Part of #310 (no milestone assigned).