### PR TITLE
Bound runaway _rift.script execution so it can't wedge the engine

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -17,7 +17,9 @@ use crate::extensions::decorate::{
     ResponseDecorator, ResponsePhase, backend_error_response, with_annotation_scope,
 };
 use crate::extensions::template::{RequestData, has_template_variables, process_template};
-use crate::scripting::{FaultDecision, ScriptEngine, ScriptRequest};
+use crate::scripting::{
+    FaultDecision, ScriptRequest, resolve_script_timeout_ms, should_inject_bounded,
+};
 #[cfg(feature = "javascript")]
 use crate::scripting::{MountebankRequest, execute_mountebank_inject};
 use crate::util::{build_response, build_response_with_headers};
@@ -397,83 +399,79 @@ async fn handle_request_inner(
                 path_params: HashMap::new(),
             };
 
-            // Create script engine and execute
-            match ScriptEngine::new(
-                &script_config.engine,
-                &script_config.code,
-                &format!("rift_script_{stub_index}"),
-            ) {
-                Ok(engine) => {
-                    let flow_store = imposter.flow_store.clone();
-                    match engine.should_inject_fault(&script_request, flow_store) {
-                        Ok(FaultDecision::Error {
-                            status,
-                            body,
-                            headers,
-                            ..
-                        }) => {
-                            imposter.advance_cycler_for_rift_script(&stub_state);
+            // Execute the script off the async worker under a wall-clock deadline (issue
+            // #308): a runaway script is interrupted at `_rift.scriptEngine.timeoutMs`
+            // (default 5s) instead of wedging the whole engine.
+            let timeout_ms = resolve_script_timeout_ms(&imposter.config);
+            let flow_store = imposter.flow_store.clone();
+            match should_inject_bounded(
+                script_config.engine.clone(),
+                script_config.code.clone(),
+                format!("rift_script_{stub_index}"),
+                script_request,
+                flow_store,
+                Duration::from_millis(timeout_ms),
+            )
+            .await
+            {
+                Ok(FaultDecision::Error {
+                    status,
+                    body,
+                    headers,
+                    ..
+                }) => {
+                    imposter.advance_cycler_for_rift_script(&stub_state);
 
-                            let mut response = Response::builder().status(status);
-                            for (k, v) in &headers {
-                                response = response.header(k, v);
-                            }
-                            response = response.header("x-rift-imposter", "true");
-                            response = response.header("x-rift-script", &script_config.engine);
-
-                            return Ok(response.body(Full::new(Bytes::from(body))).unwrap_or_else(
-                                |_| {
-                                    build_response(
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                        "Response build error",
-                                    )
-                                },
-                            ));
-                        }
-                        Ok(FaultDecision::Latency { duration_ms, .. }) => {
-                            // Apply latency then return 200 OK
-                            tokio::time::sleep(Duration::from_millis(duration_ms)).await;
-                            imposter.advance_cycler_for_rift_script(&stub_state);
-
-                            return Ok(build_response_with_headers(
-                                StatusCode::OK,
-                                [
-                                    ("x-rift-imposter", "true"),
-                                    ("x-rift-script", &script_config.engine),
-                                    ("x-rift-latency-ms", &duration_ms.to_string()),
-                                ],
-                                Bytes::new(),
-                            ));
-                        }
-                        Ok(FaultDecision::None) => {
-                            // Script says no fault - return 200 OK
-                            imposter.advance_cycler_for_rift_script(&stub_state);
-
-                            return Ok(build_response_with_headers(
-                                StatusCode::OK,
-                                [
-                                    ("x-rift-imposter", "true"),
-                                    ("x-rift-script", script_config.engine.as_str()),
-                                ],
-                                Bytes::new(),
-                            ));
-                        }
-                        Err(e) => {
-                            warn!("Rift script execution failed: {}", e);
-                            return Ok(build_response_with_headers(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
-                                format!(r#"{{"error": "Script error: {e}"}}"#),
-                            ));
-                        }
+                    let mut response = Response::builder().status(status);
+                    for (k, v) in &headers {
+                        response = response.header(k, v);
                     }
+                    response = response.header("x-rift-imposter", "true");
+                    response = response.header("x-rift-script", &script_config.engine);
+
+                    return Ok(response
+                        .body(Full::new(Bytes::from(body)))
+                        .unwrap_or_else(|_| {
+                            build_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "Response build error",
+                            )
+                        }));
+                }
+                Ok(FaultDecision::Latency { duration_ms, .. }) => {
+                    // Apply latency then return 200 OK
+                    tokio::time::sleep(Duration::from_millis(duration_ms)).await;
+                    imposter.advance_cycler_for_rift_script(&stub_state);
+
+                    return Ok(build_response_with_headers(
+                        StatusCode::OK,
+                        [
+                            ("x-rift-imposter", "true"),
+                            ("x-rift-script", &script_config.engine),
+                            ("x-rift-latency-ms", &duration_ms.to_string()),
+                        ],
+                        Bytes::new(),
+                    ));
+                }
+                Ok(FaultDecision::None) => {
+                    // Script says no fault - return 200 OK
+                    imposter.advance_cycler_for_rift_script(&stub_state);
+
+                    return Ok(build_response_with_headers(
+                        StatusCode::OK,
+                        [
+                            ("x-rift-imposter", "true"),
+                            ("x-rift-script", script_config.engine.as_str()),
+                        ],
+                        Bytes::new(),
+                    ));
                 }
                 Err(e) => {
-                    warn!("Failed to create script engine: {}", e);
+                    warn!("Rift script execution failed: {}", e);
                     return Ok(build_response_with_headers(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
-                        format!(r#"{{"error": "Script engine error: {e}"}}"#),
+                        format!(r#"{{"error": "Script error: {e}"}}"#),
                     ));
                 }
             }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -913,7 +913,8 @@ fn default_script_engine() -> String {
 }
 
 fn default_script_timeout() -> u64 {
-    5000
+    // Single source of truth with the handler's fallback (issue #308).
+    crate::scripting::DEFAULT_SCRIPT_TIMEOUT_MS
 }
 
 /// Rift response extensions (added to stub responses)

--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -1,0 +1,330 @@
+//! Bounded execution for the inline `_rift.script` (should_inject) path (issue #308).
+//!
+//! The imposter `_rift.script` path has no script pool, so a runaway script (e.g. an
+//! infinite Rhai `loop {}`) ran unbounded on the async worker and wedged the whole engine.
+//! This module runs the script off the async worker via `spawn_blocking` and interrupts it
+//! at a wall-clock deadline using the same abort-flag mechanism as the pooled path (#172):
+//! Rhai's `on_progress` callback, and a Lua instruction hook.
+
+use super::{FaultDecision, ScriptEngine, ScriptRequest};
+use crate::extensions::flow_state::FlowStore;
+use crate::imposter::ImposterConfig;
+use anyhow::Result;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tracing::warn;
+
+/// Default script timeout when `_rift.scriptEngine.timeoutMs` is not configured.
+pub const DEFAULT_SCRIPT_TIMEOUT_MS: u64 = 5000;
+
+/// The `_rift.script` wall-clock deadline for an imposter: `_rift.scriptEngine.timeoutMs`
+/// if configured, else [`DEFAULT_SCRIPT_TIMEOUT_MS`] (issue #308).
+pub fn resolve_script_timeout_ms(config: &ImposterConfig) -> u64 {
+    config
+        .rift
+        .as_ref()
+        .and_then(|r| r.script_engine.as_ref())
+        .map(|se| se.timeout_ms)
+        .unwrap_or(DEFAULT_SCRIPT_TIMEOUT_MS)
+}
+
+/// Run a `_rift.script` `should_inject` off the async worker with a wall-clock deadline
+/// (issue #308). Execution happens in `spawn_blocking` so a non-yielding script cannot
+/// starve the Tokio runtime, and at `timeout` the abort flag is set so the script self-
+/// interrupts. Rhai (`on_progress`) and Lua (instruction hook) are truly interrupted and
+/// free their thread promptly; other engines (JavaScript) are NOT interpreter-interruptible,
+/// so a runaway there still returns `Err` at the deadline but its blocking thread runs until
+/// the script finishes on its own. Returns `Err` on timeout, a compile/exec error, or a panic.
+pub async fn should_inject_bounded(
+    engine_type: String,
+    code: String,
+    rule_id: String,
+    request: ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    timeout: Duration,
+) -> Result<FaultDecision> {
+    let abort = Arc::new(AtomicBool::new(false));
+    let run_abort = Arc::clone(&abort);
+    let handle = tokio::task::spawn_blocking(move || {
+        run_should_inject_with_abort(
+            &engine_type,
+            &code,
+            &rule_id,
+            &request,
+            flow_store,
+            &run_abort,
+        )
+    });
+
+    match tokio::time::timeout(timeout, handle).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(join_err)) => Err(anyhow::anyhow!("script task panicked: {join_err}")),
+        Err(_elapsed) => {
+            // Signal the deadline: Rhai/Lua self-interrupt and free their thread promptly;
+            // for other engines this is a best-effort flag they never observe.
+            abort.store(true, Ordering::Relaxed);
+            warn!(
+                "_rift.script execution timed out after {}ms",
+                timeout.as_millis()
+            );
+            Err(anyhow::anyhow!(
+                "script execution timed out after {}ms",
+                timeout.as_millis()
+            ))
+        }
+    }
+}
+
+/// Execute `should_inject` synchronously with the abort flag wired into the interpreter, so
+/// setting `abort` interrupts a runaway script. Rhai and Lua get a real interpreter interrupt
+/// (#308/#172); other engines run without an interpreter interrupt but still off the async
+/// worker and under the request-level timeout.
+fn run_should_inject_with_abort(
+    engine_type: &str,
+    code: &str,
+    rule_id: &str,
+    request: &ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    abort: &Arc<AtomicBool>,
+) -> Result<FaultDecision> {
+    match engine_type {
+        "rhai" => super::rhai_engine::run_should_inject_with_abort_rhai(
+            code, rule_id, request, flow_store, abort,
+        ),
+        #[cfg(feature = "lua")]
+        "lua" => super::lua_engine::run_should_inject_with_abort_lua(
+            code, rule_id, request, flow_store, abort,
+        ),
+        other => {
+            let engine = ScriptEngine::new(other, code, rule_id)?;
+            engine.should_inject_fault(request, flow_store)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::flow_state::NoOpFlowStore;
+    use std::time::Instant;
+
+    fn req() -> ScriptRequest {
+        ScriptRequest {
+            method: "GET".into(),
+            path: "/hang".into(),
+            headers: Default::default(),
+            body: serde_json::Value::Null,
+            query: Default::default(),
+            path_params: Default::default(),
+        }
+    }
+
+    fn store() -> Arc<dyn FlowStore> {
+        Arc::new(NoOpFlowStore)
+    }
+
+    /// Thin wrapper over [`should_inject_bounded`] with the fixed test request/store, to
+    /// keep the call sites to just engine/code/timeout.
+    fn bounded(
+        engine: &'static str,
+        code: &'static str,
+        timeout_ms: u64,
+    ) -> impl std::future::Future<Output = Result<FaultDecision>> {
+        should_inject_bounded(
+            engine.into(),
+            code.into(),
+            "t".into(),
+            req(),
+            store(),
+            Duration::from_millis(timeout_ms),
+        )
+    }
+
+    const RUNAWAY_RHAI: &str =
+        "fn should_inject(request, flow_store){ let i = 0; loop { i += 1; } }";
+    const RUNAWAY_LUA: &str = "function should_inject(request, flow_store) while true do end end";
+
+    /// Run the sync interrupt path on a child thread, flip the abort flag after 200ms, and
+    /// require the interpreter to unwind within 5s. Running off the test thread with a
+    /// `recv_timeout` makes a regression that fails to interrupt FAIL the test (the channel
+    /// times out) rather than hang the whole suite.
+    fn assert_interrupts(engine: &'static str, code: &'static str) {
+        let abort = Arc::new(AtomicBool::new(false));
+        let a2 = Arc::clone(&abort);
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            a2.store(true, Ordering::Relaxed);
+        });
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let res = run_should_inject_with_abort(engine, code, "t", &req(), store(), &abort);
+            let _ = tx.send(res.is_err());
+        });
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(is_err) => assert!(is_err, "an interrupted script returns an error"),
+            Err(_) => panic!("runaway {engine} was NOT interrupted by the abort flag within 5s"),
+        }
+    }
+
+    // AC1/AC5: a runaway Rhai script is TRULY interrupted (the interpreter unwinds) once the
+    // abort flag is set — not merely abandoned.
+    #[test]
+    fn runaway_rhai_interrupted_by_abort() {
+        assert_interrupts("rhai", RUNAWAY_RHAI);
+    }
+
+    // AC5: same for Lua.
+    #[cfg(feature = "lua")]
+    #[test]
+    fn runaway_lua_interrupted_by_abort() {
+        assert_interrupts("lua", RUNAWAY_LUA);
+    }
+
+    // The non-rhai/non-lua dispatch branch: an unknown engine returns an error promptly.
+    #[tokio::test]
+    async fn unknown_engine_returns_error() {
+        let res = bounded("no-such-engine", "whatever", 500).await;
+        assert!(
+            res.is_err(),
+            "an unknown engine is a fast error, not a hang"
+        );
+    }
+
+    // AC4: the None and Latency decisions pass through the bounded path unchanged.
+    #[tokio::test]
+    async fn normal_rhai_returns_none_and_latency() {
+        let none = bounded(
+            "rhai",
+            "fn should_inject(request, flow_store){ #{ inject: false } }",
+            2000,
+        )
+        .await
+        .expect("fast script");
+        assert!(matches!(none, FaultDecision::None), "got {none:?}");
+
+        let latency = bounded(
+            "rhai",
+            "fn should_inject(request, flow_store){ #{ inject: true, fault: `latency`, duration_ms: 7 } }",
+            2000,
+        )
+        .await
+        .expect("fast script");
+        match latency {
+            FaultDecision::Latency { duration_ms, .. } => assert_eq!(duration_ms, 7),
+            other => panic!("expected Latency, got {other:?}"),
+        }
+    }
+
+    // AC2: the handler resolves the deadline from `_rift.scriptEngine.timeoutMs`, else the
+    // default — proving the config plumbing, not just an explicit Duration.
+    #[test]
+    fn resolves_configured_and_default_timeout() {
+        let with_timeout: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "_rift": { "scriptEngine": { "timeoutMs": 321 } },
+            "stubs": []
+        }))
+        .expect("config");
+        assert_eq!(resolve_script_timeout_ms(&with_timeout), 321);
+
+        // scriptEngine present but timeoutMs omitted → serde default (kept in sync).
+        let engine_no_timeout: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "_rift": { "scriptEngine": { "defaultEngine": "rhai" } },
+            "stubs": []
+        }))
+        .expect("config");
+        assert_eq!(
+            resolve_script_timeout_ms(&engine_no_timeout),
+            DEFAULT_SCRIPT_TIMEOUT_MS
+        );
+
+        // no scriptEngine block at all → the handler fallback default.
+        let no_engine: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http", "stubs": []
+        }))
+        .expect("config");
+        assert_eq!(
+            resolve_script_timeout_ms(&no_engine),
+            DEFAULT_SCRIPT_TIMEOUT_MS
+        );
+    }
+
+    // AC1/AC2: the async entrypoint times out a runaway script and returns an error,
+    // instead of hanging.
+    #[tokio::test]
+    async fn should_inject_bounded_times_out_runaway_rhai() {
+        let start = Instant::now();
+        let res = bounded("rhai", RUNAWAY_RHAI, 200).await;
+        assert!(res.is_err(), "runaway must yield an error, not hang");
+        assert!(
+            start.elapsed() < Duration::from_secs(3),
+            "must return near the configured timeout, not hang"
+        );
+    }
+
+    // AC2: the deadline honors the configured timeout, not a hardcoded larger default.
+    #[tokio::test]
+    async fn bounded_honors_configured_timeout() {
+        let start = Instant::now();
+        let _ = bounded("rhai", RUNAWAY_RHAI, 250).await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "must not return before the configured timeout: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must return at ~the configured timeout, not a 5s default: {elapsed:?}"
+        );
+    }
+
+    // AC3: a runaway script must not starve the async runtime — a concurrent tokio timer
+    // makes progress and completes well before the script's (much longer) timeout.
+    #[tokio::test]
+    async fn runaway_does_not_starve_async_runtime() {
+        let script = tokio::spawn(bounded("rhai", RUNAWAY_RHAI, 4000));
+
+        // This timer must fire promptly while the script is still running.
+        let timer_start = Instant::now();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let timer_elapsed = timer_start.elapsed();
+        assert!(
+            timer_elapsed < Duration::from_secs(1),
+            "async runtime is starved by the runaway script: timer took {timer_elapsed:?}"
+        );
+
+        // Let the script's own deadline clean it up.
+        let _ = script.await;
+    }
+
+    // AC4: a normal (fast) Rhai should_inject still returns the correct decision, unchanged.
+    #[tokio::test]
+    async fn normal_rhai_returns_error_decision() {
+        let code = "fn should_inject(request, flow_store){ #{ inject: true, fault: `error`, status: 503, body: `boom` } }";
+        let res = bounded("rhai", code, 2000)
+            .await
+            .expect("fast script succeeds");
+        match res {
+            FaultDecision::Error { status, body, .. } => {
+                assert_eq!(status, 503);
+                assert_eq!(body, "boom");
+            }
+            other => panic!("expected Error decision, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "lua")]
+    #[tokio::test]
+    async fn normal_lua_returns_decision() {
+        let code = "function should_inject(request, flow_store) return { inject = true, fault = 'error', status = 503, body = 'boom' } end";
+        let res = bounded("lua", code, 2000)
+            .await
+            .expect("fast lua script succeeds");
+        match res {
+            FaultDecision::Error { status, .. } => assert_eq!(status, 503),
+            other => panic!("expected Error decision, got {other:?}"),
+        }
+    }
+}

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, anyhow};
 use mlua::prelude::*;
 use serde_json::Value;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Lua script engine for fault injection
 ///
@@ -769,6 +770,42 @@ fn lua_to_json(_lua: &Lua, value: LuaValue) -> LuaResult<Value> {
         }
         _ => Ok(Value::Null),
     }
+}
+
+/// Run a Lua `should_inject` with a wall-clock interrupt hook (issue #308). An instruction
+/// hook checks the `abort` flag periodically; when the caller's deadline sets it, the hook
+/// returns an error, aborting the VM — the Lua analogue of Rhai's `on_progress` (#172).
+pub fn run_should_inject_with_abort_lua(
+    code: &str,
+    rule_id: &str,
+    request: &ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    abort: &Arc<AtomicBool>,
+) -> Result<FaultDecision> {
+    let lua = Lua::new();
+    // Disable JIT: LuaJIT trace-compiles hot loops (e.g. `while true do end`) into machine
+    // code that bypasses the instruction hook, so a runaway script would never be
+    // interrupted. Running the bytecode interpreter keeps the count hook firing (#308).
+    if let Err(e) = lua.load("if jit then jit.off() end").exec() {
+        // The whole interrupt mechanism relies on JIT being off; if this ever fails the
+        // instruction hook may be bypassed, so make the degradation visible (issue #308).
+        tracing::warn!("failed to disable LuaJIT for script interruption: {e}");
+    }
+    let flag = Arc::clone(abort);
+    lua.set_hook(
+        mlua::HookTriggers::new().every_nth_instruction(2048),
+        move |_lua, _debug| {
+            if flag.load(Ordering::Relaxed) {
+                Err(mlua::Error::runtime(
+                    "script interrupted: execution timeout",
+                ))
+            } else {
+                Ok(mlua::VmState::Continue)
+            }
+        },
+    );
+    let bytecode = compile_to_bytecode(code)?;
+    execute_lua_bytecode(&lua, &bytecode, request, flow_store, rule_id)
 }
 
 #[cfg(test)]

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -6,7 +6,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 // Engine modules (only used by proxy.rs for compilation)
+mod bounded;
 mod rhai_engine;
+pub use bounded::{DEFAULT_SCRIPT_TIMEOUT_MS, resolve_script_timeout_ms, should_inject_bounded};
+
 pub use rhai_engine::RhaiEngine;
 
 // Script pool for optimized execution

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -3,6 +3,7 @@ use anyhow::{Result, anyhow};
 use rhai::{AST, Dynamic, Engine, Map, Scope};
 use serde_json::Value;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::{FaultDecision, ScriptFlowStore, ScriptRequest};
 
@@ -541,6 +542,30 @@ pub(super) fn dynamic_to_json(value: Dynamic) -> Value {
             },
         }
     }
+}
+
+/// Run a Rhai `should_inject` with a wall-clock interrupt hook (issue #308). While the AST
+/// evaluates, Rhai calls the registered `on_progress` callback periodically; when `abort`
+/// is set (by the caller's deadline), it returns `Some(_)`, terminating execution with an
+/// error — the same mechanism the pooled path uses (#172).
+pub fn run_should_inject_with_abort_rhai(
+    code: &str,
+    rule_id: &str,
+    request: &ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    abort: &Arc<AtomicBool>,
+) -> Result<FaultDecision> {
+    let compiled = RhaiEngine::new(code, rule_id)?;
+    let mut engine = RhaiEngine::create_engine();
+    let flag = Arc::clone(abort);
+    engine.on_progress(move |_ops| {
+        if flag.load(Ordering::Relaxed) {
+            Some(Dynamic::TRUE)
+        } else {
+            None
+        }
+    });
+    execute_rhai_with_engine(&engine, compiled.ast(), request, flow_store, rule_id)
 }
 
 #[cfg(test)]

--- a/crates/rift-http-proxy/tests/script_timeout.rs
+++ b/crates/rift-http-proxy/tests/script_timeout.rs
@@ -1,0 +1,127 @@
+//! Issue #308: a runaway `_rift.script` (should_inject) is bounded by
+//! `_rift.scriptEngine.timeoutMs` and does NOT wedge unrelated imposters.
+
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn cfg(v: serde_json::Value) -> ImposterConfig {
+    serde_json::from_value(v).expect("test imposter config")
+}
+
+// A runaway should_inject on one imposter must time out AND leave a sibling imposter
+// responsive — the exact end-to-end symptom from the bug report.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runaway_script_times_out_and_sibling_stays_responsive() {
+    let manager = Arc::new(ImposterManager::new());
+
+    // Imposter A: an infinite-loop Rhai should_inject, bounded to 500ms.
+    manager
+        .create_imposter(cfg(serde_json::json!({
+            "protocol": "http", "port": 19191,
+            "_rift": { "scriptEngine": { "defaultEngine": "rhai", "timeoutMs": 500 } },
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/hang" } }],
+                "responses": [{ "_rift": { "script": { "engine": "rhai",
+                    "code": "fn should_inject(request, flow_store){ let i = 0; loop { i += 1; } }" } } }]
+            }]
+        })))
+        .await
+        .expect("create A");
+
+    // Imposter B: a plain, unrelated imposter.
+    manager
+        .create_imposter(cfg(serde_json::json!({
+            "protocol": "http", "port": 19192,
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/health" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "ok" } }]
+            }]
+        })))
+        .await
+        .expect("create B");
+
+    // Sibling responds before the runaway even starts.
+    let before = reqwest::get("http://127.0.0.1:19192/health")
+        .await
+        .expect("B reachable")
+        .status();
+    assert_eq!(before, 200);
+
+    // Fire the runaway request in the background (do not await it fully).
+    let hang = tokio::spawn(async {
+        let start = Instant::now();
+        let resp = reqwest::Client::new()
+            .get("http://127.0.0.1:19191/hang")
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await;
+        (start.elapsed(), resp)
+    });
+
+    // While the runaway script is running, the unrelated imposter must stay responsive.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let sibling_start = Instant::now();
+    let during = reqwest::Client::new()
+        .get("http://127.0.0.1:19192/health")
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .expect("sibling must respond while a script runs away")
+        .status();
+    assert_eq!(during, 200, "sibling imposter must not be wedged");
+    assert!(
+        sibling_start.elapsed() < Duration::from_secs(2),
+        "sibling response was delayed by the runaway script: {:?}",
+        sibling_start.elapsed()
+    );
+
+    // The runaway request itself is bounded: it returns a 500 near the 500ms timeout,
+    // not after the client's 10s ceiling.
+    let (elapsed, resp) = hang.await.expect("hang task");
+    let resp = resp.expect("runaway request returns a response, not a hang");
+    assert_eq!(resp.status(), 500, "runaway script yields a 500");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "runaway must be interrupted near timeoutMs, took {elapsed:?}"
+    );
+
+    manager.delete_all().await;
+}
+
+// The non-runaway handler arms still work over HTTP after the #308 rewrite: a `None`
+// decision → 200, and a `Latency` decision → 200 with the latency header.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn normal_script_none_and_latency_serve_200() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(cfg(serde_json::json!({
+            "protocol": "http", "port": 19193,
+            "stubs": [
+                { "predicates": [{ "equals": { "path": "/pass" } }],
+                  "responses": [{ "_rift": { "script": { "engine": "rhai",
+                      "code": "fn should_inject(request, flow_store){ #{ inject: false } }" } } }] },
+                { "predicates": [{ "equals": { "path": "/slow" } }],
+                  "responses": [{ "_rift": { "script": { "engine": "rhai",
+                      "code": "fn should_inject(request, flow_store){ #{ inject: true, fault: `latency`, duration_ms: 20 } }" } } }] }
+            ]
+        })))
+        .await
+        .expect("create");
+
+    let pass = reqwest::get("http://127.0.0.1:19193/pass")
+        .await
+        .expect("pass reachable");
+    assert_eq!(pass.status(), 200, "None decision serves 200");
+
+    let slow = reqwest::get("http://127.0.0.1:19193/slow")
+        .await
+        .expect("slow reachable");
+    assert_eq!(slow.status(), 200, "Latency decision serves 200");
+    assert!(
+        slow.headers().contains_key("x-rift-latency-ms"),
+        "latency response carries the latency header"
+    );
+
+    manager.delete_all().await;
+}


### PR DESCRIPTION
A single runaway `_rift.script` `should_inject` response (infinite Rhai loop) was never interrupted and wedged the whole engine — unrelated imposters and the admin API stopped responding while it ran. Same class as #172, but the imposter `_rift.script` path never went through the ScriptPool watchdog: it ran synchronously on the async worker with no timeout, and `_rift.scriptEngine.timeoutMs` was parsed but never read.

**Fix:** `scripting::should_inject_bounded` runs the script in `spawn_blocking` (so a non-yielding loop can't starve the Tokio runtime) under `tokio::time::timeout`; on the deadline it sets an abort flag so the script self-interrupts, reusing the #172 mechanism — Rhai `on_progress`, and for Lua an instruction hook (which requires `jit.off()`, since LuaJIT trace-compiles hot loops past debug hooks). The handler reads `_rift.scriptEngine.timeoutMs` (default 5s) via `resolve_script_timeout_ms`.

A runaway script now returns 500 near the configured timeout and unrelated imposters + admin stay responsive.

**Tests:** interrupt tests (fail-not-hang via child thread + recv_timeout), timeout-honoring, no-async-starvation, config resolution, None/Latency/error decisions, and an e2e (`runaway_script_times_out_and_sibling_stays_responsive`) reproducing the bug's symptom over HTTP. Rhai + Lua both covered.

**Scope note:** JavaScript on this path is not interpreter-interruptible (off-thread + request-timeout only, no Boa loop interrupt) — documented and tracked in #327.

Closes #308.