### PR TITLE
feat: extract a pluggable ResponseSequencer from the per-stub cycler

### DIFF
--- a/crates/rift-core/src/behaviors/mod.rs
+++ b/crates/rift-core/src/behaviors/mod.rs
@@ -30,7 +30,6 @@ pub use copy::{CopyBehavior, CopySource, apply_copy_behaviors};
 pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
 
 pub mod sequencer;
-pub use sequencer::{LocalSequencer, ResponseSequencer, SequenceKey};
 #[allow(unused_imports)]
 pub use extraction::{ExtractionMethod, extract_jsonpath, extract_xpath, extract_xpath_with_ns};
 #[allow(unused_imports)]
@@ -38,6 +37,7 @@ pub use lookup::{
     CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey, apply_lookup_behaviors,
 };
 pub use request::{RequestContext, header_to_title_case};
+pub use sequencer::{LocalSequencer, ResponseSequencer, SequenceKey};
 pub use transform::{
     DecorateError, apply_decorate, apply_shell_transform, is_js_config_decorate,
     rewrite_js_config_to_rhai,

--- a/crates/rift-core/src/behaviors/mod.rs
+++ b/crates/rift-core/src/behaviors/mod.rs
@@ -28,6 +28,9 @@ mod wait;
 #[allow(unused_imports)]
 pub use copy::{CopyBehavior, CopySource, apply_copy_behaviors};
 pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
+
+pub mod sequencer;
+pub use sequencer::{LocalSequencer, ResponseSequencer, SequenceKey};
 #[allow(unused_imports)]
 pub use extraction::{ExtractionMethod, extract_jsonpath, extract_xpath, extract_xpath_with_ns};
 #[allow(unused_imports)]

--- a/crates/rift-core/src/behaviors/sequencer.rs
+++ b/crates/rift-core/src/behaviors/sequencer.rs
@@ -1,0 +1,232 @@
+//! Pluggable response sequencing (issue #313): the trait extracted from the per-stub
+//! `RuleCycler` internals, so embedders can supply cursors that persist, seed
+//! deterministically, or are shared between engine instances.
+//!
+//! With no sequencer registered, imposters keep today's embedded per-stub cycler — the
+//! only addition on that path is one branch on the absent `Option`; no key building,
+//! repeat materialization, or map lookups happen. A sequencer
+//! registered via
+//! [`ImposterManager::with_sequencer`](crate::imposter::ImposterManager::with_sequencer)
+//! receives every cursor decision with a full [`SequenceKey`] and materialized repeats.
+
+use super::cycler::RuleCycler;
+use anyhow::Result;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+
+/// Identity of one cursor decision.
+#[derive(Debug, Clone, Copy)]
+pub struct SequenceKey<'a> {
+    pub port: u16,
+    /// Per-imposter slot token, minted when a stub is inserted and kept across in-place
+    /// replaces (mirrors the internal `StubState` slot lifetime).
+    pub slot: u64,
+    /// Process-independent stub identity: the explicit stub `id`, else the stable content
+    /// key (#316) without an occurrence suffix — byte-identical id-less siblings share it
+    /// (and therefore share a cursor under backends keying by `stub_key`).
+    pub stub_key: &'a str,
+    /// The stub's isolation scope (`space`, #223), or `""` for global stubs.
+    pub scope: &'a str,
+}
+
+/// Pluggable response-cursor backend. Built-ins never fail; `Err` means the backend is
+/// unavailable and surfaces as a structured backend error (#318).
+///
+/// Contract: `next` and `peek` must return an index `< response_count`; a violation is
+/// treated as a backend error (500), never silently served. `peek` may be called several
+/// times per request (response-type dispatch peeks before the single advancing `next`) —
+/// remote backends should expect a few round-trips per request.
+pub trait ResponseSequencer: Send + Sync {
+    /// Atomically advance and return the response index, honoring per-response repeats.
+    fn next(&self, key: SequenceKey<'_>, response_count: usize, repeats: &[u32]) -> Result<usize>;
+    /// Return the upcoming response index without advancing.
+    fn peek(&self, key: SequenceKey<'_>, response_count: usize, repeats: &[u32]) -> Result<usize>;
+    /// Reset cursors: one stub's (`Some(stub_key)`), or every cursor on the port (`None`).
+    /// Also the GC hook — called on stub delete, bulk stub replace, and imposter teardown.
+    fn reset_scope(&self, port: u16, stub_key: Option<&str>);
+}
+
+/// Reference sequencer with the exact semantics of the embedded per-stub cycler: the same
+/// `RuleCycler` packing, keyed by `(port, slot, scope)`. The `stub_key` is recorded per
+/// cursor so `reset_scope(port, Some(key))` works even though slots are the primary key.
+#[derive(Default)]
+pub struct LocalSequencer {
+    #[allow(clippy::type_complexity)]
+    cursors: RwLock<HashMap<(u16, u64, String), (RuleCycler, String)>>,
+}
+
+impl LocalSequencer {
+    fn with_cursor<R>(&self, key: &SequenceKey<'_>, f: impl Fn(&RuleCycler) -> R) -> R {
+        let map_key = (key.port, key.slot, key.scope.to_string());
+        {
+            let cursors = self.cursors.read();
+            if let Some((cycler, _)) = cursors.get(&map_key) {
+                return f(cycler);
+            }
+        }
+        let mut cursors = self.cursors.write();
+        let (cycler, _) = cursors
+            .entry(map_key)
+            .or_insert_with(|| (RuleCycler::new(), key.stub_key.to_string()));
+        f(cycler)
+    }
+}
+
+impl ResponseSequencer for LocalSequencer {
+    fn next(&self, key: SequenceKey<'_>, response_count: usize, repeats: &[u32]) -> Result<usize> {
+        if response_count == 0 {
+            return Ok(0);
+        }
+        // Clamp: right after `responses` shrinks, the cycler's advance can return the
+        // stale pre-clamp index once; clamping keeps the trait's `< response_count`
+        // contract instead of surfacing a one-off backend error.
+        Ok(self.with_cursor(&key, |cycler| {
+            (cycler.get_response_index_advance(response_count as u32, |i| {
+                repeats.get(i as usize).copied()
+            }) as usize)
+                .min(response_count - 1)
+        }))
+    }
+
+    fn peek(&self, key: SequenceKey<'_>, response_count: usize, _repeats: &[u32]) -> Result<usize> {
+        if response_count == 0 {
+            return Ok(0);
+        }
+        let map_key = (key.port, key.slot, key.scope.to_string());
+        Ok(self.cursors.read().get(&map_key).map_or(0, |(cycler, _)| {
+            cycler.peek_response_index(response_count as u32) as usize
+        }))
+    }
+
+    fn reset_scope(&self, port: u16, stub_key: Option<&str>) {
+        let mut cursors = self.cursors.write();
+        match stub_key {
+            None => cursors.retain(|(p, _, _), _| *p != port),
+            Some(key) => cursors.retain(|(p, _, _), (_, sk)| *p != port || sk != key),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key<'a>(slot: u64, stub_key: &'a str, scope: &'a str) -> SequenceKey<'a> {
+        SequenceKey {
+            port: 4919,
+            slot,
+            stub_key,
+            scope,
+        }
+    }
+
+    // AC1: plain sequences advance and wrap like the embedded cycler.
+    #[test]
+    fn local_sequences_and_wraps() {
+        let seq = LocalSequencer::default();
+        let repeats = [1, 1, 1];
+        for expected in [0, 1, 2, 0, 1] {
+            assert_eq!(
+                seq.next(key(1, "s", ""), 3, &repeats).expect("infallible"),
+                expected
+            );
+        }
+    }
+
+    // AC1: per-response repeat counts hold each index for `repeat` pulls.
+    #[test]
+    fn local_honors_per_response_repeats() {
+        let seq = LocalSequencer::default();
+        let repeats = [2, 3];
+        let got: Vec<usize> = (0..7)
+            .map(|_| seq.next(key(1, "s", ""), 2, &repeats).expect("infallible"))
+            .collect();
+        assert_eq!(got, vec![0, 0, 1, 1, 1, 0, 0]);
+    }
+
+    // AC1: peek returns the upcoming index without advancing.
+    #[test]
+    fn local_peek_does_not_advance() {
+        let seq = LocalSequencer::default();
+        let repeats = [1, 1];
+        assert_eq!(seq.peek(key(1, "s", ""), 2, &repeats).expect("ok"), 0);
+        assert_eq!(seq.peek(key(1, "s", ""), 2, &repeats).expect("ok"), 0);
+        assert_eq!(seq.next(key(1, "s", ""), 2, &repeats).expect("ok"), 0);
+        assert_eq!(seq.peek(key(1, "s", ""), 2, &repeats).expect("ok"), 1);
+    }
+
+    // Scopes (issue #223 spaces) cycle independently for the same slot.
+    #[test]
+    fn local_scopes_are_isolated() {
+        let seq = LocalSequencer::default();
+        let repeats = [1, 1, 1];
+        assert_eq!(seq.next(key(1, "s", "a"), 3, &repeats).expect("ok"), 0);
+        assert_eq!(seq.next(key(1, "s", "a"), 3, &repeats).expect("ok"), 1);
+        assert_eq!(
+            seq.next(key(1, "s", "b"), 3, &repeats).expect("ok"),
+            0,
+            "a different scope starts fresh"
+        );
+    }
+
+    // AC1: reset by stub key resets only that stub's cursors; reset by port drops all.
+    #[test]
+    fn local_reset_scope_by_key_and_port() {
+        let seq = LocalSequencer::default();
+        let repeats = [1, 1, 1];
+        let _ = seq.next(key(1, "alpha", ""), 3, &repeats);
+        let _ = seq.next(key(2, "beta", ""), 3, &repeats);
+
+        seq.reset_scope(4919, Some("alpha"));
+        assert_eq!(
+            seq.next(key(1, "alpha", ""), 3, &repeats).expect("ok"),
+            0,
+            "alpha restarted"
+        );
+        assert_eq!(
+            seq.next(key(2, "beta", ""), 3, &repeats).expect("ok"),
+            1,
+            "beta untouched"
+        );
+
+        seq.reset_scope(4919, None);
+        assert_eq!(
+            seq.next(key(2, "beta", ""), 3, &repeats).expect("ok"),
+            0,
+            "port-wide reset drops every cursor"
+        );
+    }
+
+    // After the response list shrinks, the next index stays in range (the trait
+    // contract), rather than leaking the cycler's stale pre-clamp value.
+    #[test]
+    fn local_clamps_after_shrink() {
+        let seq = LocalSequencer::default();
+        let repeats3 = [1, 1, 1];
+        let _ = seq.next(key(1, "s", ""), 3, &repeats3);
+        let _ = seq.next(key(1, "s", ""), 3, &repeats3);
+        let idx = seq.next(key(1, "s", ""), 1, &[1]).expect("infallible");
+        assert!(idx < 1, "index {idx} out of range after shrink to 1");
+    }
+
+    // Different ports never share cursors even with identical slots/keys.
+    #[test]
+    fn local_ports_are_isolated() {
+        let seq = LocalSequencer::default();
+        let repeats = [1, 1];
+        let a = SequenceKey {
+            port: 1000,
+            slot: 1,
+            stub_key: "s",
+            scope: "",
+        };
+        let b = SequenceKey {
+            port: 2000,
+            slot: 1,
+            stub_key: "s",
+            scope: "",
+        };
+        assert_eq!(seq.next(a, 2, &repeats).expect("ok"), 0);
+        assert_eq!(seq.next(b, 2, &repeats).expect("ok"), 0, "fresh per port");
+    }
+}

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -56,10 +56,17 @@ fn get_http_client() -> &'static reqwest::Client {
     })
 }
 
+/// Process-wide slot mint: globally unique tokens are trivially per-imposter unique, and a
+/// global counter avoids threading imposter context into every construction site.
+static NEXT_STUB_SLOT: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Debug, Clone)]
 pub struct StubState {
     pub(crate) stub: Stub,
     cycler: Arc<RuleCycler>,
+    /// Slot token for sequencer keying (issue #313): minted at insertion, preserved by
+    /// in-place replaces (which keep the StubState), dropped with the slot.
+    pub(crate) slot: u64,
 }
 
 impl StubState {
@@ -68,6 +75,7 @@ impl StubState {
         Self {
             stub,
             cycler: Arc::new(RuleCycler::new()),
+            slot: NEXT_STUB_SLOT.fetch_add(1, Ordering::Relaxed),
         }
     }
 
@@ -112,6 +120,8 @@ pub struct Imposter {
     pub shutdown_tx: Option<broadcast::Sender<()>>,
     /// Flow store for Rift extensions (stateful scripting)
     pub flow_store: Arc<dyn FlowStore>,
+    /// Pluggable response-cursor backend (issue #313); None = embedded per-stub cycler.
+    pub(crate) sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
 }
 
 impl Imposter {
@@ -125,6 +135,16 @@ impl Imposter {
     pub fn new_with_provider(
         config: ImposterConfig,
         provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
+    ) -> Self {
+        Self::new_with_hooks(config, provider, None)
+    }
+
+    /// Create a new imposter with all embedder hooks: the flow-store `provider` (#312) and
+    /// a pluggable response `sequencer` (#313; None = embedded per-stub cycler).
+    pub fn new_with_hooks(
+        config: ImposterConfig,
+        provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
+        sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
     ) -> Self {
         let stubs: Vec<StubState> = config
             .stubs
@@ -149,6 +169,7 @@ impl Imposter {
             created_at: chrono::Utc::now(),
             shutdown_tx: None,
             flow_store,
+            sequencer,
         }
     }
 

--- a/crates/rift-core/src/imposter/core/responses.rs
+++ b/crates/rift-core/src/imposter/core/responses.rs
@@ -58,7 +58,15 @@ impl Imposter {
         } else {
             sequencer.peek(key, responses.len(), &repeats)?
         };
-        Ok(responses.get(index))
+        // An out-of-range index is a sequencer contract violation; surfacing it beats
+        // silently falling through to the no-match default response (issue #313).
+        let Some(response) = responses.get(index) else {
+            anyhow::bail!(
+                "sequencer returned out-of-range index {index} for stub {stub_key} ({} responses)",
+                responses.len()
+            );
+        };
+        Ok(Some(response))
     }
 
     /// Get all stubs info for debug purposes (Rift extension)

--- a/crates/rift-core/src/imposter/core/responses.rs
+++ b/crates/rift-core/src/imposter/core/responses.rs
@@ -5,6 +5,62 @@
 use super::*;
 
 impl Imposter {
+    /// Advance and return the stub's next response — via the registered sequencer when one
+    /// is configured (issue #313), else the embedded per-stub cycler (today's hot path,
+    /// untouched). `Err` = sequencer backend unavailable; callers surface it (#318).
+    pub(crate) fn next_stub_response<'a>(
+        &self,
+        stub_state: &'a StubState,
+    ) -> anyhow::Result<Option<&'a StubResponse>> {
+        match &self.sequencer {
+            None => Ok(stub_state.get_next_response()),
+            Some(sequencer) => self.via_sequencer(stub_state, sequencer.as_ref(), true),
+        }
+    }
+
+    /// Peek the stub's upcoming response without advancing — sequencer-aware like
+    /// [`Self::next_stub_response`].
+    pub(crate) fn peek_stub_response<'a>(
+        &self,
+        stub_state: &'a StubState,
+    ) -> anyhow::Result<Option<&'a StubResponse>> {
+        match &self.sequencer {
+            None => Ok(stub_state.peek_response()),
+            Some(sequencer) => self.via_sequencer(stub_state, sequencer.as_ref(), false),
+        }
+    }
+
+    fn via_sequencer<'a>(
+        &self,
+        stub_state: &'a StubState,
+        sequencer: &dyn crate::behaviors::ResponseSequencer,
+        advance: bool,
+    ) -> anyhow::Result<Option<&'a StubResponse>> {
+        let responses = &stub_state.stub.responses;
+        if responses.is_empty() {
+            return Ok(None);
+        }
+        // stub_key is computed per decision (not cached) because in-place replaces swap
+        // `stub` under the same StubState; occurrence 0 is documented on SequenceKey.
+        let stub_key = crate::imposter::reconcile::stub_key(&stub_state.stub, 0);
+        let key = crate::behaviors::SequenceKey {
+            port: self.config.port.unwrap_or(0),
+            slot: stub_state.slot,
+            stub_key: &stub_key,
+            scope: stub_state.stub.space.as_deref().unwrap_or(""),
+        };
+        let repeats: Vec<u32> = responses
+            .iter()
+            .map(|r| r.get_repeat().unwrap_or(1).max(1))
+            .collect();
+        let index = if advance {
+            sequencer.next(key, responses.len(), &repeats)?
+        } else {
+            sequencer.peek(key, responses.len(), &repeats)?
+        };
+        Ok(responses.get(index))
+    }
+
     /// Get all stubs info for debug purposes (Rift extension)
     pub fn get_all_stubs_info(&self) -> Vec<DebugStubInfo> {
         let stubs = self.stubs.read();
@@ -33,27 +89,21 @@ impl Imposter {
     }
 
     /// Create response preview from a stub (Rift extension)
-    pub fn get_response_preview(&self, stub_state: &StubState) -> DebugResponsePreview {
-        if stub_state.stub.responses.is_empty() {
-            return DebugResponsePreview {
-                response_type: "unknown".to_string(),
-                status_code: None,
-                headers: None,
-                body_preview: None,
-            };
+    pub fn get_response_preview(
+        &self,
+        stub_state: &StubState,
+    ) -> anyhow::Result<DebugResponsePreview> {
+        // Get the current response from the cycler/sequencer
+        if let Some(response) = self.peek_stub_response(stub_state)? {
+            return Ok(create_response_preview(response));
         }
 
-        // Get the current response from the cycler
-        if let Some(response) = stub_state.peek_response() {
-            return create_response_preview(response);
-        }
-
-        DebugResponsePreview {
+        Ok(DebugResponsePreview {
             response_type: "unknown".to_string(),
             status_code: None,
             headers: None,
             body_preview: None,
-        }
+        })
     }
 
     /// Convert hyper HeaderMap to HashMap<String, String>
@@ -76,65 +126,81 @@ impl Imposter {
     pub fn execute_stub_with_rift(
         &self,
         stub_state: &StubState,
-    ) -> Option<(
-        u16,
-        HashMap<String, Vec<String>>,
-        String,
-        Option<serde_json::Value>,
-        Option<RiftResponseExtension>,
-        ResponseMode,
-        bool,
-    )> {
-        let response = stub_state.get_next_response()?;
-        execute_stub_response_with_rift(response)
+    ) -> anyhow::Result<
+        Option<(
+            u16,
+            HashMap<String, Vec<String>>,
+            String,
+            Option<serde_json::Value>,
+            Option<RiftResponseExtension>,
+            ResponseMode,
+            bool,
+        )>,
+    > {
+        let Some(response) = self.next_stub_response(stub_state)? else {
+            return Ok(None);
+        };
+        Ok(execute_stub_response_with_rift(response))
     }
 
     /// Get RiftScript response if present
     /// Note: This peeks at the current response without advancing the cycler
-    pub fn get_rift_script_response(&self, stub_state: &StubState) -> Option<RiftScriptConfig> {
-        let response = stub_state.peek_response()?;
-        get_rift_script_config(response)
+    pub fn get_rift_script_response(
+        &self,
+        stub_state: &StubState,
+    ) -> anyhow::Result<Option<RiftScriptConfig>> {
+        let Some(response) = self.peek_stub_response(stub_state)? else {
+            return Ok(None);
+        };
+        Ok(get_rift_script_config(response))
     }
 
     /// Advance cycler for RiftScript response
-    pub fn advance_cycler_for_rift_script(&self, stub_state: &StubState) {
+    pub fn advance_cycler_for_rift_script(&self, stub_state: &StubState) -> anyhow::Result<()> {
         // Just cycling as a side effect
-        _ = stub_state.get_next_response();
+        _ = self.next_stub_response(stub_state)?;
+        Ok(())
     }
 
     /// Check if a stub response is a proxy and return the proxy config
     /// Note: This peeks at the current response without advancing the cycler
-    pub fn get_proxy_response(&self, stub: &StubState) -> Option<ProxyResponse> {
-        let response = stub.peek_response()?;
+    pub fn get_proxy_response(&self, stub: &StubState) -> anyhow::Result<Option<ProxyResponse>> {
+        let Some(response) = self.peek_stub_response(stub)? else {
+            return Ok(None);
+        };
 
-        match response {
+        Ok(match response {
             StubResponse::Proxy { proxy } => Some(proxy.clone()),
             _ => None,
-        }
+        })
     }
 
     /// Advance the response cycler for a proxy response
     /// This should be called after successfully handling a proxy response
-    pub fn advance_cycler_for_proxy(&self, stub_state: &StubState) {
+    pub fn advance_cycler_for_proxy(&self, stub_state: &StubState) -> anyhow::Result<()> {
         // Assume proxies won't have a repeat count anyway, so a normal advance works.
-        _ = stub_state.get_next_response();
+        _ = self.next_stub_response(stub_state)?;
+        Ok(())
     }
 
     /// Check if a stub response is an inject and return the inject function
     /// Note: This peeks at the current response without advancing the cycler
     // Used with javascript feature
-    pub fn get_inject_response(&self, stub_state: &StubState) -> Option<String> {
-        let response = stub_state.peek_response()?;
-        match response {
+    pub fn get_inject_response(&self, stub_state: &StubState) -> anyhow::Result<Option<String>> {
+        let Some(response) = self.peek_stub_response(stub_state)? else {
+            return Ok(None);
+        };
+        Ok(match response {
             StubResponse::Inject { inject } => Some(inject.clone()),
             _ => None,
-        }
+        })
     }
 
     /// Advance the response cycler for an inject response
     /// This should be called after successfully handling an inject response
     // Used with javascript feature
-    pub fn advance_cycler_for_inject(&self, stub_state: &StubState) {
-        _ = stub_state.get_next_response();
+    pub fn advance_cycler_for_inject(&self, stub_state: &StubState) -> anyhow::Result<()> {
+        _ = self.next_stub_response(stub_state)?;
+        Ok(())
     }
 }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -271,7 +271,11 @@ async fn handle_request_inner(
         }
 
         // Check if this is a proxy response
-        if let Some(proxy_config) = imposter.get_proxy_response(&stub_state) {
+        let proxy_config = match imposter.get_proxy_response(&stub_state) {
+            Ok(config) => config,
+            Err(e) => return Ok(backend_error_response(&e)),
+        };
+        if let Some(proxy_config) = proxy_config {
             debug!("Handling proxy request to {}", proxy_config.to);
             match imposter
                 .handle_proxy_request(
@@ -285,7 +289,9 @@ async fn handle_request_inner(
             {
                 Ok((status, response_headers, body, latency)) => {
                     // Advance the cycler for this proxy response
-                    imposter.advance_cycler_for_proxy(&stub_state);
+                    if let Err(e) = imposter.advance_cycler_for_proxy(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
 
                     let mut response = Response::builder().status(status);
 
@@ -324,7 +330,11 @@ async fn handle_request_inner(
 
         // Check if this is an inject response (JavaScript function)
         #[cfg(feature = "javascript")]
-        if let Some(inject_fn) = imposter.get_inject_response(&stub_state) {
+        let inject_fn = match imposter.get_inject_response(&stub_state) {
+            Ok(inject) => inject,
+            Err(e) => return Ok(backend_error_response(&e)),
+        };
+        if let Some(inject_fn) = inject_fn {
             debug!("Handling inject response");
 
             // Build request for inject function
@@ -343,7 +353,9 @@ async fn handle_request_inner(
             ) {
                 Ok(inject_response) => {
                     // Advance the cycler for this inject response
-                    imposter.advance_cycler_for_inject(&stub_state);
+                    if let Err(e) = imposter.advance_cycler_for_inject(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
 
                     let mut response = Response::builder().status(inject_response.status_code);
 
@@ -375,7 +387,11 @@ async fn handle_request_inner(
         }
 
         // Check if this is a RiftScript response (_rift.script)
-        if let Some(script_config) = imposter.get_rift_script_response(&stub_state) {
+        let script_config = match imposter.get_rift_script_response(&stub_state) {
+            Ok(config) => config,
+            Err(e) => return Ok(backend_error_response(&e)),
+        };
+        if let Some(script_config) = script_config {
             debug!(
                 "Handling Rift script response (engine: {})",
                 script_config.engine
@@ -420,7 +436,9 @@ async fn handle_request_inner(
                     headers,
                     ..
                 }) => {
-                    imposter.advance_cycler_for_rift_script(&stub_state);
+                    if let Err(e) = imposter.advance_cycler_for_rift_script(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
 
                     let mut response = Response::builder().status(status);
                     for (k, v) in &headers {
@@ -441,7 +459,9 @@ async fn handle_request_inner(
                 Ok(FaultDecision::Latency { duration_ms, .. }) => {
                     // Apply latency then return 200 OK
                     tokio::time::sleep(Duration::from_millis(duration_ms)).await;
-                    imposter.advance_cycler_for_rift_script(&stub_state);
+                    if let Err(e) = imposter.advance_cycler_for_rift_script(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
 
                     return Ok(build_response_with_headers(
                         StatusCode::OK,
@@ -455,7 +475,9 @@ async fn handle_request_inner(
                 }
                 Ok(FaultDecision::None) => {
                     // Script says no fault - return 200 OK
-                    imposter.advance_cycler_for_rift_script(&stub_state);
+                    if let Err(e) = imposter.advance_cycler_for_rift_script(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
 
                     return Ok(build_response_with_headers(
                         StatusCode::OK,
@@ -485,8 +507,10 @@ async fn handle_request_inner(
             rift_ext,
             response_mode,
             is_fault,
-        )) = imposter.execute_stub_with_rift(&stub_state)
-        {
+        )) = match imposter.execute_stub_with_rift(&stub_state) {
+            Ok(executed) => executed,
+            Err(e) => return Ok(backend_error_response(&e)),
+        } {
             // Handle faults - simulate connection errors
             if is_fault {
                 return handle_fault_response(&body);
@@ -830,7 +854,10 @@ fn handle_debug_request(
     };
     let match_result = if let Some((stub_state, stub_index)) = matched {
         // Match found
-        let response_preview = imposter.get_response_preview(&stub_state);
+        let response_preview = match imposter.get_response_preview(&stub_state) {
+            Ok(preview) => preview,
+            Err(e) => return Ok(backend_error_response(&e)),
+        };
         DebugMatchResult {
             matched: true,
             stub_index: Some(stub_index),

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -334,6 +334,7 @@ async fn handle_request_inner(
             Ok(inject) => inject,
             Err(e) => return Ok(backend_error_response(&e)),
         };
+        #[cfg(feature = "javascript")]
         if let Some(inject_fn) = inject_fn {
             debug!("Handling inject response");
 

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -8,8 +8,8 @@ use super::fault_io::{FaultCell, FaultIo, TcpFaultKind};
 use super::handler::handle_imposter_request_decorated;
 use super::reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, StubReconcile};
 use super::types::{ImposterConfig, ImposterError, Stub};
-use crate::extensions::decorate::ResponseDecorator;
 use crate::behaviors::ResponseSequencer;
+use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -175,8 +175,11 @@ impl ImposterManager {
     /// Register a pluggable response-cursor backend (issue #313), consulted for every
     /// response-cycling decision with a full `SequenceKey` and materialized repeats.
     /// Without one, imposters keep the embedded per-stub cycler (today's hot path,
-    /// untouched). `reset_scope` fires on stub delete (that stub's key), bulk stub
-    /// replace, and imposter teardown (port-wide, the GC hook).
+    /// untouched). `reset_scope` fires on stub delete — direct or via an `apply_config`
+    /// patch — (that stub's key), bulk stub replace, and imposter teardown (port-wide,
+    /// the GC hook). A single in-place stub replace deliberately does NOT reset: the slot
+    /// survives, so slot-keyed cursors keep cycling; a `stub_key`-keyed backend whose key
+    /// changed with the content keeps the old key's cursor until port teardown reclaims it.
     #[must_use]
     pub fn with_sequencer(mut self, sequencer: Arc<dyn ResponseSequencer>) -> Self {
         self.sequencer = Some(sequencer);
@@ -619,7 +622,14 @@ impl ImposterManager {
 
             match existing.reconcile_stubs(config.stubs.clone()) {
                 StubReconcile::Unchanged => {}
-                StubReconcile::Patched => {
+                StubReconcile::Patched { removed_keys } => {
+                    // apply_config removals are stub deletes: fire the sequencer GC hook
+                    // per removed stub, same as delete_stub (issue #313).
+                    if let Some(sequencer) = &self.sequencer {
+                        for key in &removed_keys {
+                            sequencer.reset_scope(port, Some(key));
+                        }
+                    }
                     report.stub_patched.push(port);
                     self.emit(ImposterEvent::StubsChanged(port));
                     // The in-memory patch stands either way; a datadir write failure must
@@ -1883,11 +1893,22 @@ mod tests {
 
         type NextCall = (u16, u64, String, String, Vec<u32>);
 
+        fn recorded(key: &SequenceKey<'_>, repeats: &[u32]) -> NextCall {
+            (
+                key.port,
+                key.slot,
+                key.stub_key.to_string(),
+                key.scope.to_string(),
+                repeats.to_vec(),
+            )
+        }
+
         /// Delegates to LocalSequencer while recording every next() key and reset_scope().
         #[derive(Default)]
         struct RecordingSequencer {
             inner: LocalSequencer,
             nexts: Mutex<Vec<NextCall>>,
+            peeks: Mutex<Vec<NextCall>>,
             resets: Mutex<Vec<(u16, Option<String>)>>,
         }
 
@@ -1898,13 +1919,7 @@ mod tests {
                 response_count: usize,
                 repeats: &[u32],
             ) -> anyhow::Result<usize> {
-                self.nexts.lock().push((
-                    key.port,
-                    key.slot,
-                    key.stub_key.to_string(),
-                    key.scope.to_string(),
-                    repeats.to_vec(),
-                ));
+                self.nexts.lock().push(recorded(&key, repeats));
                 self.inner.next(key, response_count, repeats)
             }
             fn peek(
@@ -1913,6 +1928,7 @@ mod tests {
                 response_count: usize,
                 repeats: &[u32],
             ) -> anyhow::Result<usize> {
+                self.peeks.lock().push(recorded(&key, repeats));
                 self.inner.peek(key, response_count, repeats)
             }
             fn reset_scope(&self, port: u16, stub_key: Option<&str>) {
@@ -1925,29 +1941,26 @@ mod tests {
 
         struct FailingSequencer;
         impl ResponseSequencer for FailingSequencer {
-            fn next(
-                &self,
-                _key: SequenceKey<'_>,
-                _n: usize,
-                _r: &[u32],
-            ) -> anyhow::Result<usize> {
+            fn next(&self, _key: SequenceKey<'_>, _n: usize, _r: &[u32]) -> anyhow::Result<usize> {
                 Err(anyhow::Error::new(BackendUnavailable {
                     feature: "sequencer",
                     detail: "induced".to_string(),
                 }))
             }
-            fn peek(
-                &self,
-                _key: SequenceKey<'_>,
-                _n: usize,
-                _r: &[u32],
-            ) -> anyhow::Result<usize> {
+            fn peek(&self, _key: SequenceKey<'_>, _n: usize, _r: &[u32]) -> anyhow::Result<usize> {
                 Err(anyhow::Error::new(BackendUnavailable {
                     feature: "sequencer",
                     detail: "induced".to_string(),
                 }))
             }
             fn reset_scope(&self, _port: u16, _stub_key: Option<&str>) {}
+        }
+
+        fn manager_with_recorder() -> (Arc<RecordingSequencer>, ImposterManager) {
+            let recorder = Arc::new(RecordingSequencer::default());
+            let manager = ImposterManager::new()
+                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            (recorder, manager)
         }
 
         fn cycling_stub_json() -> serde_json::Value {
@@ -1966,9 +1979,7 @@ mod tests {
         // decisions drive the served responses (repeat honored through the real pipeline).
         #[tokio::test]
         async fn sequencer_receives_keys_and_drives_cycling() {
-            let recorder = Arc::new(RecordingSequencer::default());
-            let manager = ImposterManager::new()
-                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            let (recorder, manager) = manager_with_recorder();
             manager
                 .create_imposter(imposter_cfg(json!({
                     "protocol": "http", "port": 19520,
@@ -2005,6 +2016,11 @@ mod tests {
                 nexts.iter().all(|(_, s, ..)| *s == slot),
                 "slot token stable across requests"
             );
+            let peeks = recorder.peeks.lock().clone();
+            assert!(
+                !peeks.is_empty() && peeks.iter().all(|(_, s, ..)| *s == slot),
+                "response-type dispatch peeks route through the sequencer with the same slot"
+            );
 
             manager.delete_all().await;
         }
@@ -2013,9 +2029,7 @@ mod tests {
         // preserve-on-replace), so a slot-keyed backend keeps its cursor position.
         #[tokio::test]
         async fn slot_survives_in_place_replace() {
-            let recorder = Arc::new(RecordingSequencer::default());
-            let manager = ImposterManager::new()
-                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            let (recorder, manager) = manager_with_recorder();
             manager
                 .create_imposter(imposter_cfg(json!({
                     "protocol": "http", "port": 19521,
@@ -2024,7 +2038,9 @@ mod tests {
                 .await
                 .expect("create");
 
-            let _ = reqwest::get("http://127.0.0.1:19521/cycle").await.expect("request");
+            let _ = reqwest::get("http://127.0.0.1:19521/cycle")
+                .await
+                .expect("request");
             let slot_before = recorder.nexts.lock().last().expect("recorded").1;
 
             let replacement: Stub = serde_json::from_value(cycling_stub_json()).expect("stub");
@@ -2033,7 +2049,9 @@ mod tests {
                 .await
                 .expect("replace");
 
-            let _ = reqwest::get("http://127.0.0.1:19521/cycle").await.expect("request");
+            let _ = reqwest::get("http://127.0.0.1:19521/cycle")
+                .await
+                .expect("request");
             let slot_after = recorder.nexts.lock().last().expect("recorded").1;
             assert_eq!(
                 slot_before, slot_after,
@@ -2047,9 +2065,7 @@ mod tests {
         // imposter teardown (the GC hook).
         #[tokio::test]
         async fn reset_scope_fires_on_delete_bulk_replace_and_teardown() {
-            let recorder = Arc::new(RecordingSequencer::default());
-            let manager = ImposterManager::new()
-                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            let (recorder, manager) = manager_with_recorder();
             manager
                 .create_imposter(imposter_cfg(json!({
                     "protocol": "http", "port": 19522,
@@ -2071,9 +2087,11 @@ mod tests {
                 recorder.resets.lock()
             );
 
-            let fresh: Vec<Stub> =
-                vec![serde_json::from_value(stub_json("fresh")).expect("stub")];
-            manager.replace_stubs(19522, fresh).await.expect("replace all");
+            let fresh: Vec<Stub> = vec![serde_json::from_value(stub_json("fresh")).expect("stub")];
+            manager
+                .replace_stubs(19522, fresh)
+                .await
+                .expect("replace all");
             assert!(
                 recorder.resets.lock().contains(&(19522, None)),
                 "bulk replace resets the whole port"
@@ -2117,9 +2135,7 @@ mod tests {
         // flow id, which is orthogonal here).
         #[tokio::test]
         async fn space_scoped_stub_reports_scope() {
-            let recorder = Arc::new(RecordingSequencer::default());
-            let manager = ImposterManager::new()
-                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            let (recorder, manager) = manager_with_recorder();
             manager
                 .create_imposter(imposter_cfg(json!({
                     "protocol": "http", "port": 19524,
@@ -2144,6 +2160,133 @@ mod tests {
 
             let nexts = recorder.nexts.lock().clone();
             assert_eq!(nexts.last().expect("recorded").3, "flow-9");
+
+            manager.delete_all().await;
+        }
+
+        // A misbehaving custom sequencer returning an out-of-range index is a loud 500
+        // (contract violation), never a silent fall-through to the default response.
+        struct OobSequencer;
+        impl ResponseSequencer for OobSequencer {
+            fn next(&self, _k: SequenceKey<'_>, _n: usize, _r: &[u32]) -> anyhow::Result<usize> {
+                Ok(usize::MAX)
+            }
+            fn peek(&self, _k: SequenceKey<'_>, _n: usize, _r: &[u32]) -> anyhow::Result<usize> {
+                Ok(0)
+            }
+            fn reset_scope(&self, _port: u16, _stub_key: Option<&str>) {}
+        }
+
+        #[tokio::test]
+        async fn out_of_range_sequencer_index_surfaces_500() {
+            let manager = ImposterManager::new()
+                .with_sequencer(Arc::new(OobSequencer) as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19527,
+                    "stubs": [cycling_stub_json()]
+                })))
+                .await
+                .expect("create");
+
+            let resp = reqwest::get("http://127.0.0.1:19527/cycle")
+                .await
+                .expect("request");
+            assert_eq!(
+                resp.status(),
+                500,
+                "contract violation is a loud backend error"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // An id-less stub keys as the stable content key (~hash#0), and delete-by-INDEX
+        // resolves and resets that same key.
+        #[tokio::test]
+        async fn idless_stub_content_key_and_delete_by_index_reset() {
+            let (recorder, manager) = manager_with_recorder();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19525,
+                    "stubs": [{
+                        "predicates": [{"equals": {"path": "/anon"}}],
+                        "responses": [{"is": {"statusCode": 200, "body": "anon"}}]
+                    }]
+                })))
+                .await
+                .expect("create");
+
+            let _ = reqwest::get("http://127.0.0.1:19525/anon")
+                .await
+                .expect("request");
+            let key_used = recorder.nexts.lock().last().expect("recorded").2.clone();
+            assert!(
+                key_used.starts_with('~') && key_used.ends_with("#0"),
+                "id-less stub keys as a content key, got {key_used}"
+            );
+
+            manager
+                .delete_stub(19525, 0)
+                .await
+                .expect("delete by index");
+            assert!(
+                recorder
+                    .resets
+                    .lock()
+                    .contains(&(19525, Some(key_used.clone()))),
+                "delete-by-index resets the same content key: {:?}",
+                recorder.resets.lock()
+            );
+
+            manager.delete_all().await;
+        }
+
+        // apply_config patches are stub lifecycle too: a removed stub fires the per-stub
+        // GC hook, and an untouched sibling keeps its slot (cursor survives the patch).
+        #[tokio::test]
+        async fn apply_config_patch_resets_removed_and_preserves_sibling_slot() {
+            let (recorder, manager) = manager_with_recorder();
+            let initial = imposter_cfg(json!({
+                "protocol": "http", "port": 19526,
+                "stubs": [
+                    cycling_stub_json(),
+                    {"id": "doomed",
+                     "predicates": [{"equals": {"path": "/doomed"}}],
+                     "responses": [{"is": {"statusCode": 200, "body": "bye"}}]}
+                ]
+            }));
+            manager
+                .apply_config(vec![initial.clone()])
+                .await
+                .expect("create via apply");
+
+            let _ = reqwest::get("http://127.0.0.1:19526/cycle")
+                .await
+                .expect("request");
+            let slot_before = recorder.nexts.lock().last().expect("recorded").1;
+
+            let mut patched = initial;
+            patched.stubs.truncate(1);
+            manager.apply_config(vec![patched]).await.expect("patch");
+
+            assert!(
+                recorder
+                    .resets
+                    .lock()
+                    .contains(&(19526, Some("doomed".to_string()))),
+                "apply_config removal fires the per-stub GC hook: {:?}",
+                recorder.resets.lock()
+            );
+
+            let _ = reqwest::get("http://127.0.0.1:19526/cycle")
+                .await
+                .expect("request");
+            let slot_after = recorder.nexts.lock().last().expect("recorded").1;
+            assert_eq!(
+                slot_before, slot_after,
+                "an untouched sibling keeps its slot across an apply_config patch"
+            );
 
             manager.delete_all().await;
         }

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -9,6 +9,7 @@ use super::handler::handle_imposter_request_decorated;
 use super::reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, StubReconcile};
 use super::types::{ImposterConfig, ImposterError, Stub};
 use crate::extensions::decorate::ResponseDecorator;
+use crate::behaviors::ResponseSequencer;
 use crate::extensions::flow_state::FlowStoreProvider;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -104,6 +105,8 @@ pub struct ImposterManager {
     response_decorator: Option<Arc<dyn ResponseDecorator>>,
     /// Embedder hook to supply a custom flow store per imposter (issue #312)
     flow_store_provider: Option<Arc<dyn FlowStoreProvider>>,
+    /// Pluggable response-cursor backend (issue #313); None = embedded per-stub cycler.
+    sequencer: Option<Arc<dyn ResponseSequencer>>,
 }
 
 impl ImposterManager {
@@ -123,6 +126,7 @@ impl ImposterManager {
             event_listener: None,
             response_decorator: None,
             flow_store_provider: None,
+            sequencer: None,
         }
     }
 
@@ -165,6 +169,17 @@ impl ImposterManager {
     #[must_use]
     pub fn with_flow_store_provider(mut self, provider: Arc<dyn FlowStoreProvider>) -> Self {
         self.flow_store_provider = Some(provider);
+        self
+    }
+
+    /// Register a pluggable response-cursor backend (issue #313), consulted for every
+    /// response-cycling decision with a full `SequenceKey` and materialized repeats.
+    /// Without one, imposters keep the embedded per-stub cycler (today's hot path,
+    /// untouched). `reset_scope` fires on stub delete (that stub's key), bulk stub
+    /// replace, and imposter teardown (port-wide, the GC hook).
+    #[must_use]
+    pub fn with_sequencer(mut self, sequencer: Arc<dyn ResponseSequencer>) -> Self {
+        self.sequencer = Some(sequencer);
         self
     }
 
@@ -273,7 +288,11 @@ impl ImposterManager {
 
         info!("Imposter bound to {}:{}", bind_host, port);
         // Create imposter
-        let mut imposter = Imposter::new_with_provider(config, self.flow_store_provider.as_ref());
+        let mut imposter = Imposter::new_with_hooks(
+            config,
+            self.flow_store_provider.as_ref(),
+            self.sequencer.clone(),
+        );
 
         // Create shutdown channel for this imposter
         let (shutdown_tx, _) = broadcast::channel(1);
@@ -438,6 +457,10 @@ impl ImposterManager {
         // Clear JavaScript inject state for this imposter
         #[cfg(feature = "javascript")]
         crate::scripting::clear_imposter_state(port);
+
+        if let Some(sequencer) = &self.sequencer {
+            sequencer.reset_scope(port, None);
+        }
 
         info!("Imposter on port {} deleted", port);
         self.remove_persisted_imposter(port);
@@ -696,6 +719,9 @@ impl ImposterManager {
         if !imposter.delete_stub_by_id(id) {
             return Err(ImposterError::StubNotFound(id.to_string()));
         }
+        if let Some(sequencer) = &self.sequencer {
+            sequencer.reset_scope(port, Some(id));
+        }
         self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
@@ -734,7 +760,18 @@ impl ImposterManager {
     /// Delete a stub
     pub async fn delete_stub(&self, port: u16, index: usize) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
+        // Resolve the stub's stable key before it is gone, for the sequencer GC hook.
+        let deleted_key = if self.sequencer.is_some() {
+            imposter
+                .get_stub(index)
+                .map(|stub| crate::imposter::reconcile::stub_key(&stub, 0))
+        } else {
+            None
+        };
         imposter.delete_stub(index)?;
+        if let (Some(sequencer), Some(key)) = (&self.sequencer, deleted_key) {
+            sequencer.reset_scope(port, Some(&key));
+        }
         self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
@@ -743,6 +780,9 @@ impl ImposterManager {
     pub async fn replace_stubs(&self, port: u16, stubs: Vec<Stub>) -> Result<(), ImposterError> {
         let imposter = self.get_imposter(port)?;
         imposter.replace_stubs(stubs);
+        if let Some(sequencer) = &self.sequencer {
+            sequencer.reset_scope(port, None);
+        }
         self.emit(ImposterEvent::StubsChanged(port));
         self.persist_imposter_checked(&imposter).await
     }
@@ -1828,6 +1868,282 @@ mod tests {
                 Some(json!("v")),
                 "None provider must fall through to the configured flowState store, not NoOp"
             );
+
+            manager.delete_all().await;
+        }
+    }
+
+    // =========================================================================
+    // Issue #313: pluggable ResponseSequencer
+    // =========================================================================
+    mod response_sequencer {
+        use super::*;
+        use crate::behaviors::sequencer::{LocalSequencer, ResponseSequencer, SequenceKey};
+        use crate::extensions::decorate::BackendUnavailable;
+
+        type NextCall = (u16, u64, String, String, Vec<u32>);
+
+        /// Delegates to LocalSequencer while recording every next() key and reset_scope().
+        #[derive(Default)]
+        struct RecordingSequencer {
+            inner: LocalSequencer,
+            nexts: Mutex<Vec<NextCall>>,
+            resets: Mutex<Vec<(u16, Option<String>)>>,
+        }
+
+        impl ResponseSequencer for RecordingSequencer {
+            fn next(
+                &self,
+                key: SequenceKey<'_>,
+                response_count: usize,
+                repeats: &[u32],
+            ) -> anyhow::Result<usize> {
+                self.nexts.lock().push((
+                    key.port,
+                    key.slot,
+                    key.stub_key.to_string(),
+                    key.scope.to_string(),
+                    repeats.to_vec(),
+                ));
+                self.inner.next(key, response_count, repeats)
+            }
+            fn peek(
+                &self,
+                key: SequenceKey<'_>,
+                response_count: usize,
+                repeats: &[u32],
+            ) -> anyhow::Result<usize> {
+                self.inner.peek(key, response_count, repeats)
+            }
+            fn reset_scope(&self, port: u16, stub_key: Option<&str>) {
+                self.resets
+                    .lock()
+                    .push((port, stub_key.map(str::to_string)));
+                self.inner.reset_scope(port, stub_key);
+            }
+        }
+
+        struct FailingSequencer;
+        impl ResponseSequencer for FailingSequencer {
+            fn next(
+                &self,
+                _key: SequenceKey<'_>,
+                _n: usize,
+                _r: &[u32],
+            ) -> anyhow::Result<usize> {
+                Err(anyhow::Error::new(BackendUnavailable {
+                    feature: "sequencer",
+                    detail: "induced".to_string(),
+                }))
+            }
+            fn peek(
+                &self,
+                _key: SequenceKey<'_>,
+                _n: usize,
+                _r: &[u32],
+            ) -> anyhow::Result<usize> {
+                Err(anyhow::Error::new(BackendUnavailable {
+                    feature: "sequencer",
+                    detail: "induced".to_string(),
+                }))
+            }
+            fn reset_scope(&self, _port: u16, _stub_key: Option<&str>) {}
+        }
+
+        fn cycling_stub_json() -> serde_json::Value {
+            json!({
+                "id": "s1",
+                "predicates": [{"equals": {"path": "/cycle"}}],
+                "responses": [
+                    {"is": {"statusCode": 200, "body": "one"},
+                     "_behaviors": {"repeat": 2}},
+                    {"is": {"statusCode": 200, "body": "two"}}
+                ]
+            })
+        }
+
+        // AC2: an injected sequencer receives the correct key parts and repeats, and its
+        // decisions drive the served responses (repeat honored through the real pipeline).
+        #[tokio::test]
+        async fn sequencer_receives_keys_and_drives_cycling() {
+            let recorder = Arc::new(RecordingSequencer::default());
+            let manager = ImposterManager::new()
+                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19520,
+                    "stubs": [cycling_stub_json()]
+                })))
+                .await
+                .expect("create");
+
+            let mut bodies = Vec::new();
+            for _ in 0..3 {
+                bodies.push(
+                    reqwest::get("http://127.0.0.1:19520/cycle")
+                        .await
+                        .expect("request")
+                        .text()
+                        .await
+                        .expect("body"),
+                );
+            }
+            assert_eq!(
+                bodies,
+                vec!["one", "one", "two"],
+                "sequencer decisions must honor per-response repeats"
+            );
+
+            let nexts = recorder.nexts.lock().clone();
+            assert!(!nexts.is_empty(), "sequencer was consulted");
+            let (port, slot, stub_key, scope, repeats) = nexts[0].clone();
+            assert_eq!(port, 19520);
+            assert_eq!(stub_key, "s1", "explicit stub id is the stable key");
+            assert_eq!(scope, "", "global stub has an empty scope");
+            assert_eq!(repeats, vec![2, 1], "materialized per-response repeats");
+            assert!(
+                nexts.iter().all(|(_, s, ..)| *s == slot),
+                "slot token stable across requests"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC2/AC1: an in-place replace keeps the slot token (mirroring the embedded
+        // preserve-on-replace), so a slot-keyed backend keeps its cursor position.
+        #[tokio::test]
+        async fn slot_survives_in_place_replace() {
+            let recorder = Arc::new(RecordingSequencer::default());
+            let manager = ImposterManager::new()
+                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19521,
+                    "stubs": [cycling_stub_json()]
+                })))
+                .await
+                .expect("create");
+
+            let _ = reqwest::get("http://127.0.0.1:19521/cycle").await.expect("request");
+            let slot_before = recorder.nexts.lock().last().expect("recorded").1;
+
+            let replacement: Stub = serde_json::from_value(cycling_stub_json()).expect("stub");
+            manager
+                .replace_stub_by_id(19521, "s1", replacement)
+                .await
+                .expect("replace");
+
+            let _ = reqwest::get("http://127.0.0.1:19521/cycle").await.expect("request");
+            let slot_after = recorder.nexts.lock().last().expect("recorded").1;
+            assert_eq!(
+                slot_before, slot_after,
+                "in-place replace must keep the slot token"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC2: reset_scope fires per stub on delete, and port-wide on bulk replace and
+        // imposter teardown (the GC hook).
+        #[tokio::test]
+        async fn reset_scope_fires_on_delete_bulk_replace_and_teardown() {
+            let recorder = Arc::new(RecordingSequencer::default());
+            let manager = ImposterManager::new()
+                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19522,
+                    "stubs": [cycling_stub_json(), stub_json("other")]
+                })))
+                .await
+                .expect("create");
+
+            manager
+                .delete_stub_by_id(19522, "s1")
+                .await
+                .expect("delete by id");
+            assert!(
+                recorder
+                    .resets
+                    .lock()
+                    .contains(&(19522, Some("s1".to_string()))),
+                "stub delete resets that stub's cursors: {:?}",
+                recorder.resets.lock()
+            );
+
+            let fresh: Vec<Stub> =
+                vec![serde_json::from_value(stub_json("fresh")).expect("stub")];
+            manager.replace_stubs(19522, fresh).await.expect("replace all");
+            assert!(
+                recorder.resets.lock().contains(&(19522, None)),
+                "bulk replace resets the whole port"
+            );
+
+            recorder.resets.lock().clear();
+            manager.delete_imposter(19522).await.expect("teardown");
+            assert!(
+                recorder.resets.lock().contains(&(19522, None)),
+                "imposter teardown is the port-wide GC hook"
+            );
+        }
+
+        // A failing sequencer surfaces as the structured backend error (#318), never a
+        // silent wrong response.
+        #[tokio::test]
+        async fn failing_sequencer_surfaces_structured_503() {
+            let manager = ImposterManager::new()
+                .with_sequencer(Arc::new(FailingSequencer) as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19523,
+                    "stubs": [cycling_stub_json()]
+                })))
+                .await
+                .expect("create");
+
+            let resp = reqwest::get("http://127.0.0.1:19523/cycle")
+                .await
+                .expect("request");
+            assert_eq!(resp.status(), 503, "sequencer outage is a structured 503");
+            let body: serde_json::Value = resp.json().await.expect("json");
+            assert_eq!(body["error"], "backendUnavailable");
+            assert_eq!(body["feature"], "sequencer");
+
+            manager.delete_all().await;
+        }
+
+        // Scope (issue #223 space) is carried in the key: a space-scoped stub reports its
+        // space, exercised directly at the imposter layer (the HTTP gate needs a matching
+        // flow id, which is orthogonal here).
+        #[tokio::test]
+        async fn space_scoped_stub_reports_scope() {
+            let recorder = Arc::new(RecordingSequencer::default());
+            let manager = ImposterManager::new()
+                .with_sequencer(recorder.clone() as Arc<dyn ResponseSequencer>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19524,
+                    "stubs": []
+                })))
+                .await
+                .expect("create");
+
+            let spaced: Stub = serde_json::from_value(json!({
+                "space": "flow-9",
+                "predicates": [{"equals": {"path": "/sp"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "sp"}}]
+            }))
+            .expect("stub");
+            manager.add_stub(19524, spaced, None).await.expect("add");
+
+            let imposter = manager.get_imposter(19524).unwrap();
+            let stub_state = imposter.stubs.read()[0].clone();
+            let _ = imposter
+                .execute_stub_with_rift(&stub_state)
+                .expect("sequencer ok");
+
+            let nexts = recorder.nexts.lock().clone();
+            assert_eq!(nexts.last().expect("recorded").3, "flow-9");
 
             manager.delete_all().await;
         }

--- a/crates/rift-core/src/imposter/reconcile.rs
+++ b/crates/rift-core/src/imposter/reconcile.rs
@@ -94,7 +94,11 @@ pub(crate) enum StubReconcile {
     /// Same stubs, same order — nothing touched.
     Unchanged,
     /// Edited in place; untouched slots kept their cycling state.
-    Patched,
+    Patched {
+        /// Sequencer keys (`stub_key(stub, 0)`) of stubs the patch removed, so the
+        /// manager can fire the per-stub `reset_scope` GC hook (issue #313).
+        removed_keys: Vec<String>,
+    },
     /// More than half the stubs would change — the caller should replace the imposter
     /// wholesale instead of thrashing the stub set in place.
     Degenerate,
@@ -154,7 +158,11 @@ pub(crate) fn reconcile_stub_states(
             None => StubState::new(stub),
         })
         .collect();
-    StubReconcile::Patched
+    let removed_keys = by_key
+        .into_values()
+        .map(|state| stub_key(&state.stub, 0))
+        .collect();
+    StubReconcile::Patched { removed_keys }
 }
 
 /// Content inequality via canonical JSON. A serialization failure on either side counts
@@ -277,7 +285,7 @@ mod tests {
 
         let desired = vec![two_resp("a1", "a2"), one_resp("b"), one_resp("c2")];
         let outcome = reconcile_stub_states(&mut states, desired);
-        assert!(matches!(outcome, StubReconcile::Patched));
+        assert!(matches!(outcome, StubReconcile::Patched { .. }));
         assert_eq!(states.len(), 3);
         assert_eq!(
             next_body(&states[0]),
@@ -300,7 +308,7 @@ mod tests {
 
         let desired = vec![two_resp("b1", "b2"), two_resp("a1", "a2")];
         let outcome = reconcile_stub_states(&mut states, desired);
-        assert!(matches!(outcome, StubReconcile::Patched));
+        assert!(matches!(outcome, StubReconcile::Patched { .. }));
         assert_eq!(next_body(&states[0]), "b2", "moved stub keeps its cursor");
         assert_eq!(next_body(&states[1]), "a2", "moved stub keeps its cursor");
     }
@@ -342,7 +350,7 @@ mod tests {
         updated.id = Some("s1".into());
         let outcome =
             reconcile_stub_states(&mut states, vec![updated, one_resp("b"), one_resp("c")]);
-        assert!(matches!(outcome, StubReconcile::Patched));
+        assert!(matches!(outcome, StubReconcile::Patched { .. }));
         assert_eq!(
             next_body(&states[0]),
             "v2b",
@@ -366,7 +374,7 @@ mod tests {
             one_resp("c"),
         ];
         let outcome = reconcile_stub_states(&mut states, desired);
-        assert!(matches!(outcome, StubReconcile::Patched));
+        assert!(matches!(outcome, StubReconcile::Patched { .. }));
         assert_eq!(states.len(), 4);
         assert_eq!(next_body(&states[0]), "a2");
         assert_eq!(next_body(&states[1]), "new");

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -158,6 +158,7 @@ fn test_execute_stub() {
     };
 
     let result = imposter.execute_stub_with_rift(&StubState::new(stub));
+    let result = result.expect("sequencer path is infallible here");
     assert!(result.is_some());
     let (status, _headers, body, _behaviors, _rift_ext, _mode, is_fault) = result.unwrap();
     assert_eq!(status, 201);


### PR DESCRIPTION
Extracts a `ResponseSequencer` trait from the per-stub `RuleCycler` internals so embedders can supply response cursors that persist, seed deterministically, or are shared across engine instances.

## Design (flagged for review)
**Zero-overhead hybrid.** With no sequencer registered, imposters keep today's embedded per-stub cycler — the only addition on that path is one branch on the absent `Option` (no key building, repeat materialization, or map lookups). A sequencer injected via `ImposterManager::with_sequencer` receives every cursor decision with a full `SequenceKey{port, slot, stub_key, scope}` and materialized repeats. `LocalSequencer` ships as the tested reference implementation.

The alternative — always routing through the trait, even by default — was rejected to honor the issue's explicit "no regression budget".

## Mechanics
- `StubState` gains a `slot: u64` (global atomic mint) preserved across in-place replaces and `apply_config` patches, mirroring the cycling-state lifetime.
- 8 response-pull signatures became `Result`; sequencer `Err` surfaces via `backend_error_response` (#318): `BackendUnavailable` → 503, out-of-range index → loud 500 (never a silent fall-through to the no-match default).
- `reset_scope` GC hook fires on stub delete (direct + `apply_config` removal), bulk replace, and imposter teardown. A single in-place replace deliberately does **not** reset — the slot survives so slot-keyed cursors keep cycling.

## Tests
15 gate tests (7 `LocalSequencer` unit + 8 manager e2e over real HTTP): key/repeats contract, slot stability across in-place replace and `apply_config` patch, reset on every lifecycle path, structured 503, out-of-range 500, id-less `~hash#0` key, shrink clamp. Existing 731-test suite unchanged; verified building **with and without** `--no-default-features`.

Closes #313. Part of #310.