### PR TITLE
feat: extract a pluggable RequestJournal for recorded requests

### DIFF
--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -291,10 +291,7 @@ impl Imposter {
         self.stubs
             .write()
             .retain(|s| s.stub.space.as_deref() != Some(space));
-        let source = self.flow_id_source();
-        self.recorded_requests.write().retain(|r| {
-            Self::flow_id_for(&source, &r.headers, self.config.port.unwrap_or(0)) != space
-        });
+        self.journal.clear_flow(self.journal_port(), space);
         // Best-effort across scenarios so one bad key doesn't leave later scenarios stale,
         // but the first failure still surfaces (issue #318) — never report a clean teardown
         // while stale scenario state persists in the backend.

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -3,10 +3,6 @@
 //! This module contains the Imposter struct which represents a single
 //! running imposter instance with its configuration, stubs, and state.
 
-/// Maximum number of requests retained in memory per imposter when recording is enabled.
-/// Once the cap is reached, the oldest entry is evicted (ring-buffer semantics).
-const MAX_RECORDED_REQUESTS: usize = 10_000;
-
 /// Default scenario state when a `(flow_id, scenario)` entry is absent (WireMock parity).
 pub const INITIAL_SCENARIO_STATE: &str = "Started";
 
@@ -108,10 +104,9 @@ pub struct Imposter {
     pub stubs: RwLock<Vec<StubState>>,
     /// Recording store for proxy responses (for future proxy mode support)
     pub recording_store: Arc<RecordingStore>,
-    /// Recorded requests (if record_requests is true)
-    pub recorded_requests: RwLock<Vec<RecordedRequest>>,
-    /// Request count
-    pub request_count: AtomicU64,
+    /// Recorded-request storage (issue #314); defaults to a private LocalJournal,
+    /// or the embedder's shared journal injected via the manager.
+    pub(crate) journal: Arc<dyn crate::imposter::journal::RequestJournal>,
     /// Whether imposter is enabled
     pub enabled: AtomicBool,
     /// Creation timestamp (for future metrics/admin display)
@@ -146,6 +141,19 @@ impl Imposter {
         provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
         sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
     ) -> Self {
+        Self::new_with_hooks_and_journal(config, provider, sequencer, None)
+    }
+
+    /// Create a new imposter with all embedder hooks, including the request journal (#314).
+    ///
+    /// `config.port` must be resolved (Some) before the imposter serves requests: a shared
+    /// journal keys by port, and unresolved ports would silently multiplex onto slot 0.
+    pub fn new_with_hooks_and_journal(
+        config: ImposterConfig,
+        provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
+        sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
+        journal: Option<Arc<dyn crate::imposter::journal::RequestJournal>>,
+    ) -> Self {
         let stubs: Vec<StubState> = config
             .stubs
             .iter()
@@ -163,8 +171,8 @@ impl Imposter {
             config,
             stubs: RwLock::new(stubs),
             recording_store: Arc::new(RecordingStore::new(proxy_mode)),
-            recorded_requests: RwLock::new(Vec::new()),
-            request_count: AtomicU64::new(0),
+            journal: journal
+                .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
             enabled: AtomicBool::new(true),
             created_at: chrono::Utc::now(),
             shutdown_tx: None,
@@ -541,11 +549,12 @@ mod tests {
             timestamp: "2026-01-01T00:00:00Z".to_string(),
         };
 
+        use crate::imposter::journal::MAX_RECORDED_REQUESTS;
         for _ in 0..MAX_RECORDED_REQUESTS + 10 {
             imposter.record_request(&req);
         }
 
-        let recorded = imposter.recorded_requests.read();
+        let recorded = imposter.get_recorded_requests();
         assert_eq!(
             recorded.len(),
             MAX_RECORDED_REQUESTS,

--- a/crates/rift-core/src/imposter/core/recording.rs
+++ b/crates/rift-core/src/imposter/core/recording.rs
@@ -1,36 +1,49 @@
 //! Recorded-request storage: capture, retrieval, retention, and request counters.
 //!
-//! Part of the `Imposter` implementation; see `core/mod.rs` for the struct definition.
+//! Thin wrappers over the imposter's `RequestJournal` (issue #314) — the public method
+//! signatures are unchanged so the admin API and embedders are untouched.
 
 use super::*;
+use crate::imposter::journal::JournalRead;
 
 impl Imposter {
-    /// Record a request. Evicts the oldest entry when the cap is reached.
+    pub(super) fn journal_port(&self) -> u16 {
+        self.config.port.unwrap_or(0)
+    }
+
+    /// Record a request (when body recording is enabled), tagged with its resolved flow id.
     pub fn record_request(&self, req: &RecordedRequest) {
         if self.config.record_requests {
-            let mut requests = self.recorded_requests.write();
-            if requests.len() >= MAX_RECORDED_REQUESTS {
-                tracing::warn!(
-                    port = self.config.port,
-                    max = MAX_RECORDED_REQUESTS,
-                    "Recorded requests cap reached; oldest entry evicted"
-                );
-                requests.remove(0);
-            }
-            requests.push(req.clone());
+            let flow_id = self.resolve_flow_id_recorded(&req.headers);
+            self.journal
+                .record(self.journal_port(), &flow_id, req.clone());
         }
     }
 
-    /// Get recorded requests
-    pub fn get_recorded_requests(&self) -> Vec<RecordedRequest> {
-        self.recorded_requests.read().clone()
+    /// Read recorded requests with the backend's completeness flag intact, so embedders
+    /// can observe a degraded read programmatically (issue #314).
+    pub fn read_recorded_requests(&self) -> JournalRead {
+        self.journal.read(self.journal_port())
     }
 
-    /// Clear recorded requests
+    /// Get recorded requests. An incomplete read (backend partially unreachable) serves
+    /// the partial entries and surfaces the degradation in the log; callers that need to
+    /// react to it programmatically use [`Self::read_recorded_requests`].
+    pub fn get_recorded_requests(&self) -> Vec<RecordedRequest> {
+        let read = self.read_recorded_requests();
+        if !read.complete {
+            tracing::warn!(
+                port = self.journal_port(),
+                entries_served = read.entries.len(),
+                "request journal returned an incomplete read; serving partial results"
+            );
+        }
+        read.entries
+    }
+
+    /// Clear recorded requests. Also resets the request count to match Mountebank behavior.
     pub fn clear_recorded_requests(&self) {
-        self.recorded_requests.write().clear();
-        // Reset request count to match Mountebank behavior
-        self.request_count.store(0, Ordering::SeqCst);
+        self.journal.clear(self.journal_port());
     }
 
     /// Retain only the recorded requests for which `keep` returns true.
@@ -38,7 +51,7 @@ impl Imposter {
     /// `clear_recorded_requests` it does not reset the total request count,
     /// since other slices' requests remain.
     pub fn retain_recorded_requests<F: Fn(&RecordedRequest) -> bool>(&self, keep: F) {
-        self.recorded_requests.write().retain(|r| keep(r));
+        self.journal.retain(self.journal_port(), &keep);
     }
 
     /// Clear saved proxy responses
@@ -46,13 +59,13 @@ impl Imposter {
         self.recording_store.clear();
     }
 
-    /// Increment request count
-    pub fn increment_request_count(&self) -> u64 {
-        self.request_count.fetch_add(1, Ordering::SeqCst)
+    /// Count this request toward `numberOfRequests` (fires even when recording is off).
+    pub fn increment_request_count(&self) {
+        self.journal.note_request(self.journal_port());
     }
 
     /// Get request count
     pub fn get_request_count(&self) -> u64 {
-        self.request_count.load(Ordering::SeqCst)
+        self.journal.count(self.journal_port())
     }
 }

--- a/crates/rift-core/src/imposter/journal.rs
+++ b/crates/rift-core/src/imposter/journal.rs
@@ -1,0 +1,220 @@
+//! Pluggable recorded-request storage (issue #314): the trait extracted from the per-imposter
+//! `RwLock<Vec<RecordedRequest>>` + `AtomicU64` counter, so embedders can substitute retention
+//! policies, spill-to-disk, or external sinks.
+//!
+//! The default [`LocalJournal`] is behavior-identical to the embedded storage it replaces:
+//! same 10k cap with oldest-first eviction, same count semantics (`clear` resets it,
+//! `retain` does not). A journal injected via
+//! [`ImposterManager::with_request_journal`](crate::imposter::ImposterManager::with_request_journal)
+//! is shared across imposters and keyed by port; imposter deletion clears its port slice so
+//! stale entries never resurrect on a later imposter reusing the port.
+
+use super::types::RecordedRequest;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Cap on stored entries per port (issue #186); oldest evicted first.
+pub const MAX_RECORDED_REQUESTS: usize = 10_000;
+
+/// Result of reading a port's recorded requests.
+pub struct JournalRead {
+    pub entries: Vec<RecordedRequest>,
+    /// `false` signals the backend could not reach all of its storage; callers serve the
+    /// partial `entries` and surface the degradation rather than dropping data.
+    pub complete: bool,
+}
+
+/// Pluggable recorded-request backend, keyed by imposter port.
+pub trait RequestJournal: Send + Sync {
+    /// Called for EVERY request (even when body recording is off) — backs
+    /// `numberOfRequests`, matching the existing counter semantics.
+    fn note_request(&self, port: u16);
+    /// `flow_id` is the request's resolved flow (per the imposter's `flowIdSource`) —
+    /// carried here so scoped clears don't have to re-derive it from stored headers.
+    /// Record-time tags stay valid because `flowIdSource` is immutable per imposter;
+    /// replacing an imposter clears its port slice.
+    fn record(&self, port: u16, flow_id: &str, req: RecordedRequest);
+    fn read(&self, port: u16) -> JournalRead;
+    /// Clears entries AND resets the request count (documented contract, as today).
+    ///
+    /// Infallible by design: callers treat return as success, so an implementation whose
+    /// backend fails must resolve the failure internally (retry/queue) and log it — never
+    /// silently drop a failed clear.
+    fn clear(&self, port: u16);
+    /// Targeted deletion; does NOT reset the count (documented contract, as today).
+    fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool);
+    /// Declarative scoped clear (one correlated slice, #223) — expressible by any
+    /// backend, unlike the closure-based `retain`. Same failure contract as [`Self::clear`]:
+    /// callers treat return as success.
+    fn clear_flow(&self, port: u16, flow_id: &str);
+    fn count(&self, port: u16) -> u64;
+}
+
+#[derive(Default)]
+struct PortSlot {
+    /// Entries paired with the flow id resolved at record time (issue #314: scoped clears
+    /// must not re-derive flows from stored headers).
+    entries: RwLock<Vec<(String, RecordedRequest)>>,
+    count: AtomicU64,
+}
+
+/// Reference journal with the exact semantics of the storage it replaced.
+#[derive(Default)]
+pub struct LocalJournal {
+    ports: RwLock<HashMap<u16, Arc<PortSlot>>>,
+}
+
+impl LocalJournal {
+    fn slot(&self, port: u16) -> Arc<PortSlot> {
+        if let Some(slot) = self.ports.read().get(&port) {
+            return Arc::clone(slot);
+        }
+        Arc::clone(self.ports.write().entry(port).or_default())
+    }
+}
+
+impl RequestJournal for LocalJournal {
+    fn note_request(&self, port: u16) {
+        self.slot(port).count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+        let slot = self.slot(port);
+        let mut entries = slot.entries.write();
+        if entries.len() >= MAX_RECORDED_REQUESTS {
+            tracing::warn!(
+                port,
+                max = MAX_RECORDED_REQUESTS,
+                "Recorded requests cap reached; oldest entry evicted"
+            );
+            entries.remove(0);
+        }
+        entries.push((flow_id.to_string(), req));
+    }
+
+    fn read(&self, port: u16) -> JournalRead {
+        JournalRead {
+            entries: self
+                .slot(port)
+                .entries
+                .read()
+                .iter()
+                .map(|(_, req)| req.clone())
+                .collect(),
+            complete: true,
+        }
+    }
+
+    fn clear(&self, port: u16) {
+        let slot = self.slot(port);
+        slot.entries.write().clear();
+        slot.count.store(0, Ordering::SeqCst);
+    }
+
+    fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+        self.slot(port).entries.write().retain(|(_, req)| keep(req));
+    }
+
+    fn clear_flow(&self, port: u16, flow_id: &str) {
+        self.slot(port)
+            .entries
+            .write()
+            .retain(|(flow, _)| flow != flow_id);
+    }
+
+    fn count(&self, port: u16) -> u64 {
+        self.slot(port).count.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(path: &str) -> RecordedRequest {
+        RecordedRequest {
+            request_from: "t".into(),
+            method: "GET".into(),
+            path: path.into(),
+            query: Default::default(),
+            headers: Default::default(),
+            body: None,
+            timestamp: "t".into(),
+        }
+    }
+
+    // AC1: the 10k cap evicts oldest-first, exactly like the embedded Vec did.
+    #[test]
+    fn local_caps_at_10k_evicting_oldest() {
+        let j = LocalJournal::default();
+        for i in 0..(MAX_RECORDED_REQUESTS + 10) {
+            j.record(1, "f", req(&format!("/{i}")));
+        }
+        let read = j.read(1);
+        assert_eq!(read.entries.len(), MAX_RECORDED_REQUESTS);
+        assert_eq!(read.entries[0].path, "/10", "oldest entries evicted first");
+        assert!(read.complete, "the local backend is always complete");
+    }
+
+    // AC1: note_request counts even when nothing is recorded (recording off).
+    #[test]
+    fn local_counts_without_recording() {
+        let j = LocalJournal::default();
+        j.note_request(1);
+        j.note_request(1);
+        assert_eq!(j.count(1), 2);
+        assert!(j.read(1).entries.is_empty());
+    }
+
+    // AC1: clear drops entries AND resets the count (documented contract).
+    #[test]
+    fn local_clear_resets_count() {
+        let j = LocalJournal::default();
+        j.note_request(1);
+        j.record(1, "f", req("/a"));
+        j.clear(1);
+        assert_eq!(j.count(1), 0);
+        assert!(j.read(1).entries.is_empty());
+    }
+
+    // AC1: retain deletes targeted entries but does NOT reset the count.
+    #[test]
+    fn local_retain_preserves_count() {
+        let j = LocalJournal::default();
+        j.note_request(1);
+        j.note_request(1);
+        j.record(1, "f", req("/a"));
+        j.record(1, "f", req("/b"));
+        j.retain(1, &|r| r.path == "/b");
+        assert_eq!(j.read(1).entries.len(), 1);
+        assert_eq!(j.count(1), 2, "retain never resets the count");
+    }
+
+    // AC1: clear_flow removes exactly one correlated slice and keeps the count.
+    #[test]
+    fn local_clear_flow_removes_one_slice() {
+        let j = LocalJournal::default();
+        j.note_request(1);
+        j.record(1, "flow-a", req("/a"));
+        j.record(1, "flow-b", req("/b"));
+        j.clear_flow(1, "flow-a");
+        let read = j.read(1);
+        assert_eq!(read.entries.len(), 1);
+        assert_eq!(read.entries[0].path, "/b");
+        assert_eq!(j.count(1), 1, "scoped clear keeps the total count");
+    }
+
+    // Ports are isolated slices of the journal.
+    #[test]
+    fn local_ports_are_isolated() {
+        let j = LocalJournal::default();
+        j.record(1, "f", req("/a"));
+        j.note_request(2);
+        assert_eq!(j.read(1).entries.len(), 1);
+        assert!(j.read(2).entries.is_empty());
+        assert_eq!(j.count(1), 0);
+        assert_eq!(j.count(2), 1);
+    }
+}

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -11,6 +11,7 @@ use super::types::{ImposterConfig, ImposterError, Stub};
 use crate::behaviors::ResponseSequencer;
 use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
+use crate::imposter::journal::RequestJournal;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
@@ -107,6 +108,8 @@ pub struct ImposterManager {
     flow_store_provider: Option<Arc<dyn FlowStoreProvider>>,
     /// Pluggable response-cursor backend (issue #313); None = embedded per-stub cycler.
     sequencer: Option<Arc<dyn ResponseSequencer>>,
+    /// Pluggable recorded-request backend (issue #314); None = per-imposter LocalJournal.
+    request_journal: Option<Arc<dyn RequestJournal>>,
 }
 
 impl ImposterManager {
@@ -127,6 +130,7 @@ impl ImposterManager {
             response_decorator: None,
             flow_store_provider: None,
             sequencer: None,
+            request_journal: None,
         }
     }
 
@@ -183,6 +187,20 @@ impl ImposterManager {
     #[must_use]
     pub fn with_sequencer(mut self, sequencer: Arc<dyn ResponseSequencer>) -> Self {
         self.sequencer = Some(sequencer);
+        self
+    }
+
+    /// Register a pluggable recorded-request backend (issue #314), shared across imposters
+    /// and keyed by port. Without one, each imposter keeps a private in-memory journal with
+    /// the historical semantics (10k cap, clear-resets-count). Imposter deletion clears the
+    /// port's slice so stale entries never resurrect on a later imposter reusing the port.
+    ///
+    /// Caveat: deletion lets in-flight requests drain naturally, so a request completing
+    /// after the port clear can write one late entry into the shared journal (the private
+    /// default is immune — its storage dies with the imposter).
+    #[must_use]
+    pub fn with_request_journal(mut self, journal: Arc<dyn RequestJournal>) -> Self {
+        self.request_journal = Some(journal);
         self
     }
 
@@ -291,10 +309,11 @@ impl ImposterManager {
 
         info!("Imposter bound to {}:{}", bind_host, port);
         // Create imposter
-        let mut imposter = Imposter::new_with_hooks(
+        let mut imposter = Imposter::new_with_hooks_and_journal(
             config,
             self.flow_store_provider.as_ref(),
             self.sequencer.clone(),
+            self.request_journal.clone(),
         );
 
         // Create shutdown channel for this imposter
@@ -463,6 +482,9 @@ impl ImposterManager {
 
         if let Some(sequencer) = &self.sequencer {
             sequencer.reset_scope(port, None);
+        }
+        if let Some(journal) = &self.request_journal {
+            journal.clear(port);
         }
 
         info!("Imposter on port {} deleted", port);
@@ -2286,6 +2308,313 @@ mod tests {
             assert_eq!(
                 slot_before, slot_after,
                 "an untouched sibling keeps its slot across an apply_config patch"
+            );
+
+            manager.delete_all().await;
+        }
+    }
+
+    // =========================================================================
+    // Issue #314: pluggable RequestJournal
+    // =========================================================================
+    mod request_journal {
+        use super::*;
+        use crate::imposter::journal::{JournalRead, LocalJournal, RequestJournal};
+        use crate::imposter::types::RecordedRequest;
+
+        /// Delegates to LocalJournal while recording every trait call.
+        #[derive(Default)]
+        struct RecordingJournal {
+            inner: LocalJournal,
+            notes: Mutex<Vec<u16>>,
+            records: Mutex<Vec<(u16, String, String)>>,
+            clears: Mutex<Vec<u16>>,
+            flow_clears: Mutex<Vec<(u16, String)>>,
+            retains: Mutex<Vec<u16>>,
+        }
+
+        impl RequestJournal for RecordingJournal {
+            fn note_request(&self, port: u16) {
+                self.notes.lock().push(port);
+                self.inner.note_request(port);
+            }
+            fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+                self.records
+                    .lock()
+                    .push((port, flow_id.to_string(), req.path.clone()));
+                self.inner.record(port, flow_id, req);
+            }
+            fn read(&self, port: u16) -> JournalRead {
+                self.inner.read(port)
+            }
+            fn clear(&self, port: u16) {
+                self.clears.lock().push(port);
+                self.inner.clear(port);
+            }
+            fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+                self.retains.lock().push(port);
+                self.inner.retain(port, keep);
+            }
+            fn clear_flow(&self, port: u16, flow_id: &str) {
+                self.flow_clears.lock().push((port, flow_id.to_string()));
+                self.inner.clear_flow(port, flow_id);
+            }
+            fn count(&self, port: u16) -> u64 {
+                self.inner.count(port)
+            }
+        }
+
+        /// A journal whose reads are flagged incomplete (backend partially unreachable).
+        struct IncompleteJournal(LocalJournal);
+        impl RequestJournal for IncompleteJournal {
+            fn note_request(&self, port: u16) {
+                self.0.note_request(port);
+            }
+            fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+                self.0.record(port, flow_id, req);
+            }
+            fn read(&self, port: u16) -> JournalRead {
+                JournalRead {
+                    complete: false,
+                    ..self.0.read(port)
+                }
+            }
+            fn clear(&self, port: u16) {
+                self.0.clear(port);
+            }
+            fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+                self.0.retain(port, keep);
+            }
+            fn clear_flow(&self, port: u16, flow_id: &str) {
+                self.0.clear_flow(port, flow_id);
+            }
+            fn count(&self, port: u16) -> u64 {
+                self.0.count(port)
+            }
+        }
+
+        fn manager_with_journal() -> (Arc<RecordingJournal>, ImposterManager) {
+            let journal = Arc::new(RecordingJournal::default());
+            let manager = ImposterManager::new()
+                .with_request_journal(journal.clone() as Arc<dyn RequestJournal>);
+            (journal, manager)
+        }
+
+        // AC2: note_request fires for EVERY request even with recording off, backing
+        // numberOfRequests; nothing is recorded.
+        #[tokio::test]
+        async fn note_request_counts_even_when_recording_off() {
+            let (journal, manager) = manager_with_journal();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19530, "recordRequests": false,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+
+            let _ = reqwest::get("http://127.0.0.1:19530/x")
+                .await
+                .expect("request");
+            assert_eq!(*journal.notes.lock(), vec![19530]);
+            assert!(journal.records.lock().is_empty(), "recording is off");
+            let imposter = manager.get_imposter(19530).unwrap();
+            assert_eq!(
+                imposter.get_request_count(),
+                1,
+                "numberOfRequests backed by journal"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC2: record carries the request's resolved flow id (per flowIdSource).
+        #[tokio::test]
+        async fn record_carries_resolved_flow_id() {
+            let (journal, manager) = manager_with_journal();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19531, "recordRequests": true,
+                    "_rift": { "flowState": { "flowIdSource": "header:X-Flow-Id" } },
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+
+            let client = reqwest::Client::new();
+            let _ = client
+                .get("http://127.0.0.1:19531/x")
+                .header("X-Flow-Id", "flow-42")
+                .send()
+                .await
+                .expect("request");
+            let records = journal.records.lock().clone();
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].0, 19531);
+            assert_eq!(records[0].1, "flow-42", "flow id resolved per flowIdSource");
+
+            // No header → falls back to the imposter port, matching resolve semantics.
+            let _ = client
+                .get("http://127.0.0.1:19531/y")
+                .send()
+                .await
+                .expect("request");
+            assert_eq!(journal.records.lock().last().expect("recorded").1, "19531");
+
+            manager.delete_all().await;
+        }
+
+        // AC2: admin-facing imposter methods route through the injected journal.
+        #[tokio::test]
+        async fn admin_paths_route_through_journal() {
+            let (journal, manager) = manager_with_journal();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19532, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+
+            let _ = reqwest::get("http://127.0.0.1:19532/seen")
+                .await
+                .expect("request");
+            let imposter = manager.get_imposter(19532).unwrap();
+            let recorded = imposter.get_recorded_requests();
+            assert_eq!(recorded.len(), 1, "GET requests reads via the journal");
+            assert_eq!(recorded[0].path, "/seen");
+
+            imposter.retain_recorded_requests(|r| r.path != "/seen");
+            assert_eq!(*journal.retains.lock(), vec![19532]);
+            assert!(imposter.get_recorded_requests().is_empty());
+            assert_eq!(imposter.get_request_count(), 1, "retain keeps the count");
+
+            imposter.clear_recorded_requests();
+            assert!(journal.clears.lock().contains(&19532));
+            assert_eq!(imposter.get_request_count(), 0, "clear resets the count");
+
+            manager.delete_all().await;
+        }
+
+        // AC1/AC2: teardown_space clears exactly one correlated slice via clear_flow.
+        #[tokio::test]
+        async fn teardown_space_uses_clear_flow() {
+            let (journal, manager) = manager_with_journal();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19533, "recordRequests": true,
+                    "_rift": { "flowState": { "flowIdSource": "header:X-Flow-Id" } },
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+
+            let client = reqwest::Client::new();
+            for flow in ["sp-1", "sp-2"] {
+                let _ = client
+                    .get("http://127.0.0.1:19533/x")
+                    .header("X-Flow-Id", flow)
+                    .send()
+                    .await
+                    .expect("request");
+            }
+
+            let imposter = manager.get_imposter(19533).unwrap();
+            imposter.teardown_space("sp-1").expect("teardown");
+            assert!(
+                journal
+                    .flow_clears
+                    .lock()
+                    .contains(&(19533, "sp-1".to_string())),
+                "teardown routes through clear_flow: {:?}",
+                journal.flow_clears.lock()
+            );
+            let remaining = imposter.get_recorded_requests();
+            assert_eq!(remaining.len(), 1, "only the torn-down slice is dropped");
+
+            manager.delete_all().await;
+        }
+
+        // Imposter deletion is the port-wide GC hook for a shared backend: stale entries
+        // must not resurrect on a later imposter reusing the port.
+        #[tokio::test]
+        async fn delete_imposter_clears_the_port() {
+            let (journal, manager) = manager_with_journal();
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19534, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+            let _ = reqwest::get("http://127.0.0.1:19534/x")
+                .await
+                .expect("request");
+
+            manager.delete_imposter(19534).await.expect("delete");
+            assert!(journal.clears.lock().contains(&19534));
+            assert_eq!(journal.inner.count(19534), 0);
+            assert!(journal.inner.read(19534).entries.is_empty());
+        }
+
+        // Two live imposters sharing one injected journal stay isolated through the
+        // imposter wrappers: clear on port A leaves port B's entries and count intact.
+        #[tokio::test]
+        async fn shared_journal_isolates_ports_through_wrappers() {
+            let (_journal, manager) = manager_with_journal();
+            for port in [19536u16, 19537] {
+                manager
+                    .create_imposter(imposter_cfg(json!({
+                        "protocol": "http", "port": port, "recordRequests": true,
+                        "stubs": [stub_json("ok")]
+                    })))
+                    .await
+                    .expect("create");
+                let _ = reqwest::get(format!("http://127.0.0.1:{port}/x"))
+                    .await
+                    .expect("request");
+            }
+
+            let a = manager.get_imposter(19536).unwrap();
+            let b = manager.get_imposter(19537).unwrap();
+            a.clear_recorded_requests();
+
+            assert!(a.get_recorded_requests().is_empty());
+            assert_eq!(a.get_request_count(), 0);
+            assert_eq!(b.get_recorded_requests().len(), 1, "sibling port untouched");
+            assert_eq!(b.get_request_count(), 1);
+
+            manager.delete_all().await;
+        }
+
+        // An incomplete read (backend partially unreachable) still serves what it got.
+        #[tokio::test]
+        async fn incomplete_read_still_serves_entries() {
+            let manager = ImposterManager::new()
+                .with_request_journal(
+                    Arc::new(IncompleteJournal(LocalJournal::default())) as Arc<dyn RequestJournal>
+                );
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19535, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+
+            let _ = reqwest::get("http://127.0.0.1:19535/x")
+                .await
+                .expect("request");
+            let imposter = manager.get_imposter(19535).unwrap();
+            assert_eq!(
+                imposter.get_recorded_requests().len(),
+                1,
+                "partial data is served, not dropped"
+            );
+            let read = imposter.read_recorded_requests();
+            assert!(
+                !read.complete && read.entries.len() == 1,
+                "the completeness flag is observable at the core API"
             );
 
             manager.delete_all().await;

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -42,6 +42,9 @@ pub use types::{
 
 // Re-export core imposter
 #[allow(unused_imports)]
+pub mod journal;
+pub use journal::{JournalRead, LocalJournal, RequestJournal};
+
 pub use core::Imposter;
 
 // Re-export the imposter request handler (single-port gateway dispatch, issue #212)


### PR DESCRIPTION
Extracts recorded-request storage from the per-imposter `RwLock<Vec<RecordedRequest>>` + `AtomicU64` counter into a pluggable `RequestJournal` trait, so embedders can substitute retention policies, spill-to-disk, or external sinks.

## Design
- `RequestJournal` trait (API per the issue) keyed by port: `note_request`/`record`/`read`/`clear`/`retain`/`clear_flow`/`count`, with `JournalRead{entries, complete}`.
- **`LocalJournal` default is behavior-identical**: same 10k oldest-first cap with the same eviction warn, same count semantics (`clear` resets, `retain` does not).
- `ImposterManager::with_request_journal` injects a shared backend; imposter deletion clears the port slice (GC, mirroring #313's `reset_scope` placement) so stale entries can't resurrect on a reused port.
- `record` carries the flow id resolved at record time; `teardown_space` switched to declarative `clear_flow` (equivalent — `flowIdSource` is immutable per imposter).

## Compatibility
All existing `Imposter` method signatures are preserved, so `handler.rs`, the rift-http-proxy admin handlers, and rift-ffi are untouched (`increment_request_count` now returns `()`; its only caller ignored the value). Admin endpoints unchanged. Added `read_recorded_requests() -> JournalRead` so embedders can observe a degraded read programmatically.

## Tests
14 gate tests (6 `LocalJournal` unit + 8 manager e2e with a delegating fake): cap/eviction, count-on-recording-off, clear-vs-retain count semantics, `clear_flow` slice, port isolation, resolved-flow-id routing, admin-path routing, teardown via `clear_flow`, delete-clears-port, shared-journal isolation, incomplete-read serves partial + flag observable. Existing suite unchanged; verified building **with and without** `--no-default-features`.

## Follow-up
#330 — make `clear`/`clear_flow` fallible (a failed remote clear currently returns success, in tension with `teardown_space`'s #318 contract; the trait API here was specified verbatim by #314).

Closes #314. Part of #310.