### PR TITLE
Extract a pluggable ProxyRecordingStore for proxy recording

### DIFF
--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -19,7 +19,10 @@ use super::types::{
 use crate::backends::InMemoryFlowStore;
 use crate::behaviors::{HasRepeatBehavior, RuleCycler};
 use crate::extensions::flow_state::{FlowStore, NoOpFlowStore};
-use crate::recording::{ProxyMode, RecordedResponse, RecordingStore, RequestSignature};
+use crate::recording::{
+    ClaimOutcome, LocalProxyStore, ProxyMode, ProxyRecordingStore, RecordedResponse,
+    RequestSignature,
+};
 use anyhow::Context;
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -102,8 +105,10 @@ pub struct Imposter {
     pub config: ImposterConfig,
     /// Mutable stubs (can be modified at runtime)
     pub stubs: RwLock<Vec<StubState>>,
-    /// Recording store for proxy responses (for future proxy mode support)
-    pub recording_store: Arc<RecordingStore>,
+    /// Proxy-recording backend (issue #315); defaults to a private port-scoped
+    /// [`LocalProxyStore`] for this imposter's mode, or the embedder's shared store injected
+    /// via [`ImposterManager::with_proxy_store`](crate::imposter::ImposterManager::with_proxy_store).
+    pub(crate) proxy_store: Arc<dyn ProxyRecordingStore>,
     /// Recorded-request storage (issue #314); defaults to a private LocalJournal,
     /// or the embedder's shared journal injected via the manager.
     pub(crate) journal: Arc<dyn crate::imposter::journal::RequestJournal>,
@@ -170,7 +175,7 @@ impl Imposter {
         Self {
             config,
             stubs: RwLock::new(stubs),
-            recording_store: Arc::new(RecordingStore::new(proxy_mode)),
+            proxy_store: Arc::new(LocalProxyStore::new(proxy_mode)),
             journal: journal
                 .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
             enabled: AtomicBool::new(true),

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -4,6 +4,10 @@
 
 use super::*;
 
+/// Parts read from a successful upstream proxy response, before recording:
+/// `(status, headers, body, latency_ms)`.
+type ForwardedResponse = (u16, Vec<(String, String)>, bytes::Bytes, u64);
+
 impl Imposter {
     /// Generate predicates from request based on predicateGenerators config
     pub(crate) fn generate_predicates_from_request(
@@ -304,101 +308,146 @@ impl Imposter {
 
         // Create request signature for recording
         let signature = RequestSignature::new(method, uri.path(), uri.query(), &[]);
+        let port = self.journal_port();
 
-        // Check if we should replay cached response (based on proxy mode)
-        if !self.recording_store.should_proxy(&signature)
-            && let Some(recorded) = self.recording_store.get_recorded(&signature)
-        {
-            debug!("Returning recorded proxy response (proxyOnce mode)");
-            return Ok((
-                recorded.status,
-                recorded.headers.clone(),
-                recorded.body.clone(),
-                recorded.latency_ms,
-            ));
-        }
-
-        // Forward the request
-        let start = Instant::now();
-
-        let mut request = match method.to_uppercase().as_str() {
-            "GET" => client.get(&target_url),
-            "POST" => client.post(&target_url),
-            "PUT" => client.put(&target_url),
-            "DELETE" => client.delete(&target_url),
-            "PATCH" => client.patch(&target_url),
-            "HEAD" => client.head(&target_url),
-            _ => client.get(&target_url),
+        // Consult the proxy-recording gate. `AlreadyRecorded` replays; `Claimed` grants the
+        // right to record; `InFlight` (a concurrent proxyOnce loser) and an unavailable
+        // store proxy upstream without recording.
+        let claim_token = match self.proxy_store.try_claim(port, &signature) {
+            Ok(ClaimOutcome::AlreadyRecorded) => {
+                if let Some(recorded) = self.proxy_store.lookup(port, &signature) {
+                    debug!("Returning recorded proxy response (proxyOnce mode)");
+                    return Ok((
+                        recorded.status,
+                        recorded.headers,
+                        recorded.body,
+                        recorded.latency_ms,
+                    ));
+                }
+                // AlreadyRecorded but nothing to replay: a race (concurrent clear) or a
+                // misbehaving backend. Forward without recording rather than fail, but leave
+                // a trace since this is not an expected outcome.
+                warn!(
+                    "Proxy store reported AlreadyRecorded but lookup found nothing; forwarding without recording"
+                );
+                None
+            }
+            Ok(ClaimOutcome::InFlight) => None,
+            Ok(ClaimOutcome::Claimed(token)) => Some(token),
+            Err(e) => {
+                warn!("Proxy recording store unavailable; forwarding without recording: {e}");
+                None
+            }
         };
 
-        // Copy headers (excluding host)
-        for (key, value) in headers {
-            let key_lower = key.to_lowercase();
-            if key_lower != "host" && key_lower != "content-length" {
+        // Forward the request. Isolated so a failure releases the claim (issue #315): a
+        // proxyOnce signature must stay retryable, not wedge because the upstream call errored.
+        let start = Instant::now();
+        let forwarded: anyhow::Result<ForwardedResponse> = async {
+            let mut request = match method.to_uppercase().as_str() {
+                "GET" => client.get(&target_url),
+                "POST" => client.post(&target_url),
+                "PUT" => client.put(&target_url),
+                "DELETE" => client.delete(&target_url),
+                "PATCH" => client.patch(&target_url),
+                "HEAD" => client.head(&target_url),
+                _ => client.get(&target_url),
+            };
+
+            // Copy headers (excluding host)
+            for (key, value) in headers {
+                let key_lower = key.to_lowercase();
+                if key_lower != "host" && key_lower != "content-length" {
+                    request = request.header(key, value);
+                }
+            }
+
+            // Add inject headers
+            for (key, value) in &proxy_config.inject_headers {
                 request = request.header(key, value);
             }
+
+            // Add body if present
+            if let Some(body_str) = body {
+                request = request.body(body_str.to_string());
+            }
+
+            // Send request
+            let response = request
+                .send()
+                .await
+                .with_context(|| format!("Failed to send proxy request to {target_url}"))?;
+            let latency_ms = start.elapsed().as_millis() as u64;
+
+            let status = response.status().as_u16();
+            let response_headers: Vec<(String, String)> = response
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                .collect();
+            // Check Content-Length before reading the full body to reject obviously oversized responses
+            if let Some(content_length) = response.content_length()
+                && content_length as usize > MAX_PROXY_RESPONSE_BODY_SIZE
+            {
+                anyhow::bail!(
+                    "Proxy response body from {target_url} exceeds maximum size ({content_length} > {MAX_PROXY_RESPONSE_BODY_SIZE} bytes)"
+                );
+            }
+
+            let body_bytes = response
+                .bytes()
+                .await
+                .with_context(|| format!("Failed to read response body from {target_url}"))?;
+
+            if body_bytes.len() > MAX_PROXY_RESPONSE_BODY_SIZE {
+                anyhow::bail!(
+                    "Proxy response body from {} exceeds maximum size ({} > {} bytes)",
+                    target_url,
+                    body_bytes.len(),
+                    MAX_PROXY_RESPONSE_BODY_SIZE
+                );
+            }
+
+            Ok((status, response_headers, body_bytes, latency_ms))
         }
+        .await;
 
-        // Add inject headers
-        for (key, value) in &proxy_config.inject_headers {
-            request = request.header(key, value);
-        }
-
-        // Add body if present
-        if let Some(body_str) = body {
-            request = request.body(body_str.to_string());
-        }
-
-        // Send request
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("Failed to send proxy request to {target_url}"))?;
-        let latency_ms = start.elapsed().as_millis() as u64;
-
-        let status = response.status().as_u16();
-        let response_headers: Vec<(String, String)> = response
-            .headers()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-            .collect();
-        // Check Content-Length before reading the full body to reject obviously oversized responses
-        if let Some(content_length) = response.content_length()
-            && content_length as usize > MAX_PROXY_RESPONSE_BODY_SIZE
-        {
-            anyhow::bail!(
-                "Proxy response body from {target_url} exceeds maximum size ({content_length} > {MAX_PROXY_RESPONSE_BODY_SIZE} bytes)"
-            );
-        }
-
-        let body_bytes = response
-            .bytes()
-            .await
-            .with_context(|| format!("Failed to read response body from {target_url}"))?;
-
-        if body_bytes.len() > MAX_PROXY_RESPONSE_BODY_SIZE {
-            anyhow::bail!(
-                "Proxy response body from {} exceeds maximum size ({} > {} bytes)",
-                target_url,
-                body_bytes.len(),
-                MAX_PROXY_RESPONSE_BODY_SIZE
-            );
-        }
-
-        // Record the response
-        let recorded_response = RecordedResponse {
-            status,
-            headers: response_headers.clone(),
-            body: body_bytes.to_vec(),
-            latency_ms: if proxy_config.add_wait_behavior {
-                Some(latency_ms)
-            } else {
-                None
-            },
-            timestamp_secs: crate::util::unix_timestamp(),
+        let (status, response_headers, body_bytes, latency_ms) = match forwarded {
+            Ok(parts) => parts,
+            Err(e) => {
+                if let Some(token) = claim_token {
+                    self.proxy_store.release_claim(port, &signature, token);
+                }
+                return Err(e);
+            }
         };
 
-        self.recording_store.record(signature, recorded_response);
+        // Record the response only if we hold a claim.
+        if let Some(token) = claim_token {
+            let recorded_response = RecordedResponse {
+                status,
+                headers: response_headers.clone(),
+                body: body_bytes.to_vec(),
+                latency_ms: if proxy_config.add_wait_behavior {
+                    Some(latency_ms)
+                } else {
+                    None
+                },
+                timestamp_secs: crate::util::unix_timestamp(),
+            };
+
+            if let Err(e) =
+                self.proxy_store
+                    .record(port, signature.clone(), token, recorded_response)
+            {
+                // A failed record must release the claim, or the signature wedges for
+                // proxyOnce (issue #315) — symmetric with the upstream-failure path above.
+                warn!(
+                    "Failed to record proxy response, releasing claim so it stays retryable: {e}"
+                );
+                self.proxy_store.release_claim(port, &signature, token);
+            }
+        }
 
         // Generate and insert stub if predicateGenerators, addWaitBehavior, or addDecorateBehavior is configured
         // (Mountebank generates stubs automatically when these are enabled)

--- a/crates/rift-core/src/imposter/core/recording.rs
+++ b/crates/rift-core/src/imposter/core/recording.rs
@@ -56,7 +56,7 @@ impl Imposter {
 
     /// Clear saved proxy responses
     pub fn clear_proxy_responses(&self) {
-        self.recording_store.clear();
+        self.proxy_store.clear(self.journal_port());
     }
 
     /// Count this request toward `numberOfRequests` (fires even when recording is off).

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -12,6 +12,7 @@ use crate::behaviors::ResponseSequencer;
 use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
 use crate::imposter::journal::RequestJournal;
+use crate::recording::ProxyRecordingStore;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
@@ -110,6 +111,8 @@ pub struct ImposterManager {
     sequencer: Option<Arc<dyn ResponseSequencer>>,
     /// Pluggable recorded-request backend (issue #314); None = per-imposter LocalJournal.
     request_journal: Option<Arc<dyn RequestJournal>>,
+    /// Pluggable proxy-recording backend (issue #315); None = per-imposter LocalProxyStore.
+    proxy_store: Option<Arc<dyn ProxyRecordingStore>>,
 }
 
 impl ImposterManager {
@@ -131,6 +134,7 @@ impl ImposterManager {
             flow_store_provider: None,
             sequencer: None,
             request_journal: None,
+            proxy_store: None,
         }
     }
 
@@ -201,6 +205,21 @@ impl ImposterManager {
     #[must_use]
     pub fn with_request_journal(mut self, journal: Arc<dyn RequestJournal>) -> Self {
         self.request_journal = Some(journal);
+        self
+    }
+
+    /// Register a pluggable proxy-recording backend (issue #315), shared across imposters and
+    /// keyed by port. Without one, each imposter keeps a private in-memory
+    /// [`LocalProxyStore`](crate::recording::LocalProxyStore) for its own proxy mode with the
+    /// historical semantics (proxyOnce once-gate, caps) plus the release-on-error fix. Imposter
+    /// deletion clears the port's saved responses so a later imposter reusing the port starts
+    /// clean.
+    ///
+    /// A shared store carries a single proxy mode; embedders mixing proxy modes across ports
+    /// should keep the per-imposter default instead.
+    #[must_use]
+    pub fn with_proxy_store(mut self, store: Arc<dyn ProxyRecordingStore>) -> Self {
+        self.proxy_store = Some(store);
         self
     }
 
@@ -315,6 +334,12 @@ impl ImposterManager {
             self.sequencer.clone(),
             self.request_journal.clone(),
         );
+
+        // Inject the shared proxy-recording store, if one is registered (issue #315);
+        // otherwise the imposter keeps its private per-mode LocalProxyStore.
+        if let Some(store) = &self.proxy_store {
+            imposter.proxy_store = Arc::clone(store);
+        }
 
         // Create shutdown channel for this imposter
         let (shutdown_tx, _) = broadcast::channel(1);
@@ -485,6 +510,12 @@ impl ImposterManager {
         }
         if let Some(journal) = &self.request_journal {
             journal.clear(port);
+        }
+        // Reclaim the shared proxy store's port slice so a later imposter reusing the port
+        // doesn't inherit stale recordings (issue #315). The private default dies with the
+        // imposter, so it needs no explicit clear.
+        if let Some(store) = &self.proxy_store {
+            store.clear(port);
         }
 
         info!("Imposter on port {} deleted", port);
@@ -2615,6 +2646,235 @@ mod tests {
             assert!(
                 !read.complete && read.entries.len() == 1,
                 "the completeness flag is observable at the core API"
+            );
+
+            manager.delete_all().await;
+        }
+    }
+
+    // =========================================================================
+    // Issue #315: pluggable ProxyRecordingStore
+    // =========================================================================
+    mod proxy_store {
+        use super::*;
+        use crate::recording::{
+            ClaimOutcome, ClaimToken, LocalProxyStore, ProxyMode, ProxyRecordingStore,
+            ProxyStoreError, RecordedResponse, RequestSignature,
+        };
+
+        /// Delegates to a LocalProxyStore while recording every claim/release/clear it sees.
+        /// `fail_claim`/`fail_record` inject the `Err` paths a real external backend can take,
+        /// which the built-in store never exercises.
+        struct SpyProxyStore {
+            inner: LocalProxyStore,
+            fail_claim: bool,
+            fail_record: bool,
+            claims: Mutex<Vec<u16>>,
+            releases: Mutex<Vec<u16>>,
+            clears: Mutex<Vec<u16>>,
+        }
+
+        impl SpyProxyStore {
+            fn new() -> Self {
+                Self::with_faults(false, false)
+            }
+
+            fn with_faults(fail_claim: bool, fail_record: bool) -> Self {
+                Self {
+                    inner: LocalProxyStore::new(ProxyMode::ProxyOnce),
+                    fail_claim,
+                    fail_record,
+                    claims: Mutex::new(Vec::new()),
+                    releases: Mutex::new(Vec::new()),
+                    clears: Mutex::new(Vec::new()),
+                }
+            }
+        }
+
+        impl ProxyRecordingStore for SpyProxyStore {
+            fn try_claim(
+                &self,
+                port: u16,
+                sig: &RequestSignature,
+            ) -> std::result::Result<ClaimOutcome, ProxyStoreError> {
+                self.claims.lock().push(port);
+                if self.fail_claim {
+                    return Err(ProxyStoreError::Unavailable("spy".into()));
+                }
+                self.inner.try_claim(port, sig)
+            }
+            fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken) {
+                self.releases.lock().push(port);
+                self.inner.release_claim(port, sig, token);
+            }
+            fn record(
+                &self,
+                port: u16,
+                sig: RequestSignature,
+                token: ClaimToken,
+                resp: RecordedResponse,
+            ) -> std::result::Result<(), ProxyStoreError> {
+                if self.fail_record {
+                    // Simulate a backend that fails WITHOUT self-clearing its claim, so the
+                    // caller's release-on-error is what keeps the signature retryable.
+                    return Err(ProxyStoreError::Unavailable("spy".into()));
+                }
+                self.inner.record(port, sig, token, resp)
+            }
+            fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse> {
+                self.inner.lookup(port, sig)
+            }
+            fn clear(&self, port: u16) {
+                self.clears.lock().push(port);
+                self.inner.clear(port);
+            }
+        }
+
+        async fn upstream(manager: &ImposterManager, port: u16) {
+            let cfg = imposter_cfg(json!({
+                "port": port, "protocol": "http",
+                "stubs": [{ "responses": [{ "is": { "statusCode": 200, "body": "UP" } }] }]
+            }));
+            manager.create_imposter(cfg).await.expect("create upstream");
+        }
+
+        // AC7: a shared proxy store is injected into imposters, keyed by port, exercised on the
+        // proxy hot path, and cleared on imposter deletion.
+        #[tokio::test]
+        async fn shared_store_is_used_and_cleared_on_delete() {
+            let spy = Arc::new(SpyProxyStore::new());
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+
+            upstream(&manager, 19560).await;
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "port": 19561, "protocol": "http",
+                    "stubs": [{ "responses": [{ "proxy": {
+                        "to": "http://127.0.0.1:19560", "mode": "proxyOnce"
+                    }}]}]
+                })))
+                .await
+                .expect("create proxy imposter");
+
+            // The proxy imposter shares the injected store, not its private default.
+            let imposter = manager.get_imposter(19561).unwrap();
+            assert!(Arc::ptr_eq(
+                &imposter.proxy_store,
+                &(spy.clone() as Arc<dyn ProxyRecordingStore>)
+            ));
+
+            // Driving the proxy leg fires the shared store's claim, keyed by the imposter port.
+            let body = reqwest::get("http://127.0.0.1:19561/thing")
+                .await
+                .expect("request")
+                .text()
+                .await
+                .expect("body");
+            assert_eq!(body, "UP");
+            assert!(
+                spy.claims.lock().contains(&19561),
+                "shared store claimed on the imposter port"
+            );
+
+            // Deleting the imposter reclaims the shared store's port slice.
+            manager.delete_imposter(19561).await.expect("delete");
+            assert!(
+                spy.clears.lock().contains(&19561),
+                "delete clears the port's saved recordings"
+            );
+
+            manager.delete_all().await;
+        }
+
+        /// Build a proxyOnce imposter on `port` forwarding to `to`, sharing `spy`.
+        async fn proxy_imposter(manager: &ImposterManager, port: u16, to: &str) {
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "port": port, "protocol": "http",
+                    "stubs": [{ "responses": [{ "proxy": { "to": to, "mode": "proxyOnce" } }] }]
+                })))
+                .await
+                .expect("create proxy imposter");
+        }
+
+        // AC2 end-to-end: a failed upstream call releases the claim through
+        // handle_proxy_request, so an identical retry can claim again instead of wedging.
+        // Two identical failing requests each release → the signature never gets stuck InFlight.
+        #[tokio::test]
+        async fn upstream_failure_releases_claim_end_to_end() {
+            let spy = Arc::new(SpyProxyStore::new());
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            // Forward to a dead port so the upstream leg always fails.
+            proxy_imposter(&manager, 19571, "http://127.0.0.1:19999").await;
+
+            for _ in 0..2 {
+                let _ = reqwest::get("http://127.0.0.1:19571/wedge").await;
+            }
+
+            assert_eq!(
+                spy.releases.lock().len(),
+                2,
+                "each failed upstream call releases its claim; the signature stays reclaimable"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // The record()-failure path (issue #315, review finding): a backend that returns Err
+        // from record without self-clearing must have its claim released by the caller, or the
+        // signature wedges. Two successful upstream calls whose record fails must each release.
+        #[tokio::test]
+        async fn record_failure_releases_claim_end_to_end() {
+            let spy = Arc::new(SpyProxyStore::with_faults(false, true));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            upstream(&manager, 19572).await;
+            proxy_imposter(&manager, 19573, "http://127.0.0.1:19572").await;
+
+            for _ in 0..2 {
+                let body = reqwest::get("http://127.0.0.1:19573/rec")
+                    .await
+                    .expect("request")
+                    .text()
+                    .await
+                    .expect("body");
+                assert_eq!(body, "UP", "client still gets the upstream response");
+            }
+
+            assert_eq!(
+                spy.releases.lock().len(),
+                2,
+                "a failed record releases the claim, so the second request can claim again"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // ProxyStoreError degrade path: when try_claim returns Err (backend unavailable), the
+        // imposter still forwards upstream successfully — it just doesn't record.
+        #[tokio::test]
+        async fn store_unavailable_still_forwards() {
+            let spy = Arc::new(SpyProxyStore::with_faults(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            upstream(&manager, 19574).await;
+            proxy_imposter(&manager, 19575, "http://127.0.0.1:19574").await;
+
+            let body = reqwest::get("http://127.0.0.1:19575/degrade")
+                .await
+                .expect("request")
+                .text()
+                .await
+                .expect("body");
+            assert_eq!(
+                body, "UP",
+                "forwards upstream despite the store being unavailable"
+            );
+            assert!(
+                spy.releases.lock().is_empty(),
+                "no claim was granted, so nothing to release"
             );
 
             manager.delete_all().await;

--- a/crates/rift-core/src/recording/mod.rs
+++ b/crates/rift-core/src/recording/mod.rs
@@ -18,12 +18,16 @@
 //! - `stub_generator` - Mountebank stub generation
 
 mod mode;
+mod proxy_store;
 mod store;
 mod stub_generator;
 mod types;
 
 // Re-export main types
 pub use mode::ProxyMode;
+pub use proxy_store::{
+    ClaimOutcome, ClaimToken, LocalProxyStore, ProxyRecordingStore, ProxyStoreError,
+};
 pub use store::RecordingStore;
 #[allow(unused_imports)]
 pub use stub_generator::generate_stub;

--- a/crates/rift-core/src/recording/proxy_store.rs
+++ b/crates/rift-core/src/recording/proxy_store.rs
@@ -1,0 +1,541 @@
+//! Pluggable proxy-recording backend (issue #315): the trait extracted from the concrete
+//! per-imposter [`RecordingStore`](super::store::RecordingStore), so embedders can persist
+//! recordings or share the `proxyOnce` exactly-once gate across engine instances.
+//!
+//! The default [`LocalProxyStore`] is behavior-identical to the embedded store it replaces —
+//! same `proxyOnce`/`proxyAlways`/`proxyTransparent` semantics, the same TOCTOU fix
+//! (#171/#118), and the same caps — **plus** a release-on-error fix: a claim taken by
+//! [`try_claim`](ProxyRecordingStore::try_claim) that never reaches
+//! [`record`](ProxyRecordingStore::record) (the upstream call failed) is released via
+//! [`release_claim`](ProxyRecordingStore::release_claim), so the signature stays retryable
+//! instead of wedging forever.
+//!
+//! Unlike the concrete store, this backend is **port-scoped**: [`RequestSignature`] carries no
+//! port, so a manager-scoped store shared across imposters must key by port explicitly to keep
+//! identical signatures on different ports from colliding.
+
+use super::mode::ProxyMode;
+use super::types::{RecordedResponse, RequestSignature};
+use parking_lot::{Mutex, RwLock};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Maximum number of recorded responses per signature (proxyAlways mode).
+const MAX_RECORDINGS_PER_SIGNATURE: usize = 1000;
+
+/// Maximum total number of unique request signatures to record (per port).
+const MAX_TOTAL_SIGNATURES: usize = 10_000;
+
+/// Opaque proof that the holder won the right to record a given `(port, signature)` once.
+///
+/// Issued by [`ProxyRecordingStore::try_claim`] and consumed by
+/// [`record`](ProxyRecordingStore::record) / [`release_claim`](ProxyRecordingStore::release_claim).
+/// A token is only valid until the claim it names is settled; a stale token (the claim expired
+/// and was re-taken by another caller) is silently ignored so a late loser cannot clobber the
+/// winner's recording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClaimToken(u64);
+
+impl ClaimToken {
+    /// Construct a token from a raw value. Backends implementing [`ProxyRecordingStore`] mint
+    /// their own tokens; the value only needs to be unique within the backend.
+    #[must_use]
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// The raw token value.
+    #[must_use]
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// Outcome of [`ProxyRecordingStore::try_claim`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    /// The caller won the claim and must either [`record`](ProxyRecordingStore::record) a
+    /// response or [`release_claim`](ProxyRecordingStore::release_claim) it.
+    Claimed(ClaimToken),
+    /// Another caller already holds the claim (proxyOnce, concurrent first requests). The
+    /// caller may still proxy upstream but must not record.
+    InFlight,
+    /// A response is already recorded for this `(port, signature)`; the caller should replay
+    /// via [`lookup`](ProxyRecordingStore::lookup).
+    AlreadyRecorded,
+}
+
+/// Error returned by a [`ProxyRecordingStore`] whose backend is unavailable.
+///
+/// The built-in [`LocalProxyStore`] never returns this; it exists so external backends
+/// (shared, persistent) can signal a transient failure and let the caller degrade gracefully.
+#[derive(Debug, thiserror::Error)]
+pub enum ProxyStoreError {
+    /// The backing store could not be reached.
+    #[error("proxy recording store unavailable: {0}")]
+    Unavailable(String),
+}
+
+/// Convenience alias for fallible proxy-store operations.
+pub type Result<T> = std::result::Result<T, ProxyStoreError>;
+
+/// Pluggable proxy-recording backend, keyed by imposter port.
+pub trait ProxyRecordingStore: Send + Sync {
+    /// First caller per `(port, signature)` wins the right to record once. Returns
+    /// [`ClaimOutcome::InFlight`] if another caller already holds the claim and
+    /// [`ClaimOutcome::AlreadyRecorded`] if a response is already stored.
+    ///
+    /// `Err` = backend unavailable (built-ins never fail).
+    fn try_claim(&self, port: u16, sig: &RequestSignature) -> Result<ClaimOutcome>;
+
+    /// Releases a claim after a failed upstream call so the signature is retryable.
+    /// Stale tokens (the claim expired and was re-taken) are ignored.
+    fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken);
+
+    /// Records the proxied response against the claim named by `token`. A stale token is
+    /// ignored (the recording is dropped) so a late loser cannot overwrite the winner.
+    ///
+    /// `Err` = backend unavailable (built-ins never fail). On `Err` the caller releases the
+    /// claim (via [`release_claim`](Self::release_claim)), so an implementation that fails
+    /// mid-record must leave the claim releasable — never hold `(port, signature)` pending
+    /// after returning `Err`, or that signature wedges under `proxyOnce`.
+    fn record(
+        &self,
+        port: u16,
+        sig: RequestSignature,
+        token: ClaimToken,
+        resp: RecordedResponse,
+    ) -> Result<()>;
+
+    /// Returns the recorded response for replay, if any.
+    fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse>;
+
+    /// Clears all saved proxy responses for a port. Backs the DELETE endpoint for saved
+    /// proxy responses and the manager's port reclaim on imposter deletion.
+    fn clear(&self, port: u16);
+}
+
+/// Per-port recording state: the responses map plus the in-flight claim gate.
+#[derive(Debug, Default)]
+struct PortState {
+    responses: RwLock<HashMap<RequestSignature, Vec<RecordedResponse>>>,
+    /// Signatures with an in-flight `proxyOnce` claim, mapped to the active claim token.
+    /// Presence is the TOCTOU-safe "someone is recording this" flag (#171/#118); the token
+    /// lets [`record`](ProxyRecordingStore::record) and
+    /// [`release_claim`](ProxyRecordingStore::release_claim) reject stale callers.
+    pending: Mutex<HashMap<RequestSignature, u64>>,
+}
+
+/// Reference proxy-recording backend with the exact semantics of the embedded store it
+/// replaced, plus the release-on-error fix and explicit port scoping.
+///
+/// A `LocalProxyStore` carries a single [`ProxyMode`]: the per-imposter default is constructed
+/// with that imposter's mode. An embedder sharing one store across imposters via
+/// [`with_proxy_store`](crate::imposter::ImposterManager::with_proxy_store) therefore shares one
+/// mode across the ports it serves.
+#[derive(Debug)]
+pub struct LocalProxyStore {
+    mode: ProxyMode,
+    ports: RwLock<HashMap<u16, Arc<PortState>>>,
+    /// Monotonic source of claim tokens, unique across ports and time.
+    next_token: AtomicU64,
+}
+
+impl LocalProxyStore {
+    /// Create a store for the given proxy mode.
+    #[must_use]
+    pub fn new(mode: ProxyMode) -> Self {
+        Self {
+            mode,
+            ports: RwLock::new(HashMap::new()),
+            next_token: AtomicU64::new(0),
+        }
+    }
+
+    /// The proxy mode this store dispatches on.
+    #[must_use]
+    pub fn mode(&self) -> ProxyMode {
+        self.mode
+    }
+
+    fn slot(&self, port: u16) -> Arc<PortState> {
+        if let Some(slot) = self.ports.read().get(&port) {
+            return Arc::clone(slot);
+        }
+        Arc::clone(self.ports.write().entry(port).or_default())
+    }
+
+    fn mint_token(&self) -> u64 {
+        self.next_token.fetch_add(1, Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    fn recorded_len(&self, port: u16, sig: &RequestSignature) -> usize {
+        self.slot(port)
+            .responses
+            .read()
+            .get(sig)
+            .map_or(0, Vec::len)
+    }
+
+    #[cfg(test)]
+    fn recordings(&self, port: u16, sig: &RequestSignature) -> Vec<RecordedResponse> {
+        self.slot(port)
+            .responses
+            .read()
+            .get(sig)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+impl ProxyRecordingStore for LocalProxyStore {
+    fn try_claim(&self, port: u16, sig: &RequestSignature) -> Result<ClaimOutcome> {
+        match self.mode {
+            ProxyMode::ProxyOnce => {
+                let state = self.slot(port);
+                // Hold the responses read guard across the pending claim so record() (which
+                // needs responses.write()) cannot land a new recording between the
+                // "not recorded" check and the claim — the #171/#118 TOCTOU fix.
+                let responses = state.responses.read();
+                if responses.contains_key(sig) {
+                    return Ok(ClaimOutcome::AlreadyRecorded);
+                }
+                let mut pending = state.pending.lock();
+                if pending.contains_key(sig) {
+                    return Ok(ClaimOutcome::InFlight);
+                }
+                let token = self.mint_token();
+                pending.insert(sig.clone(), token);
+                Ok(ClaimOutcome::Claimed(ClaimToken(token)))
+            }
+            // proxyAlways / proxyTransparent never gate: every request proxies. The claim is a
+            // formality so the caller path is uniform; record() dispatches on mode.
+            ProxyMode::ProxyAlways | ProxyMode::ProxyTransparent => {
+                Ok(ClaimOutcome::Claimed(ClaimToken(self.mint_token())))
+            }
+        }
+    }
+
+    fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken) {
+        if self.mode != ProxyMode::ProxyOnce {
+            return;
+        }
+        let state = self.slot(port);
+        let mut pending = state.pending.lock();
+        // Only release if the claim is still the one this token named; a stale token whose
+        // claim was already re-taken must not free the new holder.
+        if pending.get(sig).copied() == Some(token.0) {
+            pending.remove(sig);
+        }
+    }
+
+    fn record(
+        &self,
+        port: u16,
+        sig: RequestSignature,
+        token: ClaimToken,
+        resp: RecordedResponse,
+    ) -> Result<()> {
+        let state = self.slot(port);
+        match self.mode {
+            ProxyMode::ProxyOnce => {
+                // Lock order (responses then pending) matches try_claim to avoid deadlock.
+                let mut responses = state.responses.write();
+                let mut pending = state.pending.lock();
+                // Stale or already-settled claim: drop the recording rather than clobber.
+                if pending.get(&sig).copied() != Some(token.0) {
+                    tracing::debug!(
+                        "Stale claim token; dropping recording (claim released/re-taken)"
+                    );
+                    return Ok(());
+                }
+                if responses.len() >= MAX_TOTAL_SIGNATURES && !responses.contains_key(&sig) {
+                    tracing::debug!(
+                        max = MAX_TOTAL_SIGNATURES,
+                        "Recording store full, dropping new recording"
+                    );
+                    pending.remove(&sig);
+                    return Ok(());
+                }
+                responses.entry(sig.clone()).or_insert_with(|| vec![resp]);
+                pending.remove(&sig);
+                Ok(())
+            }
+            ProxyMode::ProxyAlways => {
+                let mut responses = state.responses.write();
+                if responses.len() >= MAX_TOTAL_SIGNATURES && !responses.contains_key(&sig) {
+                    tracing::debug!(
+                        max = MAX_TOTAL_SIGNATURES,
+                        "Recording store full, dropping new recording"
+                    );
+                    return Ok(());
+                }
+                let recordings = responses.entry(sig).or_default();
+                if recordings.len() >= MAX_RECORDINGS_PER_SIGNATURE {
+                    tracing::debug!(
+                        max = MAX_RECORDINGS_PER_SIGNATURE,
+                        "Recording limit reached, dropping oldest"
+                    );
+                    recordings.remove(0);
+                }
+                recordings.push(resp);
+                Ok(())
+            }
+            // proxyTransparent never records.
+            ProxyMode::ProxyTransparent => Ok(()),
+        }
+    }
+
+    fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse> {
+        self.slot(port)
+            .responses
+            .read()
+            .get(sig)
+            .and_then(|responses| responses.first().cloned())
+    }
+
+    fn clear(&self, port: u16) {
+        if let Some(state) = self.ports.read().get(&port) {
+            state.responses.write().clear();
+            state.pending.lock().clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::unix_timestamp;
+
+    fn sig(path: &str) -> RequestSignature {
+        RequestSignature::new("GET", path, None, &[])
+    }
+
+    fn resp(status: u16, body: &str) -> RecordedResponse {
+        RecordedResponse {
+            status,
+            headers: Vec::new(),
+            body: body.as_bytes().to_vec(),
+            latency_ms: Some(10),
+            timestamp_secs: unix_timestamp(),
+        }
+    }
+
+    fn claim_token(outcome: ClaimOutcome) -> ClaimToken {
+        match outcome {
+            ClaimOutcome::Claimed(t) => t,
+            other => panic!("expected Claimed, got {other:?}"),
+        }
+    }
+
+    // AC6: proxyOnce records the first response only and replays it.
+    #[test]
+    fn local_proxy_once_records_first_only() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/test");
+
+        let token = claim_token(store.try_claim(1, &s).unwrap());
+        store
+            .record(1, s.clone(), token, resp(200, "first"))
+            .unwrap();
+
+        // Now recorded: a second claim is refused, replay serves the first response.
+        assert_eq!(
+            store.try_claim(1, &s).unwrap(),
+            ClaimOutcome::AlreadyRecorded
+        );
+        let recorded = store.lookup(1, &s).unwrap();
+        assert_eq!(recorded.status, 200);
+        assert_eq!(recorded.body, b"first");
+        assert_eq!(store.recorded_len(1, &s), 1);
+    }
+
+    // AC6: proxyAlways appends every recording.
+    #[test]
+    fn local_proxy_always_records_all() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyAlways);
+        let s = sig("/test");
+
+        let t1 = claim_token(store.try_claim(1, &s).unwrap());
+        store.record(1, s.clone(), t1, resp(200, "first")).unwrap();
+        let t2 = claim_token(store.try_claim(1, &s).unwrap());
+        store.record(1, s.clone(), t2, resp(201, "second")).unwrap();
+
+        assert_eq!(store.recorded_len(1, &s), 2);
+        // Replay serves the first.
+        assert_eq!(store.lookup(1, &s).unwrap().status, 200);
+    }
+
+    // AC6: proxyAlways evicts the oldest recording past the per-signature cap.
+    #[test]
+    fn local_proxy_always_evicts_oldest() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyAlways);
+        let s = sig("/evict");
+
+        for i in 0..=MAX_RECORDINGS_PER_SIGNATURE {
+            let t = claim_token(store.try_claim(1, &s).unwrap());
+            store
+                .record(1, s.clone(), t, resp(200, &format!("response-{i}")))
+                .unwrap();
+        }
+
+        let recordings = store.recordings(1, &s);
+        assert_eq!(recordings.len(), MAX_RECORDINGS_PER_SIGNATURE);
+        assert_eq!(recordings[0].body, b"response-1", "oldest evicted first");
+    }
+
+    // AC6: proxyTransparent never records.
+    #[test]
+    fn local_proxy_transparent_never_records() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyTransparent);
+        let s = sig("/test");
+
+        let t = claim_token(store.try_claim(1, &s).unwrap());
+        store.record(1, s.clone(), t, resp(200, "body")).unwrap();
+
+        assert!(store.lookup(1, &s).is_none());
+        assert_eq!(store.recorded_len(1, &s), 0);
+    }
+
+    // AC3: concurrent claimers get exactly one Claimed; the rest see InFlight.
+    #[test]
+    fn local_concurrent_try_claim_one_winner() {
+        use std::thread;
+
+        let store = Arc::new(LocalProxyStore::new(ProxyMode::ProxyOnce));
+        let s = sig("/concurrent");
+        let claimed = Arc::new(AtomicU64::new(0));
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let s = s.clone();
+                let claimed = Arc::clone(&claimed);
+                thread::spawn(move || {
+                    if let ClaimOutcome::Claimed(_) = store.try_claim(1, &s).unwrap() {
+                        claimed.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            claimed.load(Ordering::SeqCst),
+            1,
+            "exactly one claimer wins in proxyOnce"
+        );
+    }
+
+    // AC2 (the wedge regression): a released claim makes the signature reclaimable. Fails on
+    // the pre-fix code where a failed upstream call left the signature pending forever.
+    #[test]
+    fn local_release_makes_signature_reclaimable() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/wedge");
+
+        // First caller claims, then the upstream call "fails" so it releases.
+        let t1 = claim_token(store.try_claim(1, &s).unwrap());
+        store.release_claim(1, &s, t1);
+
+        // A subsequent request must be able to claim and record — not be told InFlight forever.
+        let outcome = store.try_claim(1, &s).unwrap();
+        let t2 = claim_token(outcome);
+        store
+            .record(1, s.clone(), t2, resp(200, "recovered"))
+            .unwrap();
+        assert_eq!(store.lookup(1, &s).unwrap().body, b"recovered");
+    }
+
+    // AC4: a stale token (its claim expired and was re-taken) neither releases nor records.
+    #[test]
+    fn local_stale_token_release_and_record_ignored() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/stale");
+
+        let t1 = claim_token(store.try_claim(1, &s).unwrap());
+        store.release_claim(1, &s, t1); // claim freed
+        let t2 = claim_token(store.try_claim(1, &s).unwrap()); // re-taken by a new caller
+
+        // Stale release must not free t2's live claim.
+        store.release_claim(1, &s, t1);
+        assert_eq!(
+            store.try_claim(1, &s).unwrap(),
+            ClaimOutcome::InFlight,
+            "stale release must not free the live claim"
+        );
+
+        // Stale record must be dropped, not stored.
+        store.record(1, s.clone(), t1, resp(500, "stale")).unwrap();
+        assert!(
+            store.lookup(1, &s).is_none(),
+            "stale record must be ignored"
+        );
+
+        // The live holder can still record.
+        store.record(1, s.clone(), t2, resp(200, "fresh")).unwrap();
+        assert_eq!(store.lookup(1, &s).unwrap().body, b"fresh");
+    }
+
+    // AC5: identical signatures on different ports do not collide through a shared store.
+    #[test]
+    fn local_ports_are_isolated() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/shared");
+
+        let t = claim_token(store.try_claim(1, &s).unwrap());
+        store.record(1, s.clone(), t, resp(200, "port-1")).unwrap();
+
+        // Port 2 sees the signature as fresh, not AlreadyRecorded.
+        assert!(matches!(
+            store.try_claim(2, &s).unwrap(),
+            ClaimOutcome::Claimed(_)
+        ));
+        assert!(store.lookup(2, &s).is_none());
+        assert_eq!(store.lookup(1, &s).unwrap().body, b"port-1");
+    }
+
+    // clear() drops a port's recordings and reopens the gate.
+    #[test]
+    fn local_clear_resets_port() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/clear");
+
+        let t = claim_token(store.try_claim(1, &s).unwrap());
+        store.record(1, s.clone(), t, resp(200, "body")).unwrap();
+        assert!(store.lookup(1, &s).is_some());
+
+        store.clear(1);
+        assert!(store.lookup(1, &s).is_none());
+        assert!(matches!(
+            store.try_claim(1, &s).unwrap(),
+            ClaimOutcome::Claimed(_)
+        ));
+    }
+
+    // The total-signatures cap drops new signatures once full (proxyOnce), as before.
+    #[test]
+    fn local_total_signatures_cap_drops_new() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+
+        for i in 0..MAX_TOTAL_SIGNATURES {
+            let s = sig(&format!("/path-{i}"));
+            let t = claim_token(store.try_claim(1, &s).unwrap());
+            store.record(1, s, t, resp(200, "ok")).unwrap();
+        }
+
+        let overflow = sig("/overflow");
+        let t = claim_token(store.try_claim(1, &overflow).unwrap());
+        store
+            .record(1, overflow.clone(), t, resp(200, "dropped"))
+            .unwrap();
+        assert!(
+            store.lookup(1, &overflow).is_none(),
+            "overflow signature dropped once the port is full"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Extract a port-scoped `ProxyRecordingStore` trait and default `LocalProxyStore` implementation (issue #315) so embedders can persist recordings or share the proxyOnce exactly-once gate across engine instances.

## Changes
- New `ProxyRecordingStore` trait with `ClaimToken`, `ClaimOutcome`, `ProxyStoreError` types
- `LocalProxyStore` backend: port-scoped, preserves #171/#118 TOCTOU semantics, adds release-on-error fix
- Wiring: `Imposter.proxy_store` injected via `ImposterManager::with_proxy_store`; cleanup on imposter delete
- **Fixes**: failed upstream proxy calls no longer wedge the signature forever; symmetric claim release on record() failure (critical for external backends)

## Test Plan
- 10 unit tests in proxy_store.rs covering gate semantics, concurrent claims, stale tokens, port isolation, caps
- 4 e2e integration tests validating upstream-failure release, record-failure release, and store-unavailability degrade paths
- All 762 rift-core lib tests pass (14 new); full workspace green except pre-existing Redis-backend tests
- Code review passed all gates: no blockers found (code-reviewer/opus, silent-failure/sonnet, test-analyzer/sonnet)

Closes #315