### PR TITLE
Make RequestJournal clear/clear_flow fallible (#330)

### DIFF
--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -291,11 +291,14 @@ impl Imposter {
         self.stubs
             .write()
             .retain(|s| s.stub.space.as_deref() != Some(space));
-        self.journal.clear_flow(self.journal_port(), space);
-        // Best-effort across scenarios so one bad key doesn't leave later scenarios stale,
-        // but the first failure still surfaces (issue #318) — never report a clean teardown
-        // while stale scenario state persists in the backend.
+        // Best-effort across the slice's clears so one failure doesn't leave later scenarios
+        // stale, but the first failure still surfaces (issues #318, #330) — never report a
+        // clean teardown while stale recorded requests or scenario state persist in the backend.
         let mut first_err = None;
+        if let Err(e) = self.journal.clear_flow(self.journal_port(), space) {
+            warn!("space teardown: failed to clear recorded requests for '{space}': {e}");
+            first_err.get_or_insert(e);
+        }
         for scenario in scenarios {
             if let Err(e) = self.delete_scenario_state(space, &scenario) {
                 warn!("space teardown: failed to reset scenario '{scenario}' for '{space}': {e}");

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -613,7 +613,7 @@ mod tests {
             "targeted retain must not reset the request count"
         );
 
-        imposter.clear_recorded_requests();
+        imposter.clear_recorded_requests().expect("clear");
         assert_eq!(imposter.get_recorded_requests().len(), 0);
         assert_eq!(
             imposter.get_request_count(),

--- a/crates/rift-core/src/imposter/core/recording.rs
+++ b/crates/rift-core/src/imposter/core/recording.rs
@@ -42,8 +42,10 @@ impl Imposter {
     }
 
     /// Clear recorded requests. Also resets the request count to match Mountebank behavior.
-    pub fn clear_recorded_requests(&self) {
-        self.journal.clear(self.journal_port());
+    /// Propagates a backend clear failure (issue #330) so callers never report a clean clear
+    /// over stale recorded state.
+    pub fn clear_recorded_requests(&self) -> anyhow::Result<()> {
+        self.journal.clear(self.journal_port())
     }
 
     /// Retain only the recorded requests for which `keep` returns true.

--- a/crates/rift-core/src/imposter/journal.rs
+++ b/crates/rift-core/src/imposter/journal.rs
@@ -39,16 +39,16 @@ pub trait RequestJournal: Send + Sync {
     fn read(&self, port: u16) -> JournalRead;
     /// Clears entries AND resets the request count (documented contract, as today).
     ///
-    /// Infallible by design: callers treat return as success, so an implementation whose
-    /// backend fails must resolve the failure internally (retry/queue) and log it — never
-    /// silently drop a failed clear.
-    fn clear(&self, port: u16);
+    /// Fallible: clearing is a correctness operation whose postcondition ("the data is gone")
+    /// callers rely on (issue #330). A backend that cannot delete must return `Err` so callers
+    /// surface the degradation rather than reporting a clean clear over stale state.
+    fn clear(&self, port: u16) -> anyhow::Result<()>;
     /// Targeted deletion; does NOT reset the count (documented contract, as today).
     fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool);
     /// Declarative scoped clear (one correlated slice, #223) — expressible by any
-    /// backend, unlike the closure-based `retain`. Same failure contract as [`Self::clear`]:
-    /// callers treat return as success.
-    fn clear_flow(&self, port: u16, flow_id: &str);
+    /// backend, unlike the closure-based `retain`. Fallible for the same reason as
+    /// [`Self::clear`]: a failed delete must surface, not be reported as success.
+    fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()>;
     fn count(&self, port: u16) -> u64;
 }
 
@@ -107,21 +107,23 @@ impl RequestJournal for LocalJournal {
         }
     }
 
-    fn clear(&self, port: u16) {
+    fn clear(&self, port: u16) -> anyhow::Result<()> {
         let slot = self.slot(port);
         slot.entries.write().clear();
         slot.count.store(0, Ordering::SeqCst);
+        Ok(())
     }
 
     fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
         self.slot(port).entries.write().retain(|(_, req)| keep(req));
     }
 
-    fn clear_flow(&self, port: u16, flow_id: &str) {
+    fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
         self.slot(port)
             .entries
             .write()
             .retain(|(flow, _)| flow != flow_id);
+        Ok(())
     }
 
     fn count(&self, port: u16) -> u64 {
@@ -174,7 +176,7 @@ mod tests {
         let j = LocalJournal::default();
         j.note_request(1);
         j.record(1, "f", req("/a"));
-        j.clear(1);
+        j.clear(1).expect("local clear is infallible");
         assert_eq!(j.count(1), 0);
         assert!(j.read(1).entries.is_empty());
     }
@@ -199,11 +201,21 @@ mod tests {
         j.note_request(1);
         j.record(1, "flow-a", req("/a"));
         j.record(1, "flow-b", req("/b"));
-        j.clear_flow(1, "flow-a");
+        j.clear_flow(1, "flow-a")
+            .expect("local clear_flow is infallible");
         let read = j.read(1);
         assert_eq!(read.entries.len(), 1);
         assert_eq!(read.entries[0].path, "/b");
         assert_eq!(j.count(1), 1, "scoped clear keeps the total count");
+    }
+
+    // AC1 (#330): the local backend never fails a clear — both clear ops return Ok.
+    #[test]
+    fn local_clear_and_clear_flow_are_ok() {
+        let j = LocalJournal::default();
+        j.record(1, "flow-a", req("/a"));
+        assert!(j.clear_flow(1, "flow-a").is_ok());
+        assert!(j.clear(1).is_ok());
     }
 
     // Ports are isolated slices of the journal.

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Server-level TLS defaults for HTTPS imposters that don't carry their own cert/key (issue #206).
 #[derive(Debug, Clone)]
@@ -509,7 +509,11 @@ impl ImposterManager {
             sequencer.reset_scope(port, None);
         }
         if let Some(journal) = &self.request_journal {
-            journal.clear(port);
+            // GC clear is best-effort: a failed backend clear must not fail the delete, but it
+            // is logged rather than dropped (issue #330).
+            if let Err(e) = journal.clear(port) {
+                warn!("failed to clear request journal for deleted imposter on port {port}: {e}");
+            }
         }
         // Reclaim the shared proxy store's port slice so a later imposter reusing the port
         // doesn't inherit stale recordings (issue #315). The private default dies with the
@@ -2378,17 +2382,17 @@ mod tests {
             fn read(&self, port: u16) -> JournalRead {
                 self.inner.read(port)
             }
-            fn clear(&self, port: u16) {
+            fn clear(&self, port: u16) -> anyhow::Result<()> {
                 self.clears.lock().push(port);
-                self.inner.clear(port);
+                self.inner.clear(port)
             }
             fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
                 self.retains.lock().push(port);
                 self.inner.retain(port, keep);
             }
-            fn clear_flow(&self, port: u16, flow_id: &str) {
+            fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
                 self.flow_clears.lock().push((port, flow_id.to_string()));
-                self.inner.clear_flow(port, flow_id);
+                self.inner.clear_flow(port, flow_id)
             }
             fn count(&self, port: u16) -> u64 {
                 self.inner.count(port)
@@ -2410,14 +2414,14 @@ mod tests {
                     ..self.0.read(port)
                 }
             }
-            fn clear(&self, port: u16) {
-                self.0.clear(port);
+            fn clear(&self, port: u16) -> anyhow::Result<()> {
+                self.0.clear(port)
             }
             fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
                 self.0.retain(port, keep);
             }
-            fn clear_flow(&self, port: u16, flow_id: &str) {
-                self.0.clear_flow(port, flow_id);
+            fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
+                self.0.clear_flow(port, flow_id)
             }
             fn count(&self, port: u16) -> u64 {
                 self.0.count(port)
@@ -2520,7 +2524,7 @@ mod tests {
             assert!(imposter.get_recorded_requests().is_empty());
             assert_eq!(imposter.get_request_count(), 1, "retain keeps the count");
 
-            imposter.clear_recorded_requests();
+            imposter.clear_recorded_requests().expect("clear");
             assert!(journal.clears.lock().contains(&19532));
             assert_eq!(imposter.get_request_count(), 0, "clear resets the count");
 
@@ -2608,7 +2612,7 @@ mod tests {
 
             let a = manager.get_imposter(19536).unwrap();
             let b = manager.get_imposter(19537).unwrap();
-            a.clear_recorded_requests();
+            a.clear_recorded_requests().expect("clear");
 
             assert!(a.get_recorded_requests().is_empty());
             assert_eq!(a.get_request_count(), 0);
@@ -2649,6 +2653,119 @@ mod tests {
             );
 
             manager.delete_all().await;
+        }
+
+        /// A journal whose two clear operations fail like an unreachable remote backend
+        /// (issue #330); everything else delegates to a working LocalJournal so imposters
+        /// still record and read normally.
+        #[derive(Default)]
+        struct FailingClearJournal(LocalJournal);
+        impl FailingClearJournal {
+            fn unavailable() -> anyhow::Error {
+                anyhow::Error::new(crate::extensions::decorate::BackendUnavailable {
+                    feature: "requestJournal",
+                    detail: "clear failed".to_string(),
+                })
+            }
+        }
+        impl RequestJournal for FailingClearJournal {
+            fn note_request(&self, port: u16) {
+                self.0.note_request(port);
+            }
+            fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+                self.0.record(port, flow_id, req);
+            }
+            fn read(&self, port: u16) -> JournalRead {
+                self.0.read(port)
+            }
+            fn clear(&self, _port: u16) -> anyhow::Result<()> {
+                Err(Self::unavailable())
+            }
+            fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+                self.0.retain(port, keep);
+            }
+            fn clear_flow(&self, _port: u16, _flow_id: &str) -> anyhow::Result<()> {
+                Err(Self::unavailable())
+            }
+            fn count(&self, port: u16) -> u64 {
+                self.0.count(port)
+            }
+        }
+
+        // AC5 (#330): a failed backend clear propagates out of clear_recorded_requests
+        // instead of being reported as a clean clear.
+        #[tokio::test]
+        async fn clear_recorded_requests_propagates_error() {
+            let manager = ImposterManager::new()
+                .with_request_journal(
+                    Arc::new(FailingClearJournal::default()) as Arc<dyn RequestJournal>
+                );
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19538, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+            let imposter = manager.get_imposter(19538).unwrap();
+            let err = imposter
+                .clear_recorded_requests()
+                .expect_err("a failed backend clear must surface");
+            assert!(
+                err.downcast_ref::<crate::extensions::decorate::BackendUnavailable>()
+                    .is_some(),
+                "the backend error is preserved for 503 mapping"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC2 (#330): teardown_space folds a clear_flow failure into its first-error report.
+        #[tokio::test]
+        async fn teardown_space_surfaces_journal_clear_failure() {
+            let manager = ImposterManager::new()
+                .with_request_journal(
+                    Arc::new(FailingClearJournal::default()) as Arc<dyn RequestJournal>
+                );
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19539, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+            let imposter = manager.get_imposter(19539).unwrap();
+            let err = imposter
+                .teardown_space("sp-1")
+                .expect_err("a failed scoped clear must surface, not report a clean teardown");
+            assert!(
+                err.downcast_ref::<crate::extensions::decorate::BackendUnavailable>()
+                    .is_some(),
+                "the backend error is preserved"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC4 (#330): the delete-time GC clear is best-effort — a failed clear is logged but
+        // must not fail the delete.
+        #[tokio::test]
+        async fn delete_imposter_survives_journal_clear_failure() {
+            let manager = ImposterManager::new()
+                .with_request_journal(
+                    Arc::new(FailingClearJournal::default()) as Arc<dyn RequestJournal>
+                );
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19540, "recordRequests": true,
+                    "stubs": [stub_json("ok")]
+                })))
+                .await
+                .expect("create");
+            manager
+                .delete_imposter(19540)
+                .await
+                .expect("delete succeeds despite a failed GC clear");
         }
     }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -6,6 +6,7 @@ use crate::admin_api::types::{
     RiftImposterExtensions, StubWithLinks, collect_body, error_response, json_response,
     make_imposter_links, make_stub_links,
 };
+use crate::extensions::decorate::backend_error_response;
 use crate::extensions::stub_analysis::analyze_stubs;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, RecordedRequest, StubResponse,
@@ -390,7 +391,9 @@ pub async fn handle_clear_requests(
     match manager.get_imposter(port) {
         Ok(imposter) => {
             if clauses.is_empty() {
-                imposter.clear_recorded_requests();
+                if let Err(e) = imposter.clear_recorded_requests() {
+                    return backend_error_response(&e);
+                }
             } else {
                 let source = flow_id_source(&imposter);
                 imposter.retain_recorded_requests(|r| !request_matches(r, &clauses, &source, port));
@@ -677,6 +680,61 @@ mod requests_filter_tests {
         let remaining = requests(handle_get_requests(19740, None, m.clone()).await).await;
         assert!(remaining.is_empty());
         let _ = m.delete_imposter(19740).await;
+    }
+
+    // A journal whose full clear fails like an unreachable remote backend (issue #330);
+    // record/read delegate to a working LocalJournal so the imposter is otherwise normal.
+    #[derive(Default)]
+    struct FailingClearJournal(crate::imposter::LocalJournal);
+    impl crate::imposter::RequestJournal for FailingClearJournal {
+        fn note_request(&self, port: u16) {
+            self.0.note_request(port);
+        }
+        fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+            self.0.record(port, flow_id, req);
+        }
+        fn read(&self, port: u16) -> crate::imposter::JournalRead {
+            self.0.read(port)
+        }
+        fn clear(&self, _port: u16) -> anyhow::Result<()> {
+            Err(anyhow::Error::new(
+                crate::extensions::decorate::BackendUnavailable {
+                    feature: "requestJournal",
+                    detail: "clear failed".to_string(),
+                },
+            ))
+        }
+        fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+            self.0.retain(port, keep);
+        }
+        fn clear_flow(&self, _port: u16, _flow_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn count(&self, port: u16) -> u64 {
+            self.0.count(port)
+        }
+    }
+
+    // AC3 (#330): an unclearable backend makes DELETE savedRequests return a structured 503
+    // rather than an unconditional 200 over stale data.
+    #[tokio::test]
+    async fn delete_requests_backend_clear_failure_maps_to_503() {
+        let manager = Arc::new(
+            ImposterManager::new().with_request_journal(Arc::new(FailingClearJournal::default())
+                as Arc<dyn crate::imposter::RequestJournal>),
+        );
+        let cfg = serde_json::from_value(serde_json::json!({
+            "port": 19742, "protocol": "http", "recordRequests": true, "stubs": []
+        }))
+        .expect("config");
+        manager.create_imposter(cfg).await.expect("create");
+        let base = "http://localhost:2525";
+        let resp = handle_clear_requests(19742, None, base, manager.clone()).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(json["error"], "backendUnavailable");
+        let _ = manager.delete_imposter(19742).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes a correctness bug where failed remote-backend clears were silently reported as success.

Makes `RequestJournal::clear` and `clear_flow` return `anyhow::Result<()>` so callers
can observe and handle backend failures instead of reporting stale state cleanup as clean.
Keeps all hot-path methods infallible for telemetry-style contracts.

- `teardown_space` folds clear failures into its first-error report (#318 pattern)
- `DELETE /imposters/:port/savedRequests` now maps backend-unavailable to 503
- `delete_imposter` GC clear logs failures but doesn't block the delete
- All 5 gate tests pass; no breaking changes to public APIs outside the trait

## Test plan
- [x] Unit tests: all 5 acceptance criteria covered by gate tests
- [x] Integration: local_clear_and_clear_flow_are_ok, teardown_space_surfaces_journal_clear_failure, delete_requests_backend_clear_failure_maps_to_503, delete_imposter_survives_journal_clear_failure, clear_recorded_requests_propagates_error all pass
- [x] Code review: zero blockers from opus/sonnet review agents
- [x] Clippy: -D warnings clean

Closes #330