### PR TITLE
test: extend criterion benches to the Mountebank imposter path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
  "boa_engine",
  "bytes",
  "chrono",
+ "criterion",
  "crossbeam",
  "futures",
  "http-body-util",

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -86,6 +86,11 @@ reqwest.workspace = true
 tokio-test = "0.4"
 uuid.workspace = true
 serial_test = "3.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "imposter_matcher_bench"
+harness = false
 
 [features]
 default = ["redis-backend", "lua", "javascript"]

--- a/crates/rift-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-core/benches/imposter_matcher_bench.rs
@@ -1,0 +1,141 @@
+//! Criterion benches for the Mountebank imposter matcher hot path.
+//!
+//! Complements `rift-http-proxy/benches/matcher_bench.rs` (which covers the proxy
+//! `RuleIndex`/`CompiledRule` engine). These target the paths most imposter requests actually
+//! hit — `stub_matches` (predicate evaluation) and `Imposter::find_matching_stub_with_client`
+//! (per-request stub scan) — so the Tier 1/2 perf work (#286–#294) has a baseline to measure.
+
+use std::collections::HashMap;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use hyper::HeaderMap;
+use rift_core::imposter::{Imposter, ImposterConfig, Predicate, stub_matches};
+use serde_json::json;
+
+fn predicates_from(values: serde_json::Value) -> Vec<Predicate> {
+    serde_json::from_value(values).expect("valid predicate fixtures")
+}
+
+/// Pure predicate evaluation, isolated from stub-scan overhead: regex `matches`, `deepEquals`
+/// over a JSON body, and combined header + query matching.
+fn bench_stub_matches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stub_matches");
+    let empty_headers: HashMap<String, String> = HashMap::new();
+
+    let regex_preds = predicates_from(json!([
+        { "matches": { "path": r"^/api/v\d+/users/\d+$" } }
+    ]));
+    group.bench_function("regex_matches", |b| {
+        b.iter(|| {
+            stub_matches(
+                black_box(&regex_preds),
+                "GET",
+                black_box("/api/v2/users/4815"),
+                None,
+                &empty_headers,
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+        })
+    });
+
+    let deep_preds = predicates_from(json!([
+        { "deepEquals": { "body": { "user": { "id": 42, "name": "ada" }, "roles": ["admin", "ops"] } } }
+    ]));
+    let body = r#"{"roles":["admin","ops"],"user":{"name":"ada","id":42}}"#;
+    group.bench_function("deep_equals_json_body", |b| {
+        b.iter(|| {
+            stub_matches(
+                black_box(&deep_preds),
+                "POST",
+                "/orders",
+                None,
+                &empty_headers,
+                black_box(Some(body)),
+                None,
+                None,
+                None,
+                0,
+            )
+        })
+    });
+
+    let header_query_preds = predicates_from(json!([
+        { "equals": { "headers": { "X-Trace": "trace-123" } } },
+        { "equals": { "query": { "page": "2" } } }
+    ]));
+    let mut headers = HashMap::new();
+    headers.insert("X-Trace".to_string(), "trace-123".to_string());
+    group.bench_function("header_and_query", |b| {
+        b.iter(|| {
+            stub_matches(
+                black_box(&header_query_preds),
+                "GET",
+                "/list",
+                black_box(Some("page=2&sort=asc")),
+                &headers,
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+        })
+    });
+
+    group.finish();
+}
+
+fn imposter_with_stubs(count: usize) -> Imposter {
+    let stubs: Vec<serde_json::Value> = (0..count)
+        .map(|i| {
+            json!({
+                "predicates": [{ "equals": { "path": format!("/api/endpoint{i}") } }],
+                "responses": [{ "is": { "statusCode": 200 } }]
+            })
+        })
+        .collect();
+    let config: ImposterConfig = serde_json::from_value(json!({
+        "protocol": "http",
+        "port": 20000,
+        "stubs": stubs,
+    }))
+    .expect("valid imposter config");
+    Imposter::new(config)
+}
+
+/// End-to-end per-request stub scan, scaled 10 → 100 → 1000 stubs. The request targets the last
+/// stub so the whole list is scanned (worst case for the current O(n) matcher).
+fn bench_find_matching_stub(c: &mut Criterion) {
+    let mut group = c.benchmark_group("find_matching_stub");
+    let headers = HeaderMap::new();
+
+    for count in [10usize, 100, 1000] {
+        let imposter = imposter_with_stubs(count);
+        let path = format!("/api/endpoint{}", count - 1);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                imposter
+                    .find_matching_stub_with_client(
+                        "GET",
+                        black_box(path.as_str()),
+                        black_box(&headers),
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+                    .expect("matching must not error")
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_stub_matches, bench_find_matching_stub);
+criterion_main!(benches);

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -35,6 +35,7 @@ COPY crates/rift-ffi/Cargo.toml ./crates/rift-ffi/
 
 # Create dummy source files to build dependencies
 RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
+             crates/rift-core/benches \
              crates/rift-lint/src crates/rift-tui/src crates/rift-types/src crates/rift-core/src crates/rift-ffi/src && \
     echo "" > crates/rift-types/src/lib.rs && \
     echo "" > crates/rift-core/src/lib.rs && \
@@ -42,6 +43,7 @@ RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/bin/verify.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/benches/matcher_bench.rs && \
+    echo "fn main() {}" > crates/rift-core/benches/imposter_matcher_bench.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-tui/src/main.rs && \


### PR DESCRIPTION
The existing benches only cover the proxy RuleIndex engine, not the stub_matches / find_matching_stub_with_client paths most imposter requests hit. Add benches over regex predicates, deepEquals JSON bodies, header/query matching, and stub-count scaling (10->1000) so the Tier 1/2 perf work has a measurable baseline.

Closes #299

Part of the Performance & load-capacity roadmap (#300).