### PR TITLE
perf: add a feature-gated mimalloc global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3229,6 +3247,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "matchit",
+ "mimalloc",
  "num_cpus",
  "parking_lot",
  "port_check",

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -79,6 +79,11 @@ libc = "0.2"
 parking_lot = "0.12"
 crossbeam = "0.8"
 
+# Optional high-throughput global allocator for the server binary (issue #293).
+# Feature-gated (default-on) so FFI/cdylib and cross-compile builds can drop it;
+# it is wired only into the `rift-http-proxy` binary, never rift-core/rift-ffi.
+mimalloc = { version = "0.1", optional = true }
+
 # XML/XPath support for Mountebank compatibility
 sxd-document = "0.3"
 sxd-xpath = "0.4"
@@ -104,10 +109,13 @@ tracing-test = "0.2"
 port_check = "0.2"
 
 [features]
-default = ["redis-backend", "lua", "javascript"]
+default = ["redis-backend", "lua", "javascript", "mimalloc"]
 redis-backend = ["rift-core/redis-backend"]
 lua = ["rift-core/lua"]
 javascript = ["rift-core/javascript"]
+# High-throughput global allocator for the server binary; drop it (e.g.
+# `--no-default-features`) for FFI/cross-compile builds that must not link it.
+mimalloc = ["dep:mimalloc"]
 
 [[bin]]
 name = "rift-verify"

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -18,6 +18,13 @@
 //! The server composition itself (CLI surface, bootstrap, metrics, gateway dispatch) lives
 //! in the `rift_http_proxy` library (issue #317); this binary is a thin caller.
 
+// Route the server binary's allocations through mimalloc (issue #293). Gated by
+// the default-on `mimalloc` feature so FFI/cross-compile builds can drop it; the
+// allocator is set only here in the binary, never in the rift-core/rift-ffi libs.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::Parser;
 use rift_http_proxy::admin_api::DEFAULT_ADMIN_PORT;
 use rift_http_proxy::server::{Cli, Commands, ServerBuilder};


### PR DESCRIPTION
Replace the system allocator with mimalloc in the rift-http-proxy binary to improve throughput on the allocation-heavy request hot path.

Wire mimalloc behind a default-on `mimalloc` feature so builds targeting FFI or cross-compilation can optionally drop it. rift-core and rift-ffi remain unaffected; the cdylib continues to export all C-ABI symbols.

Closes #293