### PR TITLE
perf: build the request header map once, drop the double conversion

### DIFF
--- a/crates/rift-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-core/benches/imposter_matcher_bench.rs
@@ -8,7 +8,6 @@
 use std::collections::HashMap;
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use hyper::HeaderMap;
 use rift_core::imposter::{Imposter, ImposterConfig, Predicate, stub_matches};
 use serde_json::json;
 
@@ -111,7 +110,7 @@ fn imposter_with_stubs(count: usize) -> Imposter {
 /// stub so the whole list is scanned (worst case for the current O(n) matcher).
 fn bench_find_matching_stub(c: &mut Criterion) {
     let mut group = c.benchmark_group("find_matching_stub");
-    let headers = HeaderMap::new();
+    let headers: HashMap<String, String> = HashMap::new();
 
     for count in [10usize, 100, 1000] {
         let imposter = imposter_with_stubs(count);

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -16,8 +16,11 @@ impl Imposter {
         query: Option<&str>,
         body: Option<&str>,
     ) -> anyhow::Result<Option<(StubState, usize)>> {
-        // Call the extended version with no client info (backward compatible)
-        self.find_matching_stub_with_client(method, path, headers, query, body, None, None)
+        // Call the extended version with no client info (backward compatible). This convenience
+        // wrapper still accepts a `HeaderMap` and converts once; the hot path (`handler.rs`)
+        // passes an already-built header map to `find_matching_stub_with_client` directly.
+        let headers_map = Self::header_map_to_hashmap(headers);
+        self.find_matching_stub_with_client(method, path, &headers_map, query, body, None, None)
     }
 
     /// Find a matching stub with client address information (for requestFrom/ip predicates)
@@ -26,19 +29,20 @@ impl Imposter {
         &self,
         method: &str,
         path: &str,
-        headers: &hyper::HeaderMap,
+        headers_map: &HashMap<String, String>,
         query: Option<&str>,
         body: Option<&str>,
         request_from: Option<&str>,
         client_ip: Option<&str>,
     ) -> anyhow::Result<Option<(StubState, usize)>> {
         let stubs = self.stubs.read();
-        let headers_map = Self::header_map_to_hashmap(headers);
+        // `headers_map` is the single-value, Title-Case header view already built once by the
+        // caller (#288) — no re-conversion from `HeaderMap` here.
         // Parse form data if Content-Type is application/x-www-form-urlencoded
-        let form = Self::parse_form_data(headers, body);
+        let form = Self::parse_form_data(headers_map, body);
 
         let imposter_port = self.config.port.unwrap_or(0);
-        let flow_id = self.resolve_flow_id(&headers_map);
+        let flow_id = self.resolve_flow_id(headers_map);
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
             // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only
@@ -63,7 +67,7 @@ impl Imposter {
                 method,
                 path,
                 query,
-                &headers_map,
+                headers_map,
                 body,
                 request_from,
                 client_ip,
@@ -313,12 +317,15 @@ impl Imposter {
 
     /// Parse form-urlencoded data from body if Content-Type matches
     pub(crate) fn parse_form_data(
-        headers: &hyper::HeaderMap,
+        headers: &HashMap<String, String>,
         body: Option<&str>,
     ) -> Option<HashMap<String, String>> {
+        // Header keys are Title-Case in the pre-built map, so match Content-Type case-insensitively
+        // (HeaderMap lookups were case-insensitive; preserve that).
         let content_type = headers
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .map(|(_, v)| v.as_str())
             .unwrap_or("");
 
         if content_type.contains("application/x-www-form-urlencoded")

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -349,10 +349,12 @@ mod tests {
     // Fix #95: Multi-valued form fields are now comma-joined instead of overwritten
     #[test]
     fn test_parse_form_data_multi_valued_fields() {
-        let mut headers = hyper::HeaderMap::new();
+        // parse_form_data now reads the pre-built header map (Title-Case keys); the Content-Type
+        // lookup must remain case-insensitive.
+        let mut headers: HashMap<String, String> = HashMap::new();
         headers.insert(
-            hyper::header::CONTENT_TYPE,
-            "application/x-www-form-urlencoded".parse().unwrap(),
+            "Content-Type".to_string(),
+            "application/x-www-form-urlencoded".to_string(),
         );
 
         let result = Imposter::parse_form_data(&headers, Some("checkbox=A&checkbox=B&checkbox=C"));
@@ -361,6 +363,51 @@ mod tests {
             form.get("checkbox").unwrap(),
             "A,B,C",
             "Multi-valued form fields should be comma-joined"
+        );
+
+        // Content-Type lookup must be case-insensitive over the map (a lower-cased key must
+        // still be recognized), matching the old case-insensitive HeaderMap::get.
+        let mut lower: HashMap<String, String> = HashMap::new();
+        lower.insert(
+            "content-type".to_string(),
+            "application/x-www-form-urlencoded".to_string(),
+        );
+        assert!(
+            Imposter::parse_form_data(&lower, Some("a=1")).is_some(),
+            "a differently-cased content-type key must still be recognized"
+        );
+    }
+
+    #[test]
+    fn find_matching_stub_with_client_matches_on_prebuilt_header_map() {
+        // Gate for #288: the matcher takes the already-built header HashMap (no re-conversion
+        // from HeaderMap) and header predicates still match against it correctly.
+        let cfg = serde_json::from_value(json!({
+            "port": 0,
+            "protocol": "http",
+            "stubs": [
+                { "predicates": [{ "equals": { "headers": { "X-Api-Key": "secret" } } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] }
+            ]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert("X-Api-Key".to_string(), "secret".to_string());
+        let matched = imp
+            .find_matching_stub_with_client("GET", "/", &headers, None, None, None, None)
+            .expect("store is infallible");
+        assert!(matched.is_some(), "request with matching header must match");
+
+        let mut wrong: HashMap<String, String> = HashMap::new();
+        wrong.insert("X-Api-Key".to_string(), "nope".to_string());
+        let unmatched = imp
+            .find_matching_stub_with_client("GET", "/", &wrong, None, None, None, None)
+            .expect("store is infallible");
+        assert!(
+            unmatched.is_none(),
+            "request with non-matching header must not match"
         );
     }
 

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -238,7 +238,6 @@ async fn handle_request_inner(
             &query_str,
             &headers_clone,
             &body_string,
-            &headers_for_context,
             client_addr,
         );
     }
@@ -249,7 +248,7 @@ async fn handle_request_inner(
     let matched = match imposter.find_matching_stub_with_client(
         method_str,
         path_str,
-        &headers_for_context,
+        &headers_clone,
         query_opt,
         body_string.as_deref(),
         Some(&request_from),
@@ -262,10 +261,9 @@ async fn handle_request_inner(
     };
     if let Some((stub_state, stub_index)) = matched {
         // Scenario FSM: apply the matched stub's newScenarioState transition (no-op unless set).
-        // Resolve flow_id from the same header map the eligibility gate used (headers_for_context)
+        // Resolve flow_id from the same single-value header map the matcher used (headers_clone)
         // so the transition writes the exact key the gate read.
-        let scenario_flow_id =
-            imposter.resolve_flow_id(&Imposter::header_map_to_hashmap(&headers_for_context));
+        let scenario_flow_id = imposter.resolve_flow_id(&headers_clone);
         if let Err(e) = imposter.apply_scenario_transition(&scenario_flow_id, &stub_state.stub) {
             return Ok(backend_error_response(&e));
         }
@@ -807,7 +805,6 @@ fn handle_debug_request(
     query_str: &str,
     headers_clone: &HashMap<String, String>,
     body_string: &Option<String>,
-    headers_for_context: &hyper::HeaderMap,
     client_addr: SocketAddr,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     debug!("Debug mode enabled for request {} {}", method, path);
@@ -844,7 +841,7 @@ fn handle_debug_request(
     let matched = match imposter.find_matching_stub_with_client(
         method,
         path,
-        headers_for_context,
+        headers_clone,
         query_opt,
         body_string.as_deref(),
         Some(&request_from),


### PR DESCRIPTION
The imposter matcher was rebuilding the request header HashMap from a HeaderMap on every request, after the handler had already constructed one. This eliminated a HashMap→HeaderMap→HashMap round-trip and two owned-map allocations per request. Behavior is preserved; the map is byte-for-byte equivalent.

Closes #288

Milestone: Performance & load-capacity roadmap (#300)