### PR TITLE
perf: stop deep-cloning the matched stub on every request

### DIFF
--- a/crates/rift-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-core/src/imposter/core/lifecycle.rs
@@ -31,7 +31,7 @@ impl Imposter {
         let mut stubs = self.stubs.write();
         let idx = index.unwrap_or(stubs.len());
         let idx = idx.min(stubs.len());
-        stubs.insert(idx, StubState::new(stub));
+        stubs.insert(idx, Arc::new(StubState::new(stub)));
     }
 
     /// Add a stub, rejecting it if its `id` duplicates an existing stub (issue #202). The
@@ -46,7 +46,7 @@ impl Imposter {
             return false;
         }
         let idx = index.unwrap_or(stubs.len()).min(stubs.len());
-        stubs.insert(idx, StubState::new(stub));
+        stubs.insert(idx, Arc::new(StubState::new(stub)));
         true
     }
 
@@ -58,9 +58,10 @@ impl Imposter {
         match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
             Some(i) => {
                 stub.id = Some(id.to_string());
-                // Swap the stub in place (like the index-based replace) to keep the slot's
-                // response-cycling state, rather than replacing the whole StubState.
-                stubs[i].stub = stub;
+                // Swap a fresh Arc that reuses the slot's cycler + slot token, so the slot's
+                // response-cycling state is kept and in-flight requests holding the old Arc keep
+                // serving their snapshot (issue #287).
+                stubs[i] = Arc::new(stubs[i].with_stub(stub));
                 true
             }
             None => false,
@@ -95,7 +96,8 @@ impl Imposter {
         if index >= stubs.len() {
             return Err(ImposterError::StubIndexOutOfBounds(index));
         }
-        stubs[index].stub = stub;
+        // Reuse the slot's cycler + slot token (issue #287); see `replace_stub_by_id`.
+        stubs[index] = Arc::new(stubs[index].with_stub(stub));
         Ok(())
     }
 

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -15,7 +15,7 @@ impl Imposter {
         headers: &hyper::HeaderMap,
         query: Option<&str>,
         body: Option<&str>,
-    ) -> anyhow::Result<Option<(StubState, usize)>> {
+    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
         // Call the extended version with no client info (backward compatible)
         self.find_matching_stub_with_client(method, path, headers, query, body, None, None)
     }
@@ -31,7 +31,7 @@ impl Imposter {
         body: Option<&str>,
         request_from: Option<&str>,
         client_ip: Option<&str>,
-    ) -> anyhow::Result<Option<(StubState, usize)>> {
+    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
         let stubs = self.stubs.read();
         let headers_map = Self::header_map_to_hashmap(headers);
         // Parse form data if Content-Type is application/x-www-form-urlencoded
@@ -70,19 +70,14 @@ impl Imposter {
                 form.as_ref(),
                 imposter_port,
             ) {
-                // PERF NOTE: this deep-clones the matched `Stub` on every request. The clone is
-                // load-bearing, not accidental: the caller (`handler.rs`) holds the returned
-                // `StubState` across `.await` points (async proxying / response building), so the
-                // `parking_lot` read guard held here MUST be released before returning — a guard
-                // cannot be held across an await without blocking all writers for the request's
-                // lifetime. Returning only `index` would force the caller to re-lock (racy against
-                // concurrent `replace_stub`) or hold the guard across await. The response-cycling
-                // state is already shared cheaply: `StubState.cycler` is an `Arc`, so advancing the
-                // cycler on this clone is visible through the stored stub. Eliminating the `Stub`
-                // clone cleanly would mean making `StubState.stub` an `Arc<Stub>` — a broader field
-                // retype across every `.stub` access/mutation site, deferred out of this
-                // behavior-preserving pass.
-                return Ok(Some((stub_state.clone(), index)));
+                // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
+                // The caller (`handler.rs`) holds the returned `Arc<StubState>` across `.await`
+                // points, so the `parking_lot` read guard must be released before returning; the
+                // `Arc` lets it do so without a copy. Response-cycling state stays shared: the
+                // `cycler` is itself an `Arc`, so advancing it via this handle is visible through
+                // the stored stub, and an in-place replace swaps a new `Arc` while in-flight
+                // requests keep serving their snapshot.
+                return Ok(Some((Arc::clone(stub_state), index)));
             }
         }
         Ok(None)

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -98,13 +98,26 @@ impl StubState {
         let response_idx = self.cycler.peek_response_index(responses.len() as u32);
         self.stub.responses.get(response_idx as usize)
     }
+
+    /// A copy carrying `stub` but preserving this slot's response-cycling state (the shared
+    /// `cycler`) and `slot`. Used by the reconcile/replace paths to swap stub content in place
+    /// now that states live behind `Arc` and cannot be mutated through a shared reference.
+    #[must_use]
+    pub(crate) fn with_stub(&self, stub: Stub) -> Self {
+        Self {
+            stub,
+            cycler: Arc::clone(&self.cycler),
+            slot: self.slot,
+        }
+    }
 }
 
 /// Runtime state of an imposter
 pub struct Imposter {
     pub config: ImposterConfig,
-    /// Mutable stubs (can be modified at runtime)
-    pub stubs: RwLock<Vec<StubState>>,
+    /// Mutable stubs (can be modified at runtime). Stored behind `Arc` so a matched request
+    /// takes a refcount bump instead of deep-cloning the whole `StubState` (issue #287).
+    pub stubs: RwLock<Vec<Arc<StubState>>>,
     /// Proxy-recording backend (issue #315); defaults to a private port-scoped
     /// [`LocalProxyStore`] for this imposter's mode, or the embedder's shared store injected
     /// via [`ImposterManager::with_proxy_store`](crate::imposter::ImposterManager::with_proxy_store).
@@ -159,10 +172,10 @@ impl Imposter {
         sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
         journal: Option<Arc<dyn crate::imposter::journal::RequestJournal>>,
     ) -> Self {
-        let stubs: Vec<StubState> = config
+        let stubs: Vec<Arc<StubState>> = config
             .stubs
             .iter()
-            .map(|stub| StubState::new(stub.clone()))
+            .map(|stub| Arc::new(StubState::new(stub.clone())))
             .collect();
 
         // Extract proxy mode from stubs (use first proxy response's mode)
@@ -190,7 +203,7 @@ impl Imposter {
     pub fn replace_stubs(&self, new_stubs: Vec<Stub>) {
         let mut stubs = self.stubs.write();
         stubs.clear();
-        stubs.extend(new_stubs.into_iter().map(StubState::new));
+        stubs.extend(new_stubs.into_iter().map(|s| Arc::new(StubState::new(s))));
     }
 
     /// Create flow store based on _rift.flowState configuration.
@@ -344,6 +357,159 @@ mod tests {
             ..Default::default()
         };
         Imposter::new(config)
+    }
+
+    #[test]
+    fn matched_stub_is_shared_arc_not_deep_cloned() {
+        // Gate for #287: a match returns the Arc<StubState> stored in the stub vector (a refcount
+        // bump), not a deep clone — proven by pointer identity with the stored entry.
+        let cfg = serde_json::from_value(json!({
+            "port": 0,
+            "protocol": "http",
+            "stubs": [
+                { "predicates": [{ "equals": { "path": "/shared" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "x" } }] }
+            ]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+        let headers = hyper::HeaderMap::new();
+        let (matched, index) = imp
+            .find_matching_stub_with_client("GET", "/shared", &headers, None, None, None, None)
+            .expect("store is infallible")
+            .expect("request must match");
+        let stored = std::sync::Arc::clone(&imp.stubs.read()[index]);
+        assert!(
+            std::sync::Arc::ptr_eq(&matched, &stored),
+            "matched stub must be the shared Arc, not a deep clone"
+        );
+    }
+
+    /// Serve the state's next response body, advancing the shared cycler.
+    fn served_body(state: &StubState) -> String {
+        let resp = state.get_next_response().expect("stub has responses");
+        serde_json::to_value(resp).expect("serialize")["is"]["body"]
+            .as_str()
+            .expect("string body")
+            .to_string()
+    }
+
+    #[test]
+    fn replace_stub_preserves_response_cursor() {
+        // Gate for #287: the index-based in-place replace reuses the slot's cycler (via
+        // `with_stub`), so the response cursor survives a content swap rather than resetting.
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/c" } }],
+                "responses": [
+                    { "is": { "statusCode": 200, "body": "A" } },
+                    { "is": { "statusCode": 200, "body": "B" } }
+                ]
+            }]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+        assert_eq!(served_body(&imp.stubs.read()[0]), "A"); // cursor now at index 1
+        let new = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/c" } }],
+            "responses": [
+                { "is": { "statusCode": 200, "body": "C" } },
+                { "is": { "statusCode": 200, "body": "D" } }
+            ]
+        }))
+        .unwrap();
+        imp.replace_stub(0, new).expect("index in bounds");
+        assert_eq!(
+            served_body(&imp.stubs.read()[0]),
+            "D",
+            "cursor (index 1) preserved and content swapped"
+        );
+    }
+
+    #[test]
+    fn replace_stub_by_id_preserves_response_cursor() {
+        // Same guarantee for the id-based in-place replace (#287).
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "id": "s1",
+                "predicates": [{ "equals": { "path": "/c" } }],
+                "responses": [
+                    { "is": { "statusCode": 200, "body": "A" } },
+                    { "is": { "statusCode": 200, "body": "B" } }
+                ]
+            }]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+        assert_eq!(served_body(&imp.stubs.read()[0]), "A"); // cursor now at index 1
+        let new = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/c" } }],
+            "responses": [
+                { "is": { "statusCode": 200, "body": "C" } },
+                { "is": { "statusCode": 200, "body": "D" } }
+            ]
+        }))
+        .unwrap();
+        assert!(imp.replace_stub_by_id("s1", new), "id exists");
+        assert_eq!(
+            served_body(&imp.stubs.read()[0]),
+            "D",
+            "cursor (index 1) preserved and content swapped"
+        );
+    }
+
+    #[test]
+    fn proxy_always_append_preserves_cursor_and_slot() {
+        // Gate for #287: the proxyAlways append branch rebuilds the entry via `with_stub`, so
+        // the appended-to stub keeps its slot token and response cursor rather than getting a
+        // fresh StubState.
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{ "responses": [{ "proxy": { "to": "http://upstream", "mode": "proxyAlways" } }] }]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+
+        // First record → inserted after the proxy stub (insert branch), 2 responses.
+        let rec = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/rec" } }],
+            "responses": [
+                { "is": { "statusCode": 200, "body": "R1" } },
+                { "is": { "statusCode": 200, "body": "R2" } }
+            ]
+        }))
+        .unwrap();
+        imp.insert_or_append_proxy_stub(rec, "http://upstream", "proxyAlways");
+
+        let rec_index = imp
+            .stubs
+            .read()
+            .iter()
+            .position(|s| !s.stub.predicates.is_empty())
+            .expect("recorded stub present");
+        let slot_before = imp.stubs.read()[rec_index].slot;
+        assert_eq!(served_body(&imp.stubs.read()[rec_index]), "R1"); // cursor now at index 1
+
+        // Second record with identical predicates → append branch: responses become [R1, R2, R3].
+        let rec2 = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/rec" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "R3" } }]
+        }))
+        .unwrap();
+        imp.insert_or_append_proxy_stub(rec2, "http://upstream", "proxyAlways");
+
+        assert_eq!(
+            imp.stubs.read()[rec_index].slot,
+            slot_before,
+            "append must reuse the slot token, not mint a fresh StubState"
+        );
+        assert_eq!(
+            served_body(&imp.stubs.read()[rec_index]),
+            "R2",
+            "cursor (index 1) preserved across the append"
+        );
     }
 
     // Fix #95: Multi-valued form fields are now comma-joined instead of overwritten

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -186,7 +186,7 @@ impl Imposter {
 
     /// Insert a generated stub at the specified index
     pub fn insert_generated_stub(&self, stub: Stub, before_index: usize) {
-        let new_stub_state = StubState::new(stub);
+        let new_stub_state = Arc::new(StubState::new(stub));
         let mut stubs = self.stubs.write();
         let index = before_index.min(stubs.len());
         stubs.insert(index, new_stub_state);
@@ -235,19 +235,22 @@ impl Imposter {
                 .map(|(idx, _)| idx);
 
             if let Some(idx) = matching_stub_idx {
-                // Append responses to existing stub
-                stubs[idx].stub.responses.extend(stub.responses);
+                // Append responses to the existing stub. States live behind `Arc` (issue #287),
+                // so rebuild the entry from a stub with the extended responses while reusing the
+                // slot's cycler + slot token.
+                let mut merged = stubs[idx].stub.clone();
+                merged.responses.extend(stub.responses);
+                let total = merged.responses.len();
+                stubs[idx] = Arc::new(stubs[idx].with_stub(merged));
                 debug!(
-                    "Appended response to existing stub at index {} (proxyAlways mode, {} total responses)",
-                    idx,
-                    stubs[idx].stub.responses.len()
+                    "Appended response to existing stub at index {idx} (proxyAlways mode, {total} total responses)"
                 );
                 return;
             }
 
             // No matching stub found: insert new stub AFTER the proxy stub
             let insert_index = (proxy_stub_index + 1).min(stubs.len());
-            stubs.insert(insert_index, StubState::new(stub));
+            stubs.insert(insert_index, Arc::new(StubState::new(stub)));
             debug!(
                 "Inserted generated stub at index {} after proxy (proxyAlways mode)",
                 insert_index
@@ -256,7 +259,7 @@ impl Imposter {
             // For proxyOnce: insert new stub BEFORE the proxy stub
             // This ensures the recorded stub matches first on subsequent requests
             let index = proxy_stub_index.min(stubs.len());
-            stubs.insert(index, StubState::new(stub));
+            stubs.insert(index, Arc::new(StubState::new(stub)));
             debug!(
                 "Inserted generated stub at index {} before proxy (proxyOnce mode)",
                 index

--- a/crates/rift-core/src/imposter/reconcile.rs
+++ b/crates/rift-core/src/imposter/reconcile.rs
@@ -4,6 +4,7 @@
 use super::core::StubState;
 use super::types::{ImposterError, Stub};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tracing::error;
 
 /// Outcome of [`ImposterManager::apply_config`](super::ImposterManager::apply_config):
@@ -110,7 +111,7 @@ pub(crate) enum StubReconcile {
 /// `replace_stub_by_id`. Returns `Degenerate` — without mutating — when the changed
 /// fraction exceeds 1/2 (pure moves cost nothing in that metric).
 pub(crate) fn reconcile_stub_states(
-    states: &mut Vec<StubState>,
+    states: &mut Vec<Arc<StubState>>,
     desired: Vec<Stub>,
 ) -> StubReconcile {
     let old_keys = stub_keys_iter(states.iter().map(|s| &s.stub));
@@ -143,19 +144,22 @@ pub(crate) fn reconcile_stub_states(
         return StubReconcile::Degenerate;
     }
 
-    let mut by_key: HashMap<String, StubState> =
+    let mut by_key: HashMap<String, Arc<StubState>> =
         old_keys.into_iter().zip(states.drain(..)).collect();
     *states = new_keys
         .into_iter()
         .zip(desired)
         .map(|(key, stub)| match by_key.remove(&key) {
-            Some(mut state) => {
+            // Same key: keep the slot's cycler + slot token; only rebuild the Arc when the
+            // stub content actually changed (issue #287).
+            Some(state) => {
                 if stubs_differ(&state.stub, &stub) {
-                    state.stub = stub;
+                    Arc::new(state.with_stub(stub))
+                } else {
+                    state
                 }
-                state
             }
-            None => StubState::new(stub),
+            None => Arc::new(StubState::new(stub)),
         })
         .collect();
     let removed_keys = by_key
@@ -208,6 +212,11 @@ mod tests {
                 {"is": {"statusCode": 200, "body": second}}
             ]
         }))
+    }
+
+    /// Build a live stub state (states are stored behind `Arc` since #287).
+    fn st(stub: Stub) -> Arc<StubState> {
+        Arc::new(StubState::new(stub))
     }
 
     /// Serve the state's next response and return its body (advances the cycler).
@@ -277,9 +286,9 @@ mod tests {
     #[test]
     fn patch_preserves_untouched_stub_cursors() {
         let mut states = vec![
-            StubState::new(two_resp("a1", "a2")),
-            StubState::new(one_resp("b")),
-            StubState::new(one_resp("c")),
+            st(two_resp("a1", "a2")),
+            st(one_resp("b")),
+            st(one_resp("c")),
         ];
         assert_eq!(next_body(&states[0]), "a1");
 
@@ -299,10 +308,7 @@ mod tests {
 
     #[test]
     fn pure_reorder_preserves_all_cursors() {
-        let mut states = vec![
-            StubState::new(two_resp("a1", "a2")),
-            StubState::new(two_resp("b1", "b2")),
-        ];
+        let mut states = vec![st(two_resp("a1", "a2")), st(two_resp("b1", "b2"))];
         assert_eq!(next_body(&states[0]), "a1");
         assert_eq!(next_body(&states[1]), "b1");
 
@@ -317,7 +323,7 @@ mod tests {
 
     #[test]
     fn degenerate_ratio_falls_back_without_mutating() {
-        let mut states = vec![StubState::new(one_resp("a")), StubState::new(one_resp("b"))];
+        let mut states = vec![st(one_resp("a")), st(one_resp("b"))];
         let outcome = reconcile_stub_states(&mut states, vec![one_resp("x"), one_resp("y")]);
         assert!(matches!(outcome, StubReconcile::Degenerate));
         assert_eq!(
@@ -330,7 +336,7 @@ mod tests {
 
     #[test]
     fn identical_stubs_are_unchanged() {
-        let mut states = vec![StubState::new(one_resp("a")), StubState::new(one_resp("b"))];
+        let mut states = vec![st(one_resp("a")), st(one_resp("b"))];
         let outcome = reconcile_stub_states(&mut states, vec![one_resp("a"), one_resp("b")]);
         assert!(matches!(outcome, StubReconcile::Unchanged));
     }
@@ -339,11 +345,7 @@ mod tests {
     fn same_id_content_change_patches_in_place_keeping_cursor() {
         let mut with_id = two_resp("v1a", "v1b");
         with_id.id = Some("s1".into());
-        let mut states = vec![
-            StubState::new(with_id),
-            StubState::new(one_resp("b")),
-            StubState::new(one_resp("c")),
-        ];
+        let mut states = vec![st(with_id), st(one_resp("b")), st(one_resp("c"))];
         assert_eq!(next_body(&states[0]), "v1a");
 
         let mut updated = two_resp("v2a", "v2b");
@@ -361,9 +363,9 @@ mod tests {
     #[test]
     fn insertion_below_threshold_patches() {
         let mut states = vec![
-            StubState::new(two_resp("a1", "a2")),
-            StubState::new(one_resp("b")),
-            StubState::new(one_resp("c")),
+            st(two_resp("a1", "a2")),
+            st(one_resp("b")),
+            st(one_resp("c")),
         ];
         assert_eq!(next_body(&states[0]), "a1");
 


### PR DESCRIPTION
Store imposter stubs as Vec<Arc<StubState>> and return Arc<StubState> from the matcher,
so matched requests bump the refcount instead of deep-cloning the entire stub
(all responses, predicates, extensions). In-place replaces rebuild the Arc while
preserving cycling state.

Note: breaking change — `Imposter.stubs` element type is now `Arc<StubState>`.

Closes #287
Milestone: Performance & load-capacity roadmap (#300)