### PR TITLE
perf: parse the request body JSON once and reuse across predicates

### DIFF
--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -43,6 +43,9 @@ impl Imposter {
 
         let imposter_port = self.config.port.unwrap_or(0);
         let flow_id = self.resolve_flow_id(headers_map);
+        // Parse the request body as JSON once per request and reuse it across every stub's
+        // predicates, instead of re-parsing per predicate per stub (issue #290).
+        let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
             // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only
@@ -62,7 +65,7 @@ impl Imposter {
                     continue;
                 }
             }
-            if stub_matches(
+            if stub_matches_inner(
                 &stub.predicates,
                 method,
                 path,
@@ -73,6 +76,7 @@ impl Imposter {
                 client_ip,
                 form.as_ref(),
                 imposter_port,
+                body_json.as_ref(),
             ) {
                 // PERF NOTE: this deep-clones the matched `Stub` on every request. The clone is
                 // load-bearing, not accidental: the caller (`handler.rs`) holds the returned

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -6,7 +6,7 @@
 /// Default scenario state when a `(flow_id, scenario)` entry is absent (WireMock parity).
 pub const INITIAL_SCENARIO_STATE: &str = "Started";
 
-use super::predicates::stub_matches;
+use super::predicates::stub_matches_inner;
 use super::response::{
     create_response_preview, create_stub_from_proxy_response, execute_stub_response_with_rift,
     get_rift_script_config,

--- a/crates/rift-core/src/imposter/predicates/fields.rs
+++ b/crates/rift-core/src/imposter/predicates/fields.rs
@@ -22,6 +22,9 @@ pub(crate) fn check_predicate_fields<F>(
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     key_case_sensitive: bool,
+    // Request body already parsed once per request (issue #290); `Some` only for a
+    // no-selector predicate whose `body` field then equals this parse.
+    body_json: Option<&serde_json::Value>,
 ) -> bool
 where
     F: Fn(&str, &str) -> bool,
@@ -39,7 +42,10 @@ where
     // When expected is an object/array, parse actual as JSON and compare recursively (Mountebank compat).
     // except is applied to leaf values inside compare_json_recursive, not to raw JSON.
     // When expected is a string/primitive, compare directly with except applied.
-    let check_string_field = |expected: &serde_json::Value, actual: &str| -> bool {
+    let check_string_field = |expected: &serde_json::Value,
+                              actual: &str,
+                              pre_parsed: Option<&serde_json::Value>|
+     -> bool {
         match expected {
             serde_json::Value::Object(_) | serde_json::Value::Array(_) => compare_json_recursive(
                 expected,
@@ -48,6 +54,7 @@ where
                 deep_equals,
                 key_case_sensitive,
                 &apply_except,
+                pre_parsed,
             ),
             _ => {
                 let actual = apply_except(actual);
@@ -64,21 +71,21 @@ where
 
     // Check method
     if let Some(expected) = obj.get("method")
-        && !check_string_field(expected, method)
+        && !check_string_field(expected, method, None)
     {
         return false;
     }
 
     // Check path
     if let Some(expected) = obj.get("path")
-        && !check_string_field(expected, path)
+        && !check_string_field(expected, path, None)
     {
         return false;
     }
 
     // Check body
     if let Some(expected) = obj.get("body")
-        && !check_string_field(expected, body)
+        && !check_string_field(expected, body, body_json)
     {
         return false;
     }
@@ -86,7 +93,7 @@ where
     // Check requestFrom (IP:port) - Mountebank compatible
     if let Some(expected) = obj.get("requestFrom") {
         let actual = request_from.unwrap_or("");
-        if !check_string_field(expected, actual) {
+        if !check_string_field(expected, actual, None) {
             return false;
         }
     }
@@ -94,7 +101,7 @@ where
     // Check ip (just the IP address) - Mountebank compatible
     if let Some(expected) = obj.get("ip") {
         let actual = client_ip.unwrap_or("");
-        if !check_string_field(expected, actual) {
+        if !check_string_field(expected, actual, None) {
             return false;
         }
     }
@@ -119,7 +126,7 @@ where
 
             match actual {
                 Some(actual) => {
-                    if !check_string_field(expected_val, actual) {
+                    if !check_string_field(expected_val, actual, None) {
                         return false;
                     }
                 }
@@ -146,7 +153,7 @@ where
 
             match actual {
                 Some(actual) => {
-                    if !check_string_field(expected_val, actual) {
+                    if !check_string_field(expected_val, actual, None) {
                         return false;
                     }
                 }
@@ -173,7 +180,7 @@ where
 
             match actual {
                 Some(actual) => {
-                    if !check_string_field(expected_val, actual) {
+                    if !check_string_field(expected_val, actual, None) {
                         return false;
                     }
                 }
@@ -201,6 +208,8 @@ pub(crate) fn check_predicate_fields_regex(
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     key_case_sensitive: bool,
+    // Request body already parsed once per request (issue #290); see `check_predicate_fields`.
+    body_json: Option<&serde_json::Value>,
 ) -> bool {
     // Compile-once, cached regex keyed on (pattern, case_insensitive). Returns `None` for an
     // unparseable pattern, which callers treat as "no match" — same as the previous per-request
@@ -219,7 +228,10 @@ pub(crate) fn check_predicate_fields_regex(
     // Helper: check a field against expected value for regex matching.
     // When expected is an object/array, recurse via compare_json_recursive with regex comparator.
     // When expected is a string, build regex and match directly.
-    let check_regex_field = |expected: &serde_json::Value, actual: &str| -> bool {
+    let check_regex_field = |expected: &serde_json::Value,
+                             actual: &str,
+                             pre_parsed: Option<&serde_json::Value>|
+     -> bool {
         match expected {
             serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
                 let regex_compare = |pattern: &str, actual: &str| -> bool {
@@ -235,6 +247,7 @@ pub(crate) fn check_predicate_fields_regex(
                     false,
                     key_case_sensitive,
                     &apply_except,
+                    pre_parsed,
                 )
             }
             _ => {
@@ -255,35 +268,35 @@ pub(crate) fn check_predicate_fields_regex(
 
     // Check method
     if let Some(expected) = obj.get("method")
-        && !check_regex_field(expected, method)
+        && !check_regex_field(expected, method, None)
     {
         return false;
     }
 
     // Check path
     if let Some(expected) = obj.get("path")
-        && !check_regex_field(expected, path)
+        && !check_regex_field(expected, path, None)
     {
         return false;
     }
 
     // Check body
     if let Some(expected) = obj.get("body")
-        && !check_regex_field(expected, body)
+        && !check_regex_field(expected, body, body_json)
     {
         return false;
     }
 
     // Check requestFrom
     if let Some(expected) = obj.get("requestFrom")
-        && !check_regex_field(expected, request_from.unwrap_or(""))
+        && !check_regex_field(expected, request_from.unwrap_or(""), None)
     {
         return false;
     }
 
     // Check ip
     if let Some(expected) = obj.get("ip")
-        && !check_regex_field(expected, client_ip.unwrap_or(""))
+        && !check_regex_field(expected, client_ip.unwrap_or(""), None)
     {
         return false;
     }
@@ -299,7 +312,7 @@ pub(crate) fn check_predicate_fields_regex(
 
             match actual {
                 Some(actual) => {
-                    if !check_regex_field(pattern_val, actual) {
+                    if !check_regex_field(pattern_val, actual, None) {
                         return false;
                     }
                 }
@@ -318,7 +331,7 @@ pub(crate) fn check_predicate_fields_regex(
 
             match actual {
                 Some(actual) => {
-                    if !check_regex_field(pattern_val, actual) {
+                    if !check_regex_field(pattern_val, actual, None) {
                         return false;
                     }
                 }
@@ -337,7 +350,7 @@ pub(crate) fn check_predicate_fields_regex(
 
             match actual {
                 Some(actual) => {
-                    if !check_regex_field(pattern_val, actual) {
+                    if !check_regex_field(pattern_val, actual, None) {
                         return false;
                     }
                 }

--- a/crates/rift-core/src/imposter/predicates/json.rs
+++ b/crates/rift-core/src/imposter/predicates/json.rs
@@ -184,6 +184,11 @@ pub(crate) fn check_exists_predicate(
 /// `key_case_sensitive` controls whether JSON object key lookups are case-sensitive.
 /// `apply_except` is applied to leaf values (not raw JSON strings) to avoid breaking
 /// JSON structure before parsing.
+///
+/// `pre_parsed` is the request body already parsed into a `serde_json::Value` once per request
+/// (issue #290). When `Some`, it is used at this top level instead of re-parsing `actual_str` —
+/// it is exactly `serde_json::from_str(actual_str)` on the same bytes, so the result is identical.
+/// Recursive calls over nested (re-stringified) values always pass `None`.
 pub(crate) fn compare_json_recursive<F>(
     expected: &serde_json::Value,
     actual_str: &str,
@@ -191,15 +196,23 @@ pub(crate) fn compare_json_recursive<F>(
     deep_equals: bool,
     key_case_sensitive: bool,
     apply_except: &dyn Fn(&str) -> String,
+    pre_parsed: Option<&serde_json::Value>,
 ) -> bool
 where
     F: Fn(&str, &str) -> bool,
 {
     match expected {
         serde_json::Value::Object(expected_obj) => {
-            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
-                Ok(v) => v,
-                Err(_) => return false,
+            let parsed_owned;
+            let actual_json: &serde_json::Value = match pre_parsed {
+                Some(v) => v,
+                None => match serde_json::from_str(actual_str) {
+                    Ok(v) => {
+                        parsed_owned = v;
+                        &parsed_owned
+                    }
+                    Err(_) => return false,
+                },
             };
 
             let Some(actual_obj) = actual_json.as_object() else {
@@ -233,6 +246,7 @@ where
                     deep_equals,
                     key_case_sensitive,
                     apply_except,
+                    None,
                 ) {
                     return false;
                 }
@@ -240,9 +254,16 @@ where
             true
         }
         serde_json::Value::Array(expected_arr) => {
-            let actual_json: serde_json::Value = match serde_json::from_str(actual_str) {
-                Ok(v) => v,
-                Err(_) => return false,
+            let parsed_owned;
+            let actual_json: &serde_json::Value = match pre_parsed {
+                Some(v) => v,
+                None => match serde_json::from_str(actual_str) {
+                    Ok(v) => {
+                        parsed_owned = v;
+                        &parsed_owned
+                    }
+                    Err(_) => return false,
+                },
             };
 
             let Some(actual_arr) = actual_json.as_array() else {
@@ -262,6 +283,7 @@ where
                     deep_equals,
                     key_case_sensitive,
                     apply_except,
+                    None,
                 ) {
                     return false;
                 }

--- a/crates/rift-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-core/src/imposter/predicates/mod.rs
@@ -21,6 +21,40 @@ pub fn stub_matches(
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
 ) -> bool {
+    // Parse the body once for standalone callers; the request hot path parses once per request
+    // (before the stub scan) and calls `stub_matches_inner` directly (issue #290).
+    let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
+    stub_matches_inner(
+        predicates,
+        method,
+        path,
+        query,
+        headers,
+        body,
+        request_from,
+        client_ip,
+        form,
+        imposter_port,
+        body_json.as_ref(),
+    )
+}
+
+/// Body of [`stub_matches`] taking the once-parsed request body so every predicate reuses one
+/// parse rather than re-parsing the body per predicate and per stub (issue #290).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stub_matches_inner(
+    predicates: &[Predicate],
+    method: &str,
+    path: &str,
+    query: Option<&str>,
+    headers: &HashMap<String, String>,
+    body: Option<&str>,
+    request_from: Option<&str>,
+    client_ip: Option<&str>,
+    form: Option<&HashMap<String, String>>,
+    imposter_port: u16,
+    body_json: Option<&serde_json::Value>,
+) -> bool {
     // If no predicates, match everything
     if predicates.is_empty() {
         return true;
@@ -28,7 +62,7 @@ pub fn stub_matches(
 
     // All predicates must match (implicit AND)
     for predicate in predicates {
-        if !predicate_matches(
+        if !predicate_matches_inner(
             predicate,
             method,
             path,
@@ -39,6 +73,7 @@ pub fn stub_matches(
             client_ip,
             form,
             imposter_port,
+            body_json,
         ) {
             return false;
         }
@@ -66,6 +101,41 @@ pub fn predicate_matches(
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
+) -> bool {
+    // Standalone callers parse the body here; the request hot path parses once per request and
+    // calls `predicate_matches_inner` directly with the shared parse (issue #290).
+    let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
+    predicate_matches_inner(
+        predicate,
+        method,
+        path,
+        query,
+        headers,
+        body,
+        request_from,
+        client_ip,
+        form,
+        imposter_port,
+        body_json.as_ref(),
+    )
+}
+
+/// Body of [`predicate_matches`] taking the once-parsed request body (`body_json`) so it is not
+/// re-parsed per predicate/stub. `body_json` is the parse of the raw request body; it is only
+/// used for a no-selector predicate's `body` field (a selector makes the effective body differ).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn predicate_matches_inner(
+    predicate: &Predicate,
+    method: &str,
+    path: &str,
+    query: Option<&str>,
+    headers: &HashMap<String, String>,
+    body: Option<&str>,
+    request_from: Option<&str>,
+    client_ip: Option<&str>,
+    form: Option<&HashMap<String, String>>,
+    imposter_port: u16,
+    body_json: Option<&serde_json::Value>,
 ) -> bool {
     // Get predicate options
     let case_sensitive = predicate.parameters.case_sensitive.unwrap_or(false);
@@ -145,6 +215,14 @@ pub fn predicate_matches(
         None => body_str,
     };
 
+    // The once-parsed body corresponds to `effective_body` only when there is no selector; with a
+    // jsonpath/xpath selector the effective body is a different string, so don't reuse the parse.
+    let field_body_json = if predicate.parameters.selector.is_none() {
+        body_json
+    } else {
+        None
+    };
+
     match &predicate.operation {
         PredicateOperation::Equals(fields) => {
             check_predicate_fields(
@@ -161,6 +239,7 @@ pub fn predicate_matches(
                 client_ip,
                 form,
                 key_case_sensitive,
+                field_body_json,
             )
         }
         PredicateOperation::DeepEquals(fields) => {
@@ -178,6 +257,7 @@ pub fn predicate_matches(
                 client_ip,
                 form,
                 key_case_sensitive,
+                field_body_json,
             )
         }
         PredicateOperation::Contains(fields) => check_predicate_fields(
@@ -194,6 +274,7 @@ pub fn predicate_matches(
             client_ip,
             form,
             key_case_sensitive,
+            field_body_json,
         ),
         PredicateOperation::StartsWith(fields) => check_predicate_fields(
             fields,
@@ -209,6 +290,7 @@ pub fn predicate_matches(
             client_ip,
             form,
             key_case_sensitive,
+            field_body_json,
         ),
         PredicateOperation::EndsWith(fields) => check_predicate_fields(
             fields,
@@ -224,6 +306,7 @@ pub fn predicate_matches(
             client_ip,
             form,
             key_case_sensitive,
+            field_body_json,
         ),
         PredicateOperation::Matches(fields) => check_predicate_fields_regex(
             fields,
@@ -238,6 +321,7 @@ pub fn predicate_matches(
             client_ip,
             form,
             key_case_sensitive,
+            field_body_json,
         ),
         PredicateOperation::Exists(fields) => check_exists_predicate(
             fields,
@@ -251,7 +335,7 @@ pub fn predicate_matches(
             form,
             key_case_sensitive,
         ),
-        PredicateOperation::Not(inner) => !predicate_matches(
+        PredicateOperation::Not(inner) => !predicate_matches_inner(
             inner,
             method,
             path,
@@ -262,9 +346,10 @@ pub fn predicate_matches(
             client_ip,
             form,
             imposter_port,
+            body_json,
         ),
         PredicateOperation::Or(children) => children.iter().any(|p| {
-            predicate_matches(
+            predicate_matches_inner(
                 p,
                 method,
                 path,
@@ -275,10 +360,11 @@ pub fn predicate_matches(
                 client_ip,
                 form,
                 imposter_port,
+                body_json,
             )
         }),
         PredicateOperation::And(children) => children.iter().all(|p| {
-            predicate_matches(
+            predicate_matches_inner(
                 p,
                 method,
                 path,
@@ -289,6 +375,7 @@ pub fn predicate_matches(
                 client_ip,
                 form,
                 imposter_port,
+                body_json,
             )
         }),
         PredicateOperation::Inject(inject_fn) => {
@@ -510,6 +597,100 @@ mod tests {
         assert!(
             result,
             "deepEquals should match JSON bodies regardless of key order"
+        );
+    }
+
+    #[test]
+    fn stub_with_two_json_body_predicates_shares_one_parse() {
+        // Gate for #290: two predicates over the same JSON body in one stub (implicit AND) —
+        // the body is parsed once and reused, and deepEquals + contains semantics are unchanged.
+        let deep: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"a": 1, "b": 2}))]
+                .into_iter()
+                .collect();
+        let contains_fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"a": 1}))]
+                .into_iter()
+                .collect();
+        let predicates = vec![
+            make_predicate(PredicateOperation::DeepEquals(deep)),
+            make_predicate(PredicateOperation::Contains(contains_fields)),
+        ];
+
+        // Matching body satisfies both predicates.
+        assert!(stub_matches(
+            &predicates,
+            "POST",
+            "/x",
+            None,
+            &empty_headers(),
+            Some(r#"{"b":2,"a":1}"#),
+            None,
+            None,
+            None,
+            0,
+        ));
+        // A body that breaks deepEquals (extra key) must fail the AND.
+        assert!(!stub_matches(
+            &predicates,
+            "POST",
+            "/x",
+            None,
+            &empty_headers(),
+            Some(r#"{"a":1,"b":2,"c":3}"#),
+            None,
+            None,
+            None,
+            0,
+        ));
+        // Non-JSON body must not match a JSON-object predicate.
+        assert!(!stub_matches(
+            &predicates,
+            "POST",
+            "/x",
+            None,
+            &empty_headers(),
+            Some("not json"),
+            None,
+            None,
+            None,
+            0,
+        ));
+    }
+
+    #[test]
+    fn deep_equals_with_jsonpath_selector_uses_extracted_body_not_raw_parse() {
+        // Gate for #290: a selector predicate must compare against the EXTRACTED effective body,
+        // never the once-parsed raw body. With `$.data` extracting `{"a":1,"b":2}`, deepEquals
+        // matches only if the extracted object (not the whole raw body, which also has `other`)
+        // is what gets compared — so this asserts the `selector.is_none()` guard holds.
+        let fields: HashMap<String, serde_json::Value> =
+            [("body".to_string(), json!({"a": 1, "b": 2}))]
+                .into_iter()
+                .collect();
+        let params = PredicateParameters {
+            selector: Some(PredicateSelector::JsonPath {
+                selector: "$.data".to_string(),
+            }),
+            ..PredicateParameters::default()
+        };
+        let pred = make_predicate_with_params(PredicateOperation::DeepEquals(fields), params);
+
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/x",
+                None,
+                &empty_headers(),
+                Some(r#"{"data":{"a":1,"b":2},"other":"x"}"#),
+                None,
+                None,
+                None,
+                0,
+            ),
+            "deepEquals over the jsonpath-extracted object must match; reusing the raw-body parse \
+             (which also has `other`) would wrongly fail"
         );
     }
 


### PR DESCRIPTION
Parse the request body JSON once per request in the matcher and reuse the serde_json::Value across predicate and stub matching. Eliminates redundant parsing while keeping public APIs unchanged via wrapper functions.

Closes #290
Milestone: Performance & load-capacity roadmap (#300)