### PR TITLE
perf: wait-free stub reads via arc-swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "arc-swap",
  "base64 0.22.1",
  "boa_engine",
  "bytes",

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -71,6 +71,7 @@ socket2 = "0.5"
 num_cpus = "1.16"
 libc = "0.2"
 parking_lot = "0.12"
+arc-swap = "1.7"
 crossbeam = "0.8"
 
 # XML/XPath support

--- a/crates/rift-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-core/src/imposter/core/lifecycle.rs
@@ -9,82 +9,86 @@ impl Imposter {
     /// Move the stub at `from` to position `to`, carrying its cycling state with it
     /// (issue #316). Stub order is match priority, so this changes matching precedence.
     pub fn move_stub(&self, from: usize, to: usize) -> Result<(), ImposterError> {
-        let mut stubs = self.stubs.write();
-        if from >= stubs.len() {
-            return Err(ImposterError::StubIndexOutOfBounds(from));
-        }
-        if to >= stubs.len() {
-            return Err(ImposterError::StubIndexOutOfBounds(to));
-        }
-        let state = stubs.remove(from);
-        stubs.insert(to, state);
-        Ok(())
+        self.mutate_stubs(|stubs| {
+            if from >= stubs.len() {
+                return Err(ImposterError::StubIndexOutOfBounds(from));
+            }
+            if to >= stubs.len() {
+                return Err(ImposterError::StubIndexOutOfBounds(to));
+            }
+            let state = stubs.remove(from);
+            stubs.insert(to, state);
+            Ok(())
+        })
     }
 
-    /// Reconcile live stubs toward `desired` under one write lock (issue #316).
+    /// Reconcile live stubs toward `desired` under one write critical section (issue #316).
     pub(crate) fn reconcile_stubs(&self, desired: Vec<Stub>) -> StubReconcile {
-        reconcile_stub_states(&mut self.stubs.write(), desired)
+        self.mutate_stubs(|stubs| reconcile_stub_states(stubs, desired))
     }
 
     /// Add a stub at a specific index
     pub fn add_stub(&self, stub: Stub, index: Option<usize>) {
-        let mut stubs = self.stubs.write();
-        let idx = index.unwrap_or(stubs.len());
-        let idx = idx.min(stubs.len());
-        stubs.insert(idx, Arc::new(StubState::new(stub)));
+        self.mutate_stubs(|stubs| {
+            let idx = index.unwrap_or(stubs.len()).min(stubs.len());
+            stubs.insert(idx, Arc::new(StubState::new(stub)));
+        });
     }
 
     /// Add a stub, rejecting it if its `id` duplicates an existing stub (issue #202). The
-    /// duplicate check and the insert happen under one write lock so concurrent adds can't race.
-    /// Returns `false` (not added) on id conflict — the caller holds the id for the error.
+    /// duplicate check and the insert happen under one write critical section so concurrent adds
+    /// can't race. Returns `false` (not added) on id conflict — the caller holds the id for the error.
     #[must_use]
     pub fn add_stub_unique(&self, stub: Stub, index: Option<usize>) -> bool {
-        let mut stubs = self.stubs.write();
-        if let Some(id) = stub.id.as_deref()
-            && stubs.iter().any(|s| s.stub.id.as_deref() == Some(id))
-        {
-            return false;
-        }
-        let idx = index.unwrap_or(stubs.len()).min(stubs.len());
-        stubs.insert(idx, Arc::new(StubState::new(stub)));
-        true
+        self.mutate_stubs(|stubs| {
+            if let Some(id) = stub.id.as_deref()
+                && stubs.iter().any(|s| s.stub.id.as_deref() == Some(id))
+            {
+                return false;
+            }
+            let idx = index.unwrap_or(stubs.len()).min(stubs.len());
+            stubs.insert(idx, Arc::new(StubState::new(stub)));
+            true
+        })
     }
 
     /// Replace the stub with `id` in place (position preserved). The replacement keeps `id` as its
     /// addressable id regardless of the supplied stub's `id`. Returns `false` if no such id.
     #[must_use]
     pub fn replace_stub_by_id(&self, id: &str, mut stub: Stub) -> bool {
-        let mut stubs = self.stubs.write();
-        match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
-            Some(i) => {
-                stub.id = Some(id.to_string());
-                // Swap a fresh Arc that reuses the slot's cycler + slot token, so the slot's
-                // response-cycling state is kept and in-flight requests holding the old Arc keep
-                // serving their snapshot (issue #287).
-                stubs[i] = Arc::new(stubs[i].with_stub(stub));
-                true
+        self.mutate_stubs(|stubs| {
+            match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
+                Some(i) => {
+                    stub.id = Some(id.to_string());
+                    // Swap a fresh Arc that reuses the slot's cycler + slot token, so the slot's
+                    // response-cycling state is kept and in-flight requests holding the old Arc keep
+                    // serving their snapshot (issue #287).
+                    stubs[i] = Arc::new(stubs[i].with_stub(stub));
+                    true
+                }
+                None => false,
             }
-            None => false,
-        }
+        })
     }
 
     /// Delete the stub with `id`. Returns `false` if no such id.
     #[must_use]
     pub fn delete_stub_by_id(&self, id: &str) -> bool {
-        let mut stubs = self.stubs.write();
-        match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
-            Some(i) => {
-                stubs.remove(i);
-                true
+        self.mutate_stubs(|stubs| {
+            match stubs.iter().position(|s| s.stub.id.as_deref() == Some(id)) {
+                Some(i) => {
+                    stubs.remove(i);
+                    true
+                }
+                None => false,
             }
-            None => false,
-        }
+        })
     }
 
     /// Get a clone of the stub with `id`, if present.
     pub fn get_stub_by_id(&self, id: &str) -> Option<Stub> {
         self.stubs
-            .read()
+            .load()
             .iter()
             .find(|s| s.stub.id.as_deref() == Some(id))
             .map(|s| s.stub.clone())
@@ -92,29 +96,31 @@ impl Imposter {
 
     /// Replace a stub at a specific index
     pub fn replace_stub(&self, index: usize, stub: Stub) -> Result<(), ImposterError> {
-        let mut stubs = self.stubs.write();
-        if index >= stubs.len() {
-            return Err(ImposterError::StubIndexOutOfBounds(index));
-        }
-        // Reuse the slot's cycler + slot token (issue #287); see `replace_stub_by_id`.
-        stubs[index] = Arc::new(stubs[index].with_stub(stub));
-        Ok(())
+        self.mutate_stubs(|stubs| {
+            if index >= stubs.len() {
+                return Err(ImposterError::StubIndexOutOfBounds(index));
+            }
+            // Reuse the slot's cycler + slot token (issue #287); see `replace_stub_by_id`.
+            stubs[index] = Arc::new(stubs[index].with_stub(stub));
+            Ok(())
+        })
     }
 
     /// Delete a stub at a specific index
     pub fn delete_stub(&self, index: usize) -> Result<(), ImposterError> {
-        let mut stubs = self.stubs.write();
-        if index >= stubs.len() {
-            return Err(ImposterError::StubIndexOutOfBounds(index));
-        }
-        stubs.remove(index);
-        Ok(())
+        self.mutate_stubs(|stubs| {
+            if index >= stubs.len() {
+                return Err(ImposterError::StubIndexOutOfBounds(index));
+            }
+            stubs.remove(index);
+            Ok(())
+        })
     }
 
     /// Get all stubs
     pub fn get_stubs(&self) -> Vec<Stub> {
         self.stubs
-            .read()
+            .load()
             .iter()
             .map(|stub_state| stub_state.stub.clone())
             .collect()
@@ -122,7 +128,7 @@ impl Imposter {
 
     /// Get a specific stub by index
     pub fn get_stub(&self, index: usize) -> Option<Stub> {
-        let stubs = self.stubs.read();
+        let stubs = self.stubs.load();
         stubs.get(index).map(|stub_state| stub_state.stub.clone())
     }
 

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -35,7 +35,7 @@ impl Imposter {
         request_from: Option<&str>,
         client_ip: Option<&str>,
     ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
-        let stubs = self.stubs.read();
+        let stubs = self.stubs.load();
         // `headers_map` is the single-value, Title-Case header view already built once by the
         // caller (#288) — no re-conversion from `HeaderMap` here.
         // Parse form data if Content-Type is application/x-www-form-urlencoded
@@ -80,8 +80,8 @@ impl Imposter {
             ) {
                 // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
                 // The caller (`handler.rs`) holds the returned `Arc<StubState>` across `.await`
-                // points, so the `parking_lot` read guard must be released before returning; the
-                // `Arc` lets it do so without a copy. Response-cycling state stays shared: the
+                // points, so the arc-swap load guard must be released before returning (issue #291);
+                // the `Arc` lets it do so without a copy. Response-cycling state stays shared: the
                 // `cycler` is itself an `Arc`, so advancing it via this handle is visible through
                 // the stored stub, and an in-place replace swaps a new `Arc` while in-flight
                 // requests keep serving their snapshot.
@@ -266,7 +266,7 @@ impl Imposter {
     pub fn scenario_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self
             .stubs
-            .read()
+            .load()
             .iter()
             .filter_map(|s| s.stub.scenario_name.clone())
             .collect();
@@ -278,7 +278,7 @@ impl Imposter {
     /// Stubs scoped to a given correlation space (issue #223).
     pub fn space_stubs(&self, space: &str) -> Vec<Stub> {
         self.stubs
-            .read()
+            .load()
             .iter()
             .filter(|s| s.stub.space.as_deref() == Some(space))
             .map(|s| s.stub.clone())
@@ -291,9 +291,7 @@ impl Imposter {
         // Snapshot scenario names BEFORE pruning stubs: a scenario declared only on this space's
         // stubs would otherwise vanish from scenario_names() and its state would never be reset.
         let scenarios = self.scenario_names();
-        self.stubs
-            .write()
-            .retain(|s| s.stub.space.as_deref() != Some(space));
+        self.mutate_stubs(|stubs| stubs.retain(|s| s.stub.space.as_deref() != Some(space)));
         // Best-effort across the slice's clears so one failure doesn't leave later scenarios
         // stale, but the first failure still surfaces (issues #318, #330) — never report a
         // clean teardown while stale recorded requests or scenario state persist in the backend.

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -24,7 +24,8 @@ use crate::recording::{
     RequestSignature,
 };
 use anyhow::Context;
-use parking_lot::RwLock;
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -116,8 +117,15 @@ impl StubState {
 pub struct Imposter {
     pub config: ImposterConfig,
     /// Mutable stubs (can be modified at runtime). Stored behind `Arc` so a matched request
-    /// takes a refcount bump instead of deep-cloning the whole `StubState` (issue #287).
-    pub stubs: RwLock<Vec<Arc<StubState>>>,
+    /// takes a refcount bump instead of deep-cloning the whole `StubState` (issue #287), and
+    /// behind `ArcSwap` so the match hot path reads wait-free (`load()`, no lock) while a
+    /// mutation atomically swaps in a fresh snapshot (issue #291). Serialize *writers* through
+    /// [`Self::mutate_stubs`] / `stubs_write`; never `store()` this field directly.
+    pub stubs: ArcSwap<Vec<Arc<StubState>>>,
+    /// Serializes stub *writers* so a read-copy-update (clone snapshot → mutate → store) can't
+    /// lose a concurrent update (issue #291). Off the request hot path — held only by admin /
+    /// reload / proxy-record mutations, never by readers.
+    stubs_write: Mutex<()>,
     /// Proxy-recording backend (issue #315); defaults to a private port-scoped
     /// [`LocalProxyStore`] for this imposter's mode, or the embedder's shared store injected
     /// via [`ImposterManager::with_proxy_store`](crate::imposter::ImposterManager::with_proxy_store).
@@ -187,7 +195,8 @@ impl Imposter {
 
         Self {
             config,
-            stubs: RwLock::new(stubs),
+            stubs: ArcSwap::from_pointee(stubs),
+            stubs_write: Mutex::new(()),
             proxy_store: Arc::new(LocalProxyStore::new(proxy_mode)),
             journal: journal
                 .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
@@ -199,11 +208,30 @@ impl Imposter {
         }
     }
 
+    /// Read-copy-update the stub vector (issue #291). Reads stay wait-free (`self.stubs.load()`);
+    /// a mutation takes the `stubs_write` mutex (serializing writers so no update is lost), clones
+    /// the current snapshot, applies `f`, then atomically swaps the new snapshot in. `f`'s return
+    /// value is passed back to the caller. Mutations are off the request hot path.
+    ///
+    /// The new snapshot is stored unconditionally — even when `f` reports a no-op via its return
+    /// value (e.g. an out-of-bounds `Err` or a duplicate-id `false`). That is safe only because
+    /// every such `f` validates *before* touching the vector, so a rejected call stores a
+    /// content-identical clone. Any `f` added here must uphold that: never partially mutate the
+    /// vector and then return an error/no-op, or the partial change would be committed silently.
+    pub(crate) fn mutate_stubs<R>(&self, f: impl FnOnce(&mut Vec<Arc<StubState>>) -> R) -> R {
+        let _writer = self.stubs_write.lock();
+        let mut next: Vec<Arc<StubState>> = self.stubs.load_full().as_ref().clone();
+        let result = f(&mut next);
+        self.stubs.store(Arc::new(next));
+        result
+    }
+
     /// Replace all stubs
     pub fn replace_stubs(&self, new_stubs: Vec<Stub>) {
-        let mut stubs = self.stubs.write();
-        stubs.clear();
-        stubs.extend(new_stubs.into_iter().map(|s| Arc::new(StubState::new(s))));
+        self.mutate_stubs(|stubs| {
+            stubs.clear();
+            stubs.extend(new_stubs.into_iter().map(|s| Arc::new(StubState::new(s))));
+        });
     }
 
     /// Create flow store based on _rift.flowState configuration.
@@ -378,7 +406,7 @@ mod tests {
             .find_matching_stub_with_client("GET", "/shared", &headers, None, None, None, None)
             .expect("store is infallible")
             .expect("request must match");
-        let stored = std::sync::Arc::clone(&imp.stubs.read()[index]);
+        let stored = std::sync::Arc::clone(&imp.stubs.load()[index]);
         assert!(
             std::sync::Arc::ptr_eq(&matched, &stored),
             "matched stub must be the shared Arc, not a deep clone"
@@ -410,7 +438,7 @@ mod tests {
         }))
         .unwrap();
         let imp = Imposter::new(cfg);
-        assert_eq!(served_body(&imp.stubs.read()[0]), "A"); // cursor now at index 1
+        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
         let new = serde_json::from_value(json!({
             "predicates": [{ "equals": { "path": "/c" } }],
             "responses": [
@@ -421,7 +449,7 @@ mod tests {
         .unwrap();
         imp.replace_stub(0, new).expect("index in bounds");
         assert_eq!(
-            served_body(&imp.stubs.read()[0]),
+            served_body(&imp.stubs.load()[0]),
             "D",
             "cursor (index 1) preserved and content swapped"
         );
@@ -443,7 +471,7 @@ mod tests {
         }))
         .unwrap();
         let imp = Imposter::new(cfg);
-        assert_eq!(served_body(&imp.stubs.read()[0]), "A"); // cursor now at index 1
+        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
         let new = serde_json::from_value(json!({
             "predicates": [{ "equals": { "path": "/c" } }],
             "responses": [
@@ -454,7 +482,7 @@ mod tests {
         .unwrap();
         assert!(imp.replace_stub_by_id("s1", new), "id exists");
         assert_eq!(
-            served_body(&imp.stubs.read()[0]),
+            served_body(&imp.stubs.load()[0]),
             "D",
             "cursor (index 1) preserved and content swapped"
         );
@@ -485,12 +513,12 @@ mod tests {
 
         let rec_index = imp
             .stubs
-            .read()
+            .load()
             .iter()
             .position(|s| !s.stub.predicates.is_empty())
             .expect("recorded stub present");
-        let slot_before = imp.stubs.read()[rec_index].slot;
-        assert_eq!(served_body(&imp.stubs.read()[rec_index]), "R1"); // cursor now at index 1
+        let slot_before = imp.stubs.load()[rec_index].slot;
+        assert_eq!(served_body(&imp.stubs.load()[rec_index]), "R1"); // cursor now at index 1
 
         // Second record with identical predicates → append branch: responses become [R1, R2, R3].
         let rec2 = serde_json::from_value(json!({
@@ -501,14 +529,127 @@ mod tests {
         imp.insert_or_append_proxy_stub(rec2, "http://upstream", "proxyAlways");
 
         assert_eq!(
-            imp.stubs.read()[rec_index].slot,
+            imp.stubs.load()[rec_index].slot,
             slot_before,
             "append must reuse the slot token, not mint a fresh StubState"
         );
         assert_eq!(
-            served_body(&imp.stubs.read()[rec_index]),
+            served_body(&imp.stubs.load()[rec_index]),
             "R2",
             "cursor (index 1) preserved across the append"
+        );
+    }
+
+    #[test]
+    fn concurrent_writers_no_lost_update() {
+        // Gate for #291: writers RCU under a serializing mutex, so N concurrent `add_stub` calls
+        // all land. A naive load→clone→mutate→store without serialization would lose updates
+        // (two writers clone the same snapshot; the second store clobbers the first).
+        use std::sync::Arc as StdArc;
+        let imp = StdArc::new(make_test_imposter());
+        let n = 32usize;
+        let handles: Vec<_> = (0..n)
+            .map(|i| {
+                let imp = StdArc::clone(&imp);
+                std::thread::spawn(move || {
+                    let stub: Stub = serde_json::from_value(json!({
+                        "id": format!("s{i}"),
+                        "responses": [{ "is": { "statusCode": 200, "body": "x" } }]
+                    }))
+                    .unwrap();
+                    imp.add_stub(stub, None);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            imp.get_stubs().len(),
+            n,
+            "every concurrent add must be retained (no lost update)"
+        );
+    }
+
+    #[test]
+    fn cursor_survives_unrelated_structural_mutation() {
+        // Gate for #291: an unrelated structural mutation (adding another stub) rebuilds the whole
+        // stub-vector snapshot. The untouched stub's `Arc<StubState>` must be carried into the new
+        // snapshot by reference (Arc clone), so its response cursor is preserved — a deep copy of
+        // the state would reset it.
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/c" } }],
+                "responses": [
+                    { "is": { "statusCode": 200, "body": "A" } },
+                    { "is": { "statusCode": 200, "body": "B" } }
+                ]
+            }]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg);
+        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
+        let other: Stub = serde_json::from_value(json!({
+            "predicates": [{ "equals": { "path": "/other" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "Z" } }]
+        }))
+        .unwrap();
+        imp.add_stub(other, None);
+        assert_eq!(
+            served_body(&imp.stubs.load()[0]),
+            "B",
+            "cursor preserved across an unrelated structural snapshot swap (Arc identity carried)"
+        );
+    }
+
+    #[test]
+    fn concurrent_reads_during_swap_consistent() {
+        // Gate for #291: readers on the match path load a consistent, wait-free snapshot while a
+        // writer swaps the entire stub set. The path always has a matching stub, so the reader
+        // must keep matching and must never tear or panic.
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{ "predicates": [{ "equals": { "path": "/p" } }],
+                        "responses": [{ "is": { "statusCode": 200, "body": "v0" } }] }]
+        }))
+        .unwrap();
+        let imp = StdArc::new(Imposter::new(cfg));
+        let stop = StdArc::new(AtomicBool::new(false));
+        let reader = {
+            let imp = StdArc::clone(&imp);
+            let stop = StdArc::clone(&stop);
+            std::thread::spawn(move || {
+                let headers = std::collections::HashMap::new();
+                let mut hits = 0u64;
+                while !stop.load(Ordering::Relaxed) {
+                    let r = imp
+                        .find_matching_stub_with_client(
+                            "GET", "/p", &headers, None, None, None, None,
+                        )
+                        .expect("store infallible");
+                    if r.is_some() {
+                        hits += 1;
+                    }
+                }
+                hits
+            })
+        };
+        for i in 1..500u32 {
+            let stub: Stub = serde_json::from_value(json!({
+                "predicates": [{ "equals": { "path": "/p" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": format!("v{i}") } }]
+            }))
+            .unwrap();
+            imp.replace_stubs(vec![stub]);
+        }
+        stop.store(true, Ordering::Release);
+        let hits = reader.join().unwrap();
+        assert!(
+            hits > 0,
+            "reader saw a consistent matching snapshot throughout the swaps"
         );
     }
 

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -187,10 +187,11 @@ impl Imposter {
     /// Insert a generated stub at the specified index
     pub fn insert_generated_stub(&self, stub: Stub, before_index: usize) {
         let new_stub_state = Arc::new(StubState::new(stub));
-        let mut stubs = self.stubs.write();
-        let index = before_index.min(stubs.len());
-        stubs.insert(index, new_stub_state);
-        debug!("Inserted generated stub at index {}", index);
+        self.mutate_stubs(|stubs| {
+            let index = before_index.min(stubs.len());
+            stubs.insert(index, new_stub_state);
+            debug!("Inserted generated stub at index {}", index);
+        });
     }
 
     /// Insert or append a generated stub based on proxy mode.
@@ -202,69 +203,69 @@ impl Imposter {
     /// For proxyOnce: Insert new stub BEFORE the proxy stub (so it matches first next time)
     /// For proxyAlways: Append response to existing stub AFTER proxy stub, or insert new AFTER proxy
     pub fn insert_or_append_proxy_stub(&self, stub: Stub, proxy_to: &str, proxy_mode: &str) {
-        let mut stubs = self.stubs.write();
-
-        // Re-locate the proxy stub under the write lock to avoid stale-index races.
-        let proxy_stub_index = stubs
-            .iter()
-            .position(|s| {
-                s.stub
-                    .responses
-                    .iter()
-                    .any(|r| matches!(r, StubResponse::Proxy { proxy } if proxy.to == proxy_to))
-            })
-            .unwrap_or(stubs.len());
-
-        if proxy_mode == "proxyAlways" {
-            // For proxyAlways, recorded stubs go AFTER the proxy stub
-            // This ensures proxy always runs first and records each request
-
-            // Try to find existing stub with matching predicates (after the proxy stub)
-            let matching_stub_idx = stubs
+        self.mutate_stubs(|stubs| {
+            // Re-locate the proxy stub inside the write critical section to avoid stale-index races.
+            let proxy_stub_index = stubs
                 .iter()
-                .map(|stub_state| &stub_state.stub)
-                .enumerate()
-                .skip(proxy_stub_index + 1) // Only look after the proxy stub
-                .find(|(_, existing)| {
-                    // Compare predicates (JSON comparison)
-                    let existing_preds =
-                        serde_json::to_string(&existing.predicates).unwrap_or_default();
-                    let new_preds = serde_json::to_string(&stub.predicates).unwrap_or_default();
-                    existing_preds == new_preds && !existing.predicates.is_empty()
+                .position(|s| {
+                    s.stub
+                        .responses
+                        .iter()
+                        .any(|r| matches!(r, StubResponse::Proxy { proxy } if proxy.to == proxy_to))
                 })
-                .map(|(idx, _)| idx);
+                .unwrap_or(stubs.len());
 
-            if let Some(idx) = matching_stub_idx {
-                // Append responses to the existing stub. States live behind `Arc` (issue #287),
-                // so rebuild the entry from a stub with the extended responses while reusing the
-                // slot's cycler + slot token.
-                let mut merged = stubs[idx].stub.clone();
-                merged.responses.extend(stub.responses);
-                let total = merged.responses.len();
-                stubs[idx] = Arc::new(stubs[idx].with_stub(merged));
+            if proxy_mode == "proxyAlways" {
+                // For proxyAlways, recorded stubs go AFTER the proxy stub
+                // This ensures proxy always runs first and records each request
+
+                // Try to find existing stub with matching predicates (after the proxy stub)
+                let matching_stub_idx = stubs
+                    .iter()
+                    .map(|stub_state| &stub_state.stub)
+                    .enumerate()
+                    .skip(proxy_stub_index + 1) // Only look after the proxy stub
+                    .find(|(_, existing)| {
+                        // Compare predicates (JSON comparison)
+                        let existing_preds =
+                            serde_json::to_string(&existing.predicates).unwrap_or_default();
+                        let new_preds = serde_json::to_string(&stub.predicates).unwrap_or_default();
+                        existing_preds == new_preds && !existing.predicates.is_empty()
+                    })
+                    .map(|(idx, _)| idx);
+
+                if let Some(idx) = matching_stub_idx {
+                    // Append responses to the existing stub. States live behind `Arc` (issue #287),
+                    // so rebuild the entry from a stub with the extended responses while reusing the
+                    // slot's cycler + slot token.
+                    let mut merged = stubs[idx].stub.clone();
+                    merged.responses.extend(stub.responses);
+                    let total = merged.responses.len();
+                    stubs[idx] = Arc::new(stubs[idx].with_stub(merged));
+                    debug!(
+                        "Appended response to existing stub at index {idx} (proxyAlways mode, {total} total responses)"
+                    );
+                    return;
+                }
+
+                // No matching stub found: insert new stub AFTER the proxy stub
+                let insert_index = (proxy_stub_index + 1).min(stubs.len());
+                stubs.insert(insert_index, Arc::new(StubState::new(stub)));
                 debug!(
-                    "Appended response to existing stub at index {idx} (proxyAlways mode, {total} total responses)"
+                    "Inserted generated stub at index {} after proxy (proxyAlways mode)",
+                    insert_index
                 );
-                return;
+            } else {
+                // For proxyOnce: insert new stub BEFORE the proxy stub
+                // This ensures the recorded stub matches first on subsequent requests
+                let index = proxy_stub_index.min(stubs.len());
+                stubs.insert(index, Arc::new(StubState::new(stub)));
+                debug!(
+                    "Inserted generated stub at index {} before proxy (proxyOnce mode)",
+                    index
+                );
             }
-
-            // No matching stub found: insert new stub AFTER the proxy stub
-            let insert_index = (proxy_stub_index + 1).min(stubs.len());
-            stubs.insert(insert_index, Arc::new(StubState::new(stub)));
-            debug!(
-                "Inserted generated stub at index {} after proxy (proxyAlways mode)",
-                insert_index
-            );
-        } else {
-            // For proxyOnce: insert new stub BEFORE the proxy stub
-            // This ensures the recorded stub matches first on subsequent requests
-            let index = proxy_stub_index.min(stubs.len());
-            stubs.insert(index, Arc::new(StubState::new(stub)));
-            debug!(
-                "Inserted generated stub at index {} before proxy (proxyOnce mode)",
-                index
-            );
-        }
+        });
     }
 
     /// Forward a request through proxy and optionally record the response

--- a/crates/rift-core/src/imposter/core/responses.rs
+++ b/crates/rift-core/src/imposter/core/responses.rs
@@ -71,7 +71,7 @@ impl Imposter {
 
     /// Get all stubs info for debug purposes (Rift extension)
     pub fn get_all_stubs_info(&self) -> Vec<DebugStubInfo> {
-        let stubs = self.stubs.read();
+        let stubs = self.stubs.load();
         stubs
             .iter()
             .map(|stub_state| &stub_state.stub)
@@ -87,7 +87,7 @@ impl Imposter {
 
     /// Get imposter info for debug purposes (Rift extension)
     pub fn get_debug_imposter_info(&self) -> DebugImposter {
-        let stubs = self.stubs.read();
+        let stubs = self.stubs.load();
         DebugImposter {
             port: self.config.port.unwrap_or(0),
             name: self.config.name.clone(),

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -1283,7 +1283,7 @@ mod tests {
 
         let untouched = manager.get_imposter(19410).unwrap();
         untouched.record_request(&recorded("/cycled"));
-        assert_eq!(next_body(&untouched.stubs.read()[0]), "a1");
+        assert_eq!(next_body(&untouched.stubs.load()[0]), "a1");
 
         let p2_changed = imposter_cfg(json!({
             "protocol": "http", "port": 19411,
@@ -1305,7 +1305,7 @@ mod tests {
         );
         assert_eq!(after.get_recorded_requests().len(), 1);
         assert_eq!(
-            next_body(&after.stubs.read()[0]),
+            next_body(&after.stubs.load()[0]),
             "a2",
             "cycler position survives a sibling patch"
         );
@@ -1632,11 +1632,11 @@ mod tests {
             .await
             .expect("create");
         let imposter = manager.get_imposter(19440).unwrap();
-        assert_eq!(next_body(&imposter.stubs.read()[0]), "a1");
+        assert_eq!(next_body(&imposter.stubs.load()[0]), "a1");
 
         manager.move_stub(19440, 0, 2).await.expect("move");
         {
-            let stubs = imposter.stubs.read();
+            let stubs = imposter.stubs.load();
             let first = serde_json::to_value(&stubs[0].stub).unwrap();
             assert_eq!(first["responses"][0]["is"]["body"], "b");
             assert_eq!(
@@ -2213,7 +2213,7 @@ mod tests {
             manager.add_stub(19524, spaced, None).await.expect("add");
 
             let imposter = manager.get_imposter(19524).unwrap();
-            let stub_state = imposter.stubs.read()[0].clone();
+            let stub_state = imposter.stubs.load()[0].clone();
             let _ = imposter
                 .execute_stub_with_rift(&stub_state)
                 .expect("sequencer ok");


### PR DESCRIPTION
Replace the RwLock on Imposter.stubs with arc_swap::ArcSwap to eliminate lock contention on the hot path. Mutations use read-copy-update via a serialized mutate_stubs helper with a write mutex, ensuring atomicity without blocking reads. Arc identity is preserved across snapshots so response cursors remain valid after mutations.

Closes #291
Milestone: perf roadmap (#300)