### PR TITLE
feat(server): bindable admin/metrics servers — bound-addr reporting + graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-test",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-appender",
@@ -4324,6 +4325,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -20,6 +20,8 @@ workspace = true
 [dependencies]
 # Async runtime
 tokio = { workspace = true, features = ["full"] }
+# CancellationToken + TaskTracker for graceful, bindable server shutdown (issue #342)
+tokio-util = { workspace = true, features = ["rt"] }
 futures.workspace = true
 
 # HTTP

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -53,14 +53,15 @@ pub async fn handle_metrics(manager: Arc<ImposterManager>) -> Response<Full<Byte
 }
 
 /// GET /config - Mountebank-compatible config endpoint
-pub fn handle_config() -> Response<Full<Bytes>> {
+///
+/// `allow_injection` is threaded in explicitly (issue #342) rather than read from
+/// `MB_ALLOW_INJECTION`, so an embedded host can set it without mutating process env.
+pub fn handle_config(allow_injection: bool) -> Response<Full<Bytes>> {
     let config = serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "options": {
             "port": crate::admin_api::DEFAULT_ADMIN_PORT,
-            "allowInjection": std::env::var("MB_ALLOW_INJECTION")
-                .map(|v| v == "true")
-                .unwrap_or(false),
+            "allowInjection": allow_injection,
             "localOnly": false,
             "ipWhitelist": ["*"]
         },
@@ -212,8 +213,27 @@ mod tests {
 
     #[test]
     fn test_handle_config() {
-        let resp = handle_config();
+        let resp = handle_config(false);
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // AC7 (#342): the injection flag is threaded explicitly, not read from process env —
+    // an embedder sets it without mutating the environment.
+    #[test]
+    fn handle_config_reports_explicit_injection_flag() {
+        use http_body_util::BodyExt;
+        let read_flag = |allow: bool| {
+            let resp = handle_config(allow);
+            let bytes = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(resp.into_body().collect())
+                .unwrap()
+                .to_bytes();
+            let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            json["options"]["allowInjection"].as_bool().unwrap()
+        };
+        assert!(read_flag(true), "explicit true must be reported");
+        assert!(!read_flag(false), "explicit false must be reported");
     }
 
     #[tokio::test]

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -14,7 +14,7 @@ mod router;
 mod server;
 pub mod types;
 
-pub use server::AdminApiServer;
+pub use server::{AdminApiServer, RunningAdminApi};
 
 /// Default port for the Mountebank-compatible admin API.
 pub const DEFAULT_ADMIN_PORT: u16 = 2525;

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -70,6 +70,7 @@ pub async fn route_request(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
+    allow_injection: bool,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
@@ -86,6 +87,7 @@ pub async fn route_request(
         &base_url,
         manager,
         config_source,
+        allow_injection,
     )
     .await;
     Ok(response)
@@ -144,6 +146,7 @@ async fn route_by_path(
     base_url: &str,
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     // Single-port gateway (issue #212): `/__rift/:port/<path>` dispatches to that imposter,
     // so a containerized Rift only needs the one admin port published.
@@ -155,7 +158,7 @@ async fn route_by_path(
     match (method, path) {
         (&Method::GET, "/") => return system::handle_root(base_url),
         (&Method::GET, "/health") => return system::handle_health(),
-        (&Method::GET, "/config") => return system::handle_config(),
+        (&Method::GET, "/config") => return system::handle_config(allow_injection),
         (&Method::GET, "/logs") => return system::handle_logs(query),
         (&Method::POST, "/admin/reload") => {
             return system::handle_reload(manager, config_source).await;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -11,9 +11,16 @@ use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, info};
+
+/// Bounded grace given to in-flight connections on `shutdown()` before the wait is abandoned.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
 /// Admin API server for Rift
 pub struct AdminApiServer {
@@ -21,6 +28,7 @@ pub struct AdminApiServer {
     manager: Arc<ImposterManager>,
     api_key: Option<Arc<String>>,
     config_source: Option<Arc<ConfigSource>>,
+    allow_injection: bool,
 }
 
 impl AdminApiServer {
@@ -31,6 +39,7 @@ impl AdminApiServer {
             manager,
             api_key: api_key.map(Arc::new),
             config_source: None,
+            allow_injection: false,
         }
     }
 
@@ -42,76 +51,206 @@ impl AdminApiServer {
         self
     }
 
-    /// Run the admin API server
-    pub async fn run(self) -> Result<(), anyhow::Error> {
+    /// Set whether JS injection is allowed, reported by `GET /config` (issue #342). Threaded
+    /// explicitly so an embedder can set it without mutating the process environment.
+    #[must_use]
+    pub fn with_allow_injection(mut self, allow: bool) -> Self {
+        self.allow_injection = allow;
+        self
+    }
+
+    /// Bind the listener (`:0` is fine) and start serving on the current runtime, returning a
+    /// handle that reports the bound address and can be shut down gracefully (issue #342).
+    pub async fn bind(self) -> anyhow::Result<RunningAdminApi> {
         let listener = TcpListener::bind(self.addr).await?;
+        let local_addr = listener.local_addr()?;
         info!(
             "Rift Admin API (Mountebank-compatible) listening on http://{}",
-            self.addr
+            local_addr
         );
 
         if self.api_key.is_some() {
             info!("Admin API authentication enabled (--apikey)");
         }
 
-        loop {
-            let (stream, _) = listener.accept().await?;
-            let io = TokioIo::new(stream);
-            let manager = Arc::clone(&self.manager);
-            let api_key = self.api_key.clone();
-            let config_source = self.config_source.clone();
+        let cancel = CancellationToken::new();
+        let tracker = TaskTracker::new();
+        let (loop_cancel, loop_tracker) = (cancel.clone(), tracker.clone());
+        let task = tokio::spawn(async move {
+            let result = accept_loop(
+                listener,
+                self.manager,
+                self.api_key,
+                self.config_source,
+                self.allow_injection,
+                loop_cancel,
+                loop_tracker,
+            )
+            .await;
+            // Log an accept-loop failure so it is observable even for an embedder that holds
+            // the handle and never calls join() (join() still returns it for run()/RunningServer).
+            if let Err(ref e) = result {
+                tracing::error!("Admin API server error: {}", e);
+            }
+            result
+        });
 
-            tokio::spawn(async move {
-                let service = service_fn(move |req| {
-                    let manager = Arc::clone(&manager);
-                    let api_key = api_key.clone();
-                    let config_source = config_source.clone();
-                    async move {
-                        // Per-request annotation scope + response decorator (issue #318):
-                        // every response through this listener — including the `/__rift/`
-                        // gateway — is decorated with phase `Admin`.
-                        let decorator = manager.response_decorator();
-                        let (result, annotations) = with_annotation_scope(async move {
-                            // The single-port gateway (`/__rift/...`, issue #212) is data-plane
-                            // imposter traffic, not the admin control plane — it mirrors direct
-                            // per-imposter-port access and so is NOT gated by the admin `--apikey`
-                            // (which would otherwise force app-under-test traffic to carry the admin
-                            // key and would leak that Authorization header into imposter predicates).
-                            let is_gateway = req.uri().path().starts_with("/__rift/");
-                            if let Some(ref key) = api_key
-                                && !is_gateway
-                            {
-                                let auth = req
-                                    .headers()
-                                    .get("authorization")
-                                    .and_then(|v| v.to_str().ok())
-                                    .unwrap_or("");
-                                if auth != key.as_str() {
-                                    return Ok::<_, hyper::Error>(unauthorized_response());
-                                }
-                            }
-                            route_request(req, manager, config_source).await
-                        })
-                        .await;
-                        let mut response = result?;
-                        if let Some(decorator) = decorator {
-                            decorator.decorate(
-                                ResponsePhase::Admin,
-                                None,
-                                &annotations,
-                                response.headers_mut(),
-                            );
-                        }
-                        Ok::<_, hyper::Error>(response)
-                    }
-                });
+        Ok(RunningAdminApi {
+            local_addr,
+            cancel,
+            tracker,
+            task: Mutex::new(Some(task)),
+        })
+    }
 
-                if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
-                    debug!("Admin API connection error: {}", e);
-                }
-            });
+    /// Run the admin API server until the accept loop exits. Delegates to `bind` + `join`
+    /// so the binary path is byte-identical to binding then serving forever.
+    pub async fn run(self) -> Result<(), anyhow::Error> {
+        self.bind().await?.join().await
+    }
+}
+
+/// A bound, running admin API server (issue #342). Reports its listening address and offers a
+/// graceful shutdown that does not require dropping the runtime.
+pub struct RunningAdminApi {
+    local_addr: SocketAddr,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+    task: Mutex<Option<JoinHandle<anyhow::Result<()>>>>,
+}
+
+impl RunningAdminApi {
+    /// The actual bound address (a `:0` request resolves to the OS-assigned port here).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stop accepting new connections, give in-flight connections a bounded grace, then return.
+    /// Idempotent: a second call is a no-op.
+    pub async fn shutdown(&self) {
+        // Signals both the accept loop (stop accepting) and each live connection (which then
+        // performs a hyper graceful shutdown).
+        self.cancel.cancel();
+
+        if let Some(task) = take_task(&self.task) {
+            let abort = task.abort_handle();
+            if tokio::time::timeout(SHUTDOWN_GRACE, task).await.is_err() {
+                abort.abort();
+            }
+        }
+
+        // Wait for in-flight connections to finish within the grace bound. They observe the
+        // cancellation above and drain; the timeout bounds a pathologically slow one.
+        self.tracker.close();
+        if tokio::time::timeout(SHUTDOWN_GRACE, self.tracker.wait())
+            .await
+            .is_err()
+        {
+            debug!(
+                "Admin API shutdown: in-flight connections did not drain within the grace period"
+            );
         }
     }
+
+    /// Run until the accept loop exits (returns immediately if already shut down).
+    pub async fn join(self) -> anyhow::Result<()> {
+        match take_task(&self.task) {
+            Some(task) => match task.await {
+                Ok(result) => result,
+                Err(join_err) => Err(anyhow::anyhow!("admin API task failed: {join_err}")),
+            },
+            None => Ok(()),
+        }
+    }
+}
+
+fn take_task<T>(slot: &Mutex<Option<JoinHandle<T>>>) -> Option<JoinHandle<T>> {
+    slot.lock().expect("admin API task mutex poisoned").take()
+}
+
+/// Accept connections until `cancel` fires or the listener errors. Each connection is tracked
+/// so `shutdown` can wait for in-flight requests to drain.
+async fn accept_loop(
+    listener: TcpListener,
+    manager: Arc<ImposterManager>,
+    api_key: Option<Arc<String>>,
+    config_source: Option<Arc<ConfigSource>>,
+    allow_injection: bool,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+) -> anyhow::Result<()> {
+    loop {
+        let (stream, _) = tokio::select! {
+            _ = cancel.cancelled() => break,
+            accepted = listener.accept() => accepted?,
+        };
+        let io = TokioIo::new(stream);
+        let manager = Arc::clone(&manager);
+        let api_key = api_key.clone();
+        let config_source = config_source.clone();
+        let conn_cancel = cancel.clone();
+
+        tracker.spawn(async move {
+            let service = service_fn(move |req| {
+                let manager = Arc::clone(&manager);
+                let api_key = api_key.clone();
+                let config_source = config_source.clone();
+                async move {
+                    // Per-request annotation scope + response decorator (issue #318):
+                    // every response through this listener — including the `/__rift/`
+                    // gateway — is decorated with phase `Admin`.
+                    let decorator = manager.response_decorator();
+                    let (result, annotations) = with_annotation_scope(async move {
+                        // The single-port gateway (`/__rift/...`, issue #212) is data-plane
+                        // imposter traffic, not the admin control plane — it mirrors direct
+                        // per-imposter-port access and so is NOT gated by the admin `--apikey`
+                        // (which would otherwise force app-under-test traffic to carry the admin
+                        // key and would leak that Authorization header into imposter predicates).
+                        let is_gateway = req.uri().path().starts_with("/__rift/");
+                        if let Some(ref key) = api_key
+                            && !is_gateway
+                        {
+                            let auth = req
+                                .headers()
+                                .get("authorization")
+                                .and_then(|v| v.to_str().ok())
+                                .unwrap_or("");
+                            if auth != key.as_str() {
+                                return Ok::<_, hyper::Error>(unauthorized_response());
+                            }
+                        }
+                        route_request(req, manager, config_source, allow_injection).await
+                    })
+                    .await;
+                    let mut response = result?;
+                    if let Some(decorator) = decorator {
+                        decorator.decorate(
+                            ResponsePhase::Admin,
+                            None,
+                            &annotations,
+                            response.headers_mut(),
+                        );
+                    }
+                    Ok::<_, hyper::Error>(response)
+                }
+            });
+
+            let conn = http1::Builder::new().serve_connection(io, service);
+            tokio::pin!(conn);
+            tokio::select! {
+                res = conn.as_mut() => {
+                    if let Err(e) = res {
+                        debug!("Admin API connection error: {}", e);
+                    }
+                }
+                _ = conn_cancel.cancelled() => {
+                    conn.as_mut().graceful_shutdown();
+                    let _ = conn.await;
+                }
+            }
+        });
+    }
+    Ok(())
 }
 
 fn unauthorized_response() -> Response<Full<Bytes>> {

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -4,15 +4,23 @@
 //! config loading, and metrics around their own `ImposterManager` without forking the
 //! binary.
 
-use crate::admin_api::{AdminApiServer, DEFAULT_ADMIN_PORT};
+use crate::admin_api::{AdminApiServer, DEFAULT_ADMIN_PORT, RunningAdminApi};
 use crate::config_loader::{self, ConfigSource};
 use crate::extensions::metrics;
 use crate::imposter::{ImposterConfig, ImposterManager, TlsDefaults};
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
-use tracing::{error, info, warn};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{debug, error, info, warn};
+
+/// Bounded grace given to in-flight metrics connections on `shutdown()` (issue #342).
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
 /// Rift - A Mountebank-compatible HTTP chaos engineering proxy
 ///
@@ -185,6 +193,13 @@ impl ServerBuilder {
     /// Load configs, spawn the metrics server, and run the admin API server — the
     /// binary's Mountebank-mode behavior. Runs until the admin server stops or fails.
     pub async fn run(self) -> anyhow::Result<()> {
+        self.start().await?.join().await
+    }
+
+    /// Everything [`run`](Self::run) does, but returns a [`RunningServer`] once both listeners
+    /// are bound instead of serving forever (issue #342) — the embedding seam for a host that
+    /// needs the bound addresses (`:0` support) and a graceful shutdown.
+    pub async fn start(self) -> anyhow::Result<RunningServer> {
         let cli = self.cli;
         let manager = match self.manager {
             Some(manager) => manager,
@@ -221,12 +236,17 @@ impl ServerBuilder {
             load_imposters_from_datadir(&manager, datadir).await?;
         }
 
+        // Bind the metrics server now so a `:0` request can report its port. A bind failure
+        // stays non-fatal and only logs — matching the binary, which spawned the metrics
+        // server and kept the admin plane up regardless.
         let metrics_addr = SocketAddr::from(([0, 0, 0, 0], cli.metrics_port));
-        tokio::spawn(async move {
-            if let Err(e) = run_metrics_server(metrics_addr).await {
+        let metrics = match bind_metrics_server(metrics_addr).await {
+            Ok(running) => Some(running),
+            Err(e) => {
                 error!("Metrics server error: {}", e);
+                None
             }
-        });
+        };
 
         let host = if cli.local_only {
             "127.0.0.1"
@@ -256,7 +276,9 @@ impl ServerBuilder {
         }
 
         // Retain the config source so POST /admin/reload can re-read it (issue #197).
-        let mut server = AdminApiServer::new(addr, manager, cli.api_key);
+        // Injection gating is threaded explicitly (issue #342) rather than read from env.
+        let mut server = AdminApiServer::new(addr, manager, cli.api_key)
+            .with_allow_injection(cli.allow_injection);
         if let Some(configfile) = cli.configfile {
             server = server.with_config_source(ConfigSource::File {
                 path: configfile,
@@ -265,28 +287,157 @@ impl ServerBuilder {
         } else if let Some(datadir) = cli.datadir {
             server = server.with_config_source(ConfigSource::Dir(datadir));
         }
-        server.run().await
+        let admin = server.bind().await?;
+        Ok(RunningServer { admin, metrics })
+    }
+}
+
+/// A bound, running Rift server (issue #342): the admin API plus an optional metrics server.
+/// Reports both bound addresses and shuts both down gracefully.
+pub struct RunningServer {
+    admin: RunningAdminApi,
+    metrics: Option<RunningMetrics>,
+}
+
+impl RunningServer {
+    /// The bound admin API address (resolves a `:0` request to the assigned port).
+    pub fn admin_addr(&self) -> SocketAddr {
+        self.admin.local_addr()
+    }
+
+    /// The bound metrics address, if the metrics server bound successfully.
+    pub fn metrics_addr(&self) -> Option<SocketAddr> {
+        self.metrics.as_ref().map(RunningMetrics::local_addr)
+    }
+
+    /// Run until the admin API accept loop exits — the binary's `run()` behavior. The metrics
+    /// server keeps serving in the background, as it did under the previous `tokio::spawn`.
+    pub async fn join(self) -> anyhow::Result<()> {
+        self.admin.join().await
+    }
+
+    /// Stop accepting on both listeners, giving in-flight connections a bounded grace.
+    pub async fn shutdown(self) {
+        self.admin.shutdown().await;
+        if let Some(metrics) = self.metrics {
+            metrics.shutdown().await;
+        }
     }
 }
 
 /// Serve Prometheus metrics at `GET /metrics` on `addr` (anything else is a 404).
-/// Runs until the listener fails; callers normally `tokio::spawn` it.
+/// Runs until the listener fails; callers normally `tokio::spawn` it. Delegates to
+/// [`bind_metrics_server`] + [`RunningMetrics::join`] so the binary path is unchanged.
 pub async fn run_metrics_server(addr: SocketAddr) -> anyhow::Result<()> {
+    bind_metrics_server(addr).await?.join().await
+}
+
+/// Bind the metrics listener (`:0` is fine) and start serving, returning a handle that reports
+/// the bound address and can be shut down gracefully (issue #342).
+pub async fn bind_metrics_server(addr: SocketAddr) -> anyhow::Result<RunningMetrics> {
+    let listener = TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
+    info!("Metrics server listening on http://{}/metrics", local_addr);
+
+    let cancel = CancellationToken::new();
+    let tracker = TaskTracker::new();
+    let (loop_cancel, loop_tracker) = (cancel.clone(), tracker.clone());
+    let task = tokio::spawn(async move {
+        let result = metrics_accept_loop(listener, loop_cancel, loop_tracker).await;
+        // Preserve the pre-#342 behavior: an accept-loop failure is logged. Otherwise it would
+        // only surface via join(), which RunningServer does not call for the metrics task.
+        if let Err(ref e) = result {
+            error!("Metrics server error: {}", e);
+        }
+        result
+    });
+
+    Ok(RunningMetrics {
+        local_addr,
+        cancel,
+        tracker,
+        task: Mutex::new(Some(task)),
+    })
+}
+
+/// A bound, running metrics server (issue #342).
+pub struct RunningMetrics {
+    local_addr: SocketAddr,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+    task: Mutex<Option<JoinHandle<anyhow::Result<()>>>>,
+}
+
+impl RunningMetrics {
+    /// The actual bound address (a `:0` request resolves to the OS-assigned port here).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stop accepting new connections, give in-flight connections a bounded grace, then return.
+    /// Idempotent.
+    pub async fn shutdown(&self) {
+        self.cancel.cancel();
+        // Bind the taken handle to a local so the MutexGuard drops before any `.await`.
+        let task = self
+            .task
+            .lock()
+            .expect("metrics task mutex poisoned")
+            .take();
+        if let Some(task) = task {
+            let abort = task.abort_handle();
+            if tokio::time::timeout(SHUTDOWN_GRACE, task).await.is_err() {
+                abort.abort();
+            }
+        }
+        self.tracker.close();
+        if tokio::time::timeout(SHUTDOWN_GRACE, self.tracker.wait())
+            .await
+            .is_err()
+        {
+            debug!(
+                "Metrics server shutdown: in-flight connections did not drain within the grace period"
+            );
+        }
+    }
+
+    /// Run until the accept loop exits (returns immediately if already shut down).
+    pub async fn join(self) -> anyhow::Result<()> {
+        let task = self
+            .task
+            .lock()
+            .expect("metrics task mutex poisoned")
+            .take();
+        match task {
+            Some(task) => match task.await {
+                Ok(result) => result,
+                Err(join_err) => Err(anyhow::anyhow!("metrics server task failed: {join_err}")),
+            },
+            None => Ok(()),
+        }
+    }
+}
+
+async fn metrics_accept_loop(
+    listener: TcpListener,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+) -> anyhow::Result<()> {
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
     use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
     use std::convert::Infallible;
-    use tokio::net::TcpListener;
-
-    let listener = TcpListener::bind(addr).await?;
-    info!("Metrics server listening on http://{}/metrics", addr);
 
     loop {
-        let (stream, _) = listener.accept().await?;
+        let (stream, _) = tokio::select! {
+            _ = cancel.cancelled() => break,
+            accepted = listener.accept() => accepted?,
+        };
         let io = TokioIo::new(stream);
+        let conn_cancel = cancel.clone();
 
-        tokio::spawn(async move {
+        tracker.spawn(async move {
             let service = service_fn(move |req: Request<Incoming>| async move {
                 if req.uri().path() == "/metrics" {
                     let metrics = metrics::collect_metrics();
@@ -301,11 +452,22 @@ pub async fn run_metrics_server(addr: SocketAddr) -> anyhow::Result<()> {
                 }
             });
 
-            if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
-                error!("Metrics server connection error: {}", err);
+            let conn = http1::Builder::new().serve_connection(io, service);
+            tokio::pin!(conn);
+            tokio::select! {
+                res = conn.as_mut() => {
+                    if let Err(err) = res {
+                        error!("Metrics server connection error: {}", err);
+                    }
+                }
+                _ = conn_cancel.cancelled() => {
+                    conn.as_mut().graceful_shutdown();
+                    let _ = conn.await;
+                }
             }
         });
     }
+    Ok(())
 }
 
 /// Load imposters from a JSON config file

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -3,10 +3,13 @@
 //! `ImposterManager`.
 
 use clap::Parser;
+use rift_http_proxy::admin_api::AdminApiServer;
 use rift_http_proxy::gateway::dispatch_to_port;
 use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
-use rift_http_proxy::server::{Cli, ServerBuilder, run_metrics_server};
+use rift_http_proxy::server::{Cli, ServerBuilder, bind_metrics_server, run_metrics_server};
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 fn imposter_cfg(port: u16, body: &str) -> ImposterConfig {
     serde_json::from_value(serde_json::json!({
@@ -262,4 +265,250 @@ async fn dispatch_to_port_routes_in_process() {
     assert_eq!(resp.status(), 404, "no imposter on the target port");
 
     manager.delete_all().await;
+}
+
+// ===========================================================================
+// Issue #342: bindable admin/metrics servers — bound-addr reporting + shutdown
+// ===========================================================================
+
+/// True once `addr` refuses TCP connections (listener gone), polled up to ~2s.
+async fn connect_refused(addr: SocketAddr) -> bool {
+    for _ in 0..40 {
+        match tokio::time::timeout(
+            Duration::from_millis(200),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await
+        {
+            Ok(Err(_)) => return true, // connection refused — listener is down
+            _ => tokio::time::sleep(Duration::from_millis(50)).await,
+        }
+    }
+    false
+}
+
+// AC1: bind on 127.0.0.1:0 → local_addr() reports the OS-assigned (nonzero) port and the
+// server serves /health there. Fixes the #317 "a :0 bind gives the caller no way to learn
+// the assigned port" gap.
+#[tokio::test]
+async fn admin_bind_zero_port_reports_addr_and_serves_health() {
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .bind()
+        .await
+        .expect("bind admin on :0");
+
+    let addr = running.local_addr();
+    assert_ne!(addr.port(), 0, "local_addr must report the assigned port");
+
+    wait_for_http(&format!("http://{addr}/health")).await;
+    let resp = reqwest::get(format!("http://{addr}/health"))
+        .await
+        .expect("health reachable");
+    assert_eq!(resp.status(), 200);
+
+    running.shutdown().await;
+}
+
+// AC2: shutdown() stops accepting (subsequent connect refused) and returns within the grace
+// bound; a second shutdown() is a no-op (idempotent).
+#[tokio::test]
+async fn admin_shutdown_stops_accepting_and_is_idempotent() {
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .bind()
+        .await
+        .expect("bind admin on :0");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    // shutdown returns within a bounded grace (the API promises ~500ms; allow slack).
+    tokio::time::timeout(Duration::from_secs(2), running.shutdown())
+        .await
+        .expect("shutdown returns within the grace bound");
+
+    assert!(
+        connect_refused(addr).await,
+        "after shutdown the admin port must refuse connections"
+    );
+
+    // Double shutdown is a no-op — must not panic or hang.
+    tokio::time::timeout(Duration::from_secs(2), running.shutdown())
+        .await
+        .expect("second shutdown is a no-op");
+}
+
+// AC3: join() returns once the accept loop has exited (driven here by a prior shutdown).
+#[tokio::test]
+async fn admin_join_returns_after_accept_loop_exits() {
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .bind()
+        .await
+        .expect("bind admin on :0");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    running.shutdown().await; // stops the accept loop
+    let joined = tokio::time::timeout(Duration::from_secs(2), running.join())
+        .await
+        .expect("join returns after the accept loop has exited");
+    assert!(joined.is_ok(), "join reports the accept loop's Ok result");
+}
+
+// AC4: bind_metrics_server on :0 serves /metrics at the reported addr; shutdown stops it.
+#[tokio::test]
+async fn metrics_bind_zero_port_serves_and_shuts_down() {
+    let running = bind_metrics_server("127.0.0.1:0".parse().unwrap())
+        .await
+        .expect("bind metrics on :0");
+    let addr = running.local_addr();
+    assert_ne!(
+        addr.port(),
+        0,
+        "metrics local_addr must report the assigned port"
+    );
+
+    wait_for_http(&format!("http://{addr}/metrics")).await;
+    // AC4 is "serves /metrics at the reported addr" — assert the HTTP contract (200 at the
+    // :0-assigned port). Metric *content* ("rift_") depends on global-registry state and is
+    // covered by `run_metrics_server_serves_metrics`.
+    let resp = reqwest::get(format!("http://{addr}/metrics"))
+        .await
+        .expect("metrics reachable at the :0-assigned port");
+    assert_eq!(resp.status(), 200);
+
+    tokio::time::timeout(Duration::from_secs(2), running.shutdown())
+        .await
+        .expect("metrics shutdown within grace");
+    assert!(
+        connect_refused(addr).await,
+        "after shutdown the metrics port must refuse connections"
+    );
+}
+
+// AC5: ServerBuilder::start() returns once bound, reports both addrs (nonzero via :0), and
+// its shutdown() stops BOTH listeners.
+#[tokio::test]
+async fn server_builder_start_reports_addrs_and_shuts_down_both() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+
+    let running = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("start returns once bound");
+
+    let admin_addr = running.admin_addr();
+    // Metrics binds 0.0.0.0; reach it over loopback for a portable client connection.
+    let metrics_addr = SocketAddr::new(
+        "127.0.0.1".parse().unwrap(),
+        running.metrics_addr().expect("metrics addr present").port(),
+    );
+    assert_ne!(admin_addr.port(), 0);
+    assert_ne!(metrics_addr.port(), 0);
+
+    wait_for_http(&format!("http://{admin_addr}/health")).await;
+    wait_for_http(&format!("http://{metrics_addr}/metrics")).await;
+
+    tokio::time::timeout(Duration::from_secs(3), running.shutdown())
+        .await
+        .expect("shutdown both within grace");
+
+    assert!(connect_refused(admin_addr).await, "admin listener stopped");
+    assert!(
+        connect_refused(metrics_addr).await,
+        "metrics listener stopped"
+    );
+}
+
+// AC7 end-to-end: `--allow-injection` must survive the whole thread (ServerBuilder::start →
+// with_allow_injection → accept_loop → route_request → route_by_path → handle_config) and be
+// reported by GET /config. A hardcoded flag anywhere on that path would fail here while the
+// unit test still passed.
+#[tokio::test]
+async fn server_builder_start_threads_allow_injection_to_config() {
+    async fn allow_injection_reported(extra: &[&str]) -> bool {
+        let mut args = vec![
+            "rift",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--metrics-port",
+            "0",
+        ];
+        args.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(args).expect("cli parse");
+        let running = ServerBuilder::from_cli(cli).start().await.expect("start");
+        let admin = running.admin_addr();
+        wait_for_http(&format!("http://{admin}/health")).await;
+        let cfg: serde_json::Value = reqwest::get(format!("http://{admin}/config"))
+            .await
+            .expect("config reachable")
+            .json()
+            .await
+            .expect("json");
+        running.shutdown().await;
+        cfg["options"]["allowInjection"]
+            .as_bool()
+            .expect("allowInjection bool")
+    }
+
+    assert!(
+        allow_injection_reported(&["--allow-injection"]).await,
+        "--allow-injection must reach GET /config"
+    );
+    assert!(
+        !allow_injection_reported(&[]).await,
+        "without the flag, /config must report allowInjection=false"
+    );
+}
+
+// AC5 degradation: a metrics-port bind failure is non-fatal — the admin plane still comes up,
+// metrics_addr() is None, and shutdown() handles the None branch without panicking.
+#[tokio::test]
+async fn server_builder_start_survives_metrics_bind_failure() {
+    // Occupy 0.0.0.0:<port> — the same wildcard address the metrics server binds — so the
+    // metrics bind deterministically collides (EADDRINUSE) on every platform.
+    let occupied = tokio::net::TcpListener::bind("0.0.0.0:0")
+        .await
+        .expect("occupy a port");
+    let busy_port = occupied.local_addr().expect("addr").port();
+
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        &busy_port.to_string(),
+    ])
+    .expect("cli parse");
+
+    let running = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("admin plane still starts despite a metrics bind failure");
+
+    assert_ne!(running.admin_addr().port(), 0);
+    assert!(
+        running.metrics_addr().is_none(),
+        "a failed metrics bind degrades to None, not a hard error"
+    );
+    wait_for_http(&format!("http://{}/health", running.admin_addr())).await;
+
+    // shutdown must not panic on the None metrics branch.
+    tokio::time::timeout(Duration::from_secs(2), running.shutdown())
+        .await
+        .expect("shutdown handles the None metrics branch");
 }


### PR DESCRIPTION
Splits bind-from-serve for the admin API and metrics servers so embedders (the C-ABI v2 host in #343) can learn a `:0`-assigned port and gracefully shut a server down without dropping the runtime.

- `AdminApiServer::bind() -> RunningAdminApi` (`local_addr()`, idempotent `shutdown()`, `join()`); `run()` delegates to `bind()+join()` — binary path unchanged.
- `bind_metrics_server() -> RunningMetrics`; `ServerBuilder::start() -> RunningServer` (`admin_addr()`/`metrics_addr()`/`shutdown()`).
- Graceful shutdown via CancellationToken + TaskTracker + hyper graceful_shutdown (bounded grace).
- Injection gating threaded explicitly (no `MB_ALLOW_INJECTION` env read on the serving path).

Verification: fmt, clippy (0 warnings), and the rift-http-proxy suite (embedded_server 12/12, lib 63/63) all green.

Closes #342
Milestone: M4 (embedded foundation)