### PR TITLE
feat(ffi): C-ABI v2 — in-process admin plane, apply_config, delete_imposter, build_info, last_error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,8 @@ version = "0.1.0"
 dependencies = [
  "reqwest",
  "rift-core",
+ "rift-http-proxy",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -23,7 +23,12 @@ workspace = true
 # Features are forwarded (not hard-coded) so the per-platform cdylib build can drop engines that
 # can't cross-compile for a given target (e.g. LuaJIT for x86_64-apple-darwin) — issue #205.
 rift-core = { path = "../rift-core", default-features = false }
+# The admin control plane (issue #343): rift_serve_admin spawns the real AdminApiServer over the
+# handle's manager. default-features=false so `mimalloc` is NOT pulled — a cdylib must never
+# impose a global allocator on its host.
+rift-http-proxy = { path = "../rift-http-proxy", default-features = false }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 # Emit a diagnostic before collapsing a typed error into a C sentinel; the embedding host
 # installs the subscriber (no-op if none is set).
@@ -34,6 +39,8 @@ reqwest.workspace = true
 
 [features]
 default = ["redis-backend", "lua", "javascript"]
-redis-backend = ["rift-core/redis-backend"]
-lua = ["rift-core/lua"]
-javascript = ["rift-core/javascript"]
+# Engine features are forwarded to BOTH rift-core and rift-http-proxy so the two share one
+# feature set (mimalloc is deliberately never forwarded — see the dependency note above).
+redis-backend = ["rift-core/redis-backend", "rift-http-proxy/redis-backend"]
+lua = ["rift-core/lua", "rift-http-proxy/lua"]
+javascript = ["rift-core/javascript", "rift-http-proxy/javascript"]

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1,32 +1,81 @@
-//! Rift C-ABI (issue #204): a tiny opaque-handle + JSON in / JSON out FFI over the rift-core
-//! engine, so a host (e.g. the JVM via Panama FFM) can embed Rift in-process.
+//! Rift C-ABI (issue #204, extended in #343): a tiny opaque-handle + JSON in / JSON out FFI over
+//! the rift-core engine, so a host (e.g. the JVM via Panama FFM) can embed Rift in-process.
 //!
 //! Boundary discipline:
 //! - **Opaque handle + JSON only.** No Rust enums/generics cross the line; the JSON codec is the
 //!   same `rift-types`/`rift-core` wire model the admin API uses, so it is version-tolerant.
 //! - **Memory created and freed on the same side.** `rift_start`/`rift_stop` own the
-//!   [`RiftHandle`]; `rift_recorded` returns a `*mut c_char` the caller must hand back to
-//!   [`rift_free`].
+//!   [`RiftHandle`]; string returns are `*mut c_char` the caller hands back to [`rift_free`]
+//!   (the one exception is [`rift_build_info`], a static string that is never freed).
 //! - **No futures cross the boundary.** The handle owns a multi-thread Tokio runtime; mutating
 //!   downcalls are blocking `block_on` calls (read-only ones like [`rift_recorded`] are plain
 //!   synchronous reads), so the host wraps them in its own blocking effect.
 //! - **One handle is safe to share across host threads:** the engine is `Sync` and every
 //!   downcall takes `&self`, so concurrent calls on the same handle are permitted.
 //!
+//! ## C-ABI v2 (issue #343)
+//! - `rift_serve_admin` spawns the *real* [`AdminApiServer`] on the handle's runtime over the
+//!   handle's manager, so an embedded host gets the byte-identical admin surface (spaces,
+//!   scenarios, flow-state, the `/__rift/` gateway, …) and inherits future admin features.
+//! - `rift_apply_config`, `rift_delete_imposter` extend the control surface; `rift_build_info`
+//!   exposes build identity; `rift_last_error` surfaces the reason a `rift_*` call failed.
+//! - The seven v1 symbols keep their exact signatures and semantics; v2 detection is the presence
+//!   of `rift_build_info`. Every *operation* entry clears the thread-local last-error and every
+//!   failure sets it (v1 functions too — additive, their return values are unchanged); the pure
+//!   accessors and `rift_free` leave it untouched so read-then-free is order-independent.
+//!
 //! All `extern "C"` functions are panic-free; under edition 2021 an unexpected unwind aborts
-//! rather than crossing the boundary (defined behaviour). A failed downcall returns its sentinel
-//! and emits a `tracing` event with the dropped error so the reason is not lost.
+//! rather than crossing the boundary (defined behaviour). A failed downcall returns its sentinel,
+//! records the reason in [`rift_last_error`], and emits a `tracing` event.
 
 use rift_core::imposter::{ImposterConfig, ImposterManager, Stub};
+use rift_http_proxy::admin_api::{AdminApiServer, RunningAdminApi};
+use rift_http_proxy::config_loader::{self, ConfigSource};
+use rift_http_proxy::server::{RunningMetrics, bind_metrics_server};
+use serde_json::{Value, json};
+use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_char};
-use std::sync::Arc;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 use tracing::warn;
 
-/// Opaque handle: a Tokio runtime (on its own threads) plus the engine it drives.
+thread_local! {
+    /// The reason the most recent `rift_*` operation on THIS thread failed, or `None`. Operation
+    /// entries clear this and their failures set it; the accessors and `rift_free` leave it alone
+    /// (see [`clear_last_error`]).
+    static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+/// Clear this thread's last-error. Called on entry to every *operation* extern fn. The pure
+/// accessors ([`rift_last_error`], [`rift_build_info`]) and the deallocator ([`rift_free`]) do
+/// NOT clear it, so "check the sentinel, read `rift_last_error`, then `rift_free` the buffer" is
+/// order-independent.
+fn clear_last_error() {
+    LAST_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+/// Record this thread's last-error message (interior NULs are replaced with a fixed note).
+fn set_last_error(msg: impl AsRef<str>) {
+    let c = CString::new(msg.as_ref()).unwrap_or_else(|_| {
+        CString::new("error message contained an interior NUL").expect("no NUL")
+    });
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(c));
+}
+
+/// Opaque handle: a Tokio runtime (on its own threads), the engine it drives, and — once
+/// [`rift_serve_admin`] is called — the in-process admin/metrics plane serving over that engine.
 pub struct RiftHandle {
     runtime: Runtime,
     manager: Arc<ImposterManager>,
+    admin: Mutex<Option<AdminPlane>>,
+}
+
+/// The admin API (and optional metrics server) serving in-process for a handle (issue #343).
+struct AdminPlane {
+    admin: RunningAdminApi,
+    metrics: Option<RunningMetrics>,
 }
 
 /// Borrow the handle from a raw pointer, or `None` if null.
@@ -59,15 +108,44 @@ fn into_c_string(s: String) -> *mut c_char {
     }
 }
 
+/// `rift_serve_admin` options (all fields optional). Typed so a wrong-JSON-type field is a serde
+/// error surfaced via `last_error` — not silently coerced to a default (a non-string `apiKey`
+/// silently disabling auth, or an out-of-range `port` truncating, would be a real footgun).
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct ServeOptions {
+    host: Option<String>,
+    port: Option<u16>,
+    api_key: Option<String>,
+    metrics_port: Option<u16>,
+    config_file: Option<String>,
+    config: Option<Value>,
+}
+
+/// Parse `{"imposters":[...]}` or a bare `[...]` into imposter configs (the reload input shape).
+fn parse_imposter_configs(v: &Value) -> Result<Vec<ImposterConfig>, String> {
+    let array = v.get("imposters").unwrap_or(v);
+    serde_json::from_value::<Vec<ImposterConfig>>(array.clone()).map_err(|e| e.to_string())
+}
+
 /// Start the engine. Returns an opaque handle, or null if the runtime could not be created.
+///
+/// Installs the process-wide rustls `ring` crypto provider (idempotently) so HTTPS imposters
+/// created through this handle work without the host installing a provider itself (issue #343).
 #[unsafe(no_mangle)]
 pub extern "C" fn rift_start() -> *mut RiftHandle {
+    clear_last_error();
+    rift_http_proxy::install_default_crypto_provider();
     match Runtime::new() {
         Ok(runtime) => Box::into_raw(Box::new(RiftHandle {
             runtime,
             manager: Arc::new(ImposterManager::new()),
+            admin: Mutex::new(None),
         })),
-        Err(_) => std::ptr::null_mut(),
+        Err(e) => {
+            set_last_error(format!("rift_start: runtime creation failed: {e}"));
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -79,24 +157,31 @@ pub extern "C" fn rift_start() -> *mut RiftHandle {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_create_imposter(h: *mut RiftHandle, json: *const c_char) -> u16 {
     unsafe {
+        clear_last_error();
         let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+            set_last_error("rift_create_imposter: null handle or config pointer");
             warn!("rift_create_imposter: null handle or config pointer");
             return 0;
         };
         let config = match serde_json::from_str::<ImposterConfig>(s) {
             Ok(c) => c,
             Err(e) => {
+                set_last_error(format!("rift_create_imposter: invalid config JSON: {e}"));
                 warn!(error = %e, "rift_create_imposter: invalid config JSON");
                 return 0;
             }
         };
-        handle
+        match handle
             .runtime
             .block_on(handle.manager.create_imposter(config))
-            .unwrap_or_else(|e| {
+        {
+            Ok(port) => port,
+            Err(e) => {
+                set_last_error(format!("rift_create_imposter: {e}"));
                 warn!(error = %e, "rift_create_imposter failed");
                 0
-            })
+            }
+        }
     }
 }
 
@@ -111,13 +196,16 @@ pub unsafe extern "C" fn rift_replace_stubs(
     json: *const c_char,
 ) -> i32 {
     unsafe {
+        clear_last_error();
         let (Some(handle), Some(s)) = (handle(h), c_str(json)) else {
+            set_last_error("rift_replace_stubs: null handle or stubs pointer");
             warn!("rift_replace_stubs: null handle or stubs pointer");
             return -1;
         };
         let stubs = match serde_json::from_str::<Vec<Stub>>(s) {
             Ok(v) => v,
             Err(e) => {
+                set_last_error(format!("rift_replace_stubs: invalid stubs JSON: {e}"));
                 warn!(error = %e, "rift_replace_stubs: invalid stubs JSON");
                 return -1;
             }
@@ -128,6 +216,7 @@ pub unsafe extern "C" fn rift_replace_stubs(
         {
             Ok(()) => 0,
             Err(e) => {
+                set_last_error(format!("rift_replace_stubs: {e}"));
                 warn!(error = %e, port, "rift_replace_stubs failed");
                 -1
             }
@@ -142,11 +231,40 @@ pub unsafe extern "C" fn rift_replace_stubs(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_delete_all(h: *mut RiftHandle) -> i32 {
     unsafe {
+        clear_last_error();
         let Some(handle) = handle(h) else {
+            set_last_error("rift_delete_all: null handle");
             return -1;
         };
         handle.runtime.block_on(handle.manager.delete_all());
         0
+    }
+}
+
+/// Delete one imposter, freeing its port. Returns `0` on success, `-1` on any error
+/// (null handle or no imposter on `port`). Issue #343.
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_delete_imposter(h: *mut RiftHandle, port: u16) -> i32 {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_delete_imposter: null handle");
+            return -1;
+        };
+        match handle
+            .runtime
+            .block_on(handle.manager.delete_imposter(port))
+        {
+            Ok(_) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_delete_imposter: {e}"));
+                warn!(error = %e, port, "rift_delete_imposter failed");
+                -1
+            }
+        }
     }
 }
 
@@ -158,12 +276,15 @@ pub unsafe extern "C" fn rift_delete_all(h: *mut RiftHandle) -> i32 {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_char {
     unsafe {
+        clear_last_error();
         let Some(handle) = handle(h) else {
+            set_last_error("rift_recorded: null handle");
             return std::ptr::null_mut();
         };
         let imposter = match handle.manager.get_imposter(port) {
             Ok(i) => i,
             Err(e) => {
+                set_last_error(format!("rift_recorded: {e}"));
                 warn!(error = %e, port, "rift_recorded: no such imposter");
                 return std::ptr::null_mut();
             }
@@ -171,6 +292,7 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
         match serde_json::to_string(&imposter.get_recorded_requests()) {
             Ok(json) => into_c_string(json),
             Err(e) => {
+                set_last_error(format!("rift_recorded: encode failed: {e}"));
                 warn!(error = %e, port, "rift_recorded: failed to encode recorded requests");
                 std::ptr::null_mut()
             }
@@ -178,10 +300,272 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
     }
 }
 
-/// Free a string previously returned by [`rift_recorded`]. Null is a no-op.
+/// Start the real admin API (and, if `metricsPort` is given, the metrics server) in-process on
+/// this handle's runtime, serving over this handle's manager (issue #343).
+///
+/// `options_json` (null or `{}` uses all defaults; every field optional):
+/// `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null}`.
+/// `configFile` is loaded and wired as the reload source (like `--configfile`); `config` is an
+/// inline `{"imposters":[...]}` applied via `apply_config`. They don't compose: `config` is a
+/// reconcile, so passing both deletes the `configFile` (and any pre-existing) imposters not in the
+/// inline set — pass one or the other.
+///
+/// Returns (caller frees) `{"adminPort":49321,"adminUrl":"http://127.0.0.1:49321","metricsPort":null}`,
+/// or null on error (bad JSON, bind failure, or already serving — one admin plane per handle).
 ///
 /// # Safety
-/// `p` must be null or a pointer returned by a `rift-ffi` function and not yet freed.
+/// `h` must be a live handle and `options_json` null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_serve_admin(
+    h: *mut RiftHandle,
+    options_json: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_serve_admin: null handle");
+            return std::ptr::null_mut();
+        };
+        let opts_str = if options_json.is_null() {
+            "{}"
+        } else {
+            match c_str(options_json) {
+                Some(s) => s,
+                None => {
+                    set_last_error("rift_serve_admin: options is not valid UTF-8");
+                    return std::ptr::null_mut();
+                }
+            }
+        };
+        // Typed parse: a wrong-type field (e.g. a non-string apiKey, an out-of-range port) is a
+        // serde error surfaced here, not a silent default.
+        let opts: ServeOptions = match serde_json::from_str(opts_str) {
+            Ok(o) => o,
+            Err(e) => {
+                set_last_error(format!("rift_serve_admin: invalid options JSON: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+
+        // Hold the slot across build+set so a concurrent serve_admin on the same handle can't
+        // race two planes into existence (one admin plane per handle).
+        let mut slot = handle.admin.lock().expect("admin mutex poisoned");
+        if slot.is_some() {
+            set_last_error("rift_serve_admin: already serving (one admin plane per handle)");
+            return std::ptr::null_mut();
+        }
+
+        match handle.runtime.block_on(build_admin_plane(handle, &opts)) {
+            Ok((plane, response)) => {
+                *slot = Some(plane);
+                into_c_string(response)
+            }
+            Err(e) => {
+                set_last_error(format!("rift_serve_admin: {e}"));
+                warn!(error = %e, "rift_serve_admin failed");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Bind the admin (and optional metrics) plane per `opts`, returning the plane plus the JSON
+/// response body. Errors are `String`s (mapped to `last_error` by the caller).
+async fn build_admin_plane(
+    handle: &RiftHandle,
+    opts: &ServeOptions,
+) -> Result<(AdminPlane, String), String> {
+    let host = opts.host.as_deref().unwrap_or("127.0.0.1");
+    let port = opts.port.unwrap_or(0);
+    let api_key = opts.api_key.clone();
+
+    // Parse both addresses up front, before any side effects (imposter creation / binding).
+    let addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .map_err(|e| format!("invalid host/port `{host}:{port}`: {e}"))?;
+    let metrics_addr: Option<SocketAddr> = match opts.metrics_port {
+        Some(mp) => Some(
+            format!("{host}:{mp}")
+                .parse()
+                .map_err(|e| format!("invalid metrics addr `{host}:{mp}`: {e}"))?,
+        ),
+        None => None,
+    };
+
+    // configFile: load and create imposters additively (does not reconcile away imposters the
+    // host already created), and remember the source so POST /admin/reload can re-read it.
+    let config_source = match opts.config_file.as_deref() {
+        Some(path) => {
+            let source = ConfigSource::File {
+                path: PathBuf::from(path),
+                no_parse: false,
+            };
+            let configs = config_loader::load_configs(&source)
+                .map_err(|e| format!("configFile load: {e}"))?;
+            for config in configs {
+                handle
+                    .manager
+                    .create_imposter(config)
+                    .await
+                    .map_err(|e| format!("configFile imposter: {e}"))?;
+            }
+            Some(source)
+        }
+        None => None,
+    };
+
+    // Inline config is the desired state applied via apply_config (reconcile), mirroring reload.
+    if let Some(cfg) = opts.config.as_ref().filter(|v| !v.is_null()) {
+        let configs = parse_imposter_configs(cfg)?;
+        handle
+            .manager
+            .apply_config(configs)
+            .await
+            .map_err(|e| format!("inline config apply: {e}"))?;
+    }
+
+    // Bind metrics first (optional), then admin — so if the second bind fails, the first
+    // listener is explicitly shut down rather than orphaned holding its port.
+    let metrics = match metrics_addr {
+        Some(maddr) => Some(
+            bind_metrics_server(maddr)
+                .await
+                .map_err(|e| format!("metrics bind: {e}"))?,
+        ),
+        None => None,
+    };
+
+    let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key);
+    if let Some(source) = config_source {
+        server = server.with_config_source(source);
+    }
+    let admin = match server.bind().await {
+        Ok(admin) => admin,
+        Err(e) => {
+            if let Some(metrics) = metrics {
+                metrics.shutdown().await;
+            }
+            return Err(format!("admin bind: {e}"));
+        }
+    };
+    let admin_addr = admin.local_addr();
+    let metrics_port_out = metrics.as_ref().map(|m| m.local_addr().port());
+
+    let response = json!({
+        "adminPort": admin_addr.port(),
+        "adminUrl": format!("http://{admin_addr}"),
+        "metricsPort": metrics_port_out,
+    })
+    .to_string();
+
+    Ok((AdminPlane { admin, metrics }, response))
+}
+
+/// Incrementally reconcile the manager toward the given config (issue #316/#343). Input is
+/// `{"imposters":[...]}` or a bare array. Returns (caller frees) a report with the same field
+/// names as `POST /admin/reload`:
+/// `{"created":[..],"replaced":[..],"stubPatched":[..],"deleted":[..],"failed":[{"port":0,"error":".."}]}`.
+/// Returns null only on invalid input / up-front validation failure — then nothing was mutated
+/// and the reason is in [`rift_last_error`]. Partial per-port failures come back in `failed`.
+///
+/// # Safety
+/// `h` must be a live handle and `config_json` a valid C string (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_apply_config(
+    h: *mut RiftHandle,
+    config_json: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(s)) = (handle(h), c_str(config_json)) else {
+            set_last_error("rift_apply_config: null handle or config pointer");
+            return std::ptr::null_mut();
+        };
+        let value: Value = match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(e) => {
+                set_last_error(format!("rift_apply_config: invalid JSON: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        let configs = match parse_imposter_configs(&value) {
+            Ok(c) => c,
+            Err(e) => {
+                set_last_error(format!("rift_apply_config: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        match handle
+            .runtime
+            .block_on(handle.manager.apply_config(configs))
+        {
+            Ok(report) => {
+                let failed: Vec<Value> = report
+                    .failed
+                    .iter()
+                    .map(|(port, e)| json!({"port": port, "error": e.to_string()}))
+                    .collect();
+                let out = json!({
+                    "created": report.created,
+                    "replaced": report.replaced,
+                    "stubPatched": report.stub_patched,
+                    "deleted": report.deleted,
+                    "failed": failed,
+                });
+                into_c_string(out.to_string())
+            }
+            Err(e) => {
+                set_last_error(format!("rift_apply_config: {e}"));
+                warn!(error = %e, "rift_apply_config validation failed");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Build identity as a STATIC JSON string — never freed; probe this symbol to detect a v2 library
+/// (issue #343). `{"version":"..","commit":"<sha>|null","builtAt":"<iso8601>|null","features":[..]}`.
+/// `commit`/`builtAt` are `null` unless stamped at build time (issue #344).
+#[unsafe(no_mangle)]
+pub extern "C" fn rift_build_info() -> *const c_char {
+    static INFO: OnceLock<CString> = OnceLock::new();
+    INFO.get_or_init(|| {
+        let mut features: Vec<&str> = Vec::new();
+        if cfg!(feature = "redis-backend") {
+            features.push("redis-backend");
+        }
+        if cfg!(feature = "lua") {
+            features.push("lua");
+        }
+        if cfg!(feature = "javascript") {
+            features.push("javascript");
+        }
+        let info = json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "commit": option_env!("RIFT_COMMIT"),
+            "builtAt": option_env!("RIFT_BUILT_AT"),
+            "features": features,
+        });
+        CString::new(info.to_string()).unwrap_or_else(|_| CString::new("{}").expect("no NUL"))
+    })
+    .as_ptr()
+}
+
+/// Take this thread's last-error message (set by a failed `rift_*` call), or null if none.
+/// Reading it clears it; the caller frees the returned string with [`rift_free`] (issue #343).
+#[unsafe(no_mangle)]
+pub extern "C" fn rift_last_error() -> *mut c_char {
+    LAST_ERROR.with(|e| match e.borrow_mut().take() {
+        Some(c) => c.into_raw(),
+        None => std::ptr::null_mut(),
+    })
+}
+
+/// Free a string previously returned by a `rift-ffi` function. Null is a no-op.
+///
+/// # Safety
+/// `p` must be null or a pointer returned by a `rift-ffi` function (never [`rift_build_info`],
+/// whose static string must not be freed) and not yet freed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_free(p: *mut c_char) {
     unsafe {
@@ -191,18 +575,29 @@ pub unsafe extern "C" fn rift_free(p: *mut c_char) {
     }
 }
 
-/// Stop the engine: gracefully shut down all imposters and drop the handle + runtime. Null is a
-/// no-op. The handle must not be used after this call.
+/// Stop the engine: shut down the admin/metrics listeners first, then gracefully shut down all
+/// imposters, and drop the handle + runtime. Null is a no-op. The handle must not be used after.
 ///
 /// # Safety
 /// `h` must be null or a pointer returned by [`rift_start`] and not previously stopped.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
     unsafe {
+        clear_last_error();
         if h.is_null() {
             return;
         }
         let handle = Box::from_raw(h);
-        handle.runtime.block_on(handle.manager.shutdown());
+        // Ordering (issue #343): admin/metrics listeners down first, then the manager.
+        let plane = handle.admin.lock().expect("admin mutex poisoned").take();
+        handle.runtime.block_on(async {
+            if let Some(plane) = plane {
+                plane.admin.shutdown().await;
+                if let Some(metrics) = plane.metrics {
+                    metrics.shutdown().await;
+                }
+            }
+            handle.manager.shutdown().await;
+        });
     }
 }

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -102,3 +102,496 @@ fn ffi_null_and_error_paths() {
         rift_stop(h);
     }
 }
+
+// ===========================================================================
+// Issue #343: C-ABI v2 — in-process admin plane, apply_config, delete_imposter,
+// build_info, last_error.
+// ===========================================================================
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().expect("tokio runtime")
+}
+
+/// Call `rift_serve_admin`, assert it succeeded, and parse the JSON (frees the buffer).
+unsafe fn serve_admin(h: *mut RiftHandle, opts: &str) -> serde_json::Value {
+    unsafe {
+        let c = cstr(opts);
+        let json = take_json(rift_serve_admin(h, c.as_ptr()));
+        serde_json::from_str(&json).expect("serve_admin returns JSON")
+    }
+}
+
+// AC1: rift_serve_admin spawns the real admin API over the handle's manager — an FFI-created
+// imposter is visible via GET /imposters, the admin control plane creates imposters that serve
+// data-plane traffic, and scenario endpoints respond.
+#[test]
+fn ffi_serve_admin_exposes_manager_and_control_plane() {
+    unsafe {
+        let h = rift_start();
+        let cfg = cstr(
+            r#"{"port":19991,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/ping"}}],"responses":[{"is":{"statusCode":200,"body":"pong"}}]}]}"#,
+        );
+        assert_eq!(rift_create_imposter(h, cfg.as_ptr()), 19991);
+
+        let info = serve_admin(h, "{}");
+        assert!(info["adminPort"].as_u64().expect("adminPort") > 0);
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            // The FFI-created imposter is visible over the real admin API.
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("admin /imposters reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("imposters array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(
+                ports.contains(&19991),
+                "FFI imposter visible via admin /imposters"
+            );
+
+            // Control plane: create an imposter over admin; it serves data-plane traffic.
+            let create = reqwest::Client::new()
+                .post(format!("{admin_url}/imposters"))
+                .json(&serde_json::json!({
+                    "port":19992,"protocol":"http",
+                    "stubs":[{"responses":[{"is":{"statusCode":201,"body":"made"}}]}]
+                }))
+                .send()
+                .await
+                .expect("admin create imposter");
+            assert!(
+                create.status().is_success(),
+                "admin created imposter over the embedded plane"
+            );
+
+            let served = reqwest::get("http://127.0.0.1:19992/anything")
+                .await
+                .expect("admin-created imposter reachable");
+            assert_eq!(served.status(), 201);
+
+            // Scenario endpoint responds (spot-check the wider control-plane surface).
+            let scen = reqwest::get(format!("{admin_url}/imposters/19991/scenarios"))
+                .await
+                .expect("scenarios endpoint reachable");
+            assert_eq!(
+                scen.status(),
+                200,
+                "scenario endpoint responds over the embedded admin"
+            );
+        });
+
+        rift_stop(h);
+    }
+}
+
+// AC2: rift_apply_config returns the reload report field names; failed is [{port,error}]; an
+// up-front validation failure returns NULL, sets last_error, and mutates nothing.
+#[test]
+fn ffi_apply_config_report_fields_and_validation() {
+    unsafe {
+        let h = rift_start();
+
+        let cfg = cstr(r#"{"imposters":[{"port":19993,"protocol":"http","stubs":[]}]}"#);
+        let report = take_json(rift_apply_config(h, cfg.as_ptr()));
+        let v: serde_json::Value = serde_json::from_str(&report).expect("report json");
+        for k in ["created", "replaced", "stubPatched", "deleted", "failed"] {
+            assert!(
+                v.get(k).is_some(),
+                "apply report has field `{k}` (reload parity)"
+            );
+        }
+        assert!(
+            v["created"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|p| p.as_u64() == Some(19993)),
+            "19993 reported as created"
+        );
+
+        // Duplicate explicit ports parse but fail up-front validation → NULL + last_error, and
+        // nothing is mutated (port 19994 is left free to bind afterward).
+        let dup = cstr(
+            r#"{"imposters":[{"port":19994,"protocol":"http","stubs":[]},{"port":19994,"protocol":"http","stubs":[]}]}"#,
+        );
+        assert!(
+            rift_apply_config(h, dup.as_ptr()).is_null(),
+            "invalid config set → NULL"
+        );
+        let err = rift_last_error();
+        assert!(!err.is_null(), "validation failure records last_error");
+        rift_free(err);
+        assert_eq!(
+            rift_create_imposter(
+                h,
+                cstr(r#"{"port":19994,"protocol":"http","stubs":[]}"#).as_ptr()
+            ),
+            19994,
+            "nothing was mutated — 19994 is still free to bind"
+        );
+
+        rift_stop(h);
+    }
+}
+
+// AC3: rift_delete_imposter frees the port (immediate re-create on the same port succeeds);
+// deleting an unknown port returns -1.
+#[test]
+fn ffi_delete_imposter_frees_port() {
+    unsafe {
+        let h = rift_start();
+        let cfg = cstr(r#"{"port":19995,"protocol":"http","stubs":[]}"#);
+        assert_eq!(rift_create_imposter(h, cfg.as_ptr()), 19995);
+
+        assert_eq!(rift_delete_imposter(h, 19995), 0, "delete ok");
+        assert_eq!(
+            rift_create_imposter(h, cfg.as_ptr()),
+            19995,
+            "port freed — re-create on the same port succeeds"
+        );
+
+        assert_eq!(rift_delete_imposter(h, 6553), -1, "unknown port → -1");
+        rift_stop(h);
+    }
+}
+
+// AC4: rift_build_info parses; version == CARGO_PKG_VERSION; features list matches the enabled
+// feature set; commit/builtAt are present (string or null).
+#[test]
+fn ffi_build_info_reports_version_and_features() {
+    unsafe {
+        let p = rift_build_info();
+        assert!(!p.is_null(), "build_info returns a static string");
+        // Static string — NOT freed.
+        let s = CStr::from_ptr(p).to_str().expect("utf8").to_owned();
+        let v: serde_json::Value = serde_json::from_str(&s).expect("build_info json");
+
+        assert_eq!(v["version"], env!("CARGO_PKG_VERSION"));
+        assert!(
+            v.get("commit").is_some(),
+            "commit field present (string or null)"
+        );
+        assert!(
+            v.get("builtAt").is_some(),
+            "builtAt field present (string or null)"
+        );
+
+        let features: Vec<&str> = v["features"]
+            .as_array()
+            .expect("features array")
+            .iter()
+            .map(|f| f.as_str().expect("feature str"))
+            .collect();
+        if cfg!(feature = "javascript") {
+            assert!(
+                features.contains(&"javascript"),
+                "javascript feature reported"
+            );
+        }
+        if cfg!(feature = "lua") {
+            assert!(features.contains(&"lua"), "lua feature reported");
+        }
+        if cfg!(feature = "redis-backend") {
+            assert!(
+                features.contains(&"redis-backend"),
+                "redis-backend feature reported"
+            );
+        }
+    }
+}
+
+// AC5: rift_last_error is set on failure, cleared by the next successful call, cleared by reading
+// it, and confined to the calling thread.
+#[test]
+fn ffi_last_error_set_cleared_and_reading_clears() {
+    unsafe {
+        let h = rift_start();
+
+        // Failure sets it.
+        assert!(rift_apply_config(h, cstr("{ not json").as_ptr()).is_null());
+        let first = rift_last_error();
+        assert!(!first.is_null(), "failure sets last_error");
+        rift_free(first);
+        // Reading cleared it.
+        assert!(rift_last_error().is_null(), "reading last_error clears it");
+
+        // Failure sets it again; a subsequent successful call clears it.
+        assert!(rift_apply_config(h, cstr("{ not json").as_ptr()).is_null());
+        assert_eq!(
+            rift_delete_all(h),
+            0,
+            "a successful call clears last_error on entry"
+        );
+        assert!(
+            rift_last_error().is_null(),
+            "next successful call cleared last_error"
+        );
+
+        // Thread-confined: set on this thread, another thread sees none.
+        assert!(rift_apply_config(h, cstr("{ not json").as_ptr()).is_null());
+        let other = std::thread::spawn(|| rift_last_error().is_null())
+            .join()
+            .expect("thread");
+        assert!(
+            other,
+            "last_error is thread-local — not visible on another thread"
+        );
+        let mine = rift_last_error();
+        assert!(!mine.is_null(), "this thread's last_error is still set");
+        rift_free(mine);
+
+        rift_stop(h);
+    }
+}
+
+// AC6: an HTTPS imposter created via FFI works without the host pre-installing a rustls provider
+// — rift_start installs the ring default provider.
+#[test]
+fn ffi_https_imposter_without_host_provider() {
+    unsafe {
+        // NB: no rustls provider is installed by this test; rift_start must do it.
+        let h = rift_start();
+        let cfg = cstr(
+            r#"{"port":19996,"protocol":"https","stubs":[{"responses":[{"is":{"statusCode":200,"body":"secure"}}]}]}"#,
+        );
+        assert_eq!(
+            rift_create_imposter(h, cfg.as_ptr()),
+            19996,
+            "HTTPS imposter binds (self-signed) — provider is installed"
+        );
+
+        let body = rt().block_on(async {
+            let client = reqwest::Client::builder()
+                .danger_accept_invalid_certs(true)
+                .build()
+                .expect("tls client");
+            let r = client
+                .get("https://127.0.0.1:19996/anything")
+                .send()
+                .await
+                .expect("https reachable");
+            assert_eq!(r.status(), 200);
+            r.text().await.expect("body")
+        });
+        assert_eq!(body, "secure");
+
+        rift_stop(h);
+    }
+}
+
+// AC7: one admin plane per handle — a second rift_serve_admin fails (NULL) with a last_error.
+#[test]
+fn ffi_one_admin_plane_per_handle() {
+    unsafe {
+        let h = rift_start();
+        let _ = serve_admin(h, "{}");
+
+        let second = rift_serve_admin(h, cstr("{}").as_ptr());
+        assert!(
+            second.is_null(),
+            "second serve_admin on the same handle fails"
+        );
+        let err = rift_last_error();
+        assert!(!err.is_null(), "already-serving failure records last_error");
+        rift_free(err);
+
+        rift_stop(h);
+    }
+}
+
+// AC1 (metricsPort option): serve_admin with metricsPort:0 binds a metrics server and reports its
+// assigned port; that port serves /metrics. Without the option, metricsPort is null.
+#[test]
+fn ffi_serve_admin_with_metrics_port() {
+    unsafe {
+        let h = rift_start();
+        let info = serve_admin(h, r#"{"metricsPort":0}"#);
+        let mp = info["metricsPort"].as_u64().expect("metricsPort reported") as u16;
+        assert_ne!(mp, 0, "metrics bound to an assigned port");
+
+        let ok = rt().block_on(async {
+            reqwest::get(format!("http://127.0.0.1:{mp}/metrics"))
+                .await
+                .expect("metrics reachable")
+                .status()
+                == 200
+        });
+        assert!(ok, "metrics server serves /metrics");
+        rift_stop(h);
+
+        // No metricsPort → null in the response.
+        let h2 = rift_start();
+        let info = serve_admin(h2, "{}");
+        assert!(info["metricsPort"].is_null(), "no metricsPort → null");
+        rift_stop(h2);
+    }
+}
+
+/// True once `url`'s host:port refuses TCP connections (listener gone), polled up to ~2s.
+async fn admin_refused(port: u16) -> bool {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..40 {
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            tokio::net::TcpStream::connect(&addr),
+        )
+        .await
+        {
+            Ok(Err(_)) => return true,
+            _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+        }
+    }
+    false
+}
+
+// AC8b: rift_stop actually shuts the admin/metrics listeners down (both ports refuse afterward).
+#[test]
+fn ffi_stop_shuts_down_admin_and_metrics() {
+    unsafe {
+        let h = rift_start();
+        let info = serve_admin(h, r#"{"metricsPort":0}"#);
+        let admin_port = info["adminPort"].as_u64().expect("adminPort") as u16;
+        let metrics_port = info["metricsPort"].as_u64().expect("metricsPort") as u16;
+        rt().block_on(async {
+            // Both are up while serving.
+            assert_eq!(
+                reqwest::get(format!("http://127.0.0.1:{admin_port}/health"))
+                    .await
+                    .expect("admin up")
+                    .status(),
+                200
+            );
+        });
+
+        rift_stop(h);
+
+        rt().block_on(async {
+            assert!(
+                admin_refused(admin_port).await,
+                "admin port closed by rift_stop"
+            );
+            assert!(
+                admin_refused(metrics_port).await,
+                "metrics port closed by rift_stop"
+            );
+        });
+    }
+}
+
+// AC1 (apiKey option) + the security contract: a string apiKey gates the admin control plane; a
+// wrong-typed apiKey is a hard error (NULL + last_error), never a silent unauthenticated plane.
+#[test]
+fn ffi_serve_admin_apikey_gates_and_rejects_wrong_type() {
+    unsafe {
+        // Wrong-type apiKey must fail loudly, not silently disable auth.
+        let h = rift_start();
+        assert!(
+            rift_serve_admin(h, cstr(r#"{"apiKey":12345}"#).as_ptr()).is_null(),
+            "non-string apiKey is rejected, not silently unauthenticated"
+        );
+        let err = rift_last_error();
+        assert!(!err.is_null(), "wrong-type apiKey records last_error");
+        rift_free(err);
+
+        // A string apiKey gates the admin API.
+        let info = serve_admin(h, r#"{"apiKey":"secret"}"#);
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+        rt().block_on(async {
+            let unauthed = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("reachable");
+            assert_eq!(unauthed.status(), 401, "admin requires the apiKey");
+
+            let authed = reqwest::Client::new()
+                .get(format!("{admin_url}/imposters"))
+                .header("authorization", "secret")
+                .send()
+                .await
+                .expect("reachable");
+            assert_eq!(authed.status(), 200, "correct apiKey is accepted");
+        });
+        rift_stop(h);
+    }
+}
+
+// AC1 (configFile option): serve_admin loads imposters from a config file and wires it as the
+// reload source; the loaded imposter is visible over the admin API.
+#[test]
+fn ffi_serve_admin_loads_config_file() {
+    unsafe {
+        let path = std::env::temp_dir().join(format!("rift_ffi_cfg_{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19998,"protocol":"http","stubs":[]}]}"#,
+        )
+        .expect("write config file");
+
+        let h = rift_start();
+        let opts = format!(
+            r#"{{"configFile":{}}}"#,
+            serde_json::json!(path.to_str().unwrap())
+        );
+        let info = serve_admin(h, &opts);
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(
+                ports.contains(&19998),
+                "configFile imposter loaded and visible"
+            );
+        });
+        rift_stop(h);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+// AC2 (per-port failure shape): a config whose port is already occupied applies with that port in
+// `failed` as {port, error} — nothing up-front-invalid, so the report (not NULL) comes back.
+#[test]
+fn ffi_apply_config_reports_per_port_failure() {
+    unsafe {
+        // Occupy 0.0.0.0:<port> — the wildcard address imposters bind — so the manager's bind for
+        // that port deterministically collides during apply.
+        let occupied = std::net::TcpListener::bind("0.0.0.0:0").expect("occupy port");
+        let busy = occupied.local_addr().expect("addr").port();
+
+        let h = rift_start();
+        let cfg = cstr(&format!(
+            r#"{{"imposters":[{{"port":{busy},"protocol":"http","stubs":[]}}]}}"#
+        ));
+        let report = take_json(rift_apply_config(h, cfg.as_ptr()));
+        let v: serde_json::Value = serde_json::from_str(&report).expect("report json");
+
+        let failed = v["failed"].as_array().expect("failed array");
+        assert_eq!(failed.len(), 1, "the occupied port failed to bind");
+        assert_eq!(
+            failed[0]["port"].as_u64(),
+            Some(u64::from(busy)),
+            "failed entry carries the port"
+        );
+        assert!(
+            failed[0]["error"].as_str().is_some_and(|s| !s.is_empty()),
+            "failed entry carries a non-empty error string"
+        );
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -10,6 +10,15 @@ pub use rift_core::{
     proxy, recording, response, routing, rule_index, scripting, stub_analysis, template, util,
 };
 
+/// Install the process-wide rustls `ring` crypto provider, idempotently (issue #343).
+///
+/// The binary does this in `main.rs`; an embedded host (the FFI `rift_start`) must too, or an
+/// HTTPS imposter hits the missing-provider path. Safe to call more than once — a provider is
+/// already-installed error is ignored, so this composes with a host that installed its own.
+pub fn install_default_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 // ===== Admin HTTP server (control plane — server crate only) =====
 pub mod admin_api;
 


### PR DESCRIPTION
Extends the rift-ffi C-ABI (v1 = start/stop/create_imposter/replace_stubs/recorded/delete_all/free) with a v2 control plane.

- `rift_serve_admin` spawns the real `AdminApiServer` (via #342's `bind()`) on the handle's runtime over the handle's manager — the byte-identical admin surface, in-process.
- `rift_apply_config` (reload-parity report), `rift_delete_imposter`, `rift_build_info` (static; commit/builtAt stamped by #344), `rift_last_error` (thread-local).
- `rift_start` installs the rustls ring provider; `rift_stop` shuts admin/metrics before the manager. v1 symbols byte-compatible.

Verification: fmt, clippy (0 warnings), round_trip 14/14, --no-default-features clean.

**Stacked on #342** (base branch `feat/rift-342-bindable-servers`). Merge #342 first, then retarget this to master.

Closes #343
Milestone: M4 (embedded foundation)