### PR TITLE
fix(ffi): rift_serve_admin configFile load leaves partial imposters on a mid-list failure

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -77,9 +77,9 @@ char *rift_recorded(RiftHandle *h, uint16_t port);
  * `options_json` (null or `{}` uses all defaults; every field optional):
  * `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null}`.
  * `configFile` is loaded and wired as the reload source (like `--configfile`); `config` is an
- * inline `{"imposters":[...]}` applied via `apply_config`. They don't compose: `config` is a
- * reconcile, so passing both deletes the `configFile` (and any pre-existing) imposters not in the
- * inline set — pass one or the other.
+ * inline `{"imposters":[...]}`. Both are applied via `apply_config` (a reconcile, so a per-port
+ * bind failure is reported in the apply report rather than aborting mid-load). They don't
+ * compose: passing both leaves only the inline set (its reconcile deletes the rest) — pass one.
  *
  * Returns (caller frees) `{"adminPort":49321,"adminUrl":"http://127.0.0.1:49321","metricsPort":null}`,
  * or null on error (bad JSON, bind failure, or already serving — one admin plane per handle).

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -28,7 +28,7 @@
 //! rather than crossing the boundary (defined behaviour). A failed downcall returns its sentinel,
 //! records the reason in [`rift_last_error`], and emits a `tracing` event.
 
-use rift_core::imposter::{ImposterConfig, ImposterManager, Stub};
+use rift_core::imposter::{ApplyReport, ImposterConfig, ImposterManager, Stub};
 use rift_http_proxy::admin_api::{AdminApiServer, RunningAdminApi};
 use rift_http_proxy::config_loader::{self, ConfigSource};
 use rift_http_proxy::server::{RunningMetrics, bind_metrics_server};
@@ -306,9 +306,9 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
 /// `options_json` (null or `{}` uses all defaults; every field optional):
 /// `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null}`.
 /// `configFile` is loaded and wired as the reload source (like `--configfile`); `config` is an
-/// inline `{"imposters":[...]}` applied via `apply_config`. They don't compose: `config` is a
-/// reconcile, so passing both deletes the `configFile` (and any pre-existing) imposters not in the
-/// inline set — pass one or the other.
+/// inline `{"imposters":[...]}`. Both are applied via `apply_config` (a reconcile, so a per-port
+/// bind failure is reported in the apply report rather than aborting mid-load). They don't
+/// compose: passing both leaves only the inline set (its reconcile deletes the rest) — pass one.
 ///
 /// Returns (caller frees) `{"adminPort":49321,"adminUrl":"http://127.0.0.1:49321","metricsPort":null}`,
 /// or null on error (bad JSON, bind failure, or already serving — one admin plane per handle).
@@ -369,6 +369,20 @@ pub unsafe extern "C" fn rift_serve_admin(
     }
 }
 
+/// Log each imposter an `apply_config` left in `report.failed` (e.g. a port that couldn't bind), so
+/// a partial apply from serve_admin's configFile/inline config is visible rather than silently
+/// dropped — the whole set otherwise applies and serve_admin still succeeds (issue #350).
+fn warn_failed(report: &ApplyReport, source: &str) {
+    for (port, error) in &report.failed {
+        warn!(
+            port,
+            %error,
+            source,
+            "rift_serve_admin: config imposter failed to apply (skipped)"
+        );
+    }
+}
+
 /// Bind the admin (and optional metrics) plane per `opts`, returning the plane plus the JSON
 /// response body. Errors are `String`s (mapped to `last_error` by the caller).
 async fn build_admin_plane(
@@ -392,8 +406,11 @@ async fn build_admin_plane(
         None => None,
     };
 
-    // configFile: load and create imposters additively (does not reconcile away imposters the
-    // host already created), and remember the source so POST /admin/reload can re-read it.
+    // configFile: apply the loaded set via apply_config, mirroring the inline `config` path and
+    // POST /admin/reload. apply_config validates the whole set up front (Err => nothing mutated)
+    // and reports per-port failures in its report rather than a half-applied create loop that
+    // would return NULL while leaving the already-created imposters behind (issue #350). The
+    // source is remembered so POST /admin/reload can re-read it.
     let config_source = match opts.config_file.as_deref() {
         Some(path) => {
             let source = ConfigSource::File {
@@ -402,13 +419,12 @@ async fn build_admin_plane(
             };
             let configs = config_loader::load_configs(&source)
                 .map_err(|e| format!("configFile load: {e}"))?;
-            for config in configs {
-                handle
-                    .manager
-                    .create_imposter(config)
-                    .await
-                    .map_err(|e| format!("configFile imposter: {e}"))?;
-            }
+            let report = handle
+                .manager
+                .apply_config(configs)
+                .await
+                .map_err(|e| format!("configFile apply: {e}"))?;
+            warn_failed(&report, "configFile");
             Some(source)
         }
         None => None,
@@ -417,11 +433,12 @@ async fn build_admin_plane(
     // Inline config is the desired state applied via apply_config (reconcile), mirroring reload.
     if let Some(cfg) = opts.config.as_ref().filter(|v| !v.is_null()) {
         let configs = parse_imposter_configs(cfg)?;
-        handle
+        let report = handle
             .manager
             .apply_config(configs)
             .await
             .map_err(|e| format!("inline config apply: {e}"))?;
+        warn_failed(&report, "inline config");
     }
 
     // Bind metrics first (optional), then admin — so if the second bind fails, the first

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -635,3 +635,126 @@ fn ffi_build_info_commit_matches_git_head() {
         );
     }
 }
+
+// Issue #350: a configFile whose N-th imposter can't bind must NOT leave partial state behind a
+// NULL return. Routed through apply_config, serve_admin succeeds (non-NULL), loads the bindable
+// imposters, and reports the unbindable one as a per-port failure instead of a half-applied loop.
+#[test]
+fn ffi_serve_admin_config_file_partial_failure_does_not_leak() {
+    unsafe {
+        // Occupy the wildcard port an imposter would bind, so one config in the file cannot bind.
+        let occupied = std::net::TcpListener::bind("0.0.0.0:0").expect("occupy port");
+        let busy = occupied.local_addr().expect("addr").port();
+
+        let path =
+            std::env::temp_dir().join(format!("rift_ffi_partial_{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"imposters":[{{"port":19970,"protocol":"http","stubs":[]}},{{"port":{busy},"protocol":"http","stubs":[]}}]}}"#
+            ),
+        )
+        .expect("write config file");
+
+        let h = rift_start();
+        let opts = format!(
+            r#"{{"configFile":{}}}"#,
+            serde_json::json!(path.to_str().unwrap())
+        );
+        // serve_admin() asserts non-NULL — the crux of the fix (the old create-loop returned NULL
+        // here after already creating 19970).
+        let info = serve_admin(h, &opts);
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(ports.contains(&19970), "the bindable imposter loaded");
+            assert!(
+                !ports.contains(&u64::from(busy)),
+                "the occupied port did not bind and was not partially left behind"
+            );
+        });
+
+        rift_stop(h);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+// Issue #350 (second-order): a retry after a partial serve_admin failure is idempotent. The first
+// attempt applies the configFile imposter, then fails at the metrics bind (NULL, admin slot unset).
+// The old create-loop's retry would hit PortInUse re-creating that imposter; apply_config's
+// reconcile treats the unchanged imposter as a no-op, so the retry succeeds with no duplicate.
+#[test]
+fn ffi_serve_admin_retry_after_partial_failure_is_idempotent() {
+    unsafe {
+        // Occupy the loopback metrics port (serve_admin binds metrics on 127.0.0.1 by default) so
+        // the FIRST serve_admin fails at the metrics bind, AFTER the configFile imposter is applied.
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("occupy port");
+        let busy_metrics = occupied.local_addr().expect("addr").port();
+
+        let path = std::env::temp_dir().join(format!("rift_ffi_retry_{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19971,"protocol":"http","stubs":[]}]}"#,
+        )
+        .expect("write config file");
+        let cf = serde_json::json!(path.to_str().unwrap());
+
+        let h = rift_start();
+
+        // First attempt: configFile applies (creates 19971), then the metrics bind fails → NULL.
+        let first = rift_serve_admin(
+            h,
+            cstr(&format!(
+                r#"{{"configFile":{cf},"metricsPort":{busy_metrics}}}"#
+            ))
+            .as_ptr(),
+        );
+        assert!(
+            first.is_null(),
+            "first serve_admin fails at the occupied metrics port"
+        );
+        let err = rift_last_error();
+        assert!(!err.is_null(), "the failure records last_error");
+        rift_free(err);
+
+        drop(occupied);
+
+        // Retry with an ephemeral metrics port: apply_config sees 19971 unchanged (reconcile no-op),
+        // so this succeeds instead of hitting PortInUse.
+        let info = serve_admin(h, &format!(r#"{{"configFile":{cf},"metricsPort":0}}"#));
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("reachable")
+                .json()
+                .await
+                .expect("json");
+            let count = imps["imposters"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .filter(|i| i["port"].as_u64() == Some(19971))
+                .count();
+            assert_eq!(
+                count, 1,
+                "imposter present exactly once after retry — no duplicate/conflict"
+            );
+        });
+
+        rift_stop(h);
+        let _ = std::fs::remove_file(&path);
+    }
+}


### PR DESCRIPTION
rift_serve_admin's configFile branch looped create_imposter per config, so if the N-th imposter couldn't bind, the first N-1 were left created while serve_admin returned NULL (partial state behind a total-failure return; a retry then hit port conflicts).

Routes the configFile set through manager.apply_config (as the inline config path and POST /admin/reload already do): the set is validated up front (Err ⇒ nothing mutated) and per-port bind failures are reported without a half-applied loop. Retry is now idempotent (unchanged imposters reconcile to a no-op), and dropped imposters are warn!-logged instead of silently swallowed.

Verification: fmt, clippy (0 warnings), round_trip 17/17 (2 new gate tests: partial-failure-does-not-leak, retry-idempotency), --no-default-features clean.

Closes #350