### PR TITLE
enhancement: top-level `fault` response resets the connection instead of returning 502 (Mountebank parity)

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -904,29 +904,28 @@ fn handle_debug_request(
     ))
 }
 
-/// Handle fault response types
+/// Handle a top-level `fault` response type. A Mountebank `fault` is a transport-level event, so
+/// it reuses the real `_rift.fault.tcp` path (issue #309): the parsed [`TcpFaultKind`] is attached
+/// as a response extension that the serve loop's `FaultIo` applies as a real reset/close/etc.,
+/// instead of framing a clean HTTP 502 (which a migrated Mountebank config would not expect).
 fn handle_fault_response(fault_type: &str) -> Result<Response<Full<Bytes>>, Infallible> {
-    match fault_type {
-        "CONNECTION_RESET_BY_PEER" => {
-            // Return empty response to simulate connection reset
-            // In real Mountebank, this would actually reset the TCP connection
-            Ok(build_response_with_headers(
-                StatusCode::BAD_GATEWAY,
-                [("x-rift-fault", "CONNECTION_RESET_BY_PEER")],
-                Bytes::new(),
-            ))
-        }
-        "RANDOM_DATA_THEN_CLOSE" => Ok(build_response_with_headers(
+    if let Some(kind) = super::fault_io::TcpFaultKind::parse(fault_type) {
+        // Carrier response: `FaultIo` aborts the connection before this is sent, so the
+        // status/body here are never observed by the client (mirrors the `_rift.fault.tcp` path).
+        let mut response = build_response_with_headers(
             StatusCode::BAD_GATEWAY,
-            [("x-rift-fault", "RANDOM_DATA_THEN_CLOSE")],
-            Bytes::from_static(b"\x00\xff\xfe\xfd"),
-        )),
-        _ => Ok(build_response_with_headers(
-            StatusCode::INTERNAL_SERVER_ERROR,
             [("x-rift-fault", fault_type)],
-            format!("Unknown fault: {fault_type}"),
-        )),
+            Bytes::new(),
+        );
+        response.extensions_mut().insert(kind);
+        return Ok(response);
     }
+    // Unrecognized fault type: a defined error, never a silent connection drop.
+    Ok(build_response_with_headers(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [("x-rift-fault", fault_type)],
+        format!("Unknown fault: {fault_type}"),
+    ))
 }
 
 /// Apply Rift fault configuration (probabilistic faults)
@@ -1026,8 +1025,45 @@ async fn apply_rift_fault(
 mod fault_precedence_tests {
     use super::super::fault_io::TcpFaultKind;
     use super::super::types::{RiftErrorFault, RiftFaultConfig, RiftLatencyFault};
-    use super::{Bytes, Full, Response, apply_rift_fault};
+    use super::{Bytes, Full, Response, apply_rift_fault, handle_fault_response};
     use std::time::Instant;
+
+    // Issue #309: a top-level `fault` response must reset/close the connection (via the same
+    // TcpFaultKind extension the serve loop's FaultIo reads for `_rift.fault.tcp`), not return a
+    // framed HTTP 502. Before the fix `handle_fault_response` attached no extension.
+    #[test]
+    fn top_level_fault_carries_real_tcp_fault_extension() {
+        let reset = handle_fault_response("CONNECTION_RESET_BY_PEER").expect("infallible");
+        assert_eq!(
+            reset.extensions().get::<TcpFaultKind>().copied(),
+            Some(TcpFaultKind::Reset),
+            "CONNECTION_RESET_BY_PEER must carry a real TCP-reset fault, not a plain 502"
+        );
+
+        let random = handle_fault_response("RANDOM_DATA_THEN_CLOSE").expect("infallible");
+        assert_eq!(
+            random.extensions().get::<TcpFaultKind>().copied(),
+            Some(TcpFaultKind::RandomData),
+            "RANDOM_DATA_THEN_CLOSE must carry a real random-data-then-close fault"
+        );
+
+        // The two remaining WireMock kinds also route to a real transport fault (unified on the
+        // same parser as `_rift.fault.tcp`), no longer falling into the 500 "Unknown fault" branch.
+        let empty = handle_fault_response("EMPTY_RESPONSE").expect("infallible");
+        assert_eq!(
+            empty.extensions().get::<TcpFaultKind>().copied(),
+            Some(TcpFaultKind::Empty)
+        );
+        let malformed = handle_fault_response("MALFORMED_RESPONSE_CHUNK").expect("infallible");
+        assert_eq!(
+            malformed.extensions().get::<TcpFaultKind>().copied(),
+            Some(TcpFaultKind::MalformedChunk)
+        );
+
+        // An unrecognized fault type stays a defined error, not a silent transport fault.
+        let unknown = handle_fault_response("NOT_A_FAULT").expect("infallible");
+        assert!(unknown.extensions().get::<TcpFaultKind>().is_none());
+    }
 
     fn error_fault(status: u16) -> RiftErrorFault {
         RiftErrorFault {

--- a/crates/rift-http-proxy/tests/top_level_fault.rs
+++ b/crates/rift-http-proxy/tests/top_level_fault.rs
@@ -1,0 +1,30 @@
+//! Issue #309: a Mountebank-style top-level `fault` response resets the TCP connection (a real
+//! transport error), not a framed HTTP 502 — end-to-end through the imposter serve loop's FaultIo.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn top_level_connection_reset_fault_resets_the_connection() {
+    let manager = Arc::new(ImposterManager::new());
+    let cfg = serde_json::from_value(serde_json::json!({
+        "port": 19940, "protocol": "http",
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/f" } }],
+            "responses": [{ "fault": "CONNECTION_RESET_BY_PEER" }]
+        }]
+    }))
+    .expect("valid imposter config");
+    manager.create_imposter(cfg).await.expect("create imposter");
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Before the fix this returned a clean 200/502; now the connection is reset, so the client
+    // sees a transport-level error (curl rc!=0 / reqwest Err), matching Mountebank.
+    let result = reqwest::get("http://127.0.0.1:19940/f").await;
+    assert!(
+        result.is_err(),
+        "top-level fault must reset the connection (transport error), got: {result:?}"
+    );
+
+    manager.delete_all().await;
+}


### PR DESCRIPTION
A top-level `fault` response (`{"fault":"CONNECTION_RESET_BY_PEER"}`) returned a clean HTTP 502 instead of resetting the TCP connection, diverging from `_rift.fault.tcp` (which does a real reset via the #242 FaultIo).

`handle_fault_response` now parses the fault via `TcpFaultKind::parse` and attaches the kind as a response extension the serve loop's `FaultIo` applies as a real reset/close. All four WireMock fault kinds (CONNECTION_RESET_BY_PEER, EMPTY_RESPONSE, MALFORMED_RESPONSE_CHUNK, RANDOM_DATA_THEN_CLOSE) now route to the real transport path; an unknown fault type still returns a defined 500.

Verification: fmt, clippy 0 warnings, a unit test asserting the extension for all 4 kinds, and an e2e asserting a real connection reset (reqwest transport error).

Closes #309