### PR TITLE
perf: trim per-request String allocations in the matcher

### DIFF
--- a/crates/rift-core/src/imposter/predicates/fields.rs
+++ b/crates/rift-core/src/imposter/predicates/fields.rs
@@ -15,7 +15,7 @@ pub(crate) fn check_predicate_fields<F>(
     query: &HashMap<String, String>,
     headers: &HashMap<String, String>,
     body: &str,
-    apply_except: &impl Fn(&str) -> String,
+    apply_except: &impl for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>,
     compare: F,
     deep_equals: bool,
     request_from: Option<&str>,
@@ -202,7 +202,7 @@ pub(crate) fn check_predicate_fields_regex(
     query: &HashMap<String, String>,
     headers: &HashMap<String, String>,
     body: &str,
-    apply_except: &impl Fn(&str) -> String,
+    apply_except: &impl for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>,
     case_sensitive: bool,
     request_from: Option<&str>,
     client_ip: Option<&str>,
@@ -251,9 +251,11 @@ pub(crate) fn check_predicate_fields_regex(
                 )
             }
             _ => {
-                let pattern = match expected {
-                    serde_json::Value::String(s) => s.as_str().to_string(),
-                    _ => expected.to_string(),
+                // Borrow a String value's pattern directly; only a non-string value needs an owned
+                // render (issue #294). The regex itself is compiled-once via `cached_regex`.
+                let pattern: std::borrow::Cow<str> = match expected {
+                    serde_json::Value::String(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                    _ => std::borrow::Cow::Owned(expected.to_string()),
                 };
                 match build_regex(&pattern) {
                     Some(re) => {

--- a/crates/rift-core/src/imposter/predicates/json.rs
+++ b/crates/rift-core/src/imposter/predicates/json.rs
@@ -195,7 +195,7 @@ pub(crate) fn compare_json_recursive<F>(
     compare: &F,
     deep_equals: bool,
     key_case_sensitive: bool,
-    apply_except: &dyn Fn(&str) -> String,
+    apply_except: &dyn for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>,
     pre_parsed: Option<&serde_json::Value>,
 ) -> bool
 where

--- a/crates/rift-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-core/src/imposter/predicates/mod.rs
@@ -152,13 +152,18 @@ pub(crate) fn predicate_matches_inner(
     // preserves the previous fall-through-to-unchanged behavior.
     let except_regex = except_pattern.and_then(|pattern| cached_regex(pattern, false));
 
-    // Helper to apply except pattern
-    let apply_except = |value: &str| -> String {
-        if let Some(re) = &except_regex {
-            return re.replace_all(value, "").to_string();
-        }
-        value.to_string()
-    };
+    // Helper to apply the except pattern. Borrows the input when no `except` is configured (the
+    // common case) so a field comparison doesn't allocate a String per predicate (issue #294);
+    // the except branch reuses `replace_all`'s native `Cow` instead of forcing an owned `String`.
+    // Pin the higher-ranked bound so the closure infers `for<'a> Fn(&'a str) -> Cow<'a, str>`
+    // (closures don't infer a borrowed return lifetime on their own).
+    fn as_except_fn<F: for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>>(f: F) -> F {
+        f
+    }
+    let apply_except = as_except_fn(|value| match &except_regex {
+        Some(re) => re.replace_all(value, ""),
+        None => std::borrow::Cow::Borrowed(value),
+    });
 
     // Helper for string comparison with case sensitivity
     let str_equals = |expected: &str, actual: &str| -> bool {


### PR DESCRIPTION
Trims two per-request `String` allocations on the imposter predicate hot path, with **behavior identical**:

- `apply_except` now returns `Cow<str>`: it borrows the input when no `except` is configured (the common case) instead of always `value.to_string()`, and the `except` branch reuses regex `replace_all`'s native `Cow`. Threaded through the field/json predicate checks as `for<'a> Fn(&'a str) -> Cow<'a, str>` (a small `as_except_fn` helper pins the higher-ranked bound, since closures don't infer a borrowed-return lifetime).
- the `matches` path borrows a `String` pattern value instead of cloning it before compilation. (The regex itself is already compiled-once via `cached_regex` — the ticket's regex-`to_string` concern is largely subsumed by that prior work.)

The script-header lowercasing the ticket also mentioned is per-script-response (not per-predicate) and the lowercase keys are a required part of the `ScriptRequest` contract, so it's left as-is.

Verification: fmt, clippy 0 warnings, predicate tests 137/137, rift-core lib 799/799 (behavior identical — the except/`matches` paths are covered by the existing `test_except_pattern` / `test_matches_method_with_except_applied` tests). Opus review: pure behavior-preserving refactor, no findings.

Part of the Performance & load-capacity roadmap.
Closes #294