### PR TITLE
ci: wire a performance regression gate into CI

### DIFF
--- a/.github/scripts/bench_regression.py
+++ b/.github/scripts/bench_regression.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Gate a PR on matcher benchmark regressions (issue #298).
+
+Reads criterion's own saved baselines (`--save-baseline base` / `pr`) from `target/criterion` and
+compares the mean estimate of each benchmark. Posts a markdown table to the GitHub job summary and
+exits non-zero if any benchmark regressed beyond REGRESSION_THRESHOLD (a relative multiple). Reading
+criterion's `estimates.json` directly avoids brittle text parsing; an unpaired or unparseable
+benchmark is skipped rather than failing the run.
+"""
+
+import glob
+import json
+import os
+import sys
+
+CRITERION_DIR = "target/criterion"
+THRESHOLD = float(os.environ.get("REGRESSION_THRESHOLD", "1.25"))
+
+
+def mean_ns(estimates_path):
+    try:
+        with open(estimates_path) as fh:
+            return float(json.load(fh)["mean"]["point_estimate"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def main():
+    rows = []  # (name, base_ns, pr_ns, ratio)
+    for base_path in glob.glob(f"{CRITERION_DIR}/**/base/estimates.json", recursive=True):
+        pr_path = base_path.replace("/base/estimates.json", "/pr/estimates.json")
+        base = mean_ns(base_path)
+        pr = mean_ns(pr_path)
+        if base is None or pr is None or base <= 0:
+            continue
+        name = base_path[len(CRITERION_DIR) + 1 : -len("/base/estimates.json")]
+        rows.append((name, base, pr, pr / base))
+
+    if not rows:
+        print("No paired benchmarks found to compare; skipping the perf gate.")
+        return 0
+
+    rows.sort(key=lambda r: r[3], reverse=True)
+
+    def fmt_ns(v):
+        return f"{v/1000:.2f} µs" if v >= 1000 else f"{v:.1f} ns"
+
+    lines = [
+        "## Matcher benchmark regression gate",
+        "",
+        f"Threshold: fail if any benchmark is more than **{(THRESHOLD-1)*100:.0f}%** slower than base.",
+        "",
+        "| Benchmark | base | PR | change |",
+        "|---|--:|--:|--:|",
+    ]
+    regressed = []
+    for name, base, pr, ratio in rows:
+        pct = (ratio - 1) * 100
+        flag = " ⚠️" if ratio > THRESHOLD else (" 🟢" if ratio < 0.9 else "")
+        lines.append(f"| `{name}` | {fmt_ns(base)} | {fmt_ns(pr)} | {pct:+.1f}%{flag} |")
+        if ratio > THRESHOLD:
+            regressed.append((name, pct))
+
+    summary = "\n".join(lines) + "\n"
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write(summary)
+    print(summary)
+
+    if regressed:
+        worst = ", ".join(f"{n} (+{p:.1f}%)" for n, p in regressed)
+        print(f"::error::Benchmark regression beyond {(THRESHOLD-1)*100:.0f}% threshold: {worst}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,59 @@
+name: Performance
+
+# Issue #298: run the criterion matcher benches on PRs and flag regressions, so a perf regression
+# can't land silently. Compares the PR head against the base by running the same benches on both
+# and diffing criterion's own mean estimates. Microbenchmarks on shared CI runners are noisy, so
+# the hard-fail threshold is deliberately generous (relative, per-benchmark); the full comparison
+# is always posted to the job summary for review.
+
+on:
+  pull_request:
+    # Only when code that can affect matcher performance changes (keeps the job off doc/CI-only PRs).
+    paths:
+      - "crates/rift-core/**"
+      - "crates/rift-http-proxy/**"
+      - "crates/rift-types/**"
+      - ".github/workflows/perf.yml"
+
+# One in-flight run per PR; a new push cancels the previous (benches are expensive).
+concurrency:
+  group: perf-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # Regression multiple beyond which the job fails. Generous on purpose — shared runners are noisy;
+  # this catches order-of-magnitude / large regressions, not single-digit-% jitter.
+  REGRESSION_THRESHOLD: "1.25"
+
+jobs:
+  bench-regression:
+    name: Matcher benchmark regression gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for base/head)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Benchmark base (${{ github.base_ref }})
+        run: |
+          git checkout --force ${{ github.event.pull_request.base.sha }}
+          cargo bench -p rift-core --bench imposter_matcher_bench -- --save-baseline base
+
+      - name: Benchmark PR head
+        run: |
+          git checkout --force ${{ github.event.pull_request.head.sha }}
+          cargo bench -p rift-core --bench imposter_matcher_bench -- --save-baseline pr
+
+      - name: Compare and gate
+        run: python3 .github/scripts/bench_regression.py


### PR DESCRIPTION
Adds a `Performance` workflow so matcher perf regressions can't land silently.

On PRs touching the matcher crates (`rift-core` / `rift-http-proxy` / `rift-types`, or the workflow itself), it:
1. runs the criterion `imposter_matcher_bench` on the **base** and on the **PR head** (criterion `--save-baseline`);
2. compares them by reading criterion's own `estimates.json` mean estimates — no fragile text parsing;
3. posts a per-benchmark table (base / PR / % change) to the job summary;
4. **fails only on a generous relative regression** (25% by default, `REGRESSION_THRESHOLD`) so shared-runner noise doesn't false-block — the issue's "use relative thresholds / watch runner noise" guidance.

The gate script (`.github/scripts/bench_regression.py`) is defensive: an unpaired or unparseable benchmark is skipped, not fatal.

Self-tested: the `paths` filter includes `perf.yml`, so this gate runs on **this** PR (base master vs head — no matcher change → green). The comparison logic was validated locally end-to-end against real criterion baselines.

Note: adding this as a **required** check is a branch-protection/ruleset decision left to a maintainer; the job runs and reports (and reds on a real regression) regardless.

Closes #298