### PR TITLE
ci(perf): install system LuaJIT for the matcher bench build

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # rift-core links the mlua LuaJIT scripting engine, which needs the system LuaJIT dev lib
+      # (same as every ci.yml build job); without it the bench build fails at mlua-sys.
+      - name: Install LuaJIT
+        run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Follow-up to #366. The new perf gate omitted the `libluajit-5.1-dev` system dependency that every `ci.yml` build job installs — `rift-core` links mlua's LuaJIT engine, so the bench build failed at `mlua-sys` and the perf job errored on its own PR. This mirrors `ci.yml`'s "Install LuaJIT" step.

Self-tests: editing `perf.yml` triggers the perf job, so this PR's own run validates the fix.

Refs #298