### PR TITLE
JavaScript _rift.script has no interpreter interrupt on timeout (leaks a blocking thread)

### DIFF
--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -33,9 +33,10 @@ pub fn resolve_script_timeout_ms(config: &ImposterConfig) -> u64 {
 /// (issue #308). Execution happens in `spawn_blocking` so a non-yielding script cannot
 /// starve the Tokio runtime, and at `timeout` the abort flag is set so the script self-
 /// interrupts. Rhai (`on_progress`) and Lua (instruction hook) are truly interrupted and
-/// free their thread promptly; other engines (JavaScript) are NOT interpreter-interruptible,
-/// so a runaway there still returns `Err` at the deadline but its blocking thread runs until
-/// the script finishes on its own. Returns `Err` on timeout, a compile/exec error, or a panic.
+/// free their thread promptly. JavaScript can't observe the deadline flag mid-run (Boa has no
+/// per-instruction interrupt), but its context caps loop iterations (issue #327), so a runaway
+/// loop terminates by throwing instead of leaking its blocking thread forever. Returns `Err` on
+/// timeout, a compile/exec error, or a panic.
 pub async fn should_inject_bounded(
     engine_type: String,
     code: String,

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -204,13 +204,34 @@ fn execute_js_script(
     result
 }
 
+/// Loop-iteration cap for a `should_inject` Boa context (issue #327). Boa exposes no
+/// per-instruction interrupt, so a runaway loop (`while(true){}`) can't observe the deadline abort
+/// flag and would run its `spawn_blocking` thread forever. This fixed cap bounds it: Boa throws
+/// once the limit is hit, the execution returns `Err`, and the thread is freed. Generous enough
+/// that no realistic boolean fault-decision script approaches it.
+const JS_SCRIPT_LOOP_ITERATION_LIMIT: u64 = 10_000_000;
+
 /// Inner function that does the actual JavaScript execution
 fn execute_js_script_inner(
     script: &str,
     request: &ScriptRequest,
     rule_id: &str,
 ) -> Result<FaultDecision> {
+    execute_js_script_inner_bounded(script, request, rule_id, JS_SCRIPT_LOOP_ITERATION_LIMIT)
+}
+
+/// As [`execute_js_script_inner`], but with an explicit loop-iteration cap so tests can bound a
+/// runaway cheaply (issue #327).
+fn execute_js_script_inner_bounded(
+    script: &str,
+    request: &ScriptRequest,
+    rule_id: &str,
+    loop_iteration_limit: u64,
+) -> Result<FaultDecision> {
     let mut context = Context::default();
+    context
+        .runtime_limits_mut()
+        .set_loop_iteration_limit(loop_iteration_limit);
 
     // Create request object
     let request_obj = create_request_object(&mut context, request)?;
@@ -1628,6 +1649,50 @@ function should_inject(request, flow_store) {
             }
             _ => panic!("Expected error fault decision"),
         }
+    }
+
+    // Issue #327: the JS should_inject Boa context caps loop iterations so a runaway script
+    // terminates (Boa throws) instead of leaking its spawn_blocking thread forever. A small
+    // injected limit keeps these tests fast and guarantees they can never hang.
+    #[test]
+    fn js_should_inject_loop_limit_terminates() {
+        set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
+        let request = ScriptRequest {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            headers: HashMap::new(),
+            body: json!({}),
+            query: HashMap::new(),
+            path_params: HashMap::new(),
+        };
+        let script = "function should_inject(request, flow_store) { while (true) {} }";
+        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        clear_current_flow_store();
+        assert!(
+            result.is_err(),
+            "a runaway JS loop must hit the iteration cap and return Err, not run unbounded"
+        );
+    }
+
+    #[test]
+    fn js_should_inject_under_limit_runs() {
+        set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
+        let request = ScriptRequest {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            headers: HashMap::new(),
+            body: json!({}),
+            query: HashMap::new(),
+            path_params: HashMap::new(),
+        };
+        let script = "function should_inject(request, flow_store) { let n = 0; for (let i = 0; i < 100; i++) { n++; } return { inject: n === 100, fault: 'latency', duration_ms: 1 }; }";
+        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        clear_current_flow_store();
+        assert!(
+            result.is_ok(),
+            "a small-loop script under the cap must run fine: {:?}",
+            result.err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
A runaway JavaScript `_rift.script` `should_inject` (e.g. `while(true){}`) ran its `spawn_blocking` thread **forever**: Boa has no per-instruction interrupt, so it never observed the deadline abort flag that Rhai/Lua self-interrupt on (#308). Each runaway request permanently leaked one blocking-pool thread (shared with Rhai/Lua, cap 512) — enough of them could eventually starve even the properly-bounded engines.

**Fix:** set a loop-iteration limit via Boa's `runtime_limits` on the `should_inject` context. A runaway loop now throws once the cap is hit, the execution returns `Err` (surfaced as the existing 500 + `x-rift-script-error`, never a silent "no fault"), and the thread is freed. The cap (10M) is generous enough that no realistic boolean fault-decision script approaches it. Applied to the should_inject path only (incl. the script-pool workers); decorate/inject contexts are unchanged, as are Rhai/Lua.

**Tests:** a runaway `while(true){}` (with a small injected cap for speed) → `Err`; a small-loop script → `Ok`.

**Known residual (follow-up):** Boa's loop counter is per-call-frame, so a deliberately *nested* runaway (`while(true){ f(); }`) can amplify past the per-frame cap — still finite (and the client is released at the wall-clock timeout regardless), but longer than a plain `while(true){}`. Boa exposes no cumulative instruction budget to close this fully; filing separately.

Verification: fmt, clippy 0, rift-core lib 810/810, `--no-default-features` compiles. Reviewed (opus): no blockers.

Part of #310. Related: #308.
Closes #327