### PR TITLE
Response-behavior failures serve the request anyway (decorate / shellTransform / binary base64)

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -641,8 +641,15 @@ async fn handle_request_inner(
                             }
                             // Behave as if decorate was absent: keep the original multi-value
                             // `headers` and pre-decorate body/status rather than serving a folded,
-                            // undecorated response.
-                            Err(e) => warn!("Decorate script error: {e}"),
+                            // undecorated response. Attach a visible signal so the skipped behavior
+                            // isn't a silent success (issue #323); the body is still served (#269).
+                            Err(e) => {
+                                warn!("Decorate script error: {e}");
+                                headers.insert(
+                                    "x-rift-decorate-error".to_string(),
+                                    vec!["true".to_string()],
+                                );
+                            }
                         }
                     }
 
@@ -652,7 +659,15 @@ async fn handle_request_inner(
                     for cmd in &parsed_behaviors.shell_transform {
                         match apply_shell_transform(cmd, &request_context, &body, status) {
                             Ok(transformed) => body = transformed,
-                            Err(e) => warn!("shellTransform command {cmd:?} failed: {e}"),
+                            // Keep the body unchanged (issue #269) but signal the failure so it
+                            // isn't a silent success (issue #323).
+                            Err(e) => {
+                                warn!("shellTransform command {cmd:?} failed: {e}");
+                                headers.insert(
+                                    "x-rift-shelltransform-error".to_string(),
+                                    vec!["true".to_string()],
+                                );
+                            }
                         }
                     }
                 }
@@ -670,6 +685,7 @@ async fn handle_request_inner(
             response = response.header("x-rift-imposter", "true");
 
             // Handle binary mode - decode base64 body if _mode is "binary"
+            let mut binary_decode_failed = false;
             let body_bytes = match response_mode {
                 ResponseMode::Binary => {
                     // Decode base64-encoded body
@@ -677,6 +693,7 @@ async fn handle_request_inner(
                         Ok(decoded) => Bytes::from(decoded),
                         Err(e) => {
                             warn!("Failed to decode base64 body: {}, using raw body", e);
+                            binary_decode_failed = true;
                             Bytes::from(body)
                         }
                     }
@@ -684,6 +701,10 @@ async fn handle_request_inner(
                 // Expand serve-time date templates ({{DAYS+N}}/{{MONTHS+N}}/{{NOW}}, issue #195).
                 ResponseMode::Text => Bytes::from(crate::extensions::apply_date_templates(&body)),
             };
+            // Signal a failed binary decode so serving the raw (still-encoded) body isn't silent (#323).
+            if binary_decode_failed {
+                response = response.header("x-rift-binary-error", "true");
+            }
 
             return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|_| {
                 build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")

--- a/crates/rift-http-proxy/tests/issue_323_behavior_failure_headers.rs
+++ b/crates/rift-http-proxy/tests/issue_323_behavior_failure_headers.rs
@@ -1,0 +1,99 @@
+//! Issue #323 gate: a response behavior that the stub author requested but that FAILS must not be
+//! a completely silent success. The fallback body is still served (preserving #269's lenient
+//! shellTransform contract), but a visible `x-rift-<behavior>-error` header is attached so the
+//! client can tell the behavior was skipped.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+async fn mk(manager: &ImposterManager, cfg: serde_json::Value) {
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+}
+
+// AC1: a decorate script that throws attaches x-rift-decorate-error (body unchanged).
+#[tokio::test]
+async fn decorate_failure_sets_error_header() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19891, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "decorate": "function (request, response) { throw new Error('boom'); }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19891/x")
+        .send()
+        .await
+        .expect("send");
+    let has_header = resp.headers().contains_key("x-rift-decorate-error");
+    let body = resp.text().await.expect("body");
+    assert!(
+        has_header,
+        "a failing decorate must attach x-rift-decorate-error, not be a silent success"
+    );
+    assert_eq!(body, "original", "the fallback body is still served");
+    let _ = manager.delete_imposter(19891).await;
+}
+
+// AC2: a failing shellTransform attaches x-rift-shelltransform-error (body kept, per #269).
+#[tokio::test]
+async fn shell_transform_failure_sets_error_header() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19892, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "shellTransform": "exit 1" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19892/x")
+        .send()
+        .await
+        .expect("send");
+    let has_header = resp.headers().contains_key("x-rift-shelltransform-error");
+    let body = resp.text().await.expect("body");
+    assert!(
+        has_header,
+        "a failing shellTransform must attach x-rift-shelltransform-error"
+    );
+    assert_eq!(body, "original", "the body is kept unchanged (issue #269)");
+    let _ = manager.delete_imposter(19892).await;
+}
+
+// AC3: a binary-mode body that isn't valid base64 attaches x-rift-binary-error.
+#[tokio::test]
+async fn binary_decode_failure_sets_error_header() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19893, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "not!valid!base64!", "_mode": "binary" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19893/x")
+        .send()
+        .await
+        .expect("send");
+    assert!(
+        resp.headers().contains_key("x-rift-binary-error"),
+        "a failing binary base64 decode must attach x-rift-binary-error"
+    );
+    let _ = manager.delete_imposter(19893).await;
+}


### PR DESCRIPTION
`decorate`, `shellTransform`, and binary-mode base64 decode each **silently served a 200** on failure — the client couldn't tell the requested behavior was skipped. For a mocking/chaos tool that's a footgun: a broken decorate or transform passes tests green while serving the wrong bytes.

**Fix (the issue's non-breaking option):** on each failure, keep serving the fallback body but attach a visible `x-rift-<behavior>-error` header (`x-rift-decorate-error`, `x-rift-shelltransform-error`, `x-rift-binary-error`) alongside the existing warn log, so the failure is client-observable and no longer a silent success.

**Why not a fail-loud 500?** Issue #269 *deliberately* established (and tests) that a shellTransform failure **keeps the body** — a unilateral 500 would regress that `static_response_shell_transform_failure_keeps_body` contract (the "some users depend on best-effort" case the issue anticipates). The header signal satisfies the "not silent" floor while preserving #269. A **strict-mode (opt-in fail-loud) knob** is a reasonable follow-up.

The header value is a static `"true"` (the error detail stays in the log — no injection surface). Multiple failing behaviors attach independent headers.

Tests: failing decorate / shellTransform / binary each attach their header (body unchanged); #269's keeps-body test stays green. Verification: fmt, clippy 0, rift-core lib 810/810, `--no-default-features` compiles. Reviewed (opus): no blockers.

Part of #310.
Closes #323