### PR TITLE
Make script flow-store errors visible to scripts, not silent fallbacks

### DIFF
--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -406,14 +406,41 @@ mod tests {
     }
 }
 
-/// Log-and-fallback for the script-facing flow-store wrappers: scripts keep their legacy
-/// fallback values on a backend failure (changing that is a breaking script contract),
-/// but the dropped error is no longer invisible (issue #318).
+// The last script flow-store op's error for the current thread, or `None` if the last op
+// succeeded. Set/cleared by `log_flow_err` on every op so a script can observe a backend failure
+// via `flow_store.last_error()` instead of only getting a silent fallback value (issue #322).
+thread_local! {
+    static LAST_FLOW_ERROR: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Take (read and clear) the last script flow-store error for the current thread. Backs the
+/// per-engine `flow_store.last_error()` accessors (issue #322).
+pub fn take_last_flow_error() -> Option<String> {
+    LAST_FLOW_ERROR.with(|e| e.borrow_mut().take())
+}
+
+/// Reset the last flow-store error at the start of a script execution, so `last_error()` reflects
+/// only ops from THIS execution — never a stale value left on a reused (pooled) worker thread
+/// (issue #322).
+pub fn clear_last_flow_error() {
+    LAST_FLOW_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+/// Route a script flow-store op result through the shared error seam: log a failure, record it so
+/// `flow_store.last_error()` can surface it (issue #322), and return the fallback; a success clears
+/// the slot so `last_error()` reflects only the most recent op.
 pub fn log_flow_err<T>(op: &str, fallback: T, result: Result<T>) -> T {
-    result.unwrap_or_else(|e| {
-        tracing::warn!("script flow_store.{op} failed; returning fallback: {e:#}");
-        fallback
-    })
+    match result {
+        Ok(value) => {
+            LAST_FLOW_ERROR.with(|e| *e.borrow_mut() = None);
+            value
+        }
+        Err(e) => {
+            tracing::warn!("script flow_store.{op} failed; returning fallback: {e:#}");
+            LAST_FLOW_ERROR.with(|slot| *slot.borrow_mut() = Some(format!("{op}: {e:#}")));
+            fallback
+        }
+    }
 }
 
 /// A deliberately failing flow store (feature `test-backend`): every operation annotates
@@ -456,6 +483,38 @@ impl FlowStore for FailingFlowStore {
     }
     fn set_ttl(&self, flow_id: &str, _ttl_seconds: i64) -> Result<()> {
         self.fail("flowStore.setTtl", flow_id, "")
+    }
+}
+
+#[cfg(test)]
+mod last_flow_error_tests {
+    use super::*;
+
+    // AC1 (issue #322): log_flow_err records a failure so last_error can surface it, and a
+    // subsequent success clears it — so last_error reflects only the most recent op.
+    #[test]
+    fn log_flow_err_records_error_and_clears_on_ok() {
+        let _ = take_last_flow_error(); // start clean on this thread
+        let out = log_flow_err("get", None::<i32>, Err(anyhow::anyhow!("redis down")));
+        assert_eq!(out, None);
+        let recorded = take_last_flow_error();
+        assert!(
+            recorded
+                .as_deref()
+                .is_some_and(|s| s.contains("get") && s.contains("redis down")),
+            "a failed op must record its error, got {recorded:?}"
+        );
+        // take() cleared it
+        assert_eq!(take_last_flow_error(), None);
+        // a success clears the slot
+        LAST_FLOW_ERROR.with(|e| *e.borrow_mut() = Some("stale".to_string()));
+        let v = log_flow_err("set", false, Ok::<bool, anyhow::Error>(true));
+        assert!(v);
+        assert_eq!(
+            take_last_flow_error(),
+            None,
+            "a successful op clears last_error"
+        );
     }
 }
 

--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -89,6 +89,9 @@ fn run_should_inject_with_abort(
     flow_store: Arc<dyn FlowStore>,
     abort: &Arc<AtomicBool>,
 ) -> Result<FaultDecision> {
+    // Start each execution with a clean last-flow-error slot so `flow_store.last_error()` can't
+    // observe a stale error left by a previous script on this reused worker thread (issue #322).
+    crate::extensions::flow_state::clear_last_flow_error();
     match engine_type {
         "rhai" => super::rhai_engine::run_should_inject_with_abort_rhai(
             code, rule_id, request, flow_store, abort,

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -71,6 +71,7 @@ fn with_current_flow_store<T>(f: impl FnOnce(&Arc<dyn FlowStore>) -> T) -> Optio
 /// - `flow_store.delete(flow_id, key)` - Delete a key (returns boolean)
 /// - `flow_store.increment(flow_id, key)` - Increment counter (returns number)
 /// - `flow_store.set_ttl(flow_id, ttl_seconds)` - Set flow expiration (returns boolean)
+/// - `flow_store.last_error()` - Take the last flow-store op's error (returns null if none)
 ///
 /// ## Return Value
 ///
@@ -498,6 +499,19 @@ fn flow_store_set_ttl(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> 
     Ok(JsValue::from(result))
 }
 
+fn flow_store_last_error(
+    _this: &JsValue,
+    _args: &[JsValue],
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    Ok(
+        match crate::extensions::flow_state::take_last_flow_error() {
+            Some(msg) => JsValue::from(js_string!(msg)),
+            None => JsValue::null(),
+        },
+    )
+}
+
 /// Register a native function method on a JS object.
 fn register_method(
     obj: &JsObject,
@@ -525,6 +539,7 @@ fn create_flow_store_object(context: &mut Context) -> Result<JsValue> {
     register_method(&obj, "delete", flow_store_delete, context)?;
     register_method(&obj, "increment", flow_store_increment, context)?;
     register_method(&obj, "set_ttl", flow_store_set_ttl, context)?;
+    register_method(&obj, "last_error", flow_store_last_error, context)?;
 
     Ok(obj.into())
 }
@@ -1693,6 +1708,39 @@ function should_inject(request, flow_store) {
             "a small-loop script under the cap must run fine: {:?}",
             result.err()
         );
+    }
+
+    // AC3 (issue #322): a JS script can observe a backend flow-store failure via
+    // flow_store.last_error() instead of only seeing a silent fallback value.
+    #[test]
+    fn js_flow_store_last_error_surfaces() {
+        use crate::extensions::flow_state::{log_flow_err, take_last_flow_error};
+        let _ = take_last_flow_error();
+        set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
+        let request = ScriptRequest {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            headers: HashMap::new(),
+            body: json!({}),
+            query: HashMap::new(),
+            path_params: HashMap::new(),
+        };
+        // Record a failure through the shared seam, then let the script observe it.
+        let _ = log_flow_err(
+            "get",
+            None::<i32>,
+            Err::<Option<i32>, _>(anyhow::anyhow!("js backend down")),
+        );
+        let script = "function should_inject(request, flow_store) { var e = flow_store.last_error(); return { inject: true, fault: 'latency', duration_ms: (e && e.indexOf('js backend down') >= 0) ? 999 : 1 }; }";
+        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        clear_current_flow_store();
+        match result {
+            Ok(FaultDecision::Latency { duration_ms, .. }) => assert_eq!(
+                duration_ms, 999,
+                "flow_store.last_error() must surface the recorded backend error to JS"
+            ),
+            other => panic!("expected Latency decision surfacing last_error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -38,6 +38,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// - `flow_store:delete(flow_id, key)` - Delete a key (returns bool)
 /// - `flow_store:increment(flow_id, key)` - Increment counter (returns number)
 /// - `flow_store:set_ttl(flow_id, ttl_seconds)` - Set flow expiration (returns bool)
+/// - `flow_store:last_error()` - Take the last flow-store op's error (returns nil if none)
 ///
 /// ## Return Value
 ///
@@ -665,6 +666,12 @@ impl LuaFlowStore {
 
         Ok(log_flow_err("setTtl", false, result))
     }
+
+    /// Take (read and clear) the last flow-store op error for this thread, or nil if the
+    /// last op succeeded (issue #322).
+    fn last_error(&self) -> LuaResult<Option<String>> {
+        Ok(crate::extensions::flow_state::take_last_flow_error())
+    }
 }
 
 impl LuaUserData for LuaFlowStore {
@@ -697,6 +704,8 @@ impl LuaUserData for LuaFlowStore {
             "set_ttl",
             |_lua, this, (flow_id, ttl_seconds): (String, i64)| this.set_ttl(flow_id, ttl_seconds),
         );
+
+        methods.add_method("last_error", |_lua, this, ()| this.last_error());
     }
 }
 
@@ -966,6 +975,71 @@ end
         // Third attempt should not inject fault
         let result3 = engine.should_inject(&request, Arc::clone(&store)).unwrap();
         assert!(matches!(result3, FaultDecision::None));
+    }
+
+    /// A flow store whose `get` always fails, used to exercise `flow_store:last_error()`
+    /// (issue #322). `should_inject` runs the script on its own spawned thread, so the
+    /// failure must be recorded by the script itself (via a real failing op) rather than
+    /// injected from the test thread's thread-local.
+    #[derive(Debug)]
+    struct FailingGetFlowStore;
+
+    impl FlowStore for FailingGetFlowStore {
+        fn get(&self, _flow_id: &str, _key: &str) -> anyhow::Result<Option<Value>> {
+            Err(anyhow::anyhow!("lua backend down"))
+        }
+        fn set(&self, _flow_id: &str, _key: &str, _value: Value) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn exists(&self, _flow_id: &str, _key: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn delete(&self, _flow_id: &str, _key: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn increment(&self, _flow_id: &str, _key: &str) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+        fn set_ttl(&self, _flow_id: &str, _ttl_seconds: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    // AC4 (issue #322): a Lua script can observe a backend flow-store failure via
+    // flow_store:last_error() instead of only seeing a silent fallback value.
+    #[tokio::test]
+    async fn lua_flow_store_last_error_surfaces() {
+        let script = r#"
+function should_inject(request, flow_store)
+    flow_store:get("flow-1", "key")
+    local err = flow_store:last_error()
+    if err and string.find(err, "lua backend down", 1, true) then
+        return { inject = true, fault = "latency", duration_ms = 999 }
+    end
+    return { inject = true, fault = "latency", duration_ms = 1 }
+end
+"#;
+
+        let engine = LuaEngine::new(script, "test-rule").unwrap();
+        let store: Arc<dyn FlowStore> = Arc::new(FailingGetFlowStore);
+
+        let request = ScriptRequest {
+            method: "GET".to_string(),
+            path: "/".to_string(),
+            headers: HashMap::new(),
+            body: json!({}),
+            query: HashMap::new(),
+            path_params: HashMap::new(),
+        };
+
+        let result = engine.should_inject(&request, store).unwrap();
+        match result {
+            FaultDecision::Latency { duration_ms, .. } => assert_eq!(
+                duration_ms, 999,
+                "flow_store:last_error() must surface the recorded backend error to Lua"
+            ),
+            other => panic!("expected Latency decision surfacing last_error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -206,6 +206,15 @@ impl ScriptFlowStore {
             self.store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
         )
     }
+
+    /// Take (read and clear) the last flow-store op error for this thread, or unit if the
+    /// last op succeeded (issue #322).
+    pub fn last_error(&mut self) -> Dynamic {
+        match crate::extensions::flow_state::take_last_flow_error() {
+            Some(msg) => Dynamic::from(msg),
+            None => Dynamic::UNIT,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -213,6 +222,30 @@ mod tests {
     use super::*;
     use crate::extensions::flow_state::NoOpFlowStore;
     use std::collections::HashMap;
+
+    // AC2 (issue #322): the Rhai flow_store.last_error() accessor surfaces the last recorded
+    // backend error (then leaves the slot taken so a following op reflects its own status).
+    #[test]
+    fn rhai_flow_store_last_error_surfaces() {
+        use crate::extensions::flow_state::{log_flow_err, take_last_flow_error};
+        let _ = take_last_flow_error();
+        let mut s = ScriptFlowStore::new(Arc::new(NoOpFlowStore));
+        // Simulate a failed op recording an error through the shared seam.
+        let _ = log_flow_err(
+            "increment",
+            0i64,
+            Err::<i64, _>(anyhow::anyhow!("backend down")),
+        );
+        let err = s.last_error();
+        assert!(
+            err.into_string()
+                .map(|x| x.contains("backend down"))
+                .unwrap_or(false),
+            "last_error() must surface the recorded backend error"
+        );
+        // last_error() took the value: a subsequent call with no new failure returns unit.
+        assert!(s.last_error().is_unit());
+    }
 
     // ============================================
     // Tests for FaultDecision enum

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -77,6 +77,7 @@ fn create_request_map(request: &ScriptRequest) -> Map {
 /// - `flow_store.delete(flow_id, key)` - Delete a key (returns bool)
 /// - `flow_store.increment(flow_id, key)` - Increment counter (returns i64)
 /// - `flow_store.set_ttl(flow_id, ttl_seconds)` - Set flow expiration (returns bool)
+/// - `flow_store.last_error()` - Take the last flow-store op's error (returns unit if none)
 ///
 /// ## Return Value
 ///
@@ -164,7 +165,8 @@ impl RhaiEngine {
             .register_fn("exists", ScriptFlowStore::exists)
             .register_fn("delete", ScriptFlowStore::delete)
             .register_fn("increment", ScriptFlowStore::increment)
-            .register_fn("set_ttl", ScriptFlowStore::set_ttl);
+            .register_fn("set_ttl", ScriptFlowStore::set_ttl)
+            .register_fn("last_error", ScriptFlowStore::last_error);
 
         // Register helper function for RFC 1123 timestamps
         engine.register_fn("timestamp_header", || -> String {

--- a/crates/rift-core/src/scripting/script_pool.rs
+++ b/crates/rift-core/src/scripting/script_pool.rs
@@ -118,6 +118,10 @@ impl ScriptWorker {
 
                             // Reset the abort flag before each task.
                             abort_flag.store(false, Ordering::Relaxed);
+                            // Reset the last-flow-error slot too: pool workers are long-lived and
+                            // reused across requests, so without this a script could observe a
+                            // previous request's flow_store error via last_error() (issue #322).
+                            crate::extensions::flow_state::clear_last_flow_error();
 
                             // Start a watchdog thread: sets the abort flag after
                             // `timeout`, causing Rhai to self-interrupt via on_progress.


### PR DESCRIPTION
Script flow-store ops (Rhai/Lua/JS) returned legacy fallback values (`nil`/`false`/`0`) on a backend failure, so a script couldn't tell a backend outage from a legitimate empty state — `flow_store.increment(flow_id, "attempts")` against a down Redis returns `0` forever and stateful/fault decisions go quietly wrong. Same silent-wrong-behavior class #318 fixed on the FSM path, one layer up.

**Fix (the issue's non-breaking option 2):** record the last op's error at the shared `log_flow_err` seam into a thread-local (set on failure as `"{op}: {err}"`, cleared on success so it reflects only the most recent op) and expose **`flow_store.last_error()`** in all three engines — returns the error string, or `nil`/unit/`null` if the last op succeeded. Existing scripts are unaffected.

```js
let n = flow_store.increment(flow_id, "attempts");
if (flow_store.last_error()) { /* backend down — handle explicitly */ }
```

**Stale-read safety:** the slot is reset at the start of every script execution — both the imposter `should_inject` dispatch (`bounded.rs`) and the **proxy script pool's per-task reset** (`script_pool.rs`, reused worker threads) — so `last_error()` can never observe a prior request's error on a pooled thread. (This second reset was added after review flagged the pool path.)

A config-gated hard-*raise* (the issue's preferred option 1) remains a possible follow-up.

Tests: seam records-on-fail / clears-on-success; Rhai / JS / Lua `last_error()` accessors each surface a recorded error. Verification: fmt, clippy 0, rift-core lib 814/814, `--no-default-features` compiles. Reviewed (opus): the pool stale-read blocker it found is fixed.

Part of #310. Related: #318.
Closes #322