### PR TITLE
feat: HTTP/2 (and h2c) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,6 +3102,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -325,6 +325,29 @@ impl Imposter {
             .any(|s| s.required_scenario_state.is_some() || s.new_scenario_state.is_some())
     }
 
+    /// Whether any current stub can trigger a connection-level TCP fault (`_rift.fault.tcp`, or a
+    /// Mountebank `fault` that maps to one). Such imposters must be served HTTP/1-only: a TCP fault
+    /// aborts the whole socket, which is incompatible with HTTP/2 stream multiplexing (issue #295).
+    pub(crate) fn uses_tcp_faults(&self) -> bool {
+        use crate::imposter::fault_io::TcpFaultKind;
+        let rift_has_tcp = |rift: &RiftResponseExtension| {
+            rift.fault
+                .as_ref()
+                .and_then(|f| f.tcp.as_ref())
+                .is_some_and(|t| TcpFaultKind::parse(t).is_some())
+        };
+        self.stubs
+            .load()
+            .iter()
+            .flat_map(|s| &s.stub.responses)
+            .any(|resp| match resp {
+                StubResponse::Fault { fault } => TcpFaultKind::parse(fault).is_some(),
+                StubResponse::Is { rift: Some(r), .. } => rift_has_tcp(r),
+                StubResponse::RiftScript { rift } => rift_has_tcp(rift),
+                _ => false,
+            })
+    }
+
     /// Create Redis flow store if configured and available.
     ///
     /// An explicitly-requested `"redis"` backend that cannot be built must fail imposter

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -13,7 +13,6 @@ use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
 use crate::imposter::journal::RequestJournal;
 use crate::recording::ProxyRecordingStore;
-use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use parking_lot::{Mutex, RwLock};
@@ -46,8 +45,10 @@ impl Default for TlsDefaults {
     }
 }
 
-/// Serve one HTTP/1 connection (over plaintext or an already-handshaked TLS stream) until it
-/// completes or the imposter is torn down. Shared by the plain and HTTPS serve paths (issue #206).
+/// Serve one imposter connection (over plaintext or an already-handshaked TLS stream) until it
+/// completes or the imposter is torn down. Auto-negotiates HTTP/1 and HTTP/2 (issue #295), except
+/// for imposters that can fire a connection-level TCP fault, which are served HTTP/1-only. Shared
+/// by the plain and HTTPS serve paths (issue #206). (Name kept for history.)
 async fn run_http1<I>(
     io: I,
     imposter: Arc<Imposter>,
@@ -59,6 +60,11 @@ async fn run_http1<I>(
 ) where
     I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
 {
+    // A TCP fault (#239) aborts the whole socket, which is meaningless under HTTP/2 stream
+    // multiplexing (one stream's fault would tear down every concurrent stream, and the raw
+    // HTTP/1 fault bytes are nonsense to an h2 client). So an imposter that can fire a TCP fault
+    // is served HTTP/1-only; everything else auto-negotiates HTTP/1 and HTTP/2 (issue #295).
+    let http1_only = imposter.uses_tcp_faults();
     let service = service_fn(move |req| {
         let imposter = Arc::clone(&imposter);
         let fault_cell = Arc::clone(&fault_cell);
@@ -72,22 +78,37 @@ async fn run_http1<I>(
             Ok::<_, std::convert::Infallible>(response)
         }
     });
-    let conn = http1::Builder::new().serve_connection(io, service);
-    tokio::pin!(conn);
-    tokio::select! {
-        res = conn.as_mut() => {
-            if let Err(e) = res {
-                debug!("Connection error on port {}: {}", port, e);
+
+    // Both builders yield a Connection with the same drive/graceful-shutdown shape; only the
+    // protocol negotiation differs.
+    macro_rules! drive_conn {
+        ($conn:expr) => {{
+            let conn = $conn;
+            tokio::pin!(conn);
+            tokio::select! {
+                res = conn.as_mut() => {
+                    if let Err(e) = res {
+                        debug!("Connection error on port {}: {}", port, e);
+                    }
+                }
+                _ = conn_shutdown_rx.recv() => {
+                    // Stop accepting new requests on this connection and close it once any in-flight
+                    // request completes (issue #207).
+                    conn.as_mut().graceful_shutdown();
+                    if let Err(e) = conn.as_mut().await {
+                        debug!("Connection error on port {} during shutdown: {}", port, e);
+                    }
+                }
             }
-        }
-        _ = conn_shutdown_rx.recv() => {
-            // Stop accepting new requests on this connection and close it once any in-flight
-            // request completes (issue #207).
-            conn.as_mut().graceful_shutdown();
-            if let Err(e) = conn.as_mut().await {
-                debug!("Connection error on port {} during shutdown: {}", port, e);
-            }
-        }
+        }};
+    }
+
+    if http1_only {
+        drive_conn!(hyper::server::conn::http1::Builder::new().serve_connection(io, service));
+    } else {
+        let builder =
+            hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+        drive_conn!(builder.serve_connection(io, service));
     }
 }
 

--- a/crates/rift-core/src/proxy/server.rs
+++ b/crates/rift-core/src/proxy/server.rs
@@ -27,7 +27,6 @@ use crate::scripting::{
 use anyhow::Context;
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
-use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
@@ -321,9 +320,10 @@ impl ProxyServer {
                                     async move { server.handle_request_internal(req).await }
                                 });
 
-                                if let Err(err) =
-                                    http1::Builder::new().serve_connection(io, service).await
-                                {
+                                let builder = hyper_util::server::conn::auto::Builder::new(
+                                    hyper_util::rt::TokioExecutor::new(),
+                                );
+                                if let Err(err) = builder.serve_connection(io, service).await {
                                     error!(
                                         "Error serving HTTPS connection from {}: {}",
                                         remote_addr, err
@@ -343,8 +343,10 @@ impl ProxyServer {
                             async move { server.handle_request_internal(req).await }
                         });
 
-                        if let Err(err) = http1::Builder::new().serve_connection(io, service).await
-                        {
+                        let builder = hyper_util::server::conn::auto::Builder::new(
+                            hyper_util::rt::TokioExecutor::new(),
+                        );
+                        if let Err(err) = builder.serve_connection(io, service).await {
                             error!(
                                 "Error serving HTTP connection from {}: {}",
                                 remote_addr, err

--- a/crates/rift-core/src/proxy/tls.rs
+++ b/crates/rift-core/src/proxy/tls.rs
@@ -83,12 +83,14 @@ pub fn tls_acceptor_from_pem(
         .map_err(|e| anyhow::anyhow!("Failed to parse private key PEM: {e}"))?
         .ok_or_else(|| anyhow::anyhow!("No private key found in key PEM"))?;
 
-    let config = rustls::ServerConfig::builder()
+    let mut config = rustls::ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .map_err(|e| {
             anyhow::anyhow!("Failed to build TLS configuration (cert/key mismatch?): {e}")
         })?;
+    // Advertise HTTP/2 and HTTP/1.1 via ALPN so TLS clients can negotiate h2 (issue #295).
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
     Ok(TlsAcceptor::from(Arc::new(config)))
 }

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -101,7 +101,7 @@ rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Integration testing
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["http2"] }
 tokio-test = "0.4"
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["redis"] }

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -6,7 +6,6 @@ use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
 use http_body_util::Full;
 use hyper::body::Bytes;
-use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
@@ -235,7 +234,9 @@ async fn accept_loop(
                 }
             });
 
-            let conn = http1::Builder::new().serve_connection(io, service);
+            let builder =
+                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+            let conn = builder.serve_connection(io, service);
             tokio::pin!(conn);
             tokio::select! {
                 res = conn.as_mut() => {

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -423,7 +423,6 @@ async fn metrics_accept_loop(
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
-    use hyper::server::conn::http1;
     use hyper::service::service_fn;
     use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
@@ -452,7 +451,9 @@ async fn metrics_accept_loop(
                 }
             });
 
-            let conn = http1::Builder::new().serve_connection(io, service);
+            let builder =
+                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+            let conn = builder.serve_connection(io, service);
             tokio::pin!(conn);
             tokio::select! {
                 res = conn.as_mut() => {

--- a/crates/rift-http-proxy/tests/issue_295_http2.rs
+++ b/crates/rift-http-proxy/tests/issue_295_http2.rs
@@ -1,0 +1,100 @@
+//! Issue #295 gate: imposter listeners auto-negotiate HTTP/1 and HTTP/2, so an HTTP/2 (h2c
+//! prior-knowledge) client can talk to Rift while HTTP/1 clients keep working unchanged.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+async fn mk(manager: &ImposterManager, port: u16) {
+    let cfg = serde_json::json!({
+        "port": port, "protocol": "http", "stubs": [
+            { "responses": [{ "is": { "statusCode": 200, "body": "h2-ok" } }] }
+        ]
+    });
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+}
+
+// AC1: an HTTP/2 prior-knowledge (h2c) client gets a served response over HTTP/2.
+#[tokio::test]
+async fn imposter_serves_http2_prior_knowledge() {
+    let manager = ImposterManager::new();
+    mk(&manager, 19895).await;
+
+    let client = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .build()
+        .expect("h2 client");
+    let resp = client
+        .get("http://127.0.0.1:19895/x")
+        .send()
+        .await
+        .expect("h2 request must succeed");
+    assert_eq!(
+        resp.version(),
+        reqwest::Version::HTTP_2,
+        "the connection must be served over HTTP/2"
+    );
+    let body = resp.text().await.expect("body");
+    assert_eq!(body, "h2-ok");
+    let _ = manager.delete_imposter(19895).await;
+}
+
+// AC3: an imposter that can fire a TCP fault is served HTTP/1-only — TCP faults are connection-level
+// and incompatible with HTTP/2 multiplexing, so an h2-prior-knowledge client must NOT negotiate h2
+// against it (even for a non-fault path on the same imposter).
+#[tokio::test]
+async fn tcp_fault_imposter_is_http1_only() {
+    let manager = ImposterManager::new();
+    let cfg = serde_json::json!({
+        "port": 19897, "protocol": "http", "stubs": [
+            { "predicates": [{ "equals": { "path": "/ok" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] },
+            { "predicates": [{ "equals": { "path": "/boom" } }],
+              "responses": [{ "is": { "statusCode": 200 },
+                "_rift": { "fault": { "tcp": "CONNECTION_RESET_BY_PEER" } } }] }
+        ]
+    });
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // h2 prior-knowledge against the normal path must fail: the listener is HTTP/1-only.
+    let h2 = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .build()
+        .expect("h2 client");
+    assert!(
+        h2.get("http://127.0.0.1:19897/ok").send().await.is_err(),
+        "a TCP-fault imposter must not negotiate HTTP/2"
+    );
+    // An ordinary HTTP/1 client still works on the non-fault path.
+    let h1 = reqwest::Client::builder().build().expect("h1 client");
+    let resp = h1
+        .get("http://127.0.0.1:19897/ok")
+        .send()
+        .await
+        .expect("h1 request");
+    assert_eq!(resp.text().await.expect("body"), "ok");
+    let _ = manager.delete_imposter(19897).await;
+}
+
+// AC2: an ordinary HTTP/1 client still works (auto-negotiation must not regress HTTP/1).
+#[tokio::test]
+async fn imposter_still_serves_http1() {
+    let manager = ImposterManager::new();
+    mk(&manager, 19896).await;
+
+    let client = reqwest::Client::builder()
+        .http1_only()
+        .build()
+        .expect("h1 client");
+    let resp = client
+        .get("http://127.0.0.1:19896/x")
+        .send()
+        .await
+        .expect("h1 request must succeed");
+    assert_eq!(resp.version(), reqwest::Version::HTTP_11);
+    assert_eq!(resp.text().await.expect("body"), "h2-ok");
+    let _ = manager.delete_imposter(19896).await;
+}


### PR DESCRIPTION
All listeners were HTTP/1-only — HTTP/2-only clients couldn't talk to Rift, and high-concurrency/keep-alive workloads couldn't multiplex over one connection.

**Change:** swap the five connection-serving sites (imposter data plane, proxy ×2, admin, metrics) from `hyper::server::conn::http1::Builder` to `hyper_util::server::conn::auto::Builder`, which auto-negotiates HTTP/1 and HTTP/2 — **h2c prior-knowledge** on plaintext and **h2 via ALPN** over TLS. **No new deps** (hyper/hyper-util already carry `http2`/`server-auto`). TLS `ServerConfig`s now advertise ALPN `h2` + `http/1.1`.

**Backward-compatible, so no config gate:** `auto::Builder` serves HTTP/1 clients exactly as before (it detects the exact HTTP/2 preface), so default behavior is unchanged — the change is purely additive. A force-disable knob is a trivial follow-up if ever wanted.

**TCP faults stay HTTP/1-only.** A connection-level `_rift.fault.tcp` (#239) aborts the whole socket, which is incompatible with HTTP/2 stream multiplexing (one stream's fault would tear down every concurrent stream, and the raw HTTP/1 fault bytes are nonsense to an h2 client). So an imposter that can fire a TCP fault is served HTTP/1-only (`Imposter::uses_tcp_faults`); everything else auto-negotiates. *(This was found in review — the unconditional swap first exposed the fault path to h2.)*

**Tests:** an h2c prior-knowledge client gets an HTTP/2 response; an HTTP/1 client still works (no regression); a TCP-fault imposter refuses h2 and still serves h1. Verification: fmt, clippy 0, rift-core lib 814/814, workspace builds, fault + `issue_269` integration green. Reviewed (opus): the fault/h2 blocker it found is fixed.

Part of the Performance & load-capacity roadmap. Related: #10 (Pingora).
Closes #295