### PR TITLE
JS should_inject loop cap is per-call-frame — nested runaway amplifies past the limit

### DIFF
--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -207,9 +207,19 @@ fn execute_js_script(
 
 /// Loop-iteration cap for a `should_inject` Boa context (issue #327). Boa exposes no
 /// per-instruction interrupt, so a runaway loop (`while(true){}`) can't observe the deadline abort
-/// flag and would run its `spawn_blocking` thread forever. This fixed cap bounds it: Boa throws
-/// once the limit is hit, the execution returns `Err`, and the thread is freed. Generous enough
-/// that no realistic boolean fault-decision script approaches it.
+/// flag and would otherwise run its `spawn_blocking` thread forever. This cap makes a single
+/// runaway loop throw once the limit is hit, so the execution returns `Err` and the thread is
+/// freed. Generous enough that no realistic boolean fault-decision script approaches it.
+///
+/// Known limitation (issue #371): Boa's loop-iteration counter is **per-call-frame** (reset to 0 on
+/// every function call), and Boa 0.20 has no cumulative-work budget or per-instruction interrupt.
+/// So a *nested* runaway — e.g. `while (true) { f(); }` where `f` loops — amplifies by roughly
+/// `limit^depth` before the outermost loop trips, occupying its thread far longer than a flat
+/// `while(true){}`. This is bounded, not infinite, and the client is still released at the
+/// wall-clock timeout with a 500; only a background thread lingers, and only for a deliberately
+/// adversarial *trusted* (operator-authored) script. Deep recursion is separately bounded by Boa's
+/// default `recursion_limit` (512). Fully closing the loop-amplification would need a Boa fuel /
+/// interrupt mechanism that 0.20 lacks.
 const JS_SCRIPT_LOOP_ITERATION_LIMIT: u64 = 10_000_000;
 
 /// Inner function that does the actual JavaScript execution


### PR DESCRIPTION
Follow-up to #327 / #370. On investigation this is an **upstream Boa 0.20 limitation with no clean code fix**:

- Boa's loop-iteration counter is **per-call-frame** (reset to 0 on each function call), and Boa 0.20 exposes **no cumulative-work budget, no fuel/gas counter, and no per-instruction interrupt**. The per-frame loop cap is the only lever, so a nested runaway (`while(true){ f(); }`) amplifies by ~`limit^depth` regardless of the value chosen.
- Tightening the cap enough to bound two-level nesting to ~1s (~10K iterations) would false-positive on legitimate scripts; keeping it generous leaves the amplification. No good middle.
- The client is **already protected** by the wall-clock timeout (gets its 500); the residual is background *thread-occupancy* for a deliberately-adversarial **trusted** (operator-authored) script. Deep recursion is separately bounded by Boa's default `recursion_limit` (512).

**This PR** corrects the loop-cap doc comment to describe the limitation accurately (the prior "the thread is freed" wording was only true for a flat runaway). No behavior change.

If active mitigation is wanted later, the tractable option is isolating bounded JS `should_inject` onto a dedicated bounded thread pool so a nested runaway can't exhaust the pool shared with Rhai/Lua (blast-radius containment) — noted for a future issue rather than done here.

Closes #371