### PR TITLE
build: publish docs via Actions only when docs change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; don't cancel a deploy already in flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v5
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Replaces the legacy branch-based Pages pipeline (which redeployed docs on every push to master and intermittently failed with GitHub's transient deploy error) with a dedicated workflow using the same github-pages Jekyll builder, triggered only on `docs/**` changes plus `workflow_dispatch`. Deployments are serialized via a `pages` concurrency group. The repo's Pages source has already been switched to `build_type=workflow`.

Milestone: standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)