### PR TITLE
Unknown flowState backend string silently falls back to NoOp (same footgun as #325)

### DIFF
--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -301,10 +301,11 @@ impl Imposter {
                     info!("Creating deliberately failing FlowStore (test-backend feature)");
                     Ok(Arc::new(crate::extensions::flow_state::FailingFlowStore))
                 }
-                other => {
-                    warn!("Unknown flow state backend '{}', using NoOp", other);
-                    Ok(Arc::new(NoOpFlowStore))
-                }
+                // An explicitly-set but unrecognized backend is a config error, not a reason to
+                // silently downgrade to NoOp (issue #377) — fail construction like the redis arm.
+                other => anyhow::bail!(
+                    "flowState.backend is \"{other}\" but no such backend exists (expected \"inmemory\" or \"redis\")"
+                ),
             };
         }
 
@@ -511,6 +512,21 @@ mod tests {
         }))
         .expect("valid imposter config");
         assert!(Imposter::new_with_hooks_and_journal(cfg, None, None, None).is_ok());
+    }
+
+    // Issue #377: an explicitly-set but unrecognized backend (a typo) must fail construction, not
+    // silently downgrade to NoOp — the same fail-loud contract #325 gave the redis arm.
+    #[test]
+    fn explicit_unknown_backend_fails_construction() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http", "stubs": [],
+            "_rift": { "flowState": { "backend": "postgres" } }
+        }))
+        .expect("valid imposter config");
+        assert!(
+            Imposter::new_with_hooks_and_journal(cfg, None, None, None).is_err(),
+            "an unrecognized flowState.backend must fail construction, not fall back to NoOp"
+        );
     }
 
     /// Serve the state's next response body, advancing the shared cycler.


### PR DESCRIPTION
Follow-up to #325. The `other =>` arm of `create_flow_store` logged a warning and returned `NoOpFlowStore` for any unrecognized `_rift.flowState.backend` — so a typo silently downgraded to NoOp (scenario FSM stuck at the initial state, no request-time error). Now it `bail!`s like the redis arm, surfaced as `ImposterError::FlowStoreConfig` → 400. The implicit NoOp (no `flowState` configured) stays silent. Test: `explicit_unknown_backend_fails_construction`. clippy 0, rift-core lib 815/815. Closes #377