### PR TITLE
docs: add sync marker recording the revision docs were reconciled against

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -34,7 +34,7 @@ search:
   button: false
 
 # Footer
-footer_content: "Copyright &copy; 2024-2025 Rift Contributors. Distributed under the <a href=\"https://github.com/EtaCassiopeia/rift/blob/master/LICENSE\">Apache License 2.0</a>."
+footer_content: "Copyright &copy; 2024-2025 Rift Contributors. Distributed under the <a href=\"https://github.com/EtaCassiopeia/rift/blob/master/LICENSE\">Apache License 2.0</a>. Docs current as of <a href=\"https://github.com/EtaCassiopeia/rift/releases/tag/v0.8.0\">v0.8.0</a>."
 
 # Back to top link
 back_to_top: true

--- a/docs/_data/sync.yml
+++ b/docs/_data/sync.yml
@@ -1,0 +1,11 @@
+# Docs sync marker — the code revision these docs were last reconciled against.
+#
+# Starting a docs-update pass (see issue #280):
+#   1. Enumerate user-facing changes since the marker:
+#        git log --oneline --merges <commit>..origin/master
+#   2. Update the affected pages.
+#   3. Bump this file AND the version in _config.yml footer_content in the same PR.
+release: v0.8.0
+commit: 54eb2dfebdc3778edf358d6c28ca6a29697d0569
+date: 2026-07-01
+tracking_issue: 280


### PR DESCRIPTION
Adds `docs/_data/sync.yml` — a marker recording the code revision the docs were last reconciled against (currently `54eb2df` / v0.8.0, the #283 merge). Jekyll never publishes `_data/`, so it travels with the docs without rendering. The next docs-update pass starts from `git log <marker-commit>..origin/master` and bumps the marker in the same PR. Also surfaces "Docs current as of v0.8.0" in the site footer.

Refs #280 (process documented in the issue's 2026-07-04 update section).

Milestone: standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)