### PR TITLE
Add a force-disable-HTTP/2 escape hatch for the auto-negotiating listeners

### DIFF
--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -64,7 +64,7 @@ async fn run_http1<I>(
     // multiplexing (one stream's fault would tear down every concurrent stream, and the raw
     // HTTP/1 fault bytes are nonsense to an h2 client). So an imposter that can fire a TCP fault
     // is served HTTP/1-only; everything else auto-negotiates HTTP/1 and HTTP/2 (issue #295).
-    let http1_only = imposter.uses_tcp_faults();
+    let http1_only = imposter.uses_tcp_faults() || crate::util::http2_disabled();
     let service = service_fn(move |req| {
         let imposter = Arc::clone(&imposter);
         let fault_cell = Arc::clone(&fault_cell);

--- a/crates/rift-core/src/proxy/server.rs
+++ b/crates/rift-core/src/proxy/server.rs
@@ -320,14 +320,28 @@ impl ProxyServer {
                                     async move { server.handle_request_internal(req).await }
                                 });
 
-                                let builder = hyper_util::server::conn::auto::Builder::new(
-                                    hyper_util::rt::TokioExecutor::new(),
-                                );
-                                if let Err(err) = builder.serve_connection(io, service).await {
-                                    error!(
-                                        "Error serving HTTPS connection from {}: {}",
-                                        remote_addr, err
+                                // Issue #378: force-disable HTTP/2 auto-negotiation as an
+                                // operational escape hatch when a client misbehaves over h2.
+                                if crate::util::http2_disabled() {
+                                    if let Err(err) = hyper::server::conn::http1::Builder::new()
+                                        .serve_connection(io, service)
+                                        .await
+                                    {
+                                        error!(
+                                            "Error serving HTTPS connection from {}: {}",
+                                            remote_addr, err
+                                        );
+                                    }
+                                } else {
+                                    let builder = hyper_util::server::conn::auto::Builder::new(
+                                        hyper_util::rt::TokioExecutor::new(),
                                     );
+                                    if let Err(err) = builder.serve_connection(io, service).await {
+                                        error!(
+                                            "Error serving HTTPS connection from {}: {}",
+                                            remote_addr, err
+                                        );
+                                    }
                                 }
                             }
                             Err(err) => {
@@ -343,14 +357,28 @@ impl ProxyServer {
                             async move { server.handle_request_internal(req).await }
                         });
 
-                        let builder = hyper_util::server::conn::auto::Builder::new(
-                            hyper_util::rt::TokioExecutor::new(),
-                        );
-                        if let Err(err) = builder.serve_connection(io, service).await {
-                            error!(
-                                "Error serving HTTP connection from {}: {}",
-                                remote_addr, err
+                        // Issue #378: force-disable HTTP/2 auto-negotiation as an operational
+                        // escape hatch when a client misbehaves over h2.
+                        if crate::util::http2_disabled() {
+                            if let Err(err) = hyper::server::conn::http1::Builder::new()
+                                .serve_connection(io, service)
+                                .await
+                            {
+                                error!(
+                                    "Error serving HTTP connection from {}: {}",
+                                    remote_addr, err
+                                );
+                            }
+                        } else {
+                            let builder = hyper_util::server::conn::auto::Builder::new(
+                                hyper_util::rt::TokioExecutor::new(),
                             );
+                            if let Err(err) = builder.serve_connection(io, service).await {
+                                error!(
+                                    "Error serving HTTP connection from {}: {}",
+                                    remote_addr, err
+                                );
+                            }
                         }
                     }
                     _ => {

--- a/crates/rift-core/src/util.rs
+++ b/crates/rift-core/src/util.rs
@@ -7,6 +7,23 @@ use hyper::{Response, StatusCode};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Whether HTTP/2 auto-negotiation should be force-disabled on the serve listeners, read once from
+/// the `RIFT_DISABLE_HTTP2` env var (issue #378). An operational escape hatch: the listeners
+/// auto-negotiate HTTP/1 and HTTP/2 by default (#295); set this (`1`/`true`/`yes`/`on`) to serve
+/// HTTP/1 only if a client misbehaves over HTTP/2.
+pub fn http2_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED
+        .get_or_init(|| http2_disabled_from(std::env::var("RIFT_DISABLE_HTTP2").ok().as_deref()))
+}
+
+/// Pure parse of the `RIFT_DISABLE_HTTP2` value, split out so it can be unit-tested without the
+/// process-global env-var races that a full end-to-end test would hit.
+fn http2_disabled_from(val: Option<&str>) -> bool {
+    val.map(|v| v.trim().to_ascii_lowercase())
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+}
+
 /// Build an HTTP response with the given status and body. Falls back to a minimal 500 if the
 /// builder fails (which should not happen with a valid `StatusCode`).
 pub fn build_response(status: StatusCode, body: impl Into<Bytes>) -> Response<Full<Bytes>> {
@@ -87,4 +104,33 @@ pub fn unix_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::http2_disabled_from;
+
+    // Issue #378: RIFT_DISABLE_HTTP2 parsing — truthy values disable, everything else keeps HTTP/2.
+    #[test]
+    fn http2_disable_env_parsing() {
+        for on in ["1", "true", "TRUE", " yes ", "On"] {
+            assert!(
+                http2_disabled_from(Some(on)),
+                "{on:?} should disable HTTP/2"
+            );
+        }
+        for off in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("2"),
+        ] {
+            assert!(
+                !http2_disabled_from(off),
+                "{off:?} should keep HTTP/2 enabled"
+            );
+        }
+    }
 }

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -234,20 +234,35 @@ async fn accept_loop(
                 }
             });
 
-            let builder =
-                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
-            let conn = builder.serve_connection(io, service);
-            tokio::pin!(conn);
-            tokio::select! {
-                res = conn.as_mut() => {
-                    if let Err(e) = res {
-                        debug!("Admin API connection error: {}", e);
+            // Both builders yield a Connection with the same drive/graceful-shutdown shape;
+            // only the protocol negotiation differs (issue #378 force-disable escape hatch).
+            macro_rules! drive_conn {
+                ($conn:expr) => {{
+                    let conn = $conn;
+                    tokio::pin!(conn);
+                    tokio::select! {
+                        res = conn.as_mut() => {
+                            if let Err(e) = res {
+                                debug!("Admin API connection error: {}", e);
+                            }
+                        }
+                        _ = conn_cancel.cancelled() => {
+                            conn.as_mut().graceful_shutdown();
+                            let _ = conn.await;
+                        }
                     }
-                }
-                _ = conn_cancel.cancelled() => {
-                    conn.as_mut().graceful_shutdown();
-                    let _ = conn.await;
-                }
+                }};
+            }
+
+            if rift_core::util::http2_disabled() {
+                drive_conn!(
+                    hyper::server::conn::http1::Builder::new().serve_connection(io, service)
+                );
+            } else {
+                let builder = hyper_util::server::conn::auto::Builder::new(
+                    hyper_util::rt::TokioExecutor::new(),
+                );
+                drive_conn!(builder.serve_connection(io, service));
             }
         });
     }

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -451,20 +451,35 @@ async fn metrics_accept_loop(
                 }
             });
 
-            let builder =
-                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
-            let conn = builder.serve_connection(io, service);
-            tokio::pin!(conn);
-            tokio::select! {
-                res = conn.as_mut() => {
-                    if let Err(err) = res {
-                        error!("Metrics server connection error: {}", err);
+            // Both builders yield a Connection with the same drive/graceful-shutdown shape;
+            // only the protocol negotiation differs (issue #378 force-disable escape hatch).
+            macro_rules! drive_conn {
+                ($conn:expr) => {{
+                    let conn = $conn;
+                    tokio::pin!(conn);
+                    tokio::select! {
+                        res = conn.as_mut() => {
+                            if let Err(err) = res {
+                                error!("Metrics server connection error: {}", err);
+                            }
+                        }
+                        _ = conn_cancel.cancelled() => {
+                            conn.as_mut().graceful_shutdown();
+                            let _ = conn.await;
+                        }
                     }
-                }
-                _ = conn_cancel.cancelled() => {
-                    conn.as_mut().graceful_shutdown();
-                    let _ = conn.await;
-                }
+                }};
+            }
+
+            if rift_core::util::http2_disabled() {
+                drive_conn!(
+                    hyper::server::conn::http1::Builder::new().serve_connection(io, service)
+                );
+            } else {
+                let builder = hyper_util::server::conn::auto::Builder::new(
+                    hyper_util::rt::TokioExecutor::new(),
+                );
+                drive_conn!(builder.serve_connection(io, service));
             }
         });
     }


### PR DESCRIPTION
Follow-up to #295. Adds an operational escape hatch: setting `RIFT_DISABLE_HTTP2` (`1`/`true`/`yes`/`on`) forces every listener back to `http1::Builder` (HTTP/1 only), for when a client misbehaves over HTTP/2. Default (unset) is unchanged auto-negotiation from #295.

Wired at all five serve sites (imposter, proxy ×2, admin, metrics) via `crate::util::http2_disabled()` (read once, `OnceLock`-cached); the imposter path reuses its existing HTTP/1-only branch (fault imposters). The env parse is split into a pure `http2_disabled_from()` so it's unit-tested without process-global env-var races.

Tests: `http2_disable_env_parsing` (parsing); `issue_295_http2` still green (default env = auto-negotiate). clippy 0, rift-core lib 815/815, workspace builds. Closes #378