### PR TITLE
Optional strict mode: fail-loud (500) on decorate/shellTransform/binary failure

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -523,6 +523,13 @@ async fn handle_request_inner(
                 return Ok(response);
             }
 
+            // Issue #375: strict mode makes a requested response behavior that fails serve a 500
+            // (still carrying the #323 signal header) instead of the fallback body. Enabled
+            // per-imposter (`strictBehaviors`) or process-wide (`RIFT_STRICT_BEHAVIORS`). Default
+            // false preserves the lenient #269/#323 contract in the Err arms below.
+            let strict_behaviors =
+                imposter.config.strict_behaviors || crate::util::strict_behaviors_env();
+
             // Expand `${request.*}` request templates (issue #269) BEFORE behaviors — matching the
             // proxy path's ordering so `shellTransform`/`decorate` operate on the expanded body.
             // Header values are templated too (the static path's AC1 requirement; the proxy path
@@ -645,6 +652,18 @@ async fn handle_request_inner(
                             // isn't a silent success (issue #323); the body is still served (#269).
                             Err(e) => {
                                 warn!("Decorate script error: {e}");
+                                if strict_behaviors {
+                                    return Ok(build_response_with_headers(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        [
+                                            ("x-rift-imposter", "true"),
+                                            ("x-rift-decorate-error", "true"),
+                                        ],
+                                        format!(
+                                            r#"{{"error": "decorate failed (strictBehaviors): {e}"}}"#
+                                        ),
+                                    ));
+                                }
                                 headers.insert(
                                     "x-rift-decorate-error".to_string(),
                                     vec!["true".to_string()],
@@ -663,6 +682,18 @@ async fn handle_request_inner(
                             // isn't a silent success (issue #323).
                             Err(e) => {
                                 warn!("shellTransform command {cmd:?} failed: {e}");
+                                if strict_behaviors {
+                                    return Ok(build_response_with_headers(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        [
+                                            ("x-rift-imposter", "true"),
+                                            ("x-rift-shelltransform-error", "true"),
+                                        ],
+                                        format!(
+                                            r#"{{"error": "shellTransform failed (strictBehaviors): {e}"}}"#
+                                        ),
+                                    ));
+                                }
                                 headers.insert(
                                     "x-rift-shelltransform-error".to_string(),
                                     vec!["true".to_string()],
@@ -692,7 +723,19 @@ async fn handle_request_inner(
                     match base64::engine::general_purpose::STANDARD.decode(&body) {
                         Ok(decoded) => Bytes::from(decoded),
                         Err(e) => {
-                            warn!("Failed to decode base64 body: {}, using raw body", e);
+                            if strict_behaviors {
+                                warn!(
+                                    "Failed to decode base64 body: {e}; failing loud (strictBehaviors)"
+                                );
+                                return Ok(build_response_with_headers(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    [("x-rift-imposter", "true"), ("x-rift-binary-error", "true")],
+                                    format!(
+                                        r#"{{"error": "binary base64 decode failed (strictBehaviors): {e}"}}"#
+                                    ),
+                                ));
+                            }
+                            warn!("Failed to decode base64 body: {e}, using raw body");
                             binary_decode_failed = true;
                             Bytes::from(body)
                         }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -787,6 +787,13 @@ pub struct ImposterConfig {
         alias = "allowCORS"
     )]
     pub allow_cors: bool,
+    /// Strict behavior mode (issue #375): when true, a requested response behavior that FAILS
+    /// (decorate / shellTransform / binary base64 decode) returns a 500 — still carrying the #323
+    /// `x-rift-<behavior>-error` header — instead of serving the fallback body. Default false keeps
+    /// the lenient contract (#269): the fallback body is served and only the header signals the
+    /// failure. Can also be forced process-wide via the `RIFT_STRICT_BEHAVIORS` env var.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub strict_behaviors: bool,
     /// Service name for documentation (optional metadata)
     #[serde(skip_serializing_if = "Option::is_none", alias = "service_name")]
     pub service_name: Option<String>,

--- a/crates/rift-core/src/util.rs
+++ b/crates/rift-core/src/util.rs
@@ -24,6 +24,25 @@ fn http2_disabled_from(val: Option<&str>) -> bool {
         .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
 }
 
+/// Whether strict behavior mode is force-enabled process-wide, read once from the
+/// `RIFT_STRICT_BEHAVIORS` env var (issue #375). When set (`1`/`true`/`yes`/`on`) it forces the
+/// fail-loud contract on every imposter regardless of its per-imposter `strictBehaviors` flag — an
+/// operational switch for CI runs that want a broken decorate/shellTransform/binary to surface as a
+/// 500 rather than a header-annotated fallback body.
+pub fn strict_behaviors_env() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        strict_behaviors_from(std::env::var("RIFT_STRICT_BEHAVIORS").ok().as_deref())
+    })
+}
+
+/// Pure parse of the `RIFT_STRICT_BEHAVIORS` value, split out so it can be unit-tested without the
+/// process-global env-var races that a full end-to-end test would hit.
+fn strict_behaviors_from(val: Option<&str>) -> bool {
+    val.map(|v| v.trim().to_ascii_lowercase())
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+}
+
 /// Build an HTTP response with the given status and body. Falls back to a minimal 500 if the
 /// builder fails (which should not happen with a valid `StatusCode`).
 pub fn build_response(status: StatusCode, body: impl Into<Bytes>) -> Response<Full<Bytes>> {
@@ -108,7 +127,31 @@ pub fn unix_timestamp() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::http2_disabled_from;
+    use super::{http2_disabled_from, strict_behaviors_from};
+
+    // Issue #375: RIFT_STRICT_BEHAVIORS parsing — truthy values force strict, everything else lenient.
+    #[test]
+    fn strict_behaviors_env_parsing() {
+        for on in ["1", "true", "TRUE", " yes ", "On"] {
+            assert!(
+                strict_behaviors_from(Some(on)),
+                "{on:?} should enable strict behaviors"
+            );
+        }
+        for off in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("2"),
+        ] {
+            assert!(
+                !strict_behaviors_from(off),
+                "{off:?} should keep behaviors lenient"
+            );
+        }
+    }
 
     // Issue #378: RIFT_DISABLE_HTTP2 parsing — truthy values disable, everything else keeps HTTP/2.
     #[test]

--- a/crates/rift-http-proxy/tests/issue_375_strict_behaviors.rs
+++ b/crates/rift-http-proxy/tests/issue_375_strict_behaviors.rs
@@ -1,0 +1,156 @@
+//! Issue #375 gate: opt-in strict mode. When `strictBehaviors: true` is set on an imposter, a
+//! requested response behavior that FAILS returns a 500 (still carrying the #323
+//! `x-rift-<behavior>-error` signal header) instead of serving the fallback body. The default
+//! (flag absent) is unchanged — lenient + header, preserving #269's keep-the-body contract.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+async fn mk(manager: &ImposterManager, cfg: serde_json::Value) {
+    let config = serde_json::from_value(cfg).expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+}
+
+// AC1: strict + failing decorate → 500 with x-rift-decorate-error, fallback body NOT served.
+#[tokio::test]
+async fn strict_decorate_failure_returns_500() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19951, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "decorate": "function (request, response) { throw new Error('boom'); }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19951/x")
+        .send()
+        .await
+        .expect("send");
+    let status = resp.status();
+    let has_header = resp.headers().contains_key("x-rift-decorate-error");
+    let body = resp.text().await.expect("body");
+    assert_eq!(
+        status, 500,
+        "strict decorate failure must fail loud with 500"
+    );
+    assert!(
+        has_header,
+        "the 500 must still carry x-rift-decorate-error so the cause is visible"
+    );
+    assert_ne!(
+        body, "original",
+        "the fallback body must NOT be served in strict mode"
+    );
+    let _ = manager.delete_imposter(19951).await;
+}
+
+// AC2: strict + failing shellTransform → 500 with x-rift-shelltransform-error.
+#[tokio::test]
+async fn strict_shell_transform_failure_returns_500() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19952, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "shellTransform": "exit 1" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19952/x")
+        .send()
+        .await
+        .expect("send");
+    let status = resp.status();
+    let has_header = resp.headers().contains_key("x-rift-shelltransform-error");
+    let body = resp.text().await.expect("body");
+    assert_eq!(
+        status, 500,
+        "strict shellTransform failure must fail loud with 500"
+    );
+    assert!(
+        has_header,
+        "the 500 must still carry x-rift-shelltransform-error"
+    );
+    assert_ne!(
+        body, "original",
+        "the fallback body must NOT be served in strict mode"
+    );
+    let _ = manager.delete_imposter(19952).await;
+}
+
+// AC3: strict + invalid binary base64 → 500 with x-rift-binary-error.
+#[tokio::test]
+async fn strict_binary_decode_failure_returns_500() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19953, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "not!valid!base64!", "_mode": "binary" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19953/x")
+        .send()
+        .await
+        .expect("send");
+    let status = resp.status();
+    assert_eq!(
+        status, 500,
+        "strict binary decode failure must fail loud with 500"
+    );
+    assert!(
+        resp.headers().contains_key("x-rift-binary-error"),
+        "the 500 must still carry x-rift-binary-error"
+    );
+    let _ = manager.delete_imposter(19953).await;
+}
+
+// AC4 (regression guard): with the flag absent, #323/#269 lenient behavior is unchanged —
+// a failing decorate still serves 200 + fallback body + the signal header.
+#[tokio::test]
+async fn default_lenient_decorate_still_200() {
+    let manager = ImposterManager::new();
+    mk(
+        &manager,
+        serde_json::json!({
+            "port": 19954, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "decorate": "function (request, response) { throw new Error('boom'); }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19954/x")
+        .send()
+        .await
+        .expect("send");
+    let status = resp.status();
+    let has_header = resp.headers().contains_key("x-rift-decorate-error");
+    let body = resp.text().await.expect("body");
+    assert_eq!(status, 200, "default mode stays lenient (issue #269)");
+    assert!(
+        has_header,
+        "default mode still signals the failure (issue #323)"
+    );
+    assert_eq!(
+        body, "original",
+        "default mode still serves the fallback body"
+    );
+    let _ = manager.delete_imposter(19954).await;
+}


### PR DESCRIPTION
Adds an opt-in strict mode (per-imposter `strictBehaviors` flag or global `RIFT_STRICT_BEHAVIORS` env var, default off) that returns 500 when a requested response behavior fails, instead of serving the fallback body. Still carries the #323 `x-rift-<behavior>-error` header. Default is unchanged, preserving the lenient #269/#323 contract.

Closes #375

Milestone: none (agent-found follow-up to #323).