### PR TITLE
Optional: hard-raise script flow-store errors (config-gated), not just last_error()

### DIFF
--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -426,21 +426,50 @@ pub fn clear_last_flow_error() {
     LAST_FLOW_ERROR.with(|e| *e.borrow_mut() = None);
 }
 
-/// Route a script flow-store op result through the shared error seam: log a failure, record it so
-/// `flow_store.last_error()` can surface it (issue #322), and return the fallback; a success clears
-/// the slot so `last_error()` reflects only the most recent op.
-pub fn log_flow_err<T>(op: &str, fallback: T, result: Result<T>) -> T {
+/// Route a script flow-store op result through the shared error seam: on failure, log it and record
+/// it so `flow_store.last_error()` can surface it (issue #322), returning the error MESSAGE so a
+/// strict engine can raise it (issue #376); on success, clear the slot so `last_error()` reflects
+/// only the most recent op. [`log_flow_err`] is the lenient wrapper built on this.
+pub fn flow_result<T>(op: &str, result: Result<T>) -> std::result::Result<T, String> {
     match result {
         Ok(value) => {
             LAST_FLOW_ERROR.with(|e| *e.borrow_mut() = None);
-            value
+            Ok(value)
         }
         Err(e) => {
-            tracing::warn!("script flow_store.{op} failed; returning fallback: {e:#}");
-            LAST_FLOW_ERROR.with(|slot| *slot.borrow_mut() = Some(format!("{op}: {e:#}")));
-            fallback
+            let msg = format!("{op}: {e:#}");
+            tracing::warn!("script flow_store.{op} failed: {e:#}");
+            LAST_FLOW_ERROR.with(|slot| *slot.borrow_mut() = Some(msg.clone()));
+            Err(msg)
         }
     }
+}
+
+/// Route a script flow-store op result through the shared error seam, returning the fallback on
+/// failure (recording it for `flow_store.last_error()`, issue #322). This is the lenient contract:
+/// a backend outage yields a fallback value rather than a script error. The strict alternative
+/// (issue #376, gated by [`strict_flow_store`]) uses [`flow_result`] directly to raise instead.
+pub fn log_flow_err<T>(op: &str, fallback: T, result: Result<T>) -> T {
+    flow_result(op, result).unwrap_or(fallback)
+}
+
+/// Whether script flow-store ops fail loud — raise a native script error on a backend failure
+/// instead of returning a fallback value + recording `last_error()` (issue #376). Read once from
+/// the `RIFT_STRICT_FLOW_STORE` env var (`1`/`true`/`yes`/`on`). Default off preserves the lenient
+/// #322 contract. A global gate (like `RIFT_DISABLE_HTTP2`, #378) because scripts run on pooled
+/// worker threads where a per-imposter flag can't be threaded without cross-engine plumbing.
+pub fn strict_flow_store() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        strict_flow_store_from(std::env::var("RIFT_STRICT_FLOW_STORE").ok().as_deref())
+    })
+}
+
+/// Pure parse of the `RIFT_STRICT_FLOW_STORE` value, split out so it can be unit-tested without the
+/// process-global env-var races that a full end-to-end test would hit.
+fn strict_flow_store_from(val: Option<&str>) -> bool {
+    val.map(|v| v.trim().to_ascii_lowercase())
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
 }
 
 /// A deliberately failing flow store (feature `test-backend`): every operation annotates
@@ -489,6 +518,31 @@ impl FlowStore for FailingFlowStore {
 #[cfg(test)]
 mod last_flow_error_tests {
     use super::*;
+
+    // AC5 (issue #376): RIFT_STRICT_FLOW_STORE parsing — truthy values fail loud, everything else
+    // keeps the lenient #322 fallback.
+    #[test]
+    fn strict_flow_store_env_parsing() {
+        for on in ["1", "true", "TRUE", " yes ", "On"] {
+            assert!(
+                strict_flow_store_from(Some(on)),
+                "{on:?} should enable strict flow-store mode"
+            );
+        }
+        for off in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("2"),
+        ] {
+            assert!(
+                !strict_flow_store_from(off),
+                "{off:?} should keep the lenient fallback"
+            );
+        }
+    }
 
     // AC1 (issue #322): log_flow_err records a failure so last_error can surface it, and a
     // subsequent success clears it — so last_error reflects only the most recent op.

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, log_flow_err};
+use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
 use crate::scripting::{FaultDecision, ScriptRequest};
 use anyhow::{Result, anyhow};
 use boa_engine::{
@@ -372,6 +372,22 @@ fn create_request_object(context: &mut Context, request: &ScriptRequest) -> Resu
 
 // Native function implementations that use thread-local storage
 
+/// Map a flow-store op outcome to a JS value: a success yields the value; a failure raises a native
+/// error in strict mode (issue #376) or returns the lenient fallback (issue #322). `None` (no store
+/// bound on this thread) also uses the fallback.
+fn js_flow_outcome<T: Into<JsValue>>(
+    outcome: Option<std::result::Result<T, String>>,
+    fallback: T,
+) -> JsResult<JsValue> {
+    match outcome {
+        Some(Ok(v)) => Ok(v.into()),
+        Some(Err(msg)) if strict_flow_store() => {
+            Err(JsNativeError::error().with_message(msg).into())
+        }
+        Some(Err(_)) | None => Ok(fallback.into()),
+    }
+}
+
 fn flow_store_get(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
     let flow_id = args
         .first()
@@ -384,14 +400,15 @@ fn flow_store_get(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsRes
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result = with_current_flow_store(|store| store.get(&flow_id, &key));
+    let outcome = with_current_flow_store(|store| flow_result("get", store.get(&flow_id, &key)));
 
-    match result {
-        Some(store_result) => match log_flow_err("get", None, store_result) {
-            Some(value) => json_to_js_result(ctx, &value),
-            None => Ok(JsValue::null()),
-        },
-        None => Ok(JsValue::null()),
+    match outcome {
+        Some(Ok(Some(value))) => json_to_js_result(ctx, &value),
+        Some(Ok(None)) => Ok(JsValue::null()),
+        Some(Err(msg)) if strict_flow_store() => {
+            Err(JsNativeError::error().with_message(msg).into())
+        }
+        Some(Err(_)) | None => Ok(JsValue::null()),
     }
 }
 
@@ -409,16 +426,11 @@ fn flow_store_set(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsRes
     let value = args.get(2).cloned().unwrap_or(JsValue::null());
 
     let json_value = js_to_json(ctx, &value)?;
-    let result = with_current_flow_store(|store| {
-        log_flow_err(
-            "set",
-            false,
-            store.set(&flow_id, &key, json_value).map(|()| true),
-        )
-    })
-    .unwrap_or(false);
+    let outcome = with_current_flow_store(|store| {
+        flow_result("set", store.set(&flow_id, &key, json_value).map(|()| true))
+    });
 
-    Ok(JsValue::from(result))
+    js_flow_outcome(outcome, false)
 }
 
 fn flow_store_exists(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> JsResult<JsValue> {
@@ -433,12 +445,10 @@ fn flow_store_exists(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> J
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result = with_current_flow_store(|store| {
-        log_flow_err("exists", false, store.exists(&flow_id, &key))
-    })
-    .unwrap_or(false);
+    let outcome =
+        with_current_flow_store(|store| flow_result("exists", store.exists(&flow_id, &key)));
 
-    Ok(JsValue::from(result))
+    js_flow_outcome(outcome, false)
 }
 
 fn flow_store_delete(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> JsResult<JsValue> {
@@ -453,12 +463,11 @@ fn flow_store_delete(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> J
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result = with_current_flow_store(|store| {
-        log_flow_err("delete", false, store.delete(&flow_id, &key).map(|()| true))
-    })
-    .unwrap_or(false);
+    let outcome = with_current_flow_store(|store| {
+        flow_result("delete", store.delete(&flow_id, &key).map(|()| true))
+    });
 
-    Ok(JsValue::from(result))
+    js_flow_outcome(outcome, false)
 }
 
 fn flow_store_increment(
@@ -477,12 +486,10 @@ fn flow_store_increment(
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
 
-    let result = with_current_flow_store(|store| {
-        log_flow_err("increment", 0, store.increment(&flow_id, &key))
-    })
-    .unwrap_or(0);
+    let outcome =
+        with_current_flow_store(|store| flow_result("increment", store.increment(&flow_id, &key)));
 
-    Ok(JsValue::from(result))
+    js_flow_outcome(outcome, 0i64)
 }
 
 fn flow_store_set_ttl(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> JsResult<JsValue> {
@@ -497,16 +504,14 @@ fn flow_store_set_ttl(_this: &JsValue, args: &[JsValue], _ctx: &mut Context) -> 
         .map(|n| n as i64)
         .ok_or_else(|| JsNativeError::typ().with_message("ttl_seconds must be a number"))?;
 
-    let result = with_current_flow_store(|store| {
-        log_flow_err(
+    let outcome = with_current_flow_store(|store| {
+        flow_result(
             "setTtl",
-            false,
             store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
         )
-    })
-    .unwrap_or(false);
+    });
 
-    Ok(JsValue::from(result))
+    js_flow_outcome(outcome, false)
 }
 
 fn flow_store_last_error(

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, log_flow_err};
+use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
 use crate::scripting::{FaultDecision, ScriptRequest};
 use anyhow::{Result, anyhow};
 use mlua::prelude::*;
@@ -608,63 +608,79 @@ impl LuaFlowStore {
         Self { store }
     }
 
-    /// Get a value from flow state
+    /// Get a value from flow state. Strict mode (issue #376) raises on a backend failure; otherwise
+    /// returns nil (the lenient #322 fallback) and records the error for `last_error()`.
     fn get(&self, lua: &Lua, flow_id: String, key: String) -> LuaResult<LuaValue> {
         let store = Arc::clone(&self.store);
 
         // Direct synchronous call - no async bridging needed
-        match log_flow_err("get", None, store.get(&flow_id, &key)) {
-            Some(value) => json_to_lua(lua, &value),
-            None => Ok(LuaValue::Nil),
+        match flow_result("get", store.get(&flow_id, &key)) {
+            Ok(Some(value)) => json_to_lua(lua, &value),
+            Ok(None) => Ok(LuaValue::Nil),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(LuaValue::Nil),
         }
     }
 
-    /// Set a value in flow state
+    /// Set a value in flow state. Strict mode raises on failure; else returns false (lenient #322).
     fn set(&self, lua: &Lua, flow_id: String, key: String, value: LuaValue) -> LuaResult<bool> {
         // Convert Lua value to JSON
         let json_value = lua_to_json(lua, value)?;
 
         let store = Arc::clone(&self.store);
 
-        let result = store.set(&flow_id, &key, json_value).map(|()| true);
-
-        Ok(log_flow_err("set", false, result))
+        match flow_result("set", store.set(&flow_id, &key, json_value).map(|()| true)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Check if a key exists
+    /// Check if a key exists. Strict mode raises on failure; else returns false (lenient #322).
     fn exists(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        Ok(log_flow_err("exists", false, store.exists(&flow_id, &key)))
+        match flow_result("exists", store.exists(&flow_id, &key)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Delete a key
+    /// Delete a key. Strict mode raises on failure; else returns false (lenient #322).
     fn delete(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        let result = store.delete(&flow_id, &key).map(|()| true);
-
-        Ok(log_flow_err("delete", false, result))
+        match flow_result("delete", store.delete(&flow_id, &key).map(|()| true)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Increment a counter
+    /// Increment a counter. Strict mode raises on failure; else returns 0 (lenient #322).
     fn increment(&self, flow_id: String, key: String) -> LuaResult<i64> {
         let store = Arc::clone(&self.store);
 
-        Ok(log_flow_err(
-            "increment",
-            0,
-            store.increment(&flow_id, &key),
-        ))
+        match flow_result("increment", store.increment(&flow_id, &key)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(0),
+        }
     }
 
-    /// Set TTL for a flow
+    /// Set TTL for a flow. Strict mode raises on failure; else returns false (lenient #322).
     fn set_ttl(&self, flow_id: String, ttl_seconds: i64) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
-        let result = store.set_ttl(&flow_id, ttl_seconds).map(|()| true);
-
-        Ok(log_flow_err("setTtl", false, result))
+        match flow_result(
+            "setTtl",
+            store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
+        ) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(_) => Ok(false),
+        }
     }
 
     /// Take (read and clear) the last flow-store op error for this thread, or nil if the

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, log_flow_err};
+use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
 use anyhow::{Result, anyhow};
 use rhai::Dynamic;
 use serde_json::Value;
@@ -161,50 +161,92 @@ impl ScriptFlowStore {
         Self { store }
     }
 
-    /// Get a value from flow state
-    pub fn get(&mut self, flow_id: String, key: String) -> Dynamic {
-        match log_flow_err("get", None, self.store.get(&flow_id, &key)) {
-            Some(val) => rhai_engine::json_to_dynamic(val),
-            None => Dynamic::UNIT,
+    /// Get a value from flow state. In strict mode (issue #376) a backend failure raises; otherwise
+    /// it returns unit (the lenient #322 fallback) and records the error for `last_error()`.
+    pub fn get(
+        &mut self,
+        flow_id: String,
+        key: String,
+    ) -> std::result::Result<Dynamic, Box<rhai::EvalAltResult>> {
+        match flow_result("get", self.store.get(&flow_id, &key)) {
+            Ok(Some(val)) => Ok(rhai_engine::json_to_dynamic(val)),
+            Ok(None) => Ok(Dynamic::UNIT),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(Dynamic::UNIT),
         }
     }
 
-    /// Set a value in flow state
-    pub fn set(&mut self, flow_id: String, key: String, value: Dynamic) -> bool {
+    /// Set a value in flow state. Strict mode raises on failure; else returns false (lenient #322).
+    pub fn set(
+        &mut self,
+        flow_id: String,
+        key: String,
+        value: Dynamic,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
         let json_val = rhai_engine::dynamic_to_json(value);
-        log_flow_err(
+        match flow_result(
             "set",
-            false,
             self.store.set(&flow_id, &key, json_val).map(|()| true),
-        )
+        ) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Check if a key exists
-    pub fn exists(&mut self, flow_id: String, key: String) -> bool {
-        log_flow_err("exists", false, self.store.exists(&flow_id, &key))
+    /// Check if a key exists. Strict mode raises on failure; else returns false (lenient #322).
+    pub fn exists(
+        &mut self,
+        flow_id: String,
+        key: String,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        match flow_result("exists", self.store.exists(&flow_id, &key)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Delete a key
-    pub fn delete(&mut self, flow_id: String, key: String) -> bool {
-        log_flow_err(
-            "delete",
-            false,
-            self.store.delete(&flow_id, &key).map(|()| true),
-        )
+    /// Delete a key. Strict mode raises on failure; else returns false (lenient #322).
+    pub fn delete(
+        &mut self,
+        flow_id: String,
+        key: String,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        match flow_result("delete", self.store.delete(&flow_id, &key).map(|()| true)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(false),
+        }
     }
 
-    /// Increment a counter
-    pub fn increment(&mut self, flow_id: String, key: String) -> i64 {
-        log_flow_err("increment", 0, self.store.increment(&flow_id, &key))
+    /// Increment a counter. Strict mode raises on failure; else returns 0 (lenient #322).
+    pub fn increment(
+        &mut self,
+        flow_id: String,
+        key: String,
+    ) -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
+        match flow_result("increment", self.store.increment(&flow_id, &key)) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(0),
+        }
     }
 
-    /// Set TTL for a flow
-    pub fn set_ttl(&mut self, flow_id: String, ttl_seconds: i64) -> bool {
-        log_flow_err(
+    /// Set TTL for a flow. Strict mode raises on failure; else returns false (lenient #322).
+    pub fn set_ttl(
+        &mut self,
+        flow_id: String,
+        ttl_seconds: i64,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        match flow_result(
             "setTtl",
-            false,
             self.store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
-        )
+        ) {
+            Ok(v) => Ok(v),
+            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(_) => Ok(false),
+        }
     }
 
     /// Take (read and clear) the last flow-store op error for this thread, or unit if the
@@ -222,6 +264,89 @@ mod tests {
     use super::*;
     use crate::extensions::flow_state::NoOpFlowStore;
     use std::collections::HashMap;
+
+    /// A flow store whose every op fails — for exercising the error branches of the wrappers.
+    struct FailingStore;
+    impl FlowStore for FailingStore {
+        fn get(&self, _: &str, _: &str) -> Result<Option<Value>> {
+            Err(anyhow!("boom"))
+        }
+        fn set(&self, _: &str, _: &str, _: Value) -> Result<()> {
+            Err(anyhow!("boom"))
+        }
+        fn exists(&self, _: &str, _: &str) -> Result<bool> {
+            Err(anyhow!("boom"))
+        }
+        fn delete(&self, _: &str, _: &str) -> Result<()> {
+            Err(anyhow!("boom"))
+        }
+        fn increment(&self, _: &str, _: &str) -> Result<i64> {
+            Err(anyhow!("boom"))
+        }
+        fn set_ttl(&self, _: &str, _: i64) -> Result<()> {
+            Err(anyhow!("boom"))
+        }
+    }
+
+    // Issue #376 lenient contract (default, strict OFF): every Rhai ScriptFlowStore op, on a backend
+    // failure, returns its documented fallback (never raises) AND records the error for
+    // `last_error()` (issue #322). Covers all six ops — the strict/lenient branch is hand-written
+    // per op, so a wrong fallback in any one would be caught here. (The strict raise is covered
+    // end-to-end per engine in issue_376_strict_flow_store.rs; it can't be unit-tested reliably
+    // because `strict_flow_store()` caches the env read per process.)
+    #[test]
+    fn rhai_flow_store_lenient_ops_return_fallback_and_record_error() {
+        use crate::extensions::flow_state::take_last_flow_error;
+        let mut s = ScriptFlowStore::new(Arc::new(FailingStore));
+
+        let _ = take_last_flow_error();
+        assert!(
+            s.get("f".into(), "k".into())
+                .expect("lenient get must not raise")
+                .is_unit(),
+            "get falls back to unit"
+        );
+        assert!(
+            take_last_flow_error().is_some_and(|e| e.contains("get")),
+            "get records last_error"
+        );
+
+        assert!(
+            !s.set("f".into(), "k".into(), Dynamic::from(1))
+                .expect("lenient set must not raise"),
+            "set falls back to false"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("set")));
+
+        assert!(
+            !s.exists("f".into(), "k".into())
+                .expect("lenient exists must not raise"),
+            "exists falls back to false"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("exists")));
+
+        assert!(
+            !s.delete("f".into(), "k".into())
+                .expect("lenient delete must not raise"),
+            "delete falls back to false"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("delete")));
+
+        assert_eq!(
+            s.increment("f".into(), "k".into())
+                .expect("lenient increment must not raise"),
+            0,
+            "increment falls back to 0"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("increment")));
+
+        assert!(
+            !s.set_ttl("f".into(), 60)
+                .expect("lenient set_ttl must not raise"),
+            "set_ttl falls back to false"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("setTtl")));
+    }
 
     // AC2 (issue #322): the Rhai flow_store.last_error() accessor surfaces the last recorded
     // backend error (then leaves the slot taken so a following op reflects its own status).
@@ -450,7 +575,9 @@ mod tests {
     fn test_script_flow_store_get() {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
-        let result = script_store.get("flow-1".to_string(), "key".to_string());
+        let result = script_store
+            .get("flow-1".to_string(), "key".to_string())
+            .expect("NoOp get never fails");
         // NoOpFlowStore returns Unit for get
         assert!(result.is_unit());
     }
@@ -459,11 +586,13 @@ mod tests {
     fn test_script_flow_store_set() {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
-        let result = script_store.set(
-            "flow-1".to_string(),
-            "key".to_string(),
-            rhai::Dynamic::from(42),
-        );
+        let result = script_store
+            .set(
+                "flow-1".to_string(),
+                "key".to_string(),
+                rhai::Dynamic::from(42),
+            )
+            .expect("NoOp set never fails");
         assert!(result);
     }
 
@@ -471,7 +600,9 @@ mod tests {
     fn test_script_flow_store_exists() {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
-        let result = script_store.exists("flow-1".to_string(), "key".to_string());
+        let result = script_store
+            .exists("flow-1".to_string(), "key".to_string())
+            .expect("NoOp exists never fails");
         assert!(!result); // NoOpFlowStore always returns false
     }
 
@@ -479,7 +610,9 @@ mod tests {
     fn test_script_flow_store_delete() {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
-        let result = script_store.delete("flow-1".to_string(), "key".to_string());
+        let result = script_store
+            .delete("flow-1".to_string(), "key".to_string())
+            .expect("NoOp delete never fails");
         assert!(result);
     }
 
@@ -488,7 +621,9 @@ mod tests {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
         // NoOpFlowStore returns 0 on error (which doesn't happen, but increment returns 1)
-        let result = script_store.increment("flow-1".to_string(), "counter".to_string());
+        let result = script_store
+            .increment("flow-1".to_string(), "counter".to_string())
+            .expect("NoOp increment never fails");
         assert_eq!(result, 1);
     }
 
@@ -496,7 +631,9 @@ mod tests {
     fn test_script_flow_store_set_ttl() {
         let store = Arc::new(NoOpFlowStore);
         let mut script_store = ScriptFlowStore::new(store);
-        let result = script_store.set_ttl("flow-1".to_string(), 3600);
+        let result = script_store
+            .set_ttl("flow-1".to_string(), 3600)
+            .expect("NoOp set_ttl never fails");
         assert!(result);
     }
 

--- a/crates/rift-http-proxy/tests/issue_376_lenient_default.rs
+++ b/crates/rift-http-proxy/tests/issue_376_lenient_default.rs
@@ -1,0 +1,76 @@
+//! Issue #376 regression guard (strict OFF = default): with `RIFT_STRICT_FLOW_STORE` unset, a
+//! script flow-store op that hits a backend failure keeps the #322 lenient contract — the op
+//! returns its fallback value (so the script proceeds) instead of raising. A `should_inject` that
+//! reads state under a failing backend then declines to inject still serves 200, not a 500.
+//!
+//! This binary never sets the env var, so `strict_flow_store()` caches `false`.
+
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::time::Duration;
+
+fn cfg(v: serde_json::Value) -> ImposterConfig {
+    serde_json::from_value(v).expect("test imposter config")
+}
+
+fn script_imposter(port: u16, engine: &str, code: &str) -> ImposterConfig {
+    cfg(serde_json::json!({
+        "protocol": "http", "port": port,
+        "_rift": { "flowState": { "backend": "failing" } },
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/go" } }],
+            "responses": [{ "_rift": { "script": { "engine": engine, "code": code } } }]
+        }]
+    }))
+}
+
+async fn assert_lenient_serves_200(port: u16, engine: &str, code: &str) {
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(script_imposter(port, engine, code))
+        .await
+        .expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::get(format!("http://127.0.0.1:{port}/go"))
+        .await
+        .expect("request");
+    assert_eq!(
+        resp.status(),
+        200,
+        "default (lenient) mode must not raise on a {engine} flow-store failure (#322 preserved)"
+    );
+    let _ = manager.delete_imposter(port).await;
+}
+
+// AC4 (Rhai): default lenient — a flow-store failure returns the fallback; script serves 200.
+#[tokio::test]
+async fn lenient_rhai_flow_store_failure_serves_200() {
+    assert_lenient_serves_200(
+        19971,
+        "rhai",
+        r#"fn should_inject(request, flow_store){ flow_store.get("f","k"); #{ inject: false } }"#,
+    )
+    .await;
+}
+
+// AC4 (Lua): default lenient.
+#[tokio::test]
+async fn lenient_lua_flow_store_failure_serves_200() {
+    assert_lenient_serves_200(
+        19972,
+        "lua",
+        r#"function should_inject(request, flow_store) flow_store:get("f","k") return { inject = false } end"#,
+    )
+    .await;
+}
+
+// AC4 (JS): default lenient.
+#[tokio::test]
+async fn lenient_js_flow_store_failure_serves_200() {
+    assert_lenient_serves_200(
+        19973,
+        "javascript",
+        r#"function should_inject(request, flow_store){ flow_store.get("f","k"); return { inject: false }; }"#,
+    )
+    .await;
+}

--- a/crates/rift-http-proxy/tests/issue_376_strict_flow_store.rs
+++ b/crates/rift-http-proxy/tests/issue_376_strict_flow_store.rs
@@ -1,0 +1,94 @@
+//! Issue #376 gate (strict ON): with `RIFT_STRICT_FLOW_STORE` enabled, a script flow-store op that
+//! hits a backend failure RAISES a native script error instead of returning a fallback value +
+//! recording `last_error()`. The raise propagates through `should_inject_bounded` to the existing
+//! 500 (`x-rift-script-error`). Covered for all three engines (Rhai / Lua / JS).
+//!
+//! The failing backend comes from rift-core's `test-backend` feature: `_rift.flowState.backend =
+//! "failing"` installs a store whose ops fail. This needs no Docker/Redis.
+//!
+//! This whole binary runs strict: the env var is set before any flow-store op executes, so the
+//! `strict_flow_store()` OnceLock caches `true` for every test here.
+
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::time::Duration;
+
+fn cfg(v: serde_json::Value) -> ImposterConfig {
+    serde_json::from_value(v).expect("test imposter config")
+}
+
+fn enable_strict() {
+    // Set before the first request (and thus the first `strict_flow_store()` read) so the process
+    // reads strict mode as ON. Idempotent: every test in this binary sets the same value.
+    unsafe { std::env::set_var("RIFT_STRICT_FLOW_STORE", "1") };
+}
+
+// A should_inject script that reads flow state then declines to inject. Under a failing backend
+// the read is the failure point.
+fn script_imposter(port: u16, engine: &str, code: &str) -> ImposterConfig {
+    cfg(serde_json::json!({
+        "protocol": "http", "port": port,
+        "_rift": { "flowState": { "backend": "failing" } },
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/go" } }],
+            "responses": [{ "_rift": { "script": { "engine": engine, "code": code } } }]
+        }]
+    }))
+}
+
+async fn assert_strict_raises(port: u16, engine: &str, code: &str) {
+    enable_strict();
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(script_imposter(port, engine, code))
+        .await
+        .expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::get(format!("http://127.0.0.1:{port}/go"))
+        .await
+        .expect("request");
+    let status = resp.status();
+    let has_err_header = resp.headers().contains_key("x-rift-script-error");
+    assert_eq!(
+        status, 500,
+        "strict mode must fail loud (500) when the {engine} flow-store op fails"
+    );
+    assert!(
+        has_err_header,
+        "the 500 must carry x-rift-script-error so the failure is visible ({engine})"
+    );
+    let _ = manager.delete_imposter(port).await;
+}
+
+// AC1: Rhai strict flow-store failure raises → 500.
+#[tokio::test]
+async fn strict_rhai_flow_store_failure_raises() {
+    assert_strict_raises(
+        19961,
+        "rhai",
+        r#"fn should_inject(request, flow_store){ flow_store.get("f","k"); #{ inject: false } }"#,
+    )
+    .await;
+}
+
+// AC2: Lua strict flow-store failure raises → 500.
+#[tokio::test]
+async fn strict_lua_flow_store_failure_raises() {
+    assert_strict_raises(
+        19962,
+        "lua",
+        r#"function should_inject(request, flow_store) flow_store:get("f","k") return { inject = false } end"#,
+    )
+    .await;
+}
+
+// AC3: JS strict flow-store failure raises → 500.
+#[tokio::test]
+async fn strict_js_flow_store_failure_raises() {
+    assert_strict_raises(
+        19963,
+        "javascript",
+        r#"function should_inject(request, flow_store){ flow_store.get("f","k"); return { inject: false }; }"#,
+    )
+    .await;
+}


### PR DESCRIPTION
Adds an opt-in strict flow-store mode via RIFT_STRICT_FLOW_STORE env var (default off).
When enabled, a script flow-store op failure raises across all three engines (Rhai/Lua/JS)
instead of returning a fallback. Default preserves the lenient #322 contract.

Closes #376
Milestone: none (agent-found follow-up to #322).