### PR TITLE
docs: reconcile docs with post-0.8.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ record.
 
 ## [Unreleased]
 
+### Added
+- HTTP/2 and h2c support via hyper auto-negotiation on HTTP and HTTPS listeners; `RIFT_DISABLE_HTTP2` escape hatch forces HTTP/1-only.
+- Socket tuning: `TCP_NODELAY` is on by default, with `RIFT_TCP_NODELAY` and `RIFT_TCP_BACKLOG` knobs.
+- Feature-gated `mimalloc` global allocator (default-on for `rift-http-proxy`).
+- `rift-verify -o json` machine-readable summary; ANSI/banner suppression when stdout is piped or `NO_COLOR` is set.
+- Opt-in strict behaviors: per-imposter `strictBehaviors` flag / `RIFT_STRICT_BEHAVIORS` env var returns `500` on a `decorate`/`shellTransform`/binary failure instead of the lenient fallback.
+- Opt-in `RIFT_STRICT_FLOW_STORE` env var raises on script flow-store op failures in all three engines.
+- `flow_store.last_error()` lets scripts distinguish a down backend from an empty result.
+- Script wall-clock timeout (`_rift.scriptEngine.timeoutMs`, default 5000 ms) plus JS loop-iteration and recursion bounds.
+
+### Changed
+- `POST /admin/reload` is now incremental (diff-based): unchanged imposters and stubs keep their runtime state, and the response reports `created`/`replaced`/`stubPatched`/`deleted`.
+- Top-level `fault` responses reset the connection at the transport level (Mountebank parity) instead of returning HTTP 502.
+- `decorate`/`shellTransform`/binary behavior failures are signaled via `x-rift-<behavior>-error` response headers instead of being served silently.
+- Bare `jsonpath` selectors (no leading `$`) are treated as root-relative.
+- Flat stub responses (top-level `statusCode`/`headers`/`body`, no `is` wrapper) are accepted and served identically to the wrapped form.
+
+### Fixed
+- An unknown `flowState` backend, or an unreachable/misconfigured redis flow-store, now fails imposter creation with `400` instead of silently downgrading to a no-op store.
+- Runaway `_rift.script` execution is bounded so it can no longer wedge the engine.
+
 ## [0.8.0] - 2026-07-01
 
 ### Added

--- a/docs/_data/sync.yml
+++ b/docs/_data/sync.yml
@@ -6,6 +6,6 @@
 #   2. Update the affected pages.
 #   3. Bump this file AND the version in _config.yml footer_content in the same PR.
 release: v0.8.0
-commit: 54eb2dfebdc3778edf358d6c28ca6a29697d0569
-date: 2026-07-01
+commit: 912e23c198243af81a18960ad0d409ef49964bef
+date: 2026-07-04
 tracking_issue: 280

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -128,7 +128,16 @@ Environment variables override CLI defaults:
 | `RIFT_DEFAULT_TLS_CERT` | Default TLS certificate (PEM) for HTTPS imposters | |
 | `RIFT_DEFAULT_TLS_KEY` | Default TLS private key (PEM) | |
 | `RIFT_NO_SELF_SIGNED_TLS` | Disable self-signed TLS fallback (`true`/`false`) | `false` |
+| `RIFT_DISABLE_HTTP2` | Force HTTP/1-only listeners, disabling HTTP/2 & h2c auto-negotiation (truthy: `1`/`true`/`yes`/`on`) | off |
+| `RIFT_TCP_BACKLOG` | Listen backlog for the accept loop (positive integer) | `1024` |
+| `RIFT_TCP_NODELAY` | `TCP_NODELAY` on accepted sockets; set `false`/`0`/`off` to disable | on |
+| `NO_COLOR` | Suppress ANSI color and the decorative banner in `rift-verify` / `rift-lint` output | |
 | `RUST_LOG` | Detailed log configuration | `info` |
+
+`RIFT_DISABLE_HTTP2` is an escape hatch for clients or intermediaries that mishandle HTTP/2; see
+[HTTP/2 and h2c]({{ site.baseurl }}/mountebank/imposters/#http2-and-h2c). `RIFT_TCP_BACKLOG` and
+`RIFT_TCP_NODELAY` are socket-tuning knobs covered under
+[Performance → Runtime socket tuning]({{ site.baseurl }}/performance/#runtime-socket-tuning).
 
 ### Docker Example
 
@@ -313,6 +322,7 @@ Options:
   -c, --show-curl         Show curl commands for each test
   -v, --verbose           Verbose output with pass/fail details
   -t, --timeout <SECS>    Request timeout in seconds [default: 10]
+  -o, --output <FMT>      Output format: text (default), json
       --dry-run           Show what would be tested without making requests
       --skip-dynamic      Skip stubs with inject/proxy/script responses
       --status-only       Only verify status codes (ignore body/headers)
@@ -338,7 +348,15 @@ rift-verify --skip-dynamic
 
 # Status-only mode for cycling responses
 rift-verify --status-only
+
+# Machine-readable summary for CI (JSON on stdout, progress on stderr)
+rift-verify -o json
 ```
+
+With `-o json`, `rift-verify` writes a single summary object to stdout —
+`{ "imposters", "stubs", "tests", "passed", "failed", "skipped" }` — and routes all progress and
+banner output to stderr, so it pipes cleanly into other tools. Color and the decorative banner are
+also suppressed automatically when stdout is not a TTY (piped) or when `NO_COLOR` is set.
 
 See [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) for details.
 

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -174,8 +174,46 @@ Simulate network-level failures:
 }
 ```
 
-TCP fault types:
-- `CONNECTION_RESET_BY_PEER` - RST packet (connection reset)
+TCP fault types (each accepts a WireMock-style canonical name or a short alias):
+
+| Fault | Aliases | Effect |
+|:------|:--------|:-------|
+| `CONNECTION_RESET_BY_PEER` | `reset` | Real TCP reset (RST) — the connection is aborted |
+| `EMPTY_RESPONSE` | `empty` | Close the connection with no bytes sent |
+| `RANDOM_DATA_THEN_CLOSE` | `random`, `garbage` | Write random bytes, then close |
+| `MALFORMED_RESPONSE_CHUNK` | `malformed` | Send a status line + a malformed chunked body, then close |
+
+These are real transport-level events applied beneath TLS, so HTTPS imposters get a genuine socket
+fault too. Because a connection-level fault aborts the whole socket, an imposter that uses any TCP
+fault is served over **HTTP/1 only** (HTTP/2 multiplexing is incompatible with mid-stream connection
+aborts).
+
+---
+
+## Top-Level Fault Response (Mountebank Parity)
+
+Mountebank lets a stub response be a bare `fault` instead of an `is`/`proxy`/`inject` body. Rift
+supports the same shape, and a top-level fault now **resets the connection at the transport level**
+rather than returning an HTTP 502 (Mountebank parity, issue #362):
+
+```json
+{
+  "stubs": [{
+    "predicates": [{ "equals": { "path": "/api/flaky" } }],
+    "responses": [{
+      "fault": "CONNECTION_RESET_BY_PEER"
+    }]
+  }]
+}
+```
+
+A client hitting this stub sees a transport error (connection reset), not a response. The recognized
+fault strings are the same set as `_rift.fault.tcp` above (`CONNECTION_RESET_BY_PEER`,
+`EMPTY_RESPONSE`, `RANDOM_DATA_THEN_CLOSE`, `MALFORMED_RESPONSE_CHUNK`, plus their aliases). An
+unrecognized fault string is a configuration error and yields `500 Unknown fault: <value>`.
+
+> **Behavior change:** before v0.8.0 a top-level `fault` returned a framed HTTP `502`. It now
+> performs a real connection reset/close, matching Mountebank's transport-fault semantics.
 
 ### Fault Precedence
 

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -36,6 +36,19 @@ is resolved exactly as for [Spaces]({{ site.baseurl }}/features/spaces/).
 With `backend: "redis"` you may also set `url`, `poolSize` (default 10), and `keyPrefix`
 (default `"rift:"`).
 
+### Backend configuration is fail-loud
+
+An explicit `flowState` block that can't be honored now **fails imposter creation** with
+`400 Bad Request` rather than silently downgrading to a no-op store:
+
+- An **unknown backend** string (anything other than `inmemory` or `redis`) is rejected at
+  construction (issue #381) — previously it logged a warning and became a no-op.
+- A **`redis` backend that can't be created** — no redis config block, a connection/pool failure, or
+  a binary built without the `redis-backend` feature — fails creation too (issue #369).
+
+Only the *implicit* no-op case is silent: an imposter with **no** `flowState` block (and no scenario
+stubs) uses a no-op store where values never persist, exactly as before.
+
 ---
 
 ## Script API
@@ -51,6 +64,7 @@ syntax). All operations take the flow id explicitly.
 | `flow_store.delete(flow_id, key)` | remove a key |
 | `flow_store.increment(flow_id, key)` | atomically increment, returns the new number |
 | `flow_store.set_ttl(flow_id, ttl_seconds)` | override the TTL for a flow |
+| `flow_store.last_error()` | last backend error (or `()` / `nil` / `null` if the last op succeeded) — see [Scripting → Flow-Store Error Semantics]({{ site.baseurl }}/features/scripting/#flow-store-error-semantics) |
 
 ---
 

--- a/docs/features/hot-reload.md
+++ b/docs/features/hot-reload.md
@@ -7,8 +7,9 @@ nav_order: 26
 
 # Hot Reload
 
-`POST /admin/reload` re-reads the startup config source and atomically replaces every running
-imposter — useful for editing imposters in a file and applying them without restarting the process.
+`POST /admin/reload` re-reads the startup config source and applies it **incrementally** — Rift
+diffs the running imposters against the new config and touches only what actually changed. Editing
+an imposter in a file and reloading no longer tears every imposter down.
 
 ---
 
@@ -16,19 +17,73 @@ imposter — useful for editing imposters in a file and applying them without re
 
 - Rift must have been started with a config source: `--configfile <file>` or `--datadir <dir>`.
   Without one, reload is a **no-op** that returns `200`.
-- The new config is **validated before** the running imposters are torn down. If it fails to parse
-  or has duplicate ports / unsupported protocols, the running imposters are left untouched and the
-  call errors.
-- A successful reload **resets transient state**: recorded requests, scenario state, response
-  cyclers (`repeat`), and flow-state TTLs all start fresh.
+- The new config is **validated in full before** any running imposter is mutated. If it fails to
+  parse or has duplicate ports / unsupported protocols, the running imposters are left untouched and
+  the call errors.
+- The reload is **incremental** (issue #319): each port is diffed and only the delta is applied.
+  Unchanged imposters — and unchanged stubs within a changed imposter — **keep their runtime
+  state**: recorded requests, scenario state, and response cyclers (`repeat`) all survive the
+  reload.
 
 ```bash
 rift --configfile ./imposters.json      # start with a config source
 
 # ...edit imposters.json...
 
-curl -X POST http://localhost:2525/admin/reload   # 200; new config now live
+curl -X POST http://localhost:2525/admin/reload   # 200; delta applied, state preserved
 ```
 
 To reload from a directory of one-imposter-per-file configs, start with `--datadir ./mb-data`
 instead; `POST /admin/reload` re-reads the directory.
+
+---
+
+## What the diff does
+
+Rift computes the change set per port and classifies each imposter:
+
+- **created** — a port present in the new config but not running.
+- **deleted** — a running port absent from the new config.
+- **replaced** — an imposter whose imposter-level fields changed, or whose stub set changed so
+  substantially (more than ~50% of stubs) that an in-place patch is not worthwhile. A replaced
+  imposter starts with fresh runtime state.
+- **stubPatched** — an imposter whose stubs changed only modestly; the differing stubs are patched
+  in place and every unchanged stub keeps its cursor/scenario state.
+
+Stubs are matched across a reload by a **stable key**: a stub's explicit `id` if it has one,
+otherwise a content hash. Reordering stubs or editing a neighbour therefore preserves the state of
+the stubs you didn't touch.
+
+## Reload response
+
+A successful reload returns `200` with the change set:
+
+```json
+{
+  "message": "Reloaded 3 imposter(s)",
+  "created": [4547],
+  "replaced": [4545],
+  "stubPatched": [4546],
+  "deleted": [4544]
+}
+```
+
+If some ports apply and others fail, the call returns `500` and reports both sides — the ports that
+did apply and the ones that failed:
+
+```json
+{
+  "errors": [{ "code": "500", "message": "Reload partially failed: ..." }],
+  "failed": ["4545: ..."],
+  "created": [],
+  "replaced": [],
+  "stubPatched": [],
+  "deleted": []
+}
+```
+
+A validation failure that is caught **before** any mutation returns `500` with an `errors` array and
+leaves every running imposter in place.
+
+> Embedders can also observe the diff programmatically: an incremental apply emits imposter change
+> events (`Created` / `Replaced` / `StubsChanged` / `Deleted`) to any registered listener.

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -359,6 +359,52 @@ return {
 
 ---
 
+## Execution Limits
+
+`_rift.script` execution is bounded so a runaway script cannot wedge the engine.
+
+- **Wall-clock timeout.** Each script runs under a deadline — `_rift.scriptEngine.timeoutMs` if
+  configured, otherwise **5000 ms**. Rhai and Lua are interrupted mid-run when the deadline passes.
+- **JavaScript (Boa) bounds.** The Boa interpreter cannot be interrupted per-instruction, so it is
+  bounded structurally instead: a loop-iteration limit of **10,000,000 iterations per call frame**
+  and a recursion limit of **512**. The client is still released at the wall-clock timeout with an
+  error; a pathological nested loop may keep a background worker busy a little longer, but it cannot
+  run unbounded.
+- **On timeout or error** — a compile error, a runtime error, or exceeding a bound — the response is
+  `500 Internal Server Error` carrying an `x-rift-script-error: true` header.
+
+```json
+{
+  "_rift": {
+    "scriptEngine": { "timeoutMs": 2000 }
+  }
+}
+```
+
+## Flow-Store Error Semantics
+
+By **default** a flow-store backend failure (e.g. a Redis outage mid-request) is **lenient**: the
+failing op returns its empty fallback (`()` / `nil` / `null`, `false`, or `0`) and the script keeps
+running. So a script can't tell "key genuinely absent" from "backend down" by the return value
+alone — use `last_error()` for that:
+
+```rhai
+let v = flow_store.get("flow-1", "attempts");
+if flow_store.last_error() != () {
+  // the backend failed on the last op — v is a fallback, not real data
+}
+```
+
+`last_error()` returns the most recent backend error (or `()` / `nil` / `null` when the last op
+succeeded) and is reset at the start of every script execution. The call syntax follows each engine:
+`flow_store.last_error()` (Rhai), `flow_store:last_error()` (Lua), `flow_store.last_error()` (JS).
+
+Set the **`RIFT_STRICT_FLOW_STORE`** environment variable (truthy: `1`/`true`/`yes`/`on`) to make a
+flow-store op failure **raise** a script error in all three engines instead of returning a fallback.
+The raised error propagates to the standard script-error path (`500` with `x-rift-script-error`).
+
+---
+
 ## Engine Comparison
 
 | Feature | JavaScript | Rhai | Lua |

--- a/docs/mountebank/behaviors.md
+++ b/docs/mountebank/behaviors.md
@@ -502,6 +502,47 @@ When multiple behaviors are defined, they execute in this order:
 
 ---
 
+## Error Semantics
+
+When a transforming behavior fails — a `decorate` function throws, a `shellTransform` command exits
+non-zero, or a `binary`/base64 body can't be decoded — Rift signals the failure rather than failing
+silently.
+
+**Default (lenient).** The fallback response (the un-transformed body) is still served with its
+normal status, and a header flags what failed:
+
+| Behavior | Failure header |
+|:---------|:---------------|
+| `decorate` | `x-rift-decorate-error: true` |
+| `shellTransform` | `x-rift-shelltransform-error: true` |
+| `binary` (base64) | `x-rift-binary-error: true` |
+
+**Strict mode.** Set the per-imposter `strictBehaviors` flag (or the `RIFT_STRICT_BEHAVIORS`
+environment variable, truthy: `1`/`true`/`yes`/`on`) to turn a behavior failure into a
+`500 Internal Server Error` — the failing behavior no longer serves a fallback. The response still
+carries the matching `x-rift-<behavior>-error` header. The per-imposter flag and the env var combine
+with **OR**: either being set forces strict mode. The default is lenient (both unset).
+
+```json
+{
+  "port": 4545,
+  "protocol": "http",
+  "strictBehaviors": true,
+  "stubs": [{
+    "responses": [{
+      "is": { "statusCode": 200, "body": "Hello" },
+      "_behaviors": {
+        "decorate": "function(request, response) { throw new Error('boom'); }"
+      }
+    }]
+  }]
+}
+```
+
+With `strictBehaviors` on, the throwing `decorate` above returns `500` instead of serving `"Hello"`.
+
+---
+
 ## Best Practices
 
 1. **Use wait sparingly** - Only for testing timeout handling

--- a/docs/mountebank/imposters.md
+++ b/docs/mountebank/imposters.md
@@ -68,6 +68,22 @@ curl -X POST http://localhost:2525/imposters \
 | `cert` | string | HTTPS only | PEM-encoded certificate |
 | `mutualAuth` | boolean | No | Require client certificate |
 
+### HTTP/2 and h2c
+
+Rift auto-negotiates the HTTP version — you don't configure it per imposter:
+
+- **HTTPS imposters** advertise `h2` and `http/1.1` via TLS ALPN, so an HTTP/2-capable client gets
+  HTTP/2 and everything else falls back to HTTP/1.1.
+- **Plain HTTP imposters** accept **h2c** (cleartext HTTP/2 via prior-knowledge) alongside HTTP/1 —
+  the listener detects the HTTP/2 preface and upgrades automatically.
+
+This is on by default and backward-compatible with HTTP/1 clients. Two things force HTTP/1-only:
+
+- an imposter that uses any **TCP fault** (`_rift.fault.tcp` or a top-level `fault`), because a
+  connection-level abort is incompatible with HTTP/2 multiplexing; and
+- setting the **`RIFT_DISABLE_HTTP2`** environment variable (truthy: `1`/`true`/`yes`/`on`), which
+  forces every listener — HTTP and HTTPS, imposter, admin, and metrics — down to HTTP/1.
+
 ### Auto-Port Assignment
 
 If you omit the `port` field, Rift will automatically assign an available port from the dynamic range (49152-65535):

--- a/docs/mountebank/predicates.md
+++ b/docs/mountebank/predicates.md
@@ -176,6 +176,10 @@ Match specific values in JSON bodies using JSONPath. The `jsonpath` selector is 
 }
 ```
 
+A leading `$` is optional. A selector that does not start with `$` is treated as **root-relative**:
+`user.name` is normalized to `$.user.name`, and `[0]` to `$[0]`. This applies wherever a `jsonpath`
+selector is used — predicates and the `copy` behavior's `jsonpath` extraction alike.
+
 ### JSONPath Operators
 
 ```json

--- a/docs/mountebank/proxy.md
+++ b/docs/mountebank/proxy.md
@@ -190,6 +190,23 @@ curl -X POST http://localhost:2525/imposters \
   -d @recorded.json
 ```
 
+### Flat Response Form
+
+Rift accepts a stub response in **flat form** — `statusCode`, `headers`, and `body` at the top level
+of the response object, with no `is` wrapper — and serves it identically to the wrapped form. This
+matters when replaying recorded or externally-generated mocks that emit flat responses:
+
+```json
+// Flat form (no "is" wrapper) — accepted and served as a 200 with the body
+{ "statusCode": 200, "body": "recorded" }
+
+// Equivalent to the canonical wrapped form
+{ "is": { "statusCode": 200, "body": "recorded" } }
+```
+
+`statusCode` defaults to `200` when omitted. If both a top-level field and an explicit `is` are
+present, `is` takes precedence.
+
 ---
 
 ## Modifying Proxied Responses

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -205,6 +205,35 @@ Rift provides 10-100x better performance while maintaining Mountebank compatibil
 
 ---
 
+## Runtime Socket Tuning
+
+Rift tunes accepted sockets for low latency out of the box and exposes a couple of knobs via
+environment variables:
+
+| Variable | Default | Effect |
+|:---------|:--------|:-------|
+| `RIFT_TCP_NODELAY` | on | `TCP_NODELAY` is set on every accepted socket (disables Nagle's algorithm) for lower request latency. Set `false`/`0`/`off` to disable. |
+| `RIFT_TCP_BACKLOG` | `1024` | Listen backlog (queue depth) for the accept loop. A larger backlog absorbs bigger connection bursts. Non-positive or unparsable values fall back to the default. |
+
+These apply to both the imposter and proxy accept loops.
+
+## Memory Allocator (mimalloc)
+
+The `rift-http-proxy` binary uses the [mimalloc](https://github.com/microsoft/mimalloc) global
+allocator by default — it improves throughput under the allocation-heavy request path. It is a
+Cargo feature named `mimalloc`, enabled in the binary's default feature set:
+
+```bash
+# Default build — mimalloc is on
+cargo build --release
+
+# Drop it (e.g. for a cross-compile or FFI build) by opting out of default features
+cargo build --release --no-default-features --features redis-backend,lua,javascript
+```
+
+Only the `rift-http-proxy` binary is affected; `rift-core` and the FFI crate use the system
+allocator.
+
 ## Build Tuning
 
 The shipped release profile is already aggressive:


### PR DESCRIPTION
Reconciles documentation with post-0.8.0 feature releases, covering HTTP/2 & h2c 
handling, strict mode toggles, incremental reload behavior, and other recent additions.

Part of #280
Milestone: docs post-0.8.0 pass (sync marker 54eb2df → 912e23c)