### PR TITLE
docs: add Embedding & SPI documentation section (embeddable server, SPI traits, FFI C-ABI)

### DIFF
--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: FFI (C-ABI)
+parent: Embedding & SPI
+nav_order: 3
+---
+
+# FFI (C-ABI)
+
+`rift-ffi` exposes a stable **C-ABI (v2)** so any language with C interop — the JVM, Node, Go,
+Python, … — can embed Rift in-process without shelling out to the binary. It builds as a `cdylib`
+(and an `rlib` for in-crate tests): `crate-type = ["cdylib", "rlib"]`.
+
+A cbindgen-generated header ships in the repo at **`crates/rift-ffi/include/rift_ffi.h`**
+(regenerate/verify with `scripts/verify-ffi-cdylib.sh`). Do not hand-edit it.
+
+---
+
+## Handle lifecycle
+
+The ABI is built around an opaque `RiftHandle` (a Tokio runtime + an `Arc<ImposterManager>`, plus an
+optional in-process admin/metrics plane).
+
+```c
+RiftHandle* h = rift_start();     // create
+// ... drive it ...
+rift_stop(h);                     // stop and free
+```
+
+| Function | Signature | Purpose |
+|:---------|:----------|:--------|
+| `rift_start` | `RiftHandle* rift_start(void)` | Create a handle (owns a runtime + manager). |
+| `rift_stop` | `void rift_stop(RiftHandle* h)` | Stop the handle's servers and free it. |
+
+---
+
+## Imposter operations
+
+| Function | Signature | Returns |
+|:---------|:----------|:--------|
+| `rift_create_imposter` | `uint16_t rift_create_imposter(RiftHandle* h, const char* json)` | The imposter port, or **`0` on any error** (`0` is never a live port). |
+| `rift_replace_stubs` | `int rift_replace_stubs(RiftHandle* h, uint16_t port, const char* json)` | `0` on success, `-1` on error. |
+| `rift_delete_imposter` | `int rift_delete_imposter(RiftHandle* h, uint16_t port)` | `0` on success, `-1` on error. |
+| `rift_delete_all` | `int rift_delete_all(RiftHandle* h)` | `0` on success, `-1` on error. |
+| `rift_recorded` | `char* rift_recorded(RiftHandle* h, uint16_t port)` | Recorded requests as a JSON string (**caller frees** with `rift_free`), or `NULL` on error. |
+| `rift_apply_config` | `char* rift_apply_config(RiftHandle* h, const char* json)` | Reconcile the full imposter set (like `POST /admin/reload`); returns the apply report JSON (caller frees). |
+
+## In-process admin plane
+
+`rift_serve_admin` starts the **real** admin API (and, if `metricsPort` is set, the metrics server)
+on the handle's runtime, serving the handle's manager — so external tooling can talk to an embedded
+Rift over HTTP.
+
+```c
+char* result = rift_serve_admin(h, "{\"port\":0}");
+// result: {"adminPort":49321,"adminUrl":"http://127.0.0.1:49321","metricsPort":null}
+rift_free(result);
+```
+
+- **Options JSON** (pass `NULL` or `{}` for all defaults; every field optional):
+  `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null}`.
+  `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
+  `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
+- **Returns** (caller frees): `{"adminPort":...,"adminUrl":"...","metricsPort":...}`, or `NULL` on
+  error (bad JSON, bind failure, or already serving — one admin plane per handle).
+
+## Build identity
+
+`rift_build_info` is a **static** JSON string (never freed) — probe it to detect a v2 library and read
+which engines are compiled in:
+
+```c
+const char* info = rift_build_info();
+// {"version":"0.8.0","commit":"<sha>|null","builtAt":"<iso8601>|null","features":["redis-backend","lua","javascript"]}
+// Do NOT call rift_free on this pointer.
+```
+
+`commit`/`builtAt` are `null` unless stamped at build time (via `build.rs`).
+
+---
+
+## Error handling & ownership conventions
+
+- **Error signaling.** Every *operation* returns a sentinel on failure — `0` (`rift_create_imposter`),
+  `-1` (the `int`-returning ops), or `NULL` (the string-returning ops).
+- **`rift_last_error`.** `char* rift_last_error(void)` returns the last error message for the current
+  thread (**caller frees**), or `NULL` if none. Every operation entry **clears** the thread-local
+  error first and sets it on failure, so read it immediately after a sentinel return.
+- **String ownership.** Every `char*` the ABI returns must be released with
+  `void rift_free(char* p)` — **except** `rift_build_info`'s pointer, which is static and must not be
+  freed. `rift_free(NULL)` is a safe no-op.
+- **Handle ownership.** Free a handle exactly once with `rift_stop`.
+
+---
+
+## Cargo features
+
+`rift-ffi` forwards engine features rather than hard-coding them, so a per-platform build can drop
+engines it doesn't need: `default = ["redis-backend", "lua", "javascript"]`. The `mimalloc` allocator
+feature is **deliberately never forwarded** — a `cdylib` must not impose a global allocator on its
+host process.
+
+```sh
+# Full-featured cdylib (default)
+cargo build -p rift-ffi --release
+
+# Minimal cdylib — no scripting engines, no Redis
+cargo build -p rift-ffi --release --no-default-features
+```

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Embedding & SPI
+nav_order: 10
+has_children: true
+permalink: /embedding/
+---
+
+# Embedding & Extension (SPI)
+
+Rift is not only a standalone binary — it is a **library** you can embed in a Rust process, drive
+over a stable **C-ABI** from any language, and extend through **service-provider-interface (SPI)**
+traits. This section documents that surface: how to run the server in-process, how to bind its admin
+and metrics planes to your own addresses, how to plug in custom storage backends, and how to call it
+through the FFI.
+
+Everything here reflects the code that ships today. If a signature in these pages ever disagrees with
+the source, the source wins — please file an issue.
+
+---
+
+## When to use which entry point
+
+| You want to… | Use | Page |
+|:-------------|:----|:-----|
+| Run the full Rift server (imposters + admin API + metrics) inside a Rust host | `ServerBuilder` | [Embeddable Server]({{ site.baseurl }}/embedding/server/) |
+| Bind the admin or metrics plane to a chosen (or ephemeral `:0`) address and learn the bound port | `AdminApiServer::bind` / `bind_metrics_server` | [Embeddable Server]({{ site.baseurl }}/embedding/server/) |
+| Replace a storage backend (flow-state, request journal, proxy recording, response sequencing) | SPI traits on `ImposterManager` | [Extension Points (SPI)]({{ site.baseurl }}/embedding/spi/) |
+| Observe reconciliation events or decorate responses | `ImposterEventListener` / `ResponseDecorator` | [Extension Points (SPI)]({{ site.baseurl }}/embedding/spi/) |
+| Drive Rift from a non-Rust host (JVM, Node, Go, …) | The C-ABI (`rift-ffi`) | [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/) |
+
+---
+
+## Crate map
+
+| Crate | Role | Exposes |
+|:------|:-----|:--------|
+| `rift-core` | The engine library — no CLI, no HTTP server wiring. | `ImposterManager` and the SPI traits (`FlowStoreProvider`, `ResponseSequencer`, `RequestJournal`, `ProxyRecordingStore`, `ImposterEventListener`, `ResponseDecorator`), behaviors, predicates, scripting. |
+| `rift-http-proxy` | The server crate — builds the `rift` binary and hosts the admin/metrics HTTP layer. | `ServerBuilder`, `RunningServer`, `AdminApiServer`, `bind_metrics_server`, the single-port gateway, `install_default_crypto_provider()`. |
+| `rift-ffi` | The C-ABI shared library (`cdylib`) plus an `rlib` for in-crate tests. | The `extern "C"` functions (`rift_start`, `rift_serve_admin`, …) and the cbindgen header. |
+| `packages/rift-node` | A Node.js consumer of the above (prebuilt binaries). | Not a Rust SPI crate — an example downstream consumer. |
+
+### Cargo features
+
+The engines and allocator are feature-gated. Relevant features:
+
+| Feature | Default (`rift-http-proxy`) | Default (`rift-ffi`) | Effect |
+|:--------|:----------------------------|:---------------------|:-------|
+| `redis-backend` | on | on | Redis flow-store backend |
+| `lua` | on | on | Lua scripting engine (mlua) |
+| `javascript` | on | on | JavaScript scripting engine (Boa) |
+| `mimalloc` | on | **never forwarded** | mimalloc global allocator (a `cdylib` must not impose an allocator on its host, so `rift-ffi` deliberately never enables it) |
+
+---
+
+## A minimal embedding
+
+```rust
+use rift_http_proxy::{ServerBuilder, Cli, install_default_crypto_provider};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Required before serving any HTTPS imposter — installs the rustls (ring) provider once.
+    install_default_crypto_provider();
+
+    // Run the standard server exactly as the `rift` binary would, from parsed CLI options.
+    ServerBuilder::from_cli(Cli::parse()).run().await
+}
+```
+
+See [Embeddable Server]({{ site.baseurl }}/embedding/server/) for injecting a custom
+`ImposterManager`, binding to ephemeral ports, and graceful shutdown.

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -1,0 +1,146 @@
+---
+layout: default
+title: Embeddable Server
+parent: Embedding & SPI
+nav_order: 1
+---
+
+# Embeddable Server
+
+The `rift` binary is a thin wrapper around library entry points in `rift-http-proxy`. A Rust host can
+run the same server in-process — optionally around its own `ImposterManager` — and bind the admin and
+metrics planes to addresses of its choosing.
+
+---
+
+## `ServerBuilder`
+
+`ServerBuilder` composes the standard admin API, imposter listeners, and (optionally) the metrics
+server, then serves them.
+
+```rust
+use rift_http_proxy::{ServerBuilder, Cli};
+use clap::Parser;
+
+// Build from parsed CLI options (same flags as the `rift` binary):
+let builder = ServerBuilder::from_cli(Cli::parse());
+```
+
+| Method | Signature | Purpose |
+|:-------|:----------|:--------|
+| `from_cli` | `fn from_cli(cli: Cli) -> Self` | Seed the builder from CLI options (port, host, configfile, datadir, TLS defaults, metrics port, …). |
+| `manager` | `fn manager(self, manager: Arc<ImposterManager>) -> Self` | **The embedding seam** — inject a pre-built `ImposterManager` (e.g. one wired with custom SPI backends) instead of letting the builder construct the default one. |
+| `run` | `async fn run(self) -> anyhow::Result<()>` | Load configs, bind, and serve **forever** (returns only on error/shutdown). |
+| `start` | `async fn start(self) -> anyhow::Result<RunningServer>` | Same, but returns a `RunningServer` handle **once bound** — supports ephemeral (`:0`) ports and programmatic shutdown. |
+
+### `RunningServer`
+
+Returned by `start()`; lets the host discover bound addresses and control lifecycle.
+
+| Method | Signature | Purpose |
+|:-------|:----------|:--------|
+| `admin_addr` | `fn admin_addr(&self) -> SocketAddr` | The bound admin API address (resolve an ephemeral `:0` to the real port). |
+| `metrics_addr` | `fn metrics_addr(&self) -> Option<SocketAddr>` | The bound metrics address, or `None` if metrics weren't started. |
+| `join` | `async fn join(self) -> anyhow::Result<()>` | Await the server until it exits. |
+| `shutdown` | `async fn shutdown(self)` | Trigger a graceful shutdown. |
+
+```rust
+use rift_http_proxy::{ServerBuilder, Cli};
+use clap::Parser;
+
+let server = ServerBuilder::from_cli(Cli::parse()).start().await?;
+println!("admin listening on {}", server.admin_addr());
+// ... run your test suite against server.admin_addr() ...
+server.shutdown().await;
+```
+
+### Injecting a custom `ImposterManager`
+
+`ImposterManager` (from `rift-core`) is the injection point for every SPI backend (see
+[Extension Points]({{ site.baseurl }}/embedding/spi/)). Build it, wire your backends, then hand it to
+the server:
+
+```rust
+use std::sync::Arc;
+use rift_core::imposter::ImposterManager;
+use rift_http_proxy::{ServerBuilder, Cli};
+use clap::Parser;
+
+let manager = Arc::new(
+    ImposterManager::new()
+        .with_flow_store_provider(my_flow_store_provider)
+        .with_request_journal(my_journal),
+);
+
+ServerBuilder::from_cli(Cli::parse())
+    .manager(manager)
+    .run()
+    .await?;
+```
+
+---
+
+## Bindable admin & metrics servers
+
+For finer control — running only the admin plane, or binding each plane independently — use the
+lower-level bind APIs. Both follow the same pattern: pass `:0` to get an OS-assigned port and read
+the actual address back from the returned handle.
+
+### `AdminApiServer`
+
+```rust
+use std::sync::Arc;
+use rift_http_proxy::admin_api::AdminApiServer;
+
+let running = AdminApiServer::new(addr, manager, api_key)   // api_key: Option<String>
+    .with_config_source(config_source)                       // ConfigSource, optional
+    .with_allow_injection(true)                              // enable JS inject, optional
+    .bind()
+    .await?;
+
+println!("admin bound to {}", running.local_addr());
+```
+
+| Item | Signature | Purpose |
+|:-----|:----------|:--------|
+| `AdminApiServer::new` | `fn new(addr: SocketAddr, manager: Arc<ImposterManager>, api_key: Option<String>) -> Self` | Construct the admin server; `api_key` (when `Some`) gates the admin API via the `Authorization` header. |
+| `with_config_source` | `fn with_config_source(self, source: ConfigSource) -> Self` | Retain the load source so `POST /admin/reload` can re-read it. |
+| `with_allow_injection` | `fn with_allow_injection(self, allow: bool) -> Self` | Enable JavaScript `inject` responses. |
+| `bind` | `async fn bind(self) -> anyhow::Result<RunningAdminApi>` | Bind and start serving; returns once bound. |
+
+`RunningAdminApi`: `local_addr(&self) -> SocketAddr`, `shutdown(&self)`, `join(self) -> anyhow::Result<()>`.
+
+`ConfigSource` (from `rift-http-proxy`) is either `File { path, no_parse }` (a single `--configfile`,
+with optional EJS preprocessing) or `Dir(PathBuf)` (a `--datadir` of one-imposter-per-file configs).
+
+### Metrics server
+
+```rust
+use rift_http_proxy::bind_metrics_server;
+
+let metrics = bind_metrics_server(addr).await?;   // addr may be `:0`
+println!("metrics bound to {}", metrics.local_addr());
+metrics.shutdown().await;
+```
+
+| Function / method | Signature | Purpose |
+|:------------------|:----------|:--------|
+| `run_metrics_server` | `async fn run_metrics_server(addr: SocketAddr) -> anyhow::Result<()>` | Serve metrics forever on a fixed address. |
+| `bind_metrics_server` | `async fn bind_metrics_server(addr: SocketAddr) -> anyhow::Result<RunningMetrics>` | Bind (supports `:0`) and return a handle. |
+| `RunningMetrics::local_addr` | `fn local_addr(&self) -> SocketAddr` | The bound metrics address. |
+| `RunningMetrics::shutdown` | `async fn shutdown(&self)` | Stop the metrics server. |
+| `RunningMetrics::join` | `async fn join(self) -> anyhow::Result<()>` | Await until it exits. |
+
+---
+
+## TLS: install the crypto provider
+
+Before serving any HTTPS imposter from an embedding host, install the default rustls (`ring`) crypto
+provider once:
+
+```rust
+rift_http_proxy::install_default_crypto_provider();
+```
+
+It is idempotent, so calling it more than once is safe. The `rift` binary does this for you; an
+embedding host must call it itself if it serves TLS.

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -1,0 +1,177 @@
+---
+layout: default
+title: Extension Points (SPI)
+parent: Embedding & SPI
+nav_order: 2
+---
+
+# Extension Points (SPI)
+
+Rift's storage and observation seams are **traits** in `rift-core`. An embedding host implements a
+trait and injects it through a builder method on `ImposterManager`; if you don't, Rift uses its
+built-in in-memory (or Redis, where applicable) implementation. The built-ins never fail — a custom
+backend may, and Rift surfaces that failure explicitly (see [Backend errors](#backend-errors-and-annotations)).
+
+All injection is via `ImposterManager` builder methods:
+
+```rust
+use std::sync::Arc;
+use rift_core::imposter::ImposterManager;
+
+let manager = ImposterManager::new()
+    .with_flow_store_provider(Arc::new(MyFlowStores))
+    .with_sequencer(Arc::new(MySequencer))
+    .with_request_journal(Arc::new(MyJournal))
+    .with_proxy_store(Arc::new(MyProxyStore))
+    .with_event_listener(Arc::new(MyListener))
+    .with_response_decorator(Arc::new(MyDecorator));
+```
+
+Then pass `Arc::new(manager)` to `ServerBuilder::manager(...)` (see
+[Embeddable Server]({{ site.baseurl }}/embedding/server/)).
+
+---
+
+## `FlowStoreProvider` — custom flow-state backend
+
+Provide a [flow-state]({{ site.baseurl }}/features/flow-state/) store per imposter, or return `None`
+to defer to the built-ins (in-memory / Redis).
+
+```rust
+pub trait FlowStoreProvider: Send + Sync {
+    /// Return a store for this imposter, or `None` to defer to the built-ins.
+    fn provide(&self, config: &ImposterConfig) -> Option<Arc<dyn FlowStore>>;
+}
+```
+
+Inject with `.with_flow_store_provider(Arc<dyn FlowStoreProvider>)`.
+
+## `ResponseSequencer` — custom response cycling
+
+Owns the per-stub cursor that drives multiple-response cycling and `repeat` (see
+[Behaviors → repeat]({{ site.baseurl }}/mountebank/behaviors/#repeat)).
+
+```rust
+pub trait ResponseSequencer: Send + Sync {
+    /// Atomically advance and return the response index, honoring per-response repeats.
+    fn next(&self, key: SequenceKey<'_>, response_count: usize, repeats: &[u32]) -> Result<usize>;
+    /// Return the upcoming response index without advancing.
+    fn peek(&self, key: SequenceKey<'_>, response_count: usize, repeats: &[u32]) -> Result<usize>;
+    /// Reset cursors: one stub's (`Some(stub_key)`) or every cursor on the port (`None`).
+    /// Also the GC hook — called on stub delete, bulk stub replace, and imposter teardown.
+    fn reset_scope(&self, port: u16, stub_key: Option<&str>);
+}
+```
+
+Inject with `.with_sequencer(Arc<dyn ResponseSequencer>)`.
+
+## `RequestJournal` — custom recorded-requests store
+
+Backs `recordRequests`, `numberOfRequests`, and the `savedRequests` admin surface.
+
+```rust
+pub trait RequestJournal: Send + Sync {
+    /// Called for EVERY request (even when body recording is off) — backs `numberOfRequests`.
+    fn note_request(&self, port: u16);
+    /// `flow_id` is the request's resolved flow (per the imposter's `flowIdSource`).
+    fn record(&self, port: u16, flow_id: &str, req: RecordedRequest);
+    fn read(&self, port: u16) -> JournalRead;
+    /// Clears entries AND resets the request count. Fallible — a remote store may fail.
+    fn clear(&self, port: u16) -> anyhow::Result<()>;
+    fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool);
+    /// Clear just one flow's entries. Fallible.
+    fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()>;
+    fn count(&self, port: u16) -> u64;
+}
+```
+
+Note that `clear` and `clear_flow` are **fallible** (`anyhow::Result<()>`): clearing is a correctness
+operation whose postcondition ("the data is gone") a remote backend can fail to guarantee, so the
+failure propagates rather than being swallowed. Inject with `.with_request_journal(Arc<dyn RequestJournal>)`.
+
+## `ProxyRecordingStore` — custom proxy-recording store
+
+Backs [proxy record/replay]({{ site.baseurl }}/mountebank/proxy/): claims the right to record a
+response once per request signature, then stores and looks up recordings.
+
+```rust
+pub trait ProxyRecordingStore: Send + Sync {
+    /// First caller per `(port, signature)` wins the right to record once.
+    /// `Err` = backend unavailable (built-ins never fail).
+    fn try_claim(&self, port: u16, sig: &RequestSignature) -> Result<ClaimOutcome>;
+    /// Release a claim after a failed upstream call so the signature is retryable.
+    fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken);
+    fn record(&self, /* port, sig, response, token */) -> Result<()>;
+    fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse>;
+    fn clear(&self, port: u16);
+}
+```
+
+Its typed error is `ProxyStoreError` (`ProxyStoreError::Unavailable(String)`). Inject with
+`.with_proxy_store(Arc<dyn ProxyRecordingStore>)`.
+
+## `ImposterEventListener` — observe reconciliation
+
+Get a callback whenever the imposter set changes (startup load, `POST /admin/reload`, admin CRUD).
+See [Hot Reload]({{ site.baseurl }}/features/hot-reload/) for how the incremental diff produces these.
+
+```rust
+pub enum ImposterEvent {
+    Created(u16),      // port created
+    Replaced(u16),     // port replaced (imposter-level change)
+    StubsChanged(u16), // in-place stub patch
+    Deleted(u16),      // port deleted
+    AllDeleted,        // every imposter removed
+}
+
+pub trait ImposterEventListener: Send + Sync {
+    fn on_event(&self, event: &ImposterEvent);
+}
+```
+
+`on_event` is called **synchronously on the mutating path** — keep implementations fast and
+non-blocking. Inject with `.with_event_listener(Arc<dyn ImposterEventListener>)`.
+
+## `ResponseDecorator` — cross-cutting response headers
+
+A hook to add operational headers to outgoing responses based on the request phase and per-request
+annotations.
+
+```rust
+pub trait ResponseDecorator: Send + Sync {
+    fn decorate(
+        &self,
+        phase: ResponsePhase,
+        req_port: Option<u16>,
+        annotations: &[(&'static str, String)],
+        headers: &mut HeaderMap,
+    );
+}
+```
+
+Inject with `.with_response_decorator(Arc<dyn ResponseDecorator>)`.
+
+---
+
+## Backend errors and annotations
+
+A custom backend signals unavailability by attaching `BackendUnavailable` to a failed operation's
+error (backends wrap with `.context(...)`, and the marker survives the chain):
+
+```rust
+pub struct BackendUnavailable {
+    pub feature: &'static str,
+    pub detail: String,
+}
+```
+
+`backend_error_response(&anyhow::Error)` maps such an error to a structured
+`503 {"error":"backendUnavailable", ...}`; any other error maps to `500`. This is how a down remote
+store becomes a clean 503 to the API caller rather than a silent fallback.
+
+Per-request operational metadata travels through a tokio task-local annotation scope:
+`annotate(key: &'static str, value: String)` records a `(key, value)` that a `ResponseDecorator` later
+reads. This is the same mechanism behind the script/behavior error headers — e.g. a script that hits a
+down flow-store backend records an annotation, and scripts can additionally observe the failure via
+`flow_store.last_error()` (see
+[Scripting → Flow-Store Error Semantics]({{ site.baseurl }}/features/scripting/#flow-store-error-semantics)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,6 +152,12 @@ See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) 
 - [REST API]({{ site.baseurl }}/api/) - Admin API reference
 - [Performance]({{ site.baseurl }}/performance/) - Benchmark results
 
+### Embedding & Extension
+- [Embedding & SPI]({{ site.baseurl }}/embedding/) - Embed Rift as a library, extend it via SPI traits
+- [Embeddable Server]({{ site.baseurl }}/embedding/server/) - `ServerBuilder`, bindable admin/metrics
+- [Extension Points (SPI)]({{ site.baseurl }}/embedding/spi/) - Pluggable flow-store, journal, proxy store, sequencer
+- [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/) - Drive Rift from any language
+
 ---
 
 ## Project Status


### PR DESCRIPTION
Documents the previously-undocumented embedding surface:
- Embeddable ServerBuilder + bindable admin/metrics servers
- Pluggable SPI traits (FlowStoreProvider, ResponseSequencer, RequestJournal, ProxyRecordingStore, ImposterEventListener, ResponseDecorator)
- Typed backend errors and FFI C-ABI v2

Part of #280 — Section A: Embedding/SPI/FFI docs.