### PR TITLE
docs: correct metrics reference and fill runtime-feature gaps (shellTransform, interpolation, _rift keys)

### DIFF
--- a/docs/configuration/native.md
+++ b/docs/configuration/native.md
@@ -130,6 +130,63 @@ rift-http-proxy --configfile imposters.json
 
 ---
 
+## Imposter Settings
+
+Besides `flowState`, the imposter-level `_rift` block accepts these settings:
+
+### `metrics`
+
+Per-imposter metric emission.
+
+```json
+"_rift": {
+  "metrics": { "enabled": false, "port": 9090 }
+}
+```
+
+| Field | Type | Default |
+|:------|:-----|:--------|
+| `enabled` | boolean | `false` |
+| `port` | integer | `9090` |
+
+### `proxy`
+
+Upstream target and connection-pool tuning for proxy responses.
+
+```json
+"_rift": {
+  "proxy": {
+    "upstream": { "host": "api.example.com", "port": 443, "protocol": "https" },
+    "connectionPool": { "maxIdlePerHost": 100, "idleTimeoutSecs": 90 }
+  }
+}
+```
+
+| Field | Type | Default |
+|:------|:-----|:--------|
+| `upstream.host` | string | — |
+| `upstream.port` | integer | — |
+| `upstream.protocol` | string | `"http"` |
+| `connectionPool.maxIdlePerHost` | integer | `100` |
+| `connectionPool.idleTimeoutSecs` | integer | `90` |
+
+### `scriptEngine`
+
+Defaults for `_rift.script` execution.
+
+```json
+"_rift": {
+  "scriptEngine": { "defaultEngine": "rhai", "timeoutMs": 5000 }
+}
+```
+
+| Field | Type | Default | Notes |
+|:------|:-----|:--------|:------|
+| `defaultEngine` | string | `"rhai"` | Engine used when a script omits `engine`. |
+| `timeoutMs` | integer | `5000` | Per-script wall-clock timeout. |
+
+---
+
 ## Fault Injection
 
 Add probabilistic fault injection to responses:
@@ -186,66 +243,59 @@ Or with fixed delay:
 
 ### TCP Faults
 
+`tcp` is a **string** naming a connection-level fault (not an object). When it fires, the connection
+is disrupted at the transport level instead of an HTTP response being sent:
+
 ```json
 "_rift": {
   "fault": {
-    "tcp": {
-      "probability": 0.05,
-      "type": "reset"
-    }
+    "tcp": "CONNECTION_RESET_BY_PEER"
   }
 }
 ```
 
-TCP fault types:
-- `reset`: RST packet (connection reset)
-- `timeout`: Connection timeout
-- `close`: Close connection without response
+TCP fault types (canonical name or short alias):
+
+| Value | Aliases | Effect |
+|:------|:--------|:-------|
+| `CONNECTION_RESET_BY_PEER` | `reset` | Real TCP reset (RST) |
+| `EMPTY_RESPONSE` | `empty` | Close with no bytes sent |
+| `RANDOM_DATA_THEN_CLOSE` | `random`, `garbage` | Write random bytes, then close |
+| `MALFORMED_RESPONSE_CHUNK` | `malformed` | Status line + malformed chunked body, then close |
+
+When `latency`, `tcp`, and `error` are combined in one `fault` block, `tcp` takes precedence over
+`error`. See [Fault Injection]({{ site.baseurl }}/features/fault-injection/) for precedence, the
+top-level `fault` response form, and scripted faults.
 
 ---
 
 ## Scripting
 
-Use multi-engine scripting for complex response logic:
-
-### Rhai (Built-in)
+`_rift.script` runs a script (engine `rhai`, `lua`, or `javascript`) that decides whether to inject a
+response. The script defines `should_inject(request, flow_store)` and returns a map with an `inject`
+flag; when `inject` is true it also carries `fault`/`status`/`body`/`headers`. The `flow_store` handle
+is keyed by `(flow_id, key)`.
 
 ```json
 {
   "_rift": {
+    "flowState": { "backend": "inmemory", "ttlSeconds": 300 },
     "script": {
       "engine": "rhai",
-      "code": "let count = flow.get('count').unwrap_or(0); flow.set('count', count + 1); #{ statusCode: 200, body: `Count: ${count + 1}` }"
+      "code": "fn should_inject(request, flow_store) { let n = flow_store.increment(\"demo\", \"count\"); #{ inject: true, fault: \"error\", status: 200, body: `count ${n}` } }"
     }
   }
 }
 ```
 
-### Lua (requires `--features lua`)
+- `rhai` is built in; `lua` requires the `lua` feature; `javascript` requires the `javascript`
+  feature. JavaScript can also use the Mountebank `inject` response format directly.
+- Scripts require `--allow-injection` and are bounded by a wall-clock timeout
+  (`_rift.scriptEngine.timeoutMs`, default 5000 ms).
 
-```json
-{
-  "_rift": {
-    "script": {
-      "engine": "lua",
-      "code": "local count = flow:get('count') or 0; flow:set('count', count + 1); return { statusCode = 200, body = 'Count: ' .. (count + 1) }"
-    }
-  }
-}
-```
-
-### JavaScript (requires `--features javascript`)
-
-```json
-{
-  "_rift": {
-    "script": {
-      "engine": "javascript",
-      "code": "const count = flow.get('count') || 0; flow.set('count', count + 1); return { statusCode: 200, body: `Count: ${count + 1}` };"
-    }
-  }
-}
-```
+See [Scripting]({{ site.baseurl }}/features/scripting/) for the full API (request object, `flow_store`
+methods, `last_error()`, return values) and [Flow State]({{ site.baseurl }}/features/flow-state/) for
+the state model.
 
 ---
 

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -7,125 +7,87 @@ nav_order: 4
 
 # Prometheus Metrics
 
-Rift exposes metrics in Prometheus format for monitoring and alerting.
+Rift exposes two metrics surfaces:
+
+1. A **Prometheus endpoint** (`GET /metrics` on the metrics port, default `9090`) with the full
+   instrumentation described below.
+2. A small **plain-text counter set** on the admin API's own `GET /metrics` (admin port, default
+   `2525`) — imposter counts and per-imposter request totals.
+
+Every metric name and label on this page is taken from the source; if a metric isn't listed here, it
+isn't emitted.
 
 ---
 
-## Enabling Metrics
+## Enabling & scraping
 
-### Default Configuration
-
-Metrics are enabled by default on port 9090:
+The metrics server starts alongside the admin server. Point Prometheus at the metrics port:
 
 ```bash
 curl http://localhost:9090/metrics
 ```
 
-### Custom Port
+Change the port with `--metrics-port` or `RIFT_METRICS_PORT`:
 
 ```bash
-# Environment variable
+rift-http-proxy --metrics-port 8090
+# or
 RIFT_METRICS_PORT=8090 rift-http-proxy
-
-# Docker
-docker run -e RIFT_METRICS_PORT=8090 -p 8090:8090 zainalpour/rift-proxy:latest
 ```
 
-### Disable Metrics
-
-```bash
-RIFT_METRICS_ENABLED=false rift-http-proxy
-```
+There is no environment variable to disable the metrics server; if you don't scrape it, it sits
+idle. (An imposter's `_rift.metrics` block controls per-imposter metric emission — see
+[Rift Extensions]({{ site.baseurl }}/configuration/native/).)
 
 ---
 
-## Available Metrics
+## Prometheus endpoint metrics (port 9090)
 
-### Request Metrics
+Histogram metrics expand into the usual `_bucket{le="…"}`, `_sum`, and `_count` series.
+
+| Metric | Type | Labels | Meaning |
+|:-------|:-----|:-------|:--------|
+| `rift_requests_total` | counter | `method`, `status` | Requests served, by method and response status. |
+| `rift_faults_injected_total` | counter | `type`, `rule_id`, `source` | Faults injected (`type` = latency/error/tcp). |
+| `rift_latency_injected_ms` | histogram | `rule_id` | Injected latency, in milliseconds. |
+| `rift_error_status_total` | counter | `status`, `rule_id` | Error-fault responses, by status. |
+| `rift_script_execution_duration_ms` | histogram | `rule_id`, `result` | Script execution time, in milliseconds. |
+| `rift_script_errors_total` | counter | `rule_id`, `error_type` | Script failures, by error type. |
+| `rift_flow_state_ops_total` | counter | `operation`, `result` | Flow-store operations (get/set/…), by result. |
+| `rift_active_flows` | gauge | `backend` | Currently-tracked flows, by backend. |
+| `rift_proxy_request_duration_ms` | histogram | `method`, `fault_applied` | Proxy handling time, in milliseconds. |
+| `rift_upstream_request_duration_ms` | histogram | `method`, `status` | Upstream (proxied) request time, in milliseconds. |
+
+Example scrape output:
 
 ```prometheus
-# Total requests processed
-rift_http_requests_total{method="GET", path="/api/users", status="200"} 1234
-
-# Request duration histogram
-rift_http_request_duration_seconds_bucket{le="0.001"} 100
-rift_http_request_duration_seconds_bucket{le="0.01"} 500
-rift_http_request_duration_seconds_bucket{le="0.1"} 900
-rift_http_request_duration_seconds_bucket{le="1"} 1000
-rift_http_request_duration_seconds_sum 45.67
-rift_http_request_duration_seconds_count 1000
+rift_requests_total{method="GET",status="200"} 1234
+rift_faults_injected_total{type="latency",rule_id="api-latency",source="rift"} 300
+rift_latency_injected_ms_bucket{rule_id="api-latency",le="100"} 120
+rift_latency_injected_ms_sum{rule_id="api-latency"} 45670
+rift_latency_injected_ms_count{rule_id="api-latency"} 300
+rift_flow_state_ops_total{operation="get",result="ok"} 5000
+rift_active_flows{backend="inmemory"} 12
 ```
 
-### Fault Injection Metrics
+## Admin `GET /metrics` (port 2525)
+
+The admin API serves a minimal hand-written counter set (`Content-Type: text/plain; version=0.0.4`):
+
+| Metric | Type | Labels | Meaning |
+|:-------|:-----|:-------|:--------|
+| `rift_imposters_total` | gauge | — | Number of imposters currently registered. |
+| `rift_imposter_requests_total` | counter | `port` | Requests per imposter (one line per port). |
 
 ```prometheus
-# Faults injected
-rift_faults_injected_total{type="latency", rule="api-latency"} 300
-rift_faults_injected_total{type="error", rule="api-errors"} 50
-
-# Injected latency histogram
-rift_injected_latency_seconds_bucket{le="0.1"} 100
-rift_injected_latency_seconds_bucket{le="0.5"} 250
-rift_injected_latency_seconds_bucket{le="1"} 300
-```
-
-### Imposter Metrics (Mountebank Mode)
-
-```prometheus
-# Imposters count
 rift_imposters_total 5
-
-# Stubs per imposter
-rift_stubs_total{port="4545"} 10
-rift_stubs_total{port="4546"} 25
-
-# Requests per imposter
-rift_imposter_requests_total{port="4545", matched="true"} 500
-rift_imposter_requests_total{port="4545", matched="false"} 12
-```
-
-### Script Execution Metrics
-
-```prometheus
-# Script execution time
-rift_script_execution_seconds_bucket{engine="rhai", le="0.001"} 950
-rift_script_execution_seconds_bucket{engine="rhai", le="0.01"} 999
-rift_script_execution_seconds_sum{engine="rhai"} 2.5
-rift_script_execution_seconds_count{engine="rhai"} 1000
-
-# Script errors
-rift_script_errors_total{engine="rhai"} 5
-```
-
-### Flow State Metrics
-
-```prometheus
-# Flow state operations
-rift_flow_state_operations_total{operation="get"} 5000
-rift_flow_state_operations_total{operation="set"} 2000
-rift_flow_state_operations_total{operation="delete"} 100
-
-# Flow state operation latency
-rift_flow_state_operation_seconds_bucket{operation="get", le="0.0001"} 4900
-rift_flow_state_operation_seconds_bucket{operation="get", le="0.001"} 5000
-```
-
-### Connection Metrics
-
-```prometheus
-# Active connections
-rift_active_connections 25
-
-# Connection pool stats
-rift_connection_pool_size{upstream="backend"} 10
-rift_connection_pool_available{upstream="backend"} 7
+rift_imposter_requests_total{port="4545"} 500
+rift_imposter_requests_total{port="4546"} 128
 ```
 
 ---
 
-## Prometheus Configuration
-
-### Basic Scrape Config
+## Prometheus configuration
 
 ```yaml
 # prometheus.yml
@@ -136,7 +98,7 @@ scrape_configs:
     scrape_interval: 15s
 ```
 
-### Kubernetes Service Discovery
+### Kubernetes service discovery
 
 ```yaml
 scrape_configs:
@@ -147,83 +109,42 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_label_app]
         regex: rift
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_number]
-        regex: "9090"
-        action: keep
 ```
 
 ---
 
-## Grafana Dashboard
+## Useful queries
 
-### Import Dashboard
-
-1. Go to Grafana → Dashboards → Import
-2. Upload the dashboard JSON or paste the ID
-3. Select your Prometheus data source
-
-### Key Panels
-
-**Request Rate:**
+**Request rate by status:**
 ```promql
-rate(rift_http_requests_total[5m])
+sum(rate(rift_requests_total[5m])) by (status)
 ```
 
-**Error Rate:**
+**5xx error ratio:**
 ```promql
-sum(rate(rift_http_requests_total{status=~"5.."}[5m]))
+sum(rate(rift_requests_total{status=~"5.."}[5m]))
 /
-sum(rate(rift_http_requests_total[5m])) * 100
+sum(rate(rift_requests_total[5m]))
 ```
 
-**P99 Latency:**
-```promql
-histogram_quantile(0.99, rate(rift_http_request_duration_seconds_bucket[5m]))
-```
-
-**Fault Injection Rate:**
+**Fault injection rate by type:**
 ```promql
 sum(rate(rift_faults_injected_total[5m])) by (type)
 ```
 
-### Sample Dashboard JSON
+**P99 upstream latency (proxy mode):**
+```promql
+histogram_quantile(0.99, sum(rate(rift_upstream_request_duration_ms_bucket[5m])) by (le))
+```
 
-```json
-{
-  "title": "Rift Metrics",
-  "panels": [
-    {
-      "title": "Request Rate",
-      "type": "graph",
-      "targets": [{
-        "expr": "sum(rate(rift_http_requests_total[5m])) by (status)"
-      }]
-    },
-    {
-      "title": "Latency Percentiles",
-      "type": "graph",
-      "targets": [
-        { "expr": "histogram_quantile(0.50, rate(rift_http_request_duration_seconds_bucket[5m]))", "legendFormat": "p50" },
-        { "expr": "histogram_quantile(0.95, rate(rift_http_request_duration_seconds_bucket[5m]))", "legendFormat": "p95" },
-        { "expr": "histogram_quantile(0.99, rate(rift_http_request_duration_seconds_bucket[5m]))", "legendFormat": "p99" }
-      ]
-    },
-    {
-      "title": "Fault Injection",
-      "type": "graph",
-      "targets": [{
-        "expr": "sum(rate(rift_faults_injected_total[5m])) by (type)"
-      }]
-    }
-  ]
-}
+**Script error rate:**
+```promql
+sum(rate(rift_script_errors_total[5m])) by (error_type)
 ```
 
 ---
 
-## Alerting Rules
-
-### High Error Rate
+## Alerting rules
 
 ```yaml
 groups:
@@ -231,50 +152,28 @@ groups:
     rules:
       - alert: RiftHighErrorRate
         expr: |
-          sum(rate(rift_http_requests_total{status=~"5.."}[5m]))
+          sum(rate(rift_requests_total{status=~"5.."}[5m]))
           /
-          sum(rate(rift_http_requests_total[5m])) > 0.05
+          sum(rate(rift_requests_total[5m])) > 0.05
         for: 5m
-        labels:
-          severity: warning
+        labels: { severity: warning }
         annotations:
-          summary: "High error rate in Rift"
-          description: "Error rate is {{ $value | humanizePercentage }}"
-```
+          summary: "High 5xx rate in Rift"
 
-### High Latency
-
-```yaml
-      - alert: RiftHighLatency
-        expr: |
-          histogram_quantile(0.99, rate(rift_http_request_duration_seconds_bucket[5m])) > 1
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "High latency in Rift"
-          description: "P99 latency is {{ $value | humanizeDuration }}"
-```
-
-### Script Errors
-
-```yaml
       - alert: RiftScriptErrors
         expr: rate(rift_script_errors_total[5m]) > 0
         for: 1m
-        labels:
-          severity: critical
+        labels: { severity: critical }
         annotations:
           summary: "Script errors in Rift"
-          description: "Script engine {{ $labels.engine }} has errors"
+          description: "error_type={{ $labels.error_type }}"
 ```
 
 ---
 
-## Best Practices
+## Best practices
 
-1. **Set reasonable scrape intervals** - 15-30 seconds is typical
-2. **Use recording rules** - Pre-compute expensive queries
-3. **Set up alerting** - Monitor error rates and latency
-4. **Retain metrics** - Keep enough history for analysis
-5. **Label cardinality** - Avoid high-cardinality labels (like request IDs)
+1. **Reasonable scrape intervals** — 15–30s is typical.
+2. **Use recording rules** for expensive dashboard queries.
+3. **Alert on error ratio and fault rate**, not raw counts.
+4. **Mind label cardinality** — `rule_id` is bounded by your config; avoid adding unbounded labels.

--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -27,8 +27,8 @@ Rift maintains full compatibility with Mountebank's HTTP/HTTPS protocol support:
 | Behaviors | Yes | Yes | wait, decorate, copy, lookup |
 | Proxy Mode | Yes | Yes | Record and replay |
 | Injection | Yes | Yes | JavaScript functions |
-| TCP Protocol | Yes | Planned | Coming soon |
-| SMTP Protocol | Yes | Planned | Coming soon |
+| TCP Protocol | Yes | No | `protocol` must be `http`/`https`; a `tcp` imposter is rejected |
+| SMTP Protocol | Yes | No | Not supported; an `smtp` imposter is rejected |
 
 ---
 
@@ -213,9 +213,15 @@ docker run -e MB_ALLOW_INJECTION=true zainalpour/rift-proxy:latest
 
 Rift may format JSON responses differently (but equivalently). If your tests compare exact string output, consider comparing parsed JSON instead.
 
-### Missing TCP/SMTP Protocol
+### TCP/SMTP Protocol Imposters
 
-These protocols are planned but not yet implemented. For now, continue using Mountebank for TCP/SMTP mocking.
+Rift imposters are **HTTP/HTTPS only** — a config whose `protocol` is `tcp` or `smtp` (or anything
+other than `http`/`https`) is rejected with an `Invalid protocol` error. For non-HTTP protocol
+mocking, continue using Mountebank.
+
+Note this is separate from **TCP fault injection**: HTTP(S) imposters *can* simulate transport-level
+failures (connection reset, etc.) via `_rift.fault.tcp` or a top-level `fault` response — see
+[Fault Injection]({{ site.baseurl }}/features/fault-injection/).
 
 ---
 

--- a/docs/mountebank/behaviors.md
+++ b/docs/mountebank/behaviors.md
@@ -199,6 +199,45 @@ Transform responses using JavaScript. The function receives request and response
 
 ---
 
+## shellTransform
+
+Pipe the response through one or more external shell commands. Useful for transforming a response
+body with an existing script or CLI tool.
+
+`shellTransform` accepts a single command string, or an array of commands that are **chained in
+sequence** (each command's output feeds the next):
+
+```json
+{
+  "is": { "statusCode": 200, "body": "hello" },
+  "_behaviors": {
+    "shellTransform": "tr a-z A-Z"
+  }
+}
+```
+
+```json
+{
+  "_behaviors": {
+    "shellTransform": ["./add-header.sh", "./rewrite-body.sh"]
+  }
+}
+```
+
+Each command runs via `sh -c "<command>"` and receives two environment variables:
+
+| Variable | JSON shape |
+|:---------|:-----------|
+| `MB_REQUEST` | `{ "method", "path", "query", "headers", "body" }` |
+| `MB_RESPONSE` | `{ "statusCode", "body" }` |
+
+The command's **stdout becomes the new response body**. A non-zero exit is a failure: by default it
+is lenient (the original body is served and an `x-rift-shelltransform-error: true` header is added);
+with `strictBehaviors` / `RIFT_STRICT_BEHAVIORS` it returns `500` (see
+[Error Semantics](#error-semantics)).
+
+---
+
 ## copy
 
 Copy values from the request to the response. Useful for echoing request data.

--- a/docs/mountebank/responses.md
+++ b/docs/mountebank/responses.md
@@ -134,6 +134,43 @@ Status codes can also be specified as strings for compatibility with some tools:
 }
 ```
 
+The `body` is standard base64 (with padding); `_mode: "binary"` tells Rift to decode it before
+serving. Omit `_mode` (or set `"text"`) for a normal text/JSON body.
+
+---
+
+## Request Interpolation
+
+Static (`is`) responses can echo values from the incoming request using `${request.…}` tokens. Rift
+substitutes them into the response **body** and **header values** before any behaviors run:
+
+| Token | Resolves to |
+|:------|:------------|
+| `${request.path}` | Request path |
+| `${request.method}` | HTTP method |
+| `${request.body}` | Raw request body |
+| `${request.query.<name>}` | Query parameter `<name>` |
+| `${request.headers.<name>}` | Request header `<name>` (case-insensitive) |
+| `${request.pathParams.<name>}` | Path parameter `<name>` |
+
+```json
+{
+  "is": {
+    "statusCode": 200,
+    "headers": { "X-Echo-Path": "${request.path}" },
+    "body": "You called ${request.method} ${request.path} with q=${request.query.q}"
+  }
+}
+```
+
+A request `GET /search?q=rust` returns `You called GET /search with q=rust` and an
+`X-Echo-Path: /search` header.
+
+These `${request.…}` tokens are distinct from the free-form `${name}` placeholders that the
+[`copy` and `lookup` behaviors]({{ site.baseurl }}/mountebank/behaviors/#copy) fill in — the two do
+not collide, because only tokens beginning with `request.` are treated as request interpolation. On
+the proxy path, only the body is interpolated (not headers).
+
 ---
 
 ## Response Cycling


### PR DESCRIPTION
Corrects the Prometheus metrics reference to real metric names and types, removes the nonexistent RIFT_METRICS_ENABLED, and fills gaps in native.md for real _rift keys. Adds missing documentation for shellTransform behavior and ${request.*} response interpolation, and corrects stale TCP/SMTP migration boundary details.

Part of #280 — Sections B (thin/missing runtime features) + C (stale fixes).