### PR TITLE
0.9.0 release omits the rift-verify binary (breaks rift-conformance consistency gate)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,8 @@ jobs:
           chmod +x "$ARCHIVE_NAME/bin/rift-lint"
           cp rift-tui "$ARCHIVE_NAME/bin/rift-tui"
           chmod +x "$ARCHIVE_NAME/bin/rift-tui"
+          cp rift-verify "$ARCHIVE_NAME/bin/rift-verify"
+          chmod +x "$ARCHIVE_NAME/bin/rift-verify"
 
           # Copy docs
           cp ../../../README.md "$ARCHIVE_NAME/" 2>/dev/null || true
@@ -249,6 +251,7 @@ jobs:
           # Copy additional binaries
           Copy-Item "rift-lint.exe" "$ARCHIVE_NAME/bin/rift-lint.exe"
           Copy-Item "rift-tui.exe" "$ARCHIVE_NAME/bin/rift-tui.exe"
+          Copy-Item "rift-verify.exe" "$ARCHIVE_NAME/bin/rift-verify.exe"
 
           # Copy docs
           if (Test-Path "../../../README.md") { Copy-Item "../../../README.md" "$ARCHIVE_NAME/" }
@@ -416,6 +419,7 @@ jobs:
           - `rift` - HTTP proxy server (Mountebank-compatible)
           - `rift-lint` - Imposter configuration validator
           - `rift-tui` - Terminal UI for managing imposters
+          - `rift-verify` - Stub verifier (checks imposters against a running engine)
 
           ### Available Platforms
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -123,6 +123,7 @@ jobs:
               bin.install "bin/rift"
               bin.install "bin/rift-lint"
               bin.install "bin/rift-tui"
+              bin.install "bin/rift-verify"
             end
 
             def caveats
@@ -131,6 +132,7 @@ jobs:
                   - rift: Main HTTP proxy server (Mountebank-compatible)
                   - rift-lint: Imposter configuration validator
                   - rift-tui: Terminal UI for managing imposters
+                  - rift-verify: Stub verifier (checks imposters against a running engine)
 
                 To start the server:
                   rift --port 2525
@@ -143,6 +145,7 @@ jobs:
             test do
               assert_match "rift", shell_output("#{bin}/rift --version")
               assert_match "rift-lint", shell_output("#{bin}/rift-lint --version")
+              assert_match "rift-verify", shell_output("#{bin}/rift-verify --version")
             end
           end
           FORMULA_EOF


### PR DESCRIPTION
The rift-verify binary is built by the release job but was never packaged into platform tarballs, Windows zip, or the Homebrew formula. rift-conformance's consistency gate requires it as a third oracle for validation. This change adds rift-verify to all distribution channels alongside rift-lint and rift-tui.

Closes #388

Milestone: standalone build/release fix (base master)