### PR TITLE
docs: add Concepts section and lift Rift-native information architecture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Changelog
+nav_order: 12
+permalink: /changelog/
+---
+
+# Changelog
+
+Rift keeps a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)–formatted changelog and follows
+[Semantic Versioning](https://semver.org/). The canonical, always-current file lives in the
+repository:
+
+- **[CHANGELOG.md](https://github.com/EtaCassiopeia/rift/blob/master/CHANGELOG.md)** — every notable
+  user-facing change, newest first, with an `[Unreleased]` section at the top.
+
+The changelog was backfilled from git history and release tags for `v0.1.0-RC` → `v0.8.0`; each
+release since is recorded as it ships. For the full commit-level history, see the
+[releases page](https://github.com/EtaCassiopeia/rift/releases).

--- a/docs/concepts/building-blocks.md
+++ b/docs/concepts/building-blocks.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Core Building Blocks
+parent: Concepts
+nav_order: 1
+---
+
+# Core Building Blocks
+
+These are the Mountebank-compatible primitives every Rift config is built from. This page explains
+what each one *is*; the reference pages under
+[Mountebank Compatibility]({{ site.baseurl }}/mountebank/) give the exact syntax and every option.
+
+---
+
+## Imposter
+
+An **imposter** is a mock server bound to a port. It declares a `protocol` (`http` or `https`), an
+optional `name`, and a list of `stubs`. Create one by `POST`ing it to the admin API (default port
+`2525`) or loading it from a config file at startup.
+
+```json
+{ "port": 4545, "protocol": "http", "stubs": [ /* … */ ] }
+```
+
+One Rift process hosts many imposters, each on its own port. → [Imposters]({{ site.baseurl }}/mountebank/imposters/)
+
+## Stub
+
+A **stub** is a single match-and-respond rule inside an imposter: a set of **predicates** and a list
+of **responses**. On each request, Rift evaluates stubs top-to-bottom and uses the **first** stub
+whose predicates all match. A stub with no predicates matches everything (a good catch-all/default,
+placed last).
+
+## Predicate
+
+A **predicate** decides whether a stub applies to a request. Predicates match on request fields
+(`method`, `path`, `query`, `headers`, `body`) with operators like `equals`, `deepEquals`,
+`contains`, `startsWith`, `endsWith`, `matches` (regex), and `exists`, plus `jsonpath`/`xpath`
+selectors and the logical combinators `and`, `or`, `not`. Multiple predicates in one stub combine
+with implicit AND. → [Predicates]({{ site.baseurl }}/mountebank/predicates/)
+
+## Response
+
+A **response** is what a matched stub returns. The three kinds:
+
+- **`is`** — a static response (`statusCode`, `headers`, `body`). Supports
+  [request interpolation]({{ site.baseurl }}/mountebank/responses/#request-interpolation).
+- **`proxy`** — forward to a real upstream and optionally record the reply for replay.
+- **`inject`** / `_rift.script` — compute the response dynamically with a script.
+
+A stub can list several responses; Rift cycles through them per request (round-robin), honoring each
+response's `repeat` count. → [Responses]({{ site.baseurl }}/mountebank/responses/)
+
+## Behavior
+
+A **behavior** post-processes a response before it's sent. Rift supports `wait` (latency), `copy` and
+`lookup` (pull request/CSV data into the response), `decorate` and `shellTransform` (transform the
+body), and `repeat` (response cycling). → [Behaviors]({{ site.baseurl }}/mountebank/behaviors/)
+
+---
+
+Once these click, the [Rift Model]({{ site.baseurl }}/concepts/rift-model/) adds state on top: making
+responses depend on what happened on *previous* requests.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Concepts
+nav_order: 3
+has_children: true
+permalink: /concepts/
+---
+
+# Concepts
+
+Rift is a high-performance mock server. It speaks the [Mountebank](http://www.mbtest.org/) API for
+compatibility, but it is a tool in its own right — with a stateful model (flow-state, scenarios,
+correlated isolation) that goes well beyond record/replay. This section explains the mental model
+once, conceptually, so the reference and feature pages make sense.
+
+Start here if you're new to Rift; jump to the reference pages when you need the exact syntax.
+
+---
+
+## The two layers
+
+Rift configuration has two layers that compose:
+
+1. **The Mountebank layer** — imposters, stubs, predicates, responses, and behaviors. If you know
+   Mountebank, this is unchanged, and your existing configs work as-is. See
+   [Core Building Blocks]({{ site.baseurl }}/concepts/building-blocks/).
+2. **The Rift layer** (`_rift`) — stateful and fidelity features Rift adds on top: flow-state,
+   scenarios, correlated isolation ("spaces"), fault injection, scripting, and response templating.
+   See [The Rift Model]({{ site.baseurl }}/concepts/rift-model/).
+
+Everything Rift-specific lives under a `_rift` key (imposter- or response-level) or under
+Rift-recognised stub fields, so a plain Mountebank config never collides with it.
+
+---
+
+## The request lifecycle
+
+When a request hits an imposter, Rift:
+
+1. **Matches** it against each stub's [predicates]({{ site.baseurl }}/mountebank/predicates/), in
+   order, and picks the first stub whose predicates all pass.
+2. **Selects a response** from that stub's `responses` (cycling through them, honoring `repeat`).
+3. **Resolves the response** — a static `is`, a `proxy` to an upstream, or a script/`inject` — and
+   applies any [fault injection]({{ site.baseurl }}/features/fault-injection/).
+4. **Runs behaviors** — latency (`wait`), request interpolation, `copy`/`lookup`, and
+   `decorate`/`shellTransform` transforms — before sending. (See
+   [Behaviors]({{ site.baseurl }}/mountebank/behaviors/#behavior-order) for the exact order.)
+
+State (flow-state, scenario state, response cursors) is read and written along the way, keyed by the
+request's **flow id**.
+
+---
+
+## In this section
+
+- [Core Building Blocks]({{ site.baseurl }}/concepts/building-blocks/) — imposters, stubs,
+  predicates, responses, behaviors.
+- [The Rift Model]({{ site.baseurl }}/concepts/rift-model/) — flow id, flow-state, scenarios, and
+  correlated isolation (spaces), and how they fit together.

--- a/docs/concepts/rift-model.md
+++ b/docs/concepts/rift-model.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: The Rift Model
+parent: Concepts
+nav_order: 2
+---
+
+# The Rift Model
+
+Plain Mountebank is essentially stateless: a request matches a stub and gets a response. Rift adds a
+**stateful layer** so a response can depend on what happened before — retry-then-succeed, call
+counters, multi-step workflows, and per-test isolation. Three concepts, all tied together by one
+idea: the **flow id**.
+
+---
+
+## Flow id — the correlation key
+
+Every request resolves to a **flow id**: the identity Rift uses to correlate a request with the state
+that belongs to it. How it's derived is set per imposter by `_rift.flowState.flowIdSource`:
+
+- **`imposter_port`** (default) — all traffic to the imposter shares one flow. Simple global state.
+- **`header:<Name>`** — the flow id is taken from a request header (e.g. `header:X-Flow-Id`), so each
+  caller/test/session gets its own isolated state.
+
+The same flow id drives both **flow-state** and **spaces**, which is what lets them stay consistent.
+
+---
+
+## Flow-state — a per-flow key/value store
+
+[Flow-state]({{ site.baseurl }}/features/flow-state/) is a `(flow_id, key)` → value store that
+[scripts]({{ site.baseurl }}/features/scripting/) read and write to build stateful behavior. A
+script can count attempts, fail the first N and then succeed, or gate on a stored value:
+
+```
+attempt 1 → 503   attempt 2 → 503   attempt 3 → 200
+```
+
+Backends are `inmemory` (default) or `redis` (shared across instances). Values expire after
+`ttlSeconds`. You can also inspect and seed flow-state directly over the admin API.
+
+## Scenarios — declarative state machines
+
+[Scenarios]({{ site.baseurl }}/features/scenarios/) let a stub advance a named finite-state machine
+**without writing a script**. A stub can require the scenario to be in a given state to match
+(`requiredScenarioState`) and move it to a new state after responding (`newScenarioState`). This
+models multi-step flows (e.g. `Started → InProgress → Complete`) declaratively; the admin API
+inspects and resets scenario state.
+
+## Spaces — correlated isolation
+
+[Spaces]({{ site.baseurl }}/features/spaces/) partition an imposter's stubs and state **per flow id**,
+so concurrent tests don't step on each other. Each flow gets its own view — its own stub overrides
+and its own state — over the same imposter port. This is how many parallel tests share one imposter
+without cross-contamination.
+
+---
+
+## How they fit together
+
+- **Flow id** decides *whose* state a request touches.
+- **Flow-state** is the general-purpose store scripts use for that flow.
+- **Scenarios** are a declarative state machine over that flow — no scripting needed.
+- **Spaces** isolate stubs and state *between* flows.
+
+Reach for the simplest one that fits: scenarios for a declarative multi-step flow, flow-state when a
+script needs arbitrary values, spaces when parallel tests must not interfere. See also
+[Fault Injection]({{ site.baseurl }}/features/fault-injection/) for stateful failure simulation built
+on flow-state.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,6 +9,12 @@ permalink: /examples/
 
 Ready-to-use examples for common use cases.
 
+> **Runnable demos.** Beyond the snippets below, the repository ships a set of `docker-compose`
+> demos — Mountebank mode, HTTPS/TLS, fault injection, scripting engines, and retry-proxy — each with
+> a working imposter config you can bring up in one command. See
+> [`docs/demo/`](https://github.com/EtaCassiopeia/rift/tree/master/docs/demo) (start with its
+> `README.md`).
+
 ---
 
 ## REST API Mock

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,12 @@ See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) 
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
 - [Migration from Mountebank]({{ site.baseurl }}/getting-started/migration/) - Switch from Mountebank to Rift
 
-### Mountebank Compatibility
+### Concepts
+- [Concepts Overview]({{ site.baseurl }}/concepts/) - The Rift mental model, start here
+- [Core Building Blocks]({{ site.baseurl }}/concepts/building-blocks/) - Imposters, stubs, predicates, responses, behaviors
+- [The Rift Model]({{ site.baseurl }}/concepts/rift-model/) - Flow-state, scenarios, and correlated isolation
+
+### Mountebank Compatibility (reference)
 - [Imposters]({{ site.baseurl }}/mountebank/imposters/) - Creating and managing mock servers
 - [Predicates]({{ site.baseurl }}/mountebank/predicates/) - Request matching (equals, contains, regex, jsonpath, xpath)
 - [Responses]({{ site.baseurl }}/mountebank/responses/) - Configuring stub responses
@@ -151,6 +156,7 @@ See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) 
 ### Reference
 - [REST API]({{ site.baseurl }}/api/) - Admin API reference
 - [Performance]({{ site.baseurl }}/performance/) - Benchmark results
+- [Changelog]({{ site.baseurl }}/changelog/) - Notable user-facing changes
 
 ### Embedding & Extension
 - [Embedding & SPI]({{ site.baseurl }}/embedding/) - Embed Rift as a library, extend it via SPI traits

--- a/docs/mountebank/index.md
+++ b/docs/mountebank/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Mountebank Compatibility
-nav_order: 3
+nav_order: 5.5
 has_children: true
 permalink: /mountebank/
 ---
@@ -9,6 +9,10 @@ permalink: /mountebank/
 # Mountebank Compatibility
 
 Rift implements the [Mountebank](http://www.mbtest.org/) REST API and configuration format. This allows you to use Rift as a drop-in replacement for Mountebank with significantly better performance.
+
+> New to the model? Start with [Concepts]({{ site.baseurl }}/concepts/) — it explains imposters,
+> stubs, predicates, responses, and behaviors conceptually, then the Rift-specific stateful features.
+> This section is the syntax-level reference for the Mountebank-compatible surface.
 
 ---
 


### PR DESCRIPTION
Adds a new Concepts section as the conceptual on-ramp (overview, core building blocks, and the Rift stateful model of flow-state/scenarios/spaces), demotes the Mountebank-compatibility section below it in the nav, surfaces the CHANGELOG from the site, and links runnable docker-compose demos from the examples page.

Part of #280 — Section D (IA restructure). With this, sections A–E are all complete.