### PR TITLE
feat(proxy): intercept CA + per-SNI leaf certificate minting (1/5, epic #394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +961,26 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2394,6 +2453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3055,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -3358,6 +3427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -5152,6 +5230,24 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -28,7 +28,8 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["http1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 rustls-pemfile = "2.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
-rcgen = "0.13"
+# x509-parser: needed to recover a loaded CA's distinguished name (CertificateParams::from_ca_cert_pem)
+rcgen = { version = "0.13", features = ["x509-parser"] }
 
 # Serialization
 serde.workspace = true

--- a/crates/rift-core/src/proxy/intercept_ca.rs
+++ b/crates/rift-core/src/proxy/intercept_ca.rs
@@ -1,0 +1,336 @@
+//! Intercept CA and per-SNI leaf certificate minting for TLS-MITM interception
+//! (epic #394, slice 1/5).
+//!
+//! A [`CertificateAuthority`] is generated once (or loaded from PEM) and mints per-host leaf
+//! certificates signed by the CA on demand. [`SniCertResolver`] adapts that into a rustls
+//! [`ResolvesServerCert`] so an interception listener can terminate TLS for any SNI without
+//! pre-provisioning certificates. The types are public because the forward-proxy listener
+//! (slice 3) and the truststore/admin surface (slices 2 & 4) live in the sibling
+//! `rift-http-proxy` crate.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
+    KeyPair, KeyUsagePurpose,
+};
+use rustls::crypto::CryptoProvider;
+use rustls::crypto::ring::default_provider;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+
+/// An in-memory certificate authority that mints per-host leaf certificates on demand.
+pub struct CertificateAuthority {
+    /// The issuing certificate. Its `params` (distinguished name, key-id method) drive the
+    /// issuer identity written into every minted leaf; when the CA is loaded from PEM this is
+    /// re-derived from the input so leaves chain to the original certificate.
+    issuer: Certificate,
+    key: KeyPair,
+    cert_pem: String,
+    cert_der: CertificateDer<'static>,
+}
+
+impl std::fmt::Debug for CertificateAuthority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the key material; the CA is identified by its certificate PEM.
+        f.debug_struct("CertificateAuthority")
+            .field("cert_pem", &self.cert_pem)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CertificateAuthority {
+    /// Generate a fresh in-memory CA.
+    pub fn generate() -> anyhow::Result<Self> {
+        let key = KeyPair::generate().map_err(|e| anyhow::anyhow!("generate CA key: {e}"))?;
+        let mut params = CertificateParams::new(Vec::<String>::new())
+            .map_err(|e| anyhow::anyhow!("build CA params: {e}"))?;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Rift Intercept CA");
+        let cert = params
+            .self_signed(&key)
+            .map_err(|e| anyhow::anyhow!("self-sign CA: {e}"))?;
+        let cert_pem = cert.pem();
+        let cert_der = cert.der().clone();
+        Ok(Self {
+            issuer: cert,
+            key,
+            cert_pem,
+            cert_der,
+        })
+    }
+
+    /// Load an existing CA from its certificate and private-key PEM. Leaves minted afterwards
+    /// chain to the supplied certificate (its distinguished name is recovered so the issuer
+    /// identity matches).
+    pub fn load_pem(cert_pem: &str, key_pem: &str) -> anyhow::Result<Self> {
+        let key =
+            KeyPair::from_pem(key_pem).map_err(|e| anyhow::anyhow!("parse CA key PEM: {e}"))?;
+        let params = CertificateParams::from_ca_cert_pem(cert_pem)
+            .map_err(|e| anyhow::anyhow!("parse CA cert PEM: {e}"))?;
+        // Re-derive an issuing certificate from the parsed params so `signed_by` writes the
+        // original CA's distinguished name into leaves. The original PEM/DER remain the trust
+        // anchor consumers pin.
+        let issuer = params
+            .self_signed(&key)
+            .map_err(|e| anyhow::anyhow!("rebuild issuer from CA PEM: {e}"))?;
+        let cert_der = pem_to_der(cert_pem)?;
+        Ok(Self {
+            issuer,
+            key,
+            cert_pem: cert_pem.to_string(),
+            cert_der,
+        })
+    }
+
+    /// The CA certificate as PEM.
+    pub fn ca_cert_pem(&self) -> &str {
+        &self.cert_pem
+    }
+
+    /// The CA certificate in DER form (the trust anchor).
+    pub fn ca_cert_der(&self) -> &CertificateDer<'static> {
+        &self.cert_der
+    }
+
+    /// Mint a leaf certificate valid for `host`, signed by this CA, packaged with its private
+    /// key and the full chain (`[leaf, ca]`) as a rustls [`CertifiedKey`].
+    pub fn mint_leaf(&self, host: &str) -> anyhow::Result<CertifiedKey> {
+        self.mint_leaf_with_provider(host, &default_provider())
+    }
+
+    fn mint_leaf_with_provider(
+        &self,
+        host: &str,
+        provider: &CryptoProvider,
+    ) -> anyhow::Result<CertifiedKey> {
+        let leaf_key =
+            KeyPair::generate().map_err(|e| anyhow::anyhow!("generate leaf key: {e}"))?;
+        let mut params = CertificateParams::new(vec![host.to_string()])
+            .map_err(|e| anyhow::anyhow!("build leaf params for {host}: {e}"))?;
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        let leaf = params
+            .signed_by(&leaf_key, &self.issuer, &self.key)
+            .map_err(|e| anyhow::anyhow!("sign leaf for {host}: {e}"))?;
+
+        let chain = vec![leaf.der().clone(), self.cert_der.clone()];
+        let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(leaf_key.serialize_der()));
+        CertifiedKey::from_der(chain, key_der, provider)
+            .map_err(|e| anyhow::anyhow!("assemble certified key for {host}: {e}"))
+    }
+}
+
+fn pem_to_der(cert_pem: &str) -> anyhow::Result<CertificateDer<'static>> {
+    let mut reader = cert_pem.as_bytes();
+    let mut certs = rustls_pemfile::certs(&mut reader);
+    let first = certs
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no certificate found in CA PEM"))?
+        .map_err(|e| anyhow::anyhow!("parse CA cert PEM: {e}"))?;
+    if certs.next().is_some() {
+        tracing::warn!(
+            "CA PEM contains multiple certificates; pinning the first as the trust anchor"
+        );
+    }
+    Ok(first)
+}
+
+/// A rustls certificate resolver that mints (and caches) one leaf per SNI host via the CA.
+#[derive(Debug)]
+pub struct SniCertResolver {
+    ca: Arc<CertificateAuthority>,
+    cache: Mutex<HashMap<String, Arc<CertifiedKey>>>,
+}
+
+impl SniCertResolver {
+    pub fn new(ca: Arc<CertificateAuthority>) -> Self {
+        Self {
+            ca,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return the certified key for `host`, minting and caching it on first request.
+    pub fn cert_for(&self, host: &str) -> anyhow::Result<Arc<CertifiedKey>> {
+        if let Some(ck) = self.lock_cache().get(host) {
+            return Ok(ck.clone());
+        }
+        let minted = Arc::new(self.ca.mint_leaf(host)?);
+        // Another thread may have minted concurrently; `or_insert` keeps the first-inserted key
+        // and every caller converges on it — the extra leaf is simply dropped.
+        Ok(self
+            .lock_cache()
+            .entry(host.to_string())
+            .or_insert(minted)
+            .clone())
+    }
+
+    fn lock_cache(&self) -> std::sync::MutexGuard<'_, HashMap<String, Arc<CertifiedKey>>> {
+        // A poisoned lock only means a thread panicked while holding it; the cached certificates
+        // remain valid, so recover rather than permanently break interception for the process.
+        self.cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl ResolvesServerCert for SniCertResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        let Some(host) = client_hello.server_name() else {
+            tracing::debug!("intercept TLS: client sent no SNI; cannot select a leaf certificate");
+            return None;
+        };
+        match self.cert_for(host) {
+            Ok(ck) => Some(ck),
+            Err(e) => {
+                // resolve() must return Option; log before dropping so a failed MITM handshake
+                // is diagnosable instead of a silent generic TLS abort.
+                tracing::warn!(host, error = %e, "intercept TLS: failed to mint leaf certificate");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustls::RootCertStore;
+    use rustls::client::WebPkiServerVerifier;
+    use rustls::client::danger::ServerCertVerifier;
+    use rustls::pki_types::{ServerName, UnixTime};
+
+    /// Verify `leaf` (with `intermediates`) is signed by `ca` and valid for `host` — a genuine
+    /// signature-chain + SAN check via rustls/webpki, trusting only the CA.
+    fn assert_chains_to_ca(
+        ca: &CertificateAuthority,
+        leaf: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        host: &str,
+    ) {
+        let mut roots = RootCertStore::empty();
+        roots.add(ca.ca_cert_der().clone()).expect("add CA root");
+        let verifier = WebPkiServerVerifier::builder_with_provider(
+            Arc::new(roots),
+            Arc::new(default_provider()),
+        )
+        .build()
+        .expect("build verifier");
+        let name = ServerName::try_from(host.to_string()).expect("server name");
+        verifier
+            .verify_server_cert(leaf, intermediates, &name, &[], UnixTime::now())
+            .unwrap_or_else(|e| panic!("leaf for {host} should chain to CA: {e:?}"));
+    }
+
+    #[test]
+    fn generate_produces_usable_ca() {
+        let ca = CertificateAuthority::generate().expect("generate CA");
+        assert!(ca.ca_cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+        // A usable CA can mint a leaf.
+        ca.mint_leaf("example.com").expect("mint leaf");
+    }
+
+    #[test]
+    fn minted_leaf_has_san_and_chains_to_ca() {
+        let ca = CertificateAuthority::generate().expect("generate CA");
+        let ck = ca.mint_leaf("cdn.example.com").expect("mint leaf");
+        // chain is [leaf, ca]
+        assert_eq!(ck.cert.len(), 2, "chain should be leaf + CA");
+        assert_eq!(&ck.cert[1], ca.ca_cert_der(), "second entry is the CA cert");
+        // Genuine signature + SAN verification against the CA as the only trust anchor.
+        assert_chains_to_ca(&ca, &ck.cert[0], &[], "cdn.example.com");
+        // Wrong host must NOT verify against the same leaf.
+        let mut roots = RootCertStore::empty();
+        roots.add(ca.ca_cert_der().clone()).unwrap();
+        let verifier = WebPkiServerVerifier::builder_with_provider(
+            Arc::new(roots),
+            Arc::new(default_provider()),
+        )
+        .build()
+        .unwrap();
+        let wrong = ServerName::try_from("other.example.org").unwrap();
+        assert!(
+            verifier
+                .verify_server_cert(&ck.cert[0], &[], &wrong, &[], UnixTime::now())
+                .is_err(),
+            "leaf minted for cdn.example.com must not be valid for other.example.org"
+        );
+    }
+
+    #[test]
+    fn resolver_caches_by_host() {
+        let ca = Arc::new(CertificateAuthority::generate().expect("generate CA"));
+        let resolver = SniCertResolver::new(ca);
+        let a1 = resolver.cert_for("a.example.com").expect("mint a");
+        let a2 = resolver.cert_for("a.example.com").expect("cache hit a");
+        assert!(
+            Arc::ptr_eq(&a1, &a2),
+            "same host must return the cached key"
+        );
+        let b = resolver.cert_for("b.example.com").expect("mint b");
+        assert!(
+            !Arc::ptr_eq(&a1, &b),
+            "different host must mint a distinct key"
+        );
+    }
+
+    #[test]
+    fn load_pem_mints_leaves_chaining_to_loaded_ca() {
+        // Build a CA out-of-band, serialise it, and load it back — the parity property.
+        let original = CertificateAuthority::generate().expect("generate CA");
+        // Reconstruct PEMs a persisted CA would carry: cert PEM + key PEM.
+        let cert_pem = original.ca_cert_pem().to_string();
+        let key_pem = original.key.serialize_pem();
+
+        let loaded = CertificateAuthority::load_pem(&cert_pem, &key_pem).expect("load CA");
+        assert_eq!(
+            loaded.ca_cert_pem(),
+            cert_pem,
+            "loaded CA exposes the original certificate PEM"
+        );
+        let ck = loaded
+            .mint_leaf("svc.internal")
+            .expect("mint via loaded CA");
+        assert_chains_to_ca(&loaded, &ck.cert[0], &[], "svc.internal");
+    }
+
+    #[test]
+    fn load_pem_rejects_garbage() {
+        assert!(
+            CertificateAuthority::load_pem("not a pem", "also not a pem").is_err(),
+            "malformed PEM input must be a typed error, not a panic or silent success"
+        );
+    }
+
+    #[test]
+    fn cert_for_dedups_under_concurrent_load() {
+        use std::thread;
+        let resolver = Arc::new(SniCertResolver::new(Arc::new(
+            CertificateAuthority::generate().expect("generate CA"),
+        )));
+        let keys: Vec<_> = (0..8)
+            .map(|_| {
+                let r = resolver.clone();
+                thread::spawn(move || r.cert_for("race.example.com").expect("mint under race"))
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+        let canonical = resolver.cert_for("race.example.com").expect("cache hit");
+        assert!(
+            keys.iter().all(|k| Arc::ptr_eq(k, &canonical)),
+            "all concurrent callers must converge on the single cached key"
+        );
+    }
+}

--- a/crates/rift-core/src/proxy/mod.rs
+++ b/crates/rift-core/src/proxy/mod.rs
@@ -28,6 +28,7 @@ mod server;
 pub(crate) mod tls;
 
 mod context;
+pub mod intercept_ca;
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
Add CertificateAuthority to support CA generation and loading from PEM.
Implement per-host leaf certificate minting signed by the CA, with an SNI ResolvesServerCert trait implementation including caching.
Provides foundation for the intercept-proxy epic.

Part of #394
Closes #395

Milestone: intercept-proxy epic (slice 1/5)