### PR TITLE
feat(proxy): truststore export — PEM + PKCS12 + JKS (2/5, epic #394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boa_ast"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +619,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -727,6 +764,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -878,6 +924,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -1035,6 +1091,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1347,6 +1423,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1571,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1933,6 +2028,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -2504,6 +2609,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "p12"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4873306de53fe82e7e484df31e1e947d61514b6ea2ed6cd7b45d63006fd9224"
+dependencies = [
+ "cbc",
+ "cipher",
+ "des",
+ "getrandom 0.2.16",
+ "hmac",
+ "lazy_static",
+ "rc2",
+ "sha1",
+ "yasna",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,6 +3168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,6 +3385,7 @@ dependencies = [
  "matchit",
  "mlua",
  "num_cpus",
+ "p12",
  "parking_lot",
  "prometheus",
  "r2d2",
@@ -3264,6 +3396,7 @@ dependencies = [
  "reqwest",
  "rhai",
  "rift-types",
+ "ring",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -3284,6 +3417,7 @@ dependencies = [
  "tracing",
  "urlencoding",
  "uuid",
+ "yasna",
 ]
 
 [[package]]
@@ -3833,6 +3967,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4629,6 +4774,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -81,6 +81,9 @@ sxd-xpath = "0.4"
 
 # JSONPath RFC 9535 support
 serde_json_path = "0.7"
+p12 = "0.6.3"
+yasna = "0.5"
+ring = "0.17"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/rift-core/src/proxy/mod.rs
+++ b/crates/rift-core/src/proxy/mod.rs
@@ -31,6 +31,7 @@ mod context;
 pub mod intercept_ca;
 #[cfg(test)]
 mod tests;
+pub mod truststore;
 
 // Re-export public API types
 // These are used by main.rs and may be used by external consumers

--- a/crates/rift-core/src/proxy/truststore.rs
+++ b/crates/rift-core/src/proxy/truststore.rs
@@ -1,0 +1,310 @@
+//! Truststore export for the intercept CA (epic #394, slice 2/5).
+//!
+//! Given the intercept [`CertificateAuthority`], emit trust material a SUT can point at so it
+//! trusts the proxy without any crypto committed to its own repo:
+//! - the CA certificate as PEM ([`ca_pem`]),
+//! - a **PKCS#12** truststore ([`export_pkcs12`]),
+//! - a **JKS** truststore for JVM SUTs ([`export_jks`]).
+//!
+//! Both stores carry a single trusted-certificate entry (the CA) and are integrity-protected by
+//! the supplied password — no private keys are included, since a truststore must not hold one.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use p12::{CertBag, ContentInfo, MacData, PFX, PKCS12Attribute, SafeBag, SafeBagKind};
+
+use super::intercept_ca::CertificateAuthority;
+
+/// Alias/friendly-name given to the single CA entry in an exported truststore.
+const CA_ALIAS: &str = "rift-intercept-ca";
+
+/// A truststore password. Its `Debug`/`Display` never render the secret so it cannot leak into
+/// logs or error messages.
+#[derive(Clone)]
+pub struct TrustStorePassword(String);
+
+impl TrustStorePassword {
+    pub fn new(password: impl Into<String>) -> Self {
+        Self(password.into())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for TrustStorePassword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TrustStorePassword(***)")
+    }
+}
+
+impl std::fmt::Display for TrustStorePassword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("***")
+    }
+}
+
+/// The CA certificate as PEM (the trust anchor an operator can also import manually).
+pub fn ca_pem(ca: &CertificateAuthority) -> String {
+    ca.ca_cert_pem().to_string()
+}
+
+/// Export a PKCS#12 truststore containing the CA certificate as a single trusted entry,
+/// integrity-protected by `password`.
+pub fn export_pkcs12(
+    ca: &CertificateAuthority,
+    password: &TrustStorePassword,
+) -> anyhow::Result<Vec<u8>> {
+    let ca_der = ca.ca_cert_der().as_ref().to_vec();
+    let bmp = bmp_string(password.as_str());
+
+    // p12's `MacData::new` obtains its MAC salt via `getrandom().unwrap()`, which panics if the
+    // OS RNG is unavailable (seccomp-restricted sandbox, very early boot). Contain that panic and
+    // surface it as a typed error so this `Result`-returning function never unwinds into callers.
+    std::panic::catch_unwind(move || {
+        let cert_bag = SafeBag {
+            bag: SafeBagKind::CertBag(CertBag::X509(ca_der)),
+            attributes: vec![PKCS12Attribute::FriendlyName(CA_ALIAS.to_string())],
+        };
+        // SafeContents ::= SEQUENCE OF SafeBag
+        let safe_contents = yasna::construct_der(|w| {
+            w.write_sequence_of(|w| cert_bag.write(w.next()));
+        });
+        // AuthenticatedSafe ::= SEQUENCE OF ContentInfo — one unencrypted Data holding the certs.
+        let auth_safe = yasna::construct_der(|w| {
+            w.write_sequence_of(|w| ContentInfo::Data(safe_contents).write(w.next()));
+        });
+        let mac_data = MacData::new(&auth_safe, &bmp);
+        let pfx = PFX {
+            version: 3,
+            auth_safe: ContentInfo::Data(auth_safe),
+            mac_data: Some(mac_data),
+        };
+        pfx.to_der()
+    })
+    .map_err(|_| anyhow::anyhow!("failed to build PKCS#12 truststore (system RNG unavailable?)"))
+}
+
+/// Export a JKS truststore containing the CA certificate as a single `trustedCertEntry`,
+/// integrity-protected by `password`. Hand-encoded per the JKS format (there is no maintained
+/// pure-Rust writer); only the cert-only subset is produced.
+pub fn export_jks(
+    ca: &CertificateAuthority,
+    password: &TrustStorePassword,
+) -> anyhow::Result<Vec<u8>> {
+    const MAGIC: u32 = 0xFEED_FEED;
+    const VERSION: u32 = 2;
+    const TAG_TRUSTED_CERT: u32 = 2;
+
+    let ca_der = ca.ca_cert_der().as_ref();
+    let millis = unix_millis();
+
+    let mut body = Vec::new();
+    body.extend_from_slice(&MAGIC.to_be_bytes());
+    body.extend_from_slice(&VERSION.to_be_bytes());
+    body.extend_from_slice(&1u32.to_be_bytes()); // entry count
+    body.extend_from_slice(&TAG_TRUSTED_CERT.to_be_bytes());
+    write_jks_utf(&mut body, CA_ALIAS);
+    body.extend_from_slice(&millis.to_be_bytes());
+    write_jks_utf(&mut body, "X.509");
+    body.extend_from_slice(&(ca_der.len() as u32).to_be_bytes());
+    body.extend_from_slice(ca_der);
+
+    // Store integrity digest: SHA1( passwordUTF16BE || "Mighty Aphrodite" || body ).
+    let mut pre = utf16be(password.as_str());
+    pre.extend_from_slice(b"Mighty Aphrodite");
+    pre.extend_from_slice(&body);
+
+    let mut out = body;
+    out.extend_from_slice(&sha1(&pre));
+    Ok(out)
+}
+
+/// Java modified-UTF-8 string with a big-endian u16 length prefix. ASCII inputs (the only ones
+/// used here) coincide with modified UTF-8.
+fn write_jks_utf(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    debug_assert!(bytes.len() <= u16::MAX as usize, "JKS UTF string too long");
+    buf.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+    buf.extend_from_slice(bytes);
+}
+
+fn utf16be(s: &str) -> Vec<u8> {
+    s.encode_utf16().flat_map(u16::to_be_bytes).collect()
+}
+
+/// PKCS#12 BMPString: UTF-16BE plus a two-byte null terminator. Must match p12's internal
+/// `bmp_string` so the MAC verifies.
+fn bmp_string(s: &str) -> Vec<u8> {
+    let mut bytes = utf16be(s);
+    bytes.push(0);
+    bytes.push(0);
+    bytes
+}
+
+fn sha1(data: &[u8]) -> Vec<u8> {
+    ring::digest::digest(&ring::digest::SHA1_FOR_LEGACY_USE_ONLY, data)
+        .as_ref()
+        .to_vec()
+}
+
+fn unix_millis() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_millis() as u64,
+        Err(_) => {
+            tracing::warn!("system clock is before UNIX_EPOCH; using 0 for JKS entry timestamp");
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ca() -> CertificateAuthority {
+        CertificateAuthority::generate().expect("generate CA")
+    }
+
+    #[test]
+    fn ca_pem_equals_ca_certificate() {
+        let ca = test_ca();
+        assert_eq!(ca_pem(&ca), ca.ca_cert_pem());
+        assert!(ca_pem(&ca).starts_with("-----BEGIN CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn pkcs12_round_trips_and_rejects_wrong_password() {
+        let ca = test_ca();
+        let pw = TrustStorePassword::new("changeit");
+        let der = export_pkcs12(&ca, &pw).expect("export pkcs12");
+
+        let pfx = PFX::parse(&der).expect("parse pkcs12");
+        assert!(
+            pfx.verify_mac("changeit"),
+            "MAC must verify with the password"
+        );
+        assert!(
+            !pfx.verify_mac("wrong-password"),
+            "MAC must fail with a wrong password"
+        );
+
+        let certs = pfx.cert_bags("changeit").expect("read cert bags");
+        assert_eq!(certs.len(), 1, "exactly one trusted cert");
+        assert_eq!(
+            &certs[0],
+            ca.ca_cert_der().as_ref(),
+            "the stored cert is the CA cert"
+        );
+    }
+
+    #[test]
+    fn jks_has_valid_structure_and_digest() {
+        let ca = test_ca();
+        let pw = TrustStorePassword::new("changeit");
+        let bytes = export_jks(&ca, &pw).expect("export jks");
+
+        // Split trailing 20-byte SHA-1 digest from the body.
+        assert!(bytes.len() > 20, "jks must have body + digest");
+        let (body, digest) = bytes.split_at(bytes.len() - 20);
+
+        // Recompute the store digest and compare.
+        let mut pre = utf16be("changeit");
+        pre.extend_from_slice(b"Mighty Aphrodite");
+        pre.extend_from_slice(body);
+        assert_eq!(sha1(&pre), digest, "store integrity digest must match");
+        // A wrong password must NOT reproduce the digest.
+        let mut wrong = utf16be("nope");
+        wrong.extend_from_slice(b"Mighty Aphrodite");
+        wrong.extend_from_slice(body);
+        assert_ne!(sha1(&wrong), digest, "wrong password must not match digest");
+
+        // Walk the body and confirm magic/version/one trustedCertEntry/CA bytes.
+        let mut p = 0usize;
+        let read_u32 = |b: &[u8], p: &mut usize| {
+            let v = u32::from_be_bytes(b[*p..*p + 4].try_into().unwrap());
+            *p += 4;
+            v
+        };
+        let read_utf = |b: &[u8], p: &mut usize| {
+            let len = u16::from_be_bytes(b[*p..*p + 2].try_into().unwrap()) as usize;
+            *p += 2;
+            let s = String::from_utf8(b[*p..*p + len].to_vec()).unwrap();
+            *p += len;
+            s
+        };
+        assert_eq!(read_u32(body, &mut p), 0xFEED_FEED, "magic");
+        assert_eq!(read_u32(body, &mut p), 2, "version");
+        assert_eq!(read_u32(body, &mut p), 1, "entry count");
+        assert_eq!(read_u32(body, &mut p), 2, "trustedCertEntry tag");
+        assert_eq!(read_utf(body, &mut p), CA_ALIAS, "alias");
+        p += 8; // creation timestamp
+        assert_eq!(read_utf(body, &mut p), "X.509", "cert type");
+        let cert_len = read_u32(body, &mut p) as usize;
+        assert_eq!(&body[p..p + cert_len], ca.ca_cert_der().as_ref(), "CA DER");
+    }
+
+    #[test]
+    fn password_debug_and_display_redact_the_secret() {
+        let pw = TrustStorePassword::new("s3cr3t");
+        assert!(!format!("{pw:?}").contains("s3cr3t"));
+        assert!(!format!("{pw}").contains("s3cr3t"));
+    }
+
+    #[test]
+    fn edge_case_passwords_round_trip_both_formats() {
+        // Empty and non-ASCII passwords exercise the UTF-16BE/BMP encoding paths that a real
+        // JVM/OpenSSL consumer relies on.
+        for pw in ["", "pä$$wörd-\u{1F510}"] {
+            let ca = test_ca();
+            let tsp = TrustStorePassword::new(pw);
+
+            let der = export_pkcs12(&ca, &tsp).expect("export pkcs12");
+            let pfx = PFX::parse(&der).expect("parse pkcs12");
+            assert!(pfx.verify_mac(pw), "pkcs12 MAC verifies for {pw:?}");
+            assert_eq!(
+                pfx.cert_bags(pw).expect("cert bags")[0],
+                ca.ca_cert_der().as_ref()
+            );
+
+            let jks = export_jks(&ca, &tsp).expect("export jks");
+            let (body, digest) = jks.split_at(jks.len() - 20);
+            let mut pre = utf16be(pw);
+            pre.extend_from_slice(b"Mighty Aphrodite");
+            pre.extend_from_slice(body);
+            assert_eq!(sha1(&pre), digest, "jks digest for {pw:?}");
+        }
+    }
+
+    /// Documents JVM compatibility: `keytool` can list the exported JKS. Ignored by default
+    /// because it requires a JDK on the runner.
+    #[test]
+    #[ignore = "requires keytool (JDK) on PATH"]
+    fn jks_is_readable_by_keytool() {
+        use std::io::Write;
+        use std::process::Command;
+
+        let ca = test_ca();
+        let pw = "changeit";
+        let bytes = export_jks(&ca, &TrustStorePassword::new(pw)).expect("export jks");
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("rift-intercept-{}.jks", std::process::id()));
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(&bytes))
+            .expect("write jks");
+
+        let out = Command::new("keytool")
+            .args(["-list", "-storetype", "JKS", "-storepass", pw, "-keystore"])
+            .arg(&path)
+            .output()
+            .expect("run keytool");
+        let _ = std::fs::remove_file(&path);
+        assert!(out.status.success(), "keytool -list should succeed");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains(CA_ALIAS),
+            "keytool should list the CA alias"
+        );
+    }
+}


### PR DESCRIPTION
Implements truststore export in three formats: PEM, PKCS#12, and JKS.
Adds ca_pem helper, export_pkcs12 with MAC-integrity protection, and
hand-encoded export_jks verified against keytool. Includes TrustStorePassword
newtype for safe password handling.

Part of #394
Closes #396

Milestone: intercept-proxy epic (slice 2/5)