### PR TITLE
feat(proxy): intercept rules + admin verbs (4/5, epic #394)

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -1,0 +1,337 @@
+//! Intercept rule CRUD + CA/truststore export admin handlers (epic #394, slice 4/5).
+//!
+//! Everything here lives under `/intercept/...` and is only reachable when the server was built
+//! `with_intercept(...)` (i.e. the intercept listener is actually running) — see
+//! `admin_api::router::route_request`.
+
+use crate::admin_api::types::{collect_body, error_response, json_response};
+use crate::intercept_rules::{InterceptRule, InterceptState};
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::{Method, Request, Response, StatusCode};
+use rift_core::proxy::truststore::{TrustStorePassword, ca_pem, export_jks, export_pkcs12};
+use serde::Serialize;
+
+const DEFAULT_TRUSTSTORE_PASSWORD: &str = "changeit";
+
+/// Dispatch a `/intercept/...` admin request. Returns `None` for any other path so the caller
+/// falls through to its normal routing (e.g. `404`).
+pub async fn route(
+    method: &Method,
+    path: &str,
+    query: Option<&str>,
+    req: Request<Incoming>,
+    state: &InterceptState,
+) -> Option<Response<Full<Bytes>>> {
+    let rest = path.strip_prefix("/intercept")?;
+    let resp = match (method, rest) {
+        (&Method::POST, "/rules") => handle_add_rules(req, state).await,
+        (&Method::GET, "/rules") => handle_list_rules(state),
+        (&Method::DELETE, "/rules") => handle_clear_rules(state),
+        (&Method::GET, "/ca.pem") => handle_ca_pem(state),
+        (&Method::GET, "/truststore.p12") => handle_truststore_p12(query, state),
+        (&Method::GET, "/truststore.jks") => handle_truststore_jks(query, state),
+        // Unmatched `/intercept/...` sub-path: let the caller apply its own 404 handling.
+        _ => return None,
+    };
+    Some(resp)
+}
+
+/// A single rule or a batch — `POST /intercept/rules` accepts either shape.
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum RuleOrRules {
+    One(InterceptRule),
+    Many(Vec<InterceptRule>),
+}
+
+/// `POST /intercept/rules` — add one rule (a bare `InterceptRule` object) or many (a JSON array).
+async fn handle_add_rules(req: Request<Incoming>, state: &InterceptState) -> Response<Full<Bytes>> {
+    let body = match collect_body(req).await {
+        Ok(b) => b,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
+    add_rules_from_bytes(&body, state)
+}
+
+/// Parse a rule (or array of rules) from a JSON body and add them to the store. Split out from
+/// `handle_add_rules` so the parse/store path is unit-testable without a `Request<Incoming>`.
+fn add_rules_from_bytes(body: &[u8], state: &InterceptState) -> Response<Full<Bytes>> {
+    let parsed: RuleOrRules = match serde_json::from_slice(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("Invalid intercept rule JSON: {e}"),
+            );
+        }
+    };
+    let added = match parsed {
+        RuleOrRules::One(rule) => {
+            state.rules.add(rule.clone());
+            vec![rule]
+        }
+        RuleOrRules::Many(rules) => {
+            for rule in &rules {
+                state.rules.add(rule.clone());
+            }
+            rules
+        }
+    };
+    json_response(StatusCode::CREATED, &added)
+}
+
+/// `GET /intercept/rules` — list all current rules.
+fn handle_list_rules(state: &InterceptState) -> Response<Full<Bytes>> {
+    json_response(StatusCode::OK, &state.rules.list())
+}
+
+#[derive(Debug, Serialize, serde::Deserialize)]
+struct DeletedResponse {
+    deleted: usize,
+}
+
+/// `DELETE /intercept/rules` — remove all rules, returning how many were removed.
+fn handle_clear_rules(state: &InterceptState) -> Response<Full<Bytes>> {
+    let deleted = state.rules.len();
+    state.rules.clear();
+    json_response(StatusCode::OK, &DeletedResponse { deleted })
+}
+
+/// `GET /intercept/ca.pem` — the intercept CA certificate, PEM-encoded.
+fn handle_ca_pem(state: &InterceptState) -> Response<Full<Bytes>> {
+    let pem = ca_pem(&state.ca);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/x-pem-file")
+        .body(Full::new(Bytes::from(pem)))
+        .unwrap_or_else(|_| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to build response",
+            )
+        })
+}
+
+/// Extract `password=` from a query string, defaulting to [`DEFAULT_TRUSTSTORE_PASSWORD`].
+fn password_from_query(query: Option<&str>) -> String {
+    query
+        .and_then(|q| {
+            q.split('&').find_map(|pair| {
+                let (k, v) = pair.split_once('=')?;
+                (k == "password").then(|| {
+                    urlencoding::decode(v)
+                        .map(|d| d.into_owned())
+                        .unwrap_or_else(|_| v.to_string())
+                })
+            })
+        })
+        .unwrap_or_else(|| DEFAULT_TRUSTSTORE_PASSWORD.to_string())
+}
+
+fn truststore_response(bytes: Vec<u8>, password: &str, filename: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/octet-stream")
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .header("x-truststore-password", password)
+        .body(Full::new(Bytes::from(bytes)))
+        .unwrap_or_else(|_| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to build response",
+            )
+        })
+}
+
+/// `GET /intercept/truststore.p12[?password=]` — PKCS#12 truststore containing the CA cert.
+fn handle_truststore_p12(query: Option<&str>, state: &InterceptState) -> Response<Full<Bytes>> {
+    let password = password_from_query(query);
+    match export_pkcs12(&state.ca, &TrustStorePassword::new(password.clone())) {
+        Ok(bytes) => truststore_response(bytes, &password, "rift-intercept-ca.p12"),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to export PKCS#12 truststore: {e}"),
+        ),
+    }
+}
+
+/// `GET /intercept/truststore.jks[?password=]` — JKS truststore containing the CA cert.
+fn handle_truststore_jks(query: Option<&str>, state: &InterceptState) -> Response<Full<Bytes>> {
+    let password = password_from_query(query);
+    match export_jks(&state.ca, &TrustStorePassword::new(password.clone())) {
+        Ok(bytes) => truststore_response(bytes, &password, "rift-intercept-ca.jks"),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to export JKS truststore: {e}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intercept_rules::{InterceptAction, InterceptRules, ServeStub};
+    use rift_core::proxy::intercept_ca::CertificateAuthority;
+    use std::sync::Arc;
+
+    fn test_state() -> InterceptState {
+        InterceptState {
+            rules: InterceptRules::new(),
+            ca: Arc::new(CertificateAuthority::generate().expect("generate CA")),
+        }
+    }
+
+    #[test]
+    fn ca_and_truststore_export_handlers() {
+        let state = test_state();
+
+        let ca_resp = handle_ca_pem(&state);
+        assert_eq!(ca_resp.status(), StatusCode::OK);
+        let ca_body = body_string(ca_resp);
+        assert!(ca_body.starts_with("-----BEGIN CERTIFICATE-----"));
+
+        let p12_resp = handle_truststore_p12(Some("password=hunter2"), &state);
+        assert_eq!(p12_resp.status(), StatusCode::OK);
+        assert_eq!(
+            p12_resp
+                .headers()
+                .get("x-truststore-password")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "hunter2"
+        );
+        // `p12` is not a direct dependency of this crate, so we assert non-empty bytes + the
+        // password header rather than round-tripping the parser (rift-core's own tests already
+        // cover the PKCS#12 encoding itself).
+        assert!(!body_bytes(p12_resp).is_empty());
+
+        let jks_resp = handle_truststore_jks(None, &state);
+        assert_eq!(jks_resp.status(), StatusCode::OK);
+        assert_eq!(
+            jks_resp
+                .headers()
+                .get("x-truststore-password")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            DEFAULT_TRUSTSTORE_PASSWORD
+        );
+        assert!(!body_bytes(jks_resp).is_empty());
+    }
+
+    #[test]
+    fn rules_endpoints_list_and_clear() {
+        let state = test_state();
+        state.rules.add(InterceptRule {
+            host: None,
+            predicates: vec![],
+            action: InterceptAction::Serve(ServeStub {
+                status_code: 200,
+                headers: Default::default(),
+                body: None,
+            }),
+        });
+
+        let list_resp = handle_list_rules(&state);
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let listed: Vec<InterceptRule> = serde_json::from_str(&body_string(list_resp)).unwrap();
+        assert_eq!(listed.len(), 1);
+
+        let clear_resp = handle_clear_rules(&state);
+        assert_eq!(clear_resp.status(), StatusCode::OK);
+        let deleted: DeletedResponse = serde_json::from_str(&body_string(clear_resp)).unwrap();
+        assert_eq!(deleted.deleted, 1);
+        assert!(state.rules.is_empty());
+    }
+
+    #[test]
+    fn password_from_query_defaults_and_decodes() {
+        assert_eq!(password_from_query(None), DEFAULT_TRUSTSTORE_PASSWORD);
+        assert_eq!(password_from_query(Some("password=abc")), "abc");
+        assert_eq!(password_from_query(Some("other=1&password=a%20b")), "a b");
+    }
+
+    #[test]
+    fn add_rules_from_bytes_stores_rule_and_rejects_bad_json() {
+        let state = test_state();
+        let json =
+            br#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"brew"}}}"#;
+        let resp = add_rules_from_bytes(json, &state);
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(state.rules.len(), 1);
+        assert_eq!(
+            state.rules.list()[0].host.as_deref(),
+            Some("cdn.example.com")
+        );
+
+        let bad = add_rules_from_bytes(b"{not json", &state);
+        assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(state.rules.len(), 1, "a rejected body must not add a rule");
+    }
+
+    // AC1/AC4: a rule created via the admin handler actually drives interception end-to-end.
+    #[tokio::test]
+    async fn rule_added_via_admin_handler_is_served_through_listener() {
+        use crate::intercept::InterceptListener;
+        use rift_core::proxy::intercept_ca::SniCertResolver;
+
+        let ca = CertificateAuthority::generate().expect("ca");
+        let ca_pem = ca.ca_cert_pem().to_string();
+        let ca = Arc::new(ca);
+        let state = InterceptState {
+            rules: InterceptRules::new(),
+            ca: ca.clone(),
+        };
+
+        // Add the rule through the ADMIN handler path (not InterceptRules::add directly).
+        let json = br#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"admin-brewed"}}}"#;
+        assert_eq!(
+            add_rules_from_bytes(json, &state).status(),
+            StatusCode::CREATED
+        );
+
+        let resolver = Arc::new(SniCertResolver::new(ca));
+        let listener = InterceptListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            resolver,
+            state.rules.clone(),
+        )
+        .await
+        .expect("bind");
+        let proxy_url = format!("http://{}", listener.local_addr());
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::https(&proxy_url).unwrap())
+            .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+            .build()
+            .unwrap();
+        let resp = client
+            .get("https://cdn.example.com/x")
+            .send()
+            .await
+            .expect("intercepted");
+        assert_eq!(resp.status(), 418);
+        assert_eq!(resp.text().await.unwrap(), "admin-brewed");
+
+        listener.shutdown().await;
+    }
+
+    fn body_bytes(resp: Response<Full<Bytes>>) -> Vec<u8> {
+        use http_body_util::BodyExt;
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(resp.into_body().collect())
+            .unwrap()
+            .to_bytes()
+            .to_vec()
+    }
+
+    fn body_string(resp: Response<Full<Bytes>>) -> String {
+        String::from_utf8(body_bytes(resp)).unwrap()
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
@@ -1,6 +1,7 @@
 //! Request handlers for the Admin API.
 
 pub mod imposters;
+pub mod intercept;
 pub mod scenarios;
 pub mod stubs;
 pub mod system;

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -2,10 +2,11 @@
 //!
 //! This module provides routing
 
-use crate::admin_api::handlers::{imposters, scenarios, stubs, system};
+use crate::admin_api::handlers::{imposters, intercept, scenarios, stubs, system};
 use crate::admin_api::types::{error_response, get_base_url, not_found};
 use crate::config_loader::ConfigSource;
 use crate::imposter::ImposterManager;
+use crate::intercept_rules::InterceptState;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
@@ -66,11 +67,13 @@ impl ImposterRoute {
 }
 
 /// Main request router
+#[allow(clippy::too_many_arguments)]
 pub async fn route_request(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
+    intercept: Option<Arc<InterceptState>>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
@@ -78,6 +81,20 @@ pub async fn route_request(
     let base_url = get_base_url(&req);
 
     debug!("Admin API: {} {}", method, path);
+
+    // Intercept control-plane routes (epic #394 slice 4): only reachable when an intercept
+    // listener is actually running (i.e. the server was built `with_intercept(...)`). Nothing
+    // else in `route_by_path` handles `/intercept`, so an unmatched sub-path or a missing
+    // intercept state both fall through to the ordinary 404.
+    if path == "/intercept" || path.starts_with("/intercept/") {
+        let resp = match intercept.as_ref() {
+            Some(state) => intercept::route(&method, &path, query.as_deref(), req, state)
+                .await
+                .unwrap_or_else(not_found),
+            None => not_found(),
+        };
+        return Ok(resp);
+    }
 
     let response = route_by_path(
         &method,

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -4,6 +4,7 @@ use crate::admin_api::router::route_request;
 use crate::config_loader::ConfigSource;
 use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
+use crate::intercept_rules::InterceptState;
 use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::service::service_fn;
@@ -28,6 +29,7 @@ pub struct AdminApiServer {
     api_key: Option<Arc<String>>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
+    intercept: Option<Arc<InterceptState>>,
 }
 
 impl AdminApiServer {
@@ -39,6 +41,7 @@ impl AdminApiServer {
             api_key: api_key.map(Arc::new),
             config_source: None,
             allow_injection: false,
+            intercept: None,
         }
     }
 
@@ -55,6 +58,15 @@ impl AdminApiServer {
     #[must_use]
     pub fn with_allow_injection(mut self, allow: bool) -> Self {
         self.allow_injection = allow;
+        self
+    }
+
+    /// Wire the `/intercept/...` admin routes (rule CRUD + CA/truststore export, epic #394 slice
+    /// 4) to `state`. Without this, `/intercept/...` responds `404` — the admin server has no
+    /// intercept surface unless an embedder explicitly opts in.
+    #[must_use]
+    pub fn with_intercept(mut self, state: Arc<InterceptState>) -> Self {
+        self.intercept = Some(state);
         self
     }
 
@@ -82,6 +94,7 @@ impl AdminApiServer {
                 self.api_key,
                 self.config_source,
                 self.allow_injection,
+                self.intercept,
                 loop_cancel,
                 loop_tracker,
             )
@@ -169,12 +182,14 @@ fn take_task<T>(slot: &Mutex<Option<JoinHandle<T>>>) -> Option<JoinHandle<T>> {
 
 /// Accept connections until `cancel` fires or the listener errors. Each connection is tracked
 /// so `shutdown` can wait for in-flight requests to drain.
+#[allow(clippy::too_many_arguments)]
 async fn accept_loop(
     listener: TcpListener,
     manager: Arc<ImposterManager>,
     api_key: Option<Arc<String>>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
+    intercept: Option<Arc<InterceptState>>,
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
@@ -187,6 +202,7 @@ async fn accept_loop(
         let manager = Arc::clone(&manager);
         let api_key = api_key.clone();
         let config_source = config_source.clone();
+        let intercept = intercept.clone();
         let conn_cancel = cancel.clone();
 
         tracker.spawn(async move {
@@ -194,6 +210,7 @@ async fn accept_loop(
                 let manager = Arc::clone(&manager);
                 let api_key = api_key.clone();
                 let config_source = config_source.clone();
+                let intercept = intercept.clone();
                 async move {
                     // Per-request annotation scope + response decorator (issue #318):
                     // every response through this listener — including the `/__rift/`
@@ -218,7 +235,7 @@ async fn accept_loop(
                                 return Ok::<_, hyper::Error>(unauthorized_response());
                             }
                         }
-                        route_request(req, manager, config_source, allow_injection).await
+                        route_request(req, manager, config_source, allow_injection, intercept).await
                     })
                     .await;
                     let mut response = result?;

--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -1,27 +1,33 @@
-//! Inbound forward-proxy intercept listener (epic #394, slice 3/5).
+//! Inbound forward-proxy intercept listener (epic #394, slice 3/5 + slice 4/5).
 //!
 //! An opt-in listener a SUT points at via `https.proxyHost`/`proxyPort`. It accepts HTTP
 //! `CONNECT`, TLS-terminates the tunnel using the per-SNI cert resolver from slice 1
-//! ([`SniCertResolver`]), and hands the decrypted request to a minimal handler. Predicate-based
-//! redirect/serve of intercepted requests is slice 4; here the handler proves end-to-end
-//! termination by answering with a fixed 200.
+//! ([`SniCertResolver`]), and matches the decrypted request against an [`InterceptRules`] store
+//! (slice 4): a matching rule either serves an inline stub or forwards to a named imposter port.
+//! With no matching rule (including an empty store), the handler falls back to a fixed 200 that
+//! echoes the intercepted host, so slice-3 behavior is unchanged by default.
 //!
 //! It is entirely opt-in: nothing runs until [`InterceptListener::bind`] is called, so the
 //! default imposter-on-a-port model is unchanged.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::intercept_rules::{InterceptAction, InterceptRules, ServeStub};
 use rift_core::proxy::intercept_ca::SniCertResolver;
 use rustls::ServerConfig;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio_rustls::TlsAcceptor;
 
 const MAX_HEAD_BYTES: usize = 16 * 1024;
+/// Upper bound on an intercepted request body we will buffer before forwarding/matching. Bounds
+/// memory use for a misbehaving or malicious `content-length`.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
 /// Per-stage deadline for the CONNECT read, TLS handshake, and request read. Bounds a slow or
 /// silent client so its connection task cannot park indefinitely (slowloris).
 const IO_TIMEOUT: Duration = Duration::from_secs(30);
@@ -53,7 +59,14 @@ pub struct InterceptListener {
 impl InterceptListener {
     /// Bind an intercept listener on `addr` and start accepting connections. Use `127.0.0.1:0`
     /// to get an OS-assigned port (read it back via [`local_addr`](Self::local_addr)).
-    pub async fn bind(addr: SocketAddr, resolver: Arc<SniCertResolver>) -> anyhow::Result<Self> {
+    ///
+    /// `rules` is matched against every intercepted request (issue #398); an empty store falls
+    /// back to the fixed slice-3 200 response.
+    pub async fn bind(
+        addr: SocketAddr,
+        resolver: Arc<SniCertResolver>,
+        rules: InterceptRules,
+    ) -> anyhow::Result<Self> {
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
         let tls = build_tls_acceptor(resolver)?;
@@ -66,8 +79,9 @@ impl InterceptListener {
                     accepted = listener.accept() => match accepted {
                         Ok((stream, peer)) => {
                             let tls = tls.clone();
+                            let rules = rules.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, tls).await {
+                                if let Err(e) = handle_connection(stream, tls, rules).await {
                                     tracing::debug!(%peer, error = %e, "intercept connection ended");
                                 }
                             });
@@ -112,7 +126,11 @@ fn build_tls_acceptor(resolver: Arc<SniCertResolver>) -> anyhow::Result<TlsAccep
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
-async fn handle_connection(mut stream: TcpStream, tls: TlsAcceptor) -> anyhow::Result<()> {
+async fn handle_connection(
+    mut stream: TcpStream,
+    tls: TlsAcceptor,
+    rules: InterceptRules,
+) -> anyhow::Result<()> {
     let head = timeout(IO_TIMEOUT, read_connect_head(&mut stream))
         .await
         .map_err(|_| anyhow::anyhow!("timed out reading CONNECT head"))??;
@@ -141,20 +159,220 @@ async fn handle_connection(mut stream: TcpStream, tls: TlsAcceptor) -> anyhow::R
         }
     };
 
-    let request_head = timeout(IO_TIMEOUT, read_request_head(&mut tls_stream))
+    let (head_bytes, leftover) = timeout(IO_TIMEOUT, read_request_message(&mut tls_stream))
         .await
         .map_err(|_| anyhow::anyhow!("timed out reading intercepted request head"))??;
-    let (method, path) = parse_request_line(&request_head);
+    let (method, path, query, headers) = parse_request_head(&head_bytes);
 
-    let body = format!("rift intercepted {method} {path} for {}\n", target.host);
-    let response = format!(
-        "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-        body.len(),
+    let content_length = headers
+        .get("content-length")
+        .and_then(|v| v.trim().parse::<usize>().ok());
+    // Diagnose the cases where a body silently won't be matched/forwarded (this slice reads only
+    // content-length-framed bodies; chunked/streamed bodies are not decoded — see #394).
+    if content_length.is_none() {
+        if let Some(raw) = headers.get("content-length") {
+            tracing::warn!(%target, content_length = %raw, "malformed content-length; treating request as bodyless");
+        } else if headers.contains_key("transfer-encoding") {
+            tracing::warn!(%target, "intercepted request uses transfer-encoding (e.g. chunked); body is not decoded and is treated as empty");
+        }
+    }
+    let body_bytes = match content_length {
+        Some(len) => {
+            if len > MAX_BODY_BYTES {
+                tracing::warn!(%target, len, cap = MAX_BODY_BYTES, "intercepted request body exceeds cap; truncating for match/forward");
+            }
+            Some(
+                timeout(IO_TIMEOUT, read_body(&mut tls_stream, leftover, len))
+                    .await
+                    .map_err(|_| anyhow::anyhow!("timed out reading intercepted request body"))??,
+            )
+        }
+        None => None,
+    };
+    let body = body_bytes
+        .as_deref()
+        .map(|b| String::from_utf8_lossy(b).into_owned());
+
+    let action = rules.match_request(
+        &target.host,
+        &method,
+        &path,
+        query.as_deref(),
+        &headers,
+        body.as_deref(),
     );
-    tls_stream.write_all(response.as_bytes()).await?;
+
+    match action {
+        Some(InterceptAction::Serve(stub)) => {
+            if let Err(e) = write_stub_response(&mut tls_stream, &stub).await {
+                tracing::warn!(%target, error = %e, "failed to render intercept stub response");
+            }
+        }
+        Some(InterceptAction::Forward(forward)) => {
+            let forward_result = forward_and_relay(
+                &mut tls_stream,
+                &method,
+                &path,
+                query.as_deref(),
+                &headers,
+                body_bytes.as_deref(),
+                forward.port,
+            )
+            .await;
+            if let Err(e) = forward_result {
+                tracing::warn!(%target, port = forward.port, error = %e, "intercept forward failed");
+                let _ = write_bad_gateway(&mut tls_stream).await;
+            }
+        }
+        None => {
+            let body = format!("rift intercepted {method} {path} for {}\n", target.host);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            tls_stream.write_all(response.as_bytes()).await?;
+        }
+    }
+
     tls_stream.flush().await?;
     let _ = tls_stream.shutdown().await;
     Ok(())
+}
+
+/// Render an [`InterceptAction::Serve`] stub as an HTTP/1.1 response and write it out.
+/// `content-length` and `connection` are always computed/set here, overriding any same-named
+/// entry in `stub.headers`, so the response stays well-formed regardless of stub configuration.
+async fn write_stub_response<S>(stream: &mut S, stub: &ServeStub) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let body = stub.body.clone().unwrap_or_default();
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\n",
+        stub.status_code,
+        reason_phrase(stub.status_code)
+    );
+    for (name, value) in &stub.headers {
+        if is_hop_by_hop(name) {
+            continue;
+        }
+        // Guard against header/response splitting via CR/LF in admin-supplied stub headers.
+        if name.contains(['\r', '\n']) || value.contains(['\r', '\n']) {
+            tracing::warn!(header = %name, "skipping intercept stub header containing CR/LF");
+            continue;
+        }
+        head.push_str(&format!("{name}: {value}\r\n"));
+    }
+    head.push_str(&format!("content-length: {}\r\n", body.len()));
+    head.push_str("connection: close\r\n\r\n");
+    stream.write_all(head.as_bytes()).await?;
+    stream.write_all(body.as_bytes()).await?;
+    Ok(())
+}
+
+/// Forward the decrypted request to `http://127.0.0.1:{port}{path}[?query]` and relay the
+/// upstream status, headers, and body back over `stream`. Returns `Err` on any connection or I/O
+/// failure so the caller can answer `502 Bad Gateway` without panicking.
+async fn forward_and_relay<S>(
+    stream: &mut S,
+    method: &str,
+    path: &str,
+    query: Option<&str>,
+    headers: &HashMap<String, String>,
+    body: Option<&[u8]>,
+    port: u16,
+) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let url = match query {
+        Some(q) => format!("http://127.0.0.1:{port}{path}?{q}"),
+        None => format!("http://127.0.0.1:{port}{path}"),
+    };
+    let reqwest_method = reqwest::Method::from_bytes(method.as_bytes())
+        .map_err(|e| anyhow::anyhow!("invalid method '{method}': {e}"))?;
+
+    // Relay the imposter's own response verbatim: never follow redirects (a 3xx from the imposter
+    // is a response to hand back, not to chase), and bound the forward by the same IO timeout.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(IO_TIMEOUT)
+        .build()
+        .map_err(|e| anyhow::anyhow!("building forward client: {e}"))?;
+    let mut builder = client.request(reqwest_method, &url);
+    for (name, value) in headers {
+        if is_hop_by_hop(name) {
+            continue;
+        }
+        builder = builder.header(name, value);
+    }
+    if let Some(bytes) = body {
+        builder = builder.body(bytes.to_vec());
+    }
+
+    let upstream = builder
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("forward to 127.0.0.1:{port} failed: {e}"))?;
+
+    let status = upstream.status();
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\n",
+        status.as_u16(),
+        status.canonical_reason().unwrap_or("")
+    );
+    let mut saw_content_length = false;
+    for (name, value) in upstream.headers() {
+        let name_str = name.as_str();
+        if is_hop_by_hop(name_str) {
+            continue;
+        }
+        if name_str.eq_ignore_ascii_case("content-length") {
+            saw_content_length = true;
+        }
+        if let Ok(value_str) = value.to_str() {
+            head.push_str(&format!("{name_str}: {value_str}\r\n"));
+        }
+    }
+
+    let body_bytes = upstream
+        .bytes()
+        .await
+        .map_err(|e| anyhow::anyhow!("reading upstream body from 127.0.0.1:{port}: {e}"))?;
+    if !saw_content_length {
+        head.push_str(&format!("content-length: {}\r\n", body_bytes.len()));
+    }
+    head.push_str("connection: close\r\n\r\n");
+
+    stream.write_all(head.as_bytes()).await?;
+    stream.write_all(&body_bytes).await?;
+    Ok(())
+}
+
+async fn write_bad_gateway<S>(stream: &mut S) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    stream
+        .write_all(b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 0\r\nconnection: close\r\n\r\n")
+        .await?;
+    Ok(())
+}
+
+/// Hop-by-hop / connection-management headers we recompute ourselves rather than pass through
+/// verbatim in either direction (request forwarding or response relaying).
+fn is_hop_by_hop(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "host" | "connection" | "content-length" | "transfer-encoding"
+    )
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    hyper::StatusCode::from_u16(status)
+        .ok()
+        .and_then(|s| s.canonical_reason())
+        .unwrap_or("")
 }
 
 /// Read the `CONNECT` request head one byte at a time, stopping exactly at the terminating
@@ -176,9 +394,12 @@ async fn read_connect_head(stream: &mut TcpStream) -> anyhow::Result<Vec<u8>> {
     Ok(buf)
 }
 
-async fn read_request_head<S>(stream: &mut S) -> anyhow::Result<Vec<u8>>
+/// Read the intercepted request's head (request line + headers), returning it split from any
+/// bytes already read past the terminating `\r\n\r\n` (the start of the body, since reads happen
+/// in fixed-size chunks and can over-read past the header boundary).
+async fn read_request_message<S>(stream: &mut S) -> anyhow::Result<(Vec<u8>, Vec<u8>)>
 where
-    S: tokio::io::AsyncRead + Unpin,
+    S: AsyncRead + Unpin,
 {
     let mut buf = Vec::new();
     let mut chunk = [0u8; 1024];
@@ -188,14 +409,46 @@ where
             anyhow::bail!("connection closed before request head completed");
         }
         buf.extend_from_slice(&chunk[..n]);
-        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
-            break;
+        if let Some(pos) = find_double_crlf(&buf) {
+            let leftover = buf.split_off(pos + 4);
+            return Ok((buf, leftover));
         }
         if buf.len() > MAX_HEAD_BYTES {
             anyhow::bail!("request head exceeds {MAX_HEAD_BYTES} bytes");
         }
     }
-    Ok(buf)
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Read exactly `content_length` bytes of body, starting from bytes already buffered past the
+/// header boundary (`leftover`). Capped at [`MAX_BODY_BYTES`] regardless of the claimed length.
+async fn read_body<S>(
+    stream: &mut S,
+    leftover: Vec<u8>,
+    content_length: usize,
+) -> anyhow::Result<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    let target_len = content_length.min(MAX_BODY_BYTES);
+    let mut body = leftover;
+    if body.len() > target_len {
+        body.truncate(target_len);
+        return Ok(body);
+    }
+    let mut chunk = [0u8; 8192];
+    while body.len() < target_len {
+        let want = (target_len - body.len()).min(chunk.len());
+        let n = stream.read(&mut chunk[..want]).await?;
+        if n == 0 {
+            anyhow::bail!("connection closed before request body completed");
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+    Ok(body)
 }
 
 fn parse_connect(head: &[u8]) -> Option<ConnectTarget> {
@@ -221,18 +474,37 @@ fn parse_connect(head: &[u8]) -> Option<ConnectTarget> {
     })
 }
 
-fn parse_request_line(head: &[u8]) -> (String, String) {
+/// Parse the request line and header block of an intercepted request into `(method, path, query,
+/// headers)`. Header names are lowercased so lookups (e.g. `content-length`) are case-insensitive.
+fn parse_request_head(head: &[u8]) -> (String, String, Option<String>, HashMap<String, String>) {
     let text = String::from_utf8_lossy(head);
-    let line = text.lines().next().unwrap_or("");
-    let mut parts = line.split_whitespace();
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("").to_string();
-    let path = parts.next().unwrap_or("").to_string();
-    (method, path)
+    let raw_target = parts.next().unwrap_or("").to_string();
+    let (path, query) = match raw_target.split_once('?') {
+        Some((p, q)) => (p.to_string(), Some(q.to_string())),
+        None => (raw_target, None),
+    };
+
+    let mut headers = HashMap::new();
+    for line in lines {
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+    (method, path, query, headers)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::intercept_rules::{ForwardTarget, InterceptRule};
     use rift_core::proxy::intercept_ca::CertificateAuthority;
 
     #[test]
@@ -252,29 +524,47 @@ mod tests {
         assert!(parse_connect(b"CONNECT host:notaport HTTP/1.1\r\n\r\n").is_none());
     }
 
-    async fn start_listener() -> (InterceptListener, String) {
+    #[test]
+    fn parse_request_head_splits_path_query_and_lowercases_headers() {
+        let head = b"GET /a/b?x=1 HTTP/1.1\r\nHost: cdn.example.com\r\nX-Foo: Bar\r\n\r\n";
+        let (method, path, query, headers) = parse_request_head(head);
+        assert_eq!(method, "GET");
+        assert_eq!(path, "/a/b");
+        assert_eq!(query.as_deref(), Some("x=1"));
+        assert_eq!(
+            headers.get("host").map(String::as_str),
+            Some("cdn.example.com")
+        );
+        assert_eq!(headers.get("x-foo").map(String::as_str), Some("Bar"));
+    }
+
+    async fn start_listener(rules: InterceptRules) -> (InterceptListener, String) {
         let ca = CertificateAuthority::generate().expect("ca");
         let ca_pem = ca.ca_cert_pem().to_string();
         let resolver = Arc::new(SniCertResolver::new(Arc::new(ca)));
-        let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver)
+        let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules)
             .await
             .expect("bind");
         (listener, ca_pem)
     }
 
+    fn trusting_client(proxy_url: &str, ca_pem: &str) -> reqwest::Client {
+        reqwest::Client::builder()
+            .proxy(reqwest::Proxy::https(proxy_url).unwrap())
+            .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+            .build()
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn intercepts_https_via_connect_and_trusts_minted_leaf() {
-        let (listener, ca_pem) = start_listener().await;
+        let (listener, ca_pem) = start_listener(InterceptRules::new()).await;
         let proxy_url = format!("http://{}", listener.local_addr());
 
         // A client that trusts ONLY the intercept CA and routes HTTPS through the proxy. reqwest
         // issues CONNECT to the proxy, we MITM-terminate with a per-SNI leaf, and the client
         // validates that leaf against the CA it was handed.
-        let client = reqwest::Client::builder()
-            .proxy(reqwest::Proxy::https(&proxy_url).unwrap())
-            .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
-            .build()
-            .unwrap();
+        let client = trusting_client(&proxy_url, &ca_pem);
 
         let resp = client
             .get("https://cdn.example.com/config.json")
@@ -293,7 +583,7 @@ mod tests {
 
     #[tokio::test]
     async fn non_connect_request_is_rejected_without_panic() {
-        let (listener, _ca_pem) = start_listener().await;
+        let (listener, _ca_pem) = start_listener(InterceptRules::new()).await;
         let addr = listener.local_addr();
 
         let mut stream = TcpStream::connect(addr).await.unwrap();
@@ -311,7 +601,7 @@ mod tests {
 
     #[tokio::test]
     async fn tls_handshake_failure_is_handled_and_listener_survives() {
-        let (listener, ca_pem) = start_listener().await;
+        let (listener, ca_pem) = start_listener(InterceptRules::new()).await;
         let addr = listener.local_addr();
 
         // A client that CONNECTs, reads the 200, then sends non-TLS garbage. The server-side
@@ -329,17 +619,131 @@ mod tests {
 
         // The listener still serves a subsequent legitimate intercept.
         let proxy_url = format!("http://{addr}");
-        let client = reqwest::Client::builder()
-            .proxy(reqwest::Proxy::https(&proxy_url).unwrap())
-            .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
-            .build()
-            .unwrap();
+        let client = trusting_client(&proxy_url, &ca_pem);
         let resp = client
             .get("https://cdn.example.com/still-up")
             .send()
             .await
             .expect("listener should still serve after a failed handshake");
         assert_eq!(resp.status(), 200);
+
+        listener.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn serve_rule_returns_inline_stub() {
+        let rules = InterceptRules::new();
+        rules.add(InterceptRule {
+            host: Some("cdn.example.com".to_string()),
+            predicates: vec![],
+            action: InterceptAction::Serve(ServeStub {
+                status_code: 418,
+                headers: HashMap::from([("x-rift".to_string(), "1".to_string())]),
+                body: Some("brewed".to_string()),
+            }),
+        });
+        let (listener, ca_pem) = start_listener(rules).await;
+        let proxy_url = format!("http://{}", listener.local_addr());
+        let client = trusting_client(&proxy_url, &ca_pem);
+
+        let resp = client
+            .get("https://cdn.example.com/x")
+            .send()
+            .await
+            .expect("request intercepted");
+        assert_eq!(resp.status(), 418);
+        assert_eq!(resp.headers().get("x-rift").unwrap(), "1");
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("brewed"), "got: {body}");
+
+        listener.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn forward_rule_proxies_to_imposter_port() {
+        // A trivial local HTTP server standing in for an imposter.
+        let imposter = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let imposter_port = imposter.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            if let Ok((mut s, _)) = imposter.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = s.read(&mut buf).await;
+                let body = "from-imposter";
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = s.write_all(resp.as_bytes()).await;
+                let _ = s.shutdown().await;
+            }
+        });
+
+        let rules = InterceptRules::new();
+        rules.add(InterceptRule {
+            host: None,
+            predicates: vec![],
+            action: InterceptAction::Forward(ForwardTarget {
+                port: imposter_port,
+            }),
+        });
+        let (listener, ca_pem) = start_listener(rules).await;
+        let proxy_url = format!("http://{}", listener.local_addr());
+        let client = trusting_client(&proxy_url, &ca_pem);
+
+        let resp = client
+            .get("https://cdn.example.com/anything")
+            .send()
+            .await
+            .expect("request intercepted");
+        assert_eq!(resp.status(), 200);
+        let body = resp.text().await.unwrap();
+        assert_eq!(body, "from-imposter");
+
+        listener.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn no_matching_rule_falls_back_to_default() {
+        let (listener, ca_pem) = start_listener(InterceptRules::new()).await;
+        let proxy_url = format!("http://{}", listener.local_addr());
+        let client = trusting_client(&proxy_url, &ca_pem);
+
+        let resp = client
+            .get("https://cdn.example.com/whatever")
+            .send()
+            .await
+            .expect("request intercepted");
+        assert_eq!(resp.status(), 200);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("cdn.example.com"), "got: {body}");
+
+        listener.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_forward_port_returns_502() {
+        // Bind then immediately drop a listener to get a port that is very likely closed for
+        // the lifetime of the test.
+        let closed = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let closed_port = closed.local_addr().unwrap().port();
+        drop(closed);
+
+        let rules = InterceptRules::new();
+        rules.add(InterceptRule {
+            host: None,
+            predicates: vec![],
+            action: InterceptAction::Forward(ForwardTarget { port: closed_port }),
+        });
+        let (listener, ca_pem) = start_listener(rules).await;
+        let proxy_url = format!("http://{}", listener.local_addr());
+        let client = trusting_client(&proxy_url, &ca_pem);
+
+        let resp = client
+            .get("https://cdn.example.com/x")
+            .send()
+            .await
+            .expect("request intercepted");
+        assert_eq!(resp.status(), 502);
 
         listener.shutdown().await;
     }

--- a/crates/rift-http-proxy/src/intercept_rules.rs
+++ b/crates/rift-http-proxy/src/intercept_rules.rs
@@ -1,0 +1,228 @@
+//! Intercept rules matched against decrypted requests from the forward-proxy listener
+//! (epic #394, slice 4/5).
+//!
+//! A rule is a `(host?, predicates)` match against the intercepted request paired with an
+//! [`InterceptAction`]: serve an inline stub, or forward the request to a named imposter port.
+//! Rules reuse the existing Mountebank-compatible predicate engine
+//! ([`rift_core::imposter::predicates::stub_matches`]) so the same predicate JSON shape works
+//! here as everywhere else in Rift.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use rift_core::imposter::stub_matches;
+use rift_core::proxy::intercept_ca::CertificateAuthority;
+use rift_types::Predicate;
+
+/// A single intercept rule: an optional host filter plus predicates (AND-ed together), and the
+/// action to take when both match.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct InterceptRule {
+    /// Exact-match intercepted host (case-insensitive). `None` matches any host.
+    #[serde(default)]
+    pub host: Option<String>,
+    /// Predicates matched against the decrypted request (implicit AND, same as stub matching).
+    #[serde(default)]
+    pub predicates: Vec<Predicate>,
+    pub action: InterceptAction,
+}
+
+/// What to do with an intercepted request that matches a rule.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InterceptAction {
+    /// Answer inline with a fixed stub response.
+    Serve(ServeStub),
+    /// Forward the request to a named imposter port on localhost.
+    Forward(ForwardTarget),
+}
+
+/// An inline stub response for a [`InterceptAction::Serve`] rule.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServeStub {
+    #[serde(default = "default_status")]
+    pub status_code: u16,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+fn default_status() -> u16 {
+    200
+}
+
+/// A localhost imposter port to forward an intercepted request to.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ForwardTarget {
+    pub port: u16,
+}
+
+/// Shared, mutable rule store. Cheap to clone (an `Arc` inside) so the listener and the admin API
+/// can each hold a handle to the same rules.
+#[derive(Debug, Clone, Default)]
+pub struct InterceptRules(Arc<RwLock<Vec<InterceptRule>>>);
+
+impl InterceptRules {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a rule.
+    pub fn add(&self, rule: InterceptRule) {
+        self.write().push(rule);
+    }
+
+    /// A snapshot clone of all current rules, in insertion order.
+    pub fn list(&self) -> Vec<InterceptRule> {
+        self.read().clone()
+    }
+
+    /// Remove all rules.
+    pub fn clear(&self) {
+        self.write().clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.read().is_empty()
+    }
+
+    /// The action of the first rule whose host matches (or has no host filter) AND whose
+    /// predicates all match the given request. `None` if no rule matches.
+    #[allow(clippy::too_many_arguments)]
+    pub fn match_request(
+        &self,
+        host: &str,
+        method: &str,
+        path: &str,
+        query: Option<&str>,
+        headers: &HashMap<String, String>,
+        body: Option<&str>,
+    ) -> Option<InterceptAction> {
+        let rules = self.read();
+        rules
+            .iter()
+            .find(|rule| {
+                let host_matches = rule
+                    .host
+                    .as_deref()
+                    .is_none_or(|h| h.eq_ignore_ascii_case(host));
+                host_matches
+                    && (rule.predicates.is_empty()
+                        || stub_matches(
+                            &rule.predicates,
+                            method,
+                            path,
+                            query,
+                            headers,
+                            body,
+                            None,
+                            None,
+                            None,
+                            0,
+                        ))
+            })
+            .map(|rule| rule.action.clone())
+    }
+
+    /// Recover a poisoned lock rather than propagate the panic — a reader/writer panicking while
+    /// holding the lock does not corrupt the `Vec`, so continuing to serve rules is safe.
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Vec<InterceptRule>> {
+        self.0.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, Vec<InterceptRule>> {
+        self.0.write().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// Shared control-plane state for the intercept feature: the rule store the listener matches
+/// against, and the CA the admin API exports (cert + truststores).
+#[derive(Clone)]
+pub struct InterceptState {
+    pub rules: InterceptRules,
+    pub ca: Arc<CertificateAuthority>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn predicate_path_equals(path: &str) -> Predicate {
+        let value = serde_json::json!({ "equals": { "path": path } });
+        serde_json::from_value(value).expect("valid predicate JSON")
+    }
+
+    #[test]
+    fn rules_crud_roundtrip() {
+        let rules = InterceptRules::new();
+        assert!(rules.is_empty());
+        assert_eq!(rules.len(), 0);
+
+        let rule = InterceptRule {
+            host: Some("cdn.example.com".to_string()),
+            predicates: vec![],
+            action: InterceptAction::Serve(ServeStub {
+                status_code: 200,
+                headers: HashMap::new(),
+                body: Some("hi".to_string()),
+            }),
+        };
+        rules.add(rule.clone());
+        assert_eq!(rules.len(), 1);
+        assert!(!rules.is_empty());
+        assert_eq!(rules.list(), vec![rule]);
+
+        rules.clear();
+        assert!(rules.is_empty());
+        assert_eq!(rules.list(), Vec::new());
+    }
+
+    #[test]
+    fn predicate_narrows_match() {
+        let rules = InterceptRules::new();
+        rules.add(InterceptRule {
+            host: None,
+            predicates: vec![predicate_path_equals("/only-this")],
+            action: InterceptAction::Forward(ForwardTarget { port: 4545 }),
+        });
+
+        let headers = HashMap::new();
+        let matched =
+            rules.match_request("any.example.com", "GET", "/only-this", None, &headers, None);
+        assert_eq!(
+            matched,
+            Some(InterceptAction::Forward(ForwardTarget { port: 4545 }))
+        );
+
+        let unmatched =
+            rules.match_request("any.example.com", "GET", "/other", None, &headers, None);
+        assert_eq!(unmatched, None);
+    }
+
+    #[test]
+    fn host_filter_is_case_insensitive_and_none_matches_any() {
+        let rules = InterceptRules::new();
+        rules.add(InterceptRule {
+            host: Some("CDN.example.com".to_string()),
+            predicates: vec![],
+            action: InterceptAction::Forward(ForwardTarget { port: 1 }),
+        });
+        let headers = HashMap::new();
+        assert!(
+            rules
+                .match_request("cdn.example.com", "GET", "/", None, &headers, None)
+                .is_some()
+        );
+        assert!(
+            rules
+                .match_request("other.example.com", "GET", "/", None, &headers, None)
+                .is_none()
+        );
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -25,6 +25,9 @@ pub mod admin_api;
 // Inbound forward-proxy intercept listener (TLS-MITM, epic #394 slice 3)
 pub mod intercept;
 
+// Intercept rules (predicate match -> serve/forward) + admin control state (epic #394 slice 4)
+pub mod intercept_rules;
+
 // Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
 pub mod config_loader;
 

--- a/crates/rift-types/src/predicate.rs
+++ b/crates/rift-types/src/predicate.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A single predicate: matcher parameters plus the operation to apply.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Predicate {
     #[serde(flatten)]
@@ -17,7 +17,7 @@ pub struct Predicate {
 }
 
 /// The matching operation a predicate performs (Mountebank-compatible).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PredicateOperation {
     Equals(HashMap<String, serde_json::Value>),
@@ -34,7 +34,7 @@ pub enum PredicateOperation {
 }
 
 /// Matcher parameters shared across operations (case sensitivity, selectors, etc.).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PredicateParameters {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -48,7 +48,7 @@ pub struct PredicateParameters {
 }
 
 /// A structured selector applied to the request body before matching.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PredicateSelector {
     XPath {


### PR DESCRIPTION
Implements InterceptRules matched with the existing predicate engine. Each rule either serves an inline stub or forwards to a localhost imposter port. The intercept listener dispatches through the rule store. Adds admin endpoints for managing rules (POST/GET/DELETE /intercept/rules) and exporting CA/truststore.

Part of #394
Closes #398

Milestone: intercept-proxy epic (slice 4/5)