### PR TITLE
docs(proxy): intercept-mode docs + end-to-end example (5/5, epic #394)

### DIFF
--- a/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
+++ b/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
@@ -1,0 +1,76 @@
+//! Runnable end-to-end example (epic #394, slice 5): mock a hard-coded external HTTPS config CDN
+//! with Rift's intercept proxy — replacing a mitmproxy sidecar with no committed crypto.
+//!
+//! Run: `cargo test -p rift-http-proxy --test intercept_config_cdn_example`
+//!
+//! Scenario: a feature-flag SDK always fetches `https://cdn.example.com/config.json`. Its target
+//! host is hard-coded, so we can't point it at a mock port — we intercept the TLS call and answer
+//! it from Rift. This is the executable companion to `docs/features/intercept-proxy.md`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
+use rift_http_proxy::intercept::InterceptListener;
+use rift_http_proxy::intercept_rules::{InterceptAction, InterceptRule, InterceptRules, ServeStub};
+
+#[tokio::test]
+async fn intercepts_external_config_cdn_without_mitmproxy() {
+    // 1. Rift generates an intercept CA at startup (or load one via `CertificateAuthority::load_pem`).
+    //    No CA cert, private key, or truststore is committed to the repo.
+    let ca = Arc::new(CertificateAuthority::generate().expect("generate intercept CA"));
+    let ca_pem = ca.ca_cert_pem().to_string();
+
+    // 2. Declare an intercept rule: when the SUT calls cdn.example.com/config.json, serve the flag
+    //    config inline. (Swap `Serve` for `InterceptAction::Forward { port }` to route the call to
+    //    one of your imposters instead.)
+    let rules = InterceptRules::new();
+    let path_predicate =
+        serde_json::from_value(serde_json::json!({ "equals": { "path": "/config.json" } }))
+            .expect("valid predicate");
+    let mut headers = HashMap::new();
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    rules.add(InterceptRule {
+        host: Some("cdn.example.com".to_string()),
+        predicates: vec![path_predicate],
+        action: InterceptAction::Serve(ServeStub {
+            status_code: 200,
+            headers,
+            body: Some(r#"{"featureX":"ON"}"#.to_string()),
+        }),
+    });
+
+    // 3. Start the intercept listener. An embedder would also expose the admin API by building the
+    //    admin server `with_intercept(...)`; here we drive the rule store directly.
+    let resolver = Arc::new(SniCertResolver::new(ca));
+    let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules)
+        .await
+        .expect("bind intercept listener");
+
+    // 4. The SUT: an HTTP client that trusts ONLY the intercept CA and routes HTTPS through the
+    //    listener. The JVM equivalent is:
+    //      -Djavax.net.ssl.trustStore=ts.jks -Djavax.net.ssl.trustStorePassword=changeit
+    //      -Dhttps.proxyHost=<host> -Dhttps.proxyPort=<port>
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::https(format!("http://{}", listener.local_addr())).unwrap())
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap();
+
+    // 5. The SUT's hard-coded HTTPS call is intercepted and answered by Rift — no mitmproxy.
+    let resp = client
+        .get("https://cdn.example.com/config.json")
+        .send()
+        .await
+        .expect("config fetched through the intercept proxy");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json")
+    );
+    assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
+
+    listener.shutdown().await;
+}

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -68,6 +68,7 @@ Rift provides advanced features for service virtualization and chaos engineering
 - [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) - Overlap detection and warnings
 - [Debug Mode]({{ site.baseurl }}/features/debug-mode/) - Request matching diagnostics
 - [TLS/HTTPS]({{ site.baseurl }}/features/tls/) - Secure connections
+- [Intercept Proxy (TLS-MITM)]({{ site.baseurl }}/features/intercept-proxy/) - Mock a hard-coded external HTTPS host without mitmproxy
 - [Metrics]({{ site.baseurl }}/features/metrics/) - Prometheus monitoring
 - [Configuration Linting]({{ site.baseurl }}/features/linting/) - Validate imposter configs before loading
 - [Terminal UI]({{ site.baseurl }}/features/tui/) - Interactive imposter management

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -1,0 +1,149 @@
+---
+layout: default
+title: Intercept Proxy (TLS-MITM)
+parent: Features
+nav_order: 16
+---
+
+# Intercept / Redirect Proxy Mode
+
+Mock an external **HTTPS** dependency whose target host the system-under-test (SUT) **hard-codes** —
+for example a feature-flag SDK that always fetches its config from
+`https://cdn.example.com/config.json`. You can't point such a client at a mock port, so Rift can sit
+in the request path as a **forward proxy**, terminate the TLS call, match it with the ordinary
+predicate engine, and either serve a stub inline or forward it to one of your imposters.
+
+This replaces the usual **mitmproxy** sidecar (a container, a Python redirect addon, and checked-in
+CA/key/truststore files) with a couple of Rift admin calls and **no committed crypto**.
+
+> This is the Rift-native mechanism. The `zio-bdd` `MockControl` `Intercept` capability
+> (EtaCassiopeia/zio-bdd#219) wraps it for BDD tests via `EmbeddedRift`.
+
+---
+
+## How it works
+
+1. The SUT is pointed at Rift's **intercept listener** as its HTTPS proxy
+   (`https.proxyHost` / `https.proxyPort`).
+2. The SUT issues `CONNECT cdn.example.com:443`; Rift answers `200 Connection Established` and
+   **TLS-terminates** the tunnel, minting a per-host leaf certificate on the fly, signed by an
+   **intercept CA** Rift generates at startup.
+3. The decrypted request is matched against **intercept rules** using the same
+   [predicate engine]({{ site.baseurl }}/features/) as imposters.
+4. A matching rule either **serves an inline stub** or **forwards** the request to one of your
+   imposters on `127.0.0.1:<port>`.
+
+The one constraint TLS-MITM cannot remove: **the SUT must trust the intercept CA.** Rift automates
+provisioning that trust (it emits a CA cert and a ready-to-use truststore) — see
+[Trusting the CA](#trusting-the-ca-from-the-sut).
+
+---
+
+## Enabling the listener
+
+The intercept listener is an opt-in, embedder-facing API — nothing runs until you start it, so the
+default imposter-on-a-port model is unchanged. A minimal, complete, runnable example lives in
+[`crates/rift-http-proxy/tests/intercept_config_cdn_example.rs`](https://github.com/EtaCassiopeia/rift/blob/master/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs)
+(run it with `cargo test -p rift-http-proxy --test intercept_config_cdn_example`). In outline:
+
+```rust
+use std::sync::Arc;
+use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
+use rift_http_proxy::intercept::InterceptListener;
+use rift_http_proxy::intercept_rules::InterceptRules;
+
+let ca = Arc::new(CertificateAuthority::generate()?);      // or CertificateAuthority::load_pem(cert, key)
+let rules = InterceptRules::new();
+let resolver = Arc::new(SniCertResolver::new(ca.clone())); // mints one leaf per SNI host
+let listener = InterceptListener::bind("127.0.0.1:0".parse()?, resolver, rules.clone()).await?;
+// Point the SUT at `listener.local_addr()` as its HTTPS proxy, trusting `ca`.
+```
+
+To expose rule configuration and CA export over the admin API, build the admin server
+`with_intercept(Arc::new(InterceptState { rules, ca }))`.
+
+---
+
+## Configuring rules (admin API)
+
+A rule matches an intercepted request by **host** (exact, case-insensitive; omit for any) and
+**predicates** (the usual Mountebank predicate JSON, AND-ed), and carries one action.
+
+### Serve an inline stub
+
+```bash
+curl -X POST http://localhost:2525/intercept/rules -d '{
+  "host": "cdn.example.com",
+  "predicates": [{ "equals": { "path": "/config.json" } }],
+  "action": { "serve": {
+    "statusCode": 200,
+    "headers": { "content-type": "application/json" },
+    "body": "{\"featureX\":\"ON\"}"
+  }}
+}'
+```
+
+### Forward to one of your imposters
+
+```bash
+# The SUT's HTTPS call is decrypted and forwarded to the imposter on 127.0.0.1:4545,
+# which does its own predicate/space matching and returns the response.
+curl -X POST http://localhost:2525/intercept/rules -d '{
+  "host": "cdn.example.com",
+  "action": { "forward": { "port": 4545 } }
+}'
+```
+
+| Verb & path | Effect |
+|:--|:--|
+| `POST /intercept/rules` | Add one rule (object) or many (array) |
+| `GET /intercept/rules` | List all rules |
+| `DELETE /intercept/rules` | Remove all rules |
+
+When no rule matches, the request falls through to a default `200` (so an unconfigured host is
+answered rather than hanging). Non-goals: HTTP/2, WebSockets, and chunked request bodies are not
+decoded (see [Limitations](#limitations)).
+
+---
+
+## Trusting the CA from the SUT
+
+Export the CA and a ready-to-use truststore — nothing crypto needs to live in your repo:
+
+```bash
+curl http://localhost:2525/intercept/ca.pem -o rift-ca.pem                       # PEM
+curl "http://localhost:2525/intercept/truststore.p12?password=changeit" -o ts.p12 # PKCS#12
+curl "http://localhost:2525/intercept/truststore.jks?password=changeit" -o ts.jks # JKS (JVM)
+```
+
+The truststore endpoints return the store bytes plus an `x-truststore-password` response header
+echoing the password used (default `changeit`, override with `?password=`).
+
+**JVM SUT — one-line wiring** (trust the CA and route HTTPS through the intercept listener):
+
+```
+-Djavax.net.ssl.trustStore=ts.jks -Djavax.net.ssl.trustStorePassword=changeit \
+-Dhttps.proxyHost=<rift-host> -Dhttps.proxyPort=<intercept-port>
+```
+
+---
+
+## What this replaces
+
+The classic mitmproxy setup — a `mitmproxy` container, a Python `request()` redirect addon, and
+committed CA cert + private key + dhparams + JKS truststore — collapses to: generate a CA (or load
+one), post a rule, and hand the SUT the emitted truststore. Fewer moving parts, **no committed
+private keys**, and it works identically for the container and embedded adapters.
+
+---
+
+## Limitations
+
+- **The SUT must trust the intercept CA** — this is inherent to HTTPS MITM; Rift only automates
+  provisioning it.
+- **Not a general mitmproxy replacement** — no HTTP/2 / h2c, WebSocket proxying, or flow scripting.
+- **Request bodies are read only when `Content-Length`-framed** — chunked / streamed request bodies
+  are not decoded and are treated as empty for matching and forwarding (logged at `warn`).
+- **Forward-proxy (`CONNECT`) only** — transparent interception is not implemented.
+- The listener is started by an **embedder** (or the zio-bdd adapter); a CLI flag to start it from
+  the standalone `rift` binary is a follow-up.


### PR DESCRIPTION
Documents the intercept/redirect proxy feature with comprehensive configuration
guidance, CA certificate handling, truststore setup, and demonstrates a complete
end-to-end example using config-CDN interception without external tools.

Part of #394
Closes #399

Milestone: intercept-proxy epic (slice 5/5 — final)