### PR TITLE
feat(ffi): make the embedded admin plane entirely FFI — direct C-ABI for scenario state + correlated spaces (drop the loopback HTTP hop)

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -71,6 +71,77 @@ int32_t rift_delete_imposter(RiftHandle *h, uint16_t port);
 char *rift_recorded(RiftHandle *h, uint16_t port);
 
 /**
+ * Get a scenario/flow-state value as JSON `{"flowId","key","value"}` the caller frees with
+ * [`rift_free`]. Returns null if the handle/port is unknown, the key is absent, or encoding
+ * fails (reason in `rift_last_error`).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id`/`key` must be null or valid C strings.
+ */
+char *rift_flow_state_get(RiftHandle *h, uint16_t port, const char *flow_id, const char *key);
+
+/**
+ * Set a scenario/flow-state value from a bare JSON value (`value_json`). Returns `0` on success,
+ * `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+ */
+int32_t rift_flow_state_put(RiftHandle *h,
+                            uint16_t port,
+                            const char *flow_id,
+                            const char *key,
+                            const char *value_json);
+
+/**
+ * Delete a scenario/flow-state key. Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+ */
+int32_t rift_flow_state_delete(RiftHandle *h, uint16_t port, const char *flow_id, const char *key);
+
+/**
+ * Register a stub scoped to `flow_id` (its `space` is set from `flow_id`, ignoring any `space`
+ * in the JSON, mirroring the admin path). Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+ */
+int32_t rift_space_add_stub(RiftHandle *h,
+                            uint16_t port,
+                            const char *flow_id,
+                            const char *stub_json);
+
+/**
+ * List a space's scoped stubs as JSON `{"space","stubs":[…]}` the caller frees with
+ * [`rift_free`], or null on error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+ */
+char *rift_space_list_stubs(RiftHandle *h, uint16_t port, const char *flow_id);
+
+/**
+ * Tear down a space in one call (its scoped stubs, recorded requests, and scenario state — never
+ * a global reset). Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+ */
+int32_t rift_space_delete(RiftHandle *h, uint16_t port, const char *flow_id);
+
+/**
+ * The requests recorded for `flow_id` — filtered by the space's resolved flow-id, the same
+ * resolution the space-inspection view uses (the header-filtered `received`, issue #201) — as a
+ * JSON array the caller frees with [`rift_free`], or null on error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+ */
+char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
+
+/**
  * Start the real admin API (and, if `metricsPort` is given, the metrics server) in-process on
  * this handle's runtime, serving over this handle's manager (issue #343).
  *

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -300,6 +300,281 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
     }
 }
 
+// ── Admin long tail over direct C-ABI: scenario state + correlated spaces (issue #411) ──────────
+// Each function calls the same `ImposterManager`/`Imposter` methods the admin-HTTP handlers call
+// and returns the same JSON, so an embedder can drive scenario state and correlated spaces with
+// zero loopback HTTP (no `rift_serve_admin` needed).
+
+/// Get a scenario/flow-state value as JSON `{"flowId","key","value"}` the caller frees with
+/// [`rift_free`]. Returns null if the handle/port is unknown, the key is absent, or encoding
+/// fails (reason in `rift_last_error`).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id`/`key` must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_flow_state_get(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+    key: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id), Some(key)) = (handle(h), c_str(flow_id), c_str(key))
+        else {
+            set_last_error("rift_flow_state_get: null handle or string pointer");
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_get: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        match imposter.flow_get(flow_id, key) {
+            Ok(Some(value)) => {
+                into_c_string(json!({ "flowId": flow_id, "key": key, "value": value }).to_string())
+            }
+            Ok(None) => {
+                set_last_error("rift_flow_state_get: flow-state key not found");
+                std::ptr::null_mut()
+            }
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_get: {e}"));
+                warn!(error = %e, port, "rift_flow_state_get failed");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Set a scenario/flow-state value from a bare JSON value (`value_json`). Returns `0` on success,
+/// `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_flow_state_put(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+    key: *const c_char,
+    value_json: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id), Some(key), Some(value_json)) =
+            (handle(h), c_str(flow_id), c_str(key), c_str(value_json))
+        else {
+            set_last_error("rift_flow_state_put: null handle or string pointer");
+            return -1;
+        };
+        let value = match serde_json::from_str::<Value>(value_json) {
+            Ok(v) => v,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_put: invalid value JSON: {e}"));
+                return -1;
+            }
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_put: {e}"));
+                return -1;
+            }
+        };
+        match imposter.flow_set(flow_id, key, value) {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_put: {e}"));
+                warn!(error = %e, port, "rift_flow_state_put failed");
+                -1
+            }
+        }
+    }
+}
+
+/// Delete a scenario/flow-state key. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_flow_state_delete(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+    key: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id), Some(key)) = (handle(h), c_str(flow_id), c_str(key))
+        else {
+            set_last_error("rift_flow_state_delete: null handle or string pointer");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_delete: {e}"));
+                return -1;
+            }
+        };
+        match imposter.flow_delete(flow_id, key) {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_flow_state_delete: {e}"));
+                warn!(error = %e, port, "rift_flow_state_delete failed");
+                -1
+            }
+        }
+    }
+}
+
+/// Register a stub scoped to `flow_id` (its `space` is set from `flow_id`, ignoring any `space`
+/// in the JSON, mirroring the admin path). Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_space_add_stub(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+    stub_json: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id), Some(stub_json)) =
+            (handle(h), c_str(flow_id), c_str(stub_json))
+        else {
+            set_last_error("rift_space_add_stub: null handle or string pointer");
+            return -1;
+        };
+        let mut stub = match serde_json::from_str::<Stub>(stub_json) {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(format!("rift_space_add_stub: invalid stub JSON: {e}"));
+                return -1;
+            }
+        };
+        stub.space = Some(flow_id.to_string());
+        match handle
+            .runtime
+            .block_on(handle.manager.add_stub(port, stub, None))
+        {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_space_add_stub: {e}"));
+                warn!(error = %e, port, "rift_space_add_stub failed");
+                -1
+            }
+        }
+    }
+}
+
+/// List a space's scoped stubs as JSON `{"space","stubs":[…]}` the caller frees with
+/// [`rift_free`], or null on error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_space_list_stubs(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id)) = (handle(h), c_str(flow_id)) else {
+            set_last_error("rift_space_list_stubs: null handle or flow_id pointer");
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_space_list_stubs: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        into_c_string(
+            json!({ "space": flow_id, "stubs": imposter.space_stubs(flow_id) }).to_string(),
+        )
+    }
+}
+
+/// Tear down a space in one call (its scoped stubs, recorded requests, and scenario state — never
+/// a global reset). Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_space_delete(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id)) = (handle(h), c_str(flow_id)) else {
+            set_last_error("rift_space_delete: null handle or flow_id pointer");
+            return -1;
+        };
+        match handle
+            .runtime
+            .block_on(handle.manager.teardown_space(port, flow_id))
+        {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_space_delete: {e}"));
+                warn!(error = %e, port, "rift_space_delete failed");
+                -1
+            }
+        }
+    }
+}
+
+/// The requests recorded for `flow_id` — filtered by the space's resolved flow-id, the same
+/// resolution the space-inspection view uses (the header-filtered `received`, issue #201) — as a
+/// JSON array the caller frees with [`rift_free`], or null on error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_space_recorded(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(flow_id)) = (handle(h), c_str(flow_id)) else {
+            set_last_error("rift_space_recorded: null handle or flow_id pointer");
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_space_recorded: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        let recorded: Vec<_> = imposter
+            .get_recorded_requests()
+            .into_iter()
+            .filter(|r| imposter.resolve_flow_id_recorded(&r.headers) == flow_id)
+            .collect();
+        match serde_json::to_string(&recorded) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_space_recorded: encode failed: {e}"));
+                warn!(error = %e, port, "rift_space_recorded: failed to encode");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
 /// Start the real admin API (and, if `metricsPort` is given, the metrics server) in-process on
 /// this handle's runtime, serving over this handle's manager (issue #343).
 ///

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -758,3 +758,163 @@ fn ffi_serve_admin_retry_after_partial_failure_is_idempotent() {
         let _ = std::fs::remove_file(&path);
     }
 }
+
+/// Issue #411: the admin long tail — scenario/flow-state and correlated spaces — over direct
+/// C-ABI, with the same wire fidelity as the admin-HTTP handlers.
+#[test]
+fn ffi_admin_plane_round_trip() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null());
+        let config = cstr(
+            r#"{ "port": 19991, "protocol": "http", "recordRequests": true,
+                 "_rift": { "flowState": { "backend": "inmemory" } }, "stubs": [] }"#,
+        );
+        let port = rift_create_imposter(h, config.as_ptr());
+        assert_eq!(port, 19991);
+
+        // --- flow state: put -> get (JSON {flowId,key,value}) -> delete -> get(null) ---
+        let flow = cstr("flow-1");
+        let key = cstr("state");
+        let val = cstr(r#""paid""#);
+        assert_eq!(
+            rift_flow_state_put(h, port, flow.as_ptr(), key.as_ptr(), val.as_ptr()),
+            0
+        );
+        let got: serde_json::Value = serde_json::from_str(&take_json(rift_flow_state_get(
+            h,
+            port,
+            flow.as_ptr(),
+            key.as_ptr(),
+        )))
+        .unwrap();
+        assert_eq!(got["flowId"], "flow-1");
+        assert_eq!(got["key"], "state");
+        assert_eq!(got["value"], "paid");
+        assert_eq!(
+            rift_flow_state_delete(h, port, flow.as_ptr(), key.as_ptr()),
+            0
+        );
+        assert!(
+            rift_flow_state_get(h, port, flow.as_ptr(), key.as_ptr()).is_null(),
+            "get after delete returns null (not found)"
+        );
+
+        // --- correlated space stubs: add -> list ({space,stubs}) -> delete -> list(empty) ---
+        let space = cstr("space-a");
+        let stub = cstr(
+            r#"{ "predicates": [{ "equals": { "path": "/x" } }], "responses": [{ "is": { "statusCode": 204 } }] }"#,
+        );
+        assert_eq!(
+            rift_space_add_stub(h, port, space.as_ptr(), stub.as_ptr()),
+            0
+        );
+        let listed: serde_json::Value =
+            serde_json::from_str(&take_json(rift_space_list_stubs(h, port, space.as_ptr())))
+                .unwrap();
+        assert_eq!(listed["space"], "space-a");
+        assert_eq!(listed["stubs"].as_array().unwrap().len(), 1);
+        assert_eq!(rift_space_delete(h, port, space.as_ptr()), 0);
+        let after: serde_json::Value =
+            serde_json::from_str(&take_json(rift_space_list_stubs(h, port, space.as_ptr())))
+                .unwrap();
+        assert_eq!(
+            after["stubs"].as_array().unwrap().len(),
+            0,
+            "teardown removed the space's stubs"
+        );
+
+        // --- header-filtered recorded (issue #201): default flow-id source is the port ---
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let _ = reqwest::get("http://127.0.0.1:19991/ping").await;
+        });
+        let matching = cstr("19991");
+        let recorded: serde_json::Value =
+            serde_json::from_str(&take_json(rift_space_recorded(h, port, matching.as_ptr())))
+                .unwrap();
+        assert_eq!(
+            recorded.as_array().unwrap().len(),
+            1,
+            "recorded filtered to the matching flow-id"
+        );
+        let other = cstr("other-flow");
+        let none: serde_json::Value =
+            serde_json::from_str(&take_json(rift_space_recorded(h, port, other.as_ptr()))).unwrap();
+        assert_eq!(
+            none.as_array().unwrap().len(),
+            0,
+            "a non-matching flow-id yields no recorded requests"
+        );
+
+        assert_eq!(rift_delete_all(h), 0);
+        rift_stop(h);
+    }
+}
+
+/// Issue #411: null-handle and unknown-port error paths map to the crate's sentinels.
+#[test]
+fn ffi_admin_plane_error_paths() {
+    unsafe {
+        let flow = cstr("f");
+        let key = cstr("k");
+        let one = cstr("1");
+        // Null handle -> the documented sentinel for each return shape...
+        assert!(
+            rift_flow_state_get(std::ptr::null_mut(), 1, flow.as_ptr(), key.as_ptr()).is_null()
+        );
+        // ...and the failure records `last_error` (reading it clears it).
+        let err = rift_last_error();
+        assert!(!err.is_null(), "flow_state_get failure records last_error");
+        rift_free(err);
+
+        assert_eq!(
+            rift_flow_state_put(
+                std::ptr::null_mut(),
+                1,
+                flow.as_ptr(),
+                key.as_ptr(),
+                one.as_ptr()
+            ),
+            -1
+        );
+        assert_eq!(
+            rift_flow_state_delete(std::ptr::null_mut(), 1, flow.as_ptr(), key.as_ptr()),
+            -1
+        );
+        assert_eq!(
+            rift_space_add_stub(std::ptr::null_mut(), 1, flow.as_ptr(), key.as_ptr()),
+            -1
+        );
+        assert!(rift_space_list_stubs(std::ptr::null_mut(), 1, flow.as_ptr()).is_null());
+        assert_eq!(
+            rift_space_delete(std::ptr::null_mut(), 1, flow.as_ptr()),
+            -1
+        );
+        assert!(rift_space_recorded(std::ptr::null_mut(), 1, flow.as_ptr()).is_null());
+
+        // Live handle, unknown port -> same sentinels for all seven.
+        let h = rift_start();
+        assert!(rift_flow_state_get(h, 65000, flow.as_ptr(), key.as_ptr()).is_null());
+        assert_eq!(
+            rift_flow_state_put(h, 65000, flow.as_ptr(), key.as_ptr(), one.as_ptr()),
+            -1
+        );
+        assert_eq!(
+            rift_flow_state_delete(h, 65000, flow.as_ptr(), key.as_ptr()),
+            -1
+        );
+        assert_eq!(
+            rift_space_add_stub(h, 65000, flow.as_ptr(), cstr("{}").as_ptr()),
+            -1
+        );
+        assert_eq!(rift_space_delete(h, 65000, flow.as_ptr()), -1);
+        assert!(rift_space_list_stubs(h, 65000, flow.as_ptr()).is_null());
+        assert!(rift_space_recorded(h, 65000, flow.as_ptr()).is_null());
+        // The last failure also recorded a message (AC3).
+        let err2 = rift_last_error();
+        assert!(!err2.is_null(), "unknown-port failure records last_error");
+        rift_free(err2);
+        rift_stop(h);
+    }
+}

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -45,11 +45,36 @@ rift_stop(h);                     // stop and free
 | `rift_recorded` | `char* rift_recorded(RiftHandle* h, uint16_t port)` | Recorded requests as a JSON string (**caller frees** with `rift_free`), or `NULL` on error. |
 | `rift_apply_config` | `char* rift_apply_config(RiftHandle* h, const char* json)` | Reconcile the full imposter set (like `POST /admin/reload`); returns the apply report JSON (caller frees). |
 
-## In-process admin plane
+## Admin long tail over FFI (scenario state + correlated spaces)
+
+The admin "long tail" — scenario/flow-state and the correlated per-space stub plane — has direct
+C-ABI entry points, so an embedder can drive it with **zero loopback HTTP** (no `rift_serve_admin`).
+Each mirrors the corresponding admin-HTTP handler exactly (same `ImposterManager` calls, same JSON):
+
+| Function | Signature | Returns |
+|---|---|---|
+| `rift_flow_state_get` | `char* rift_flow_state_get(RiftHandle* h, uint16_t port, const char* flow_id, const char* key)` | JSON `{"flowId","key","value"}` (**caller frees**), or `NULL` if unknown/absent. |
+| `rift_flow_state_put` | `int rift_flow_state_put(RiftHandle* h, uint16_t port, const char* flow_id, const char* key, const char* value_json)` | `0` on success, `-1` on error. `value_json` is the bare JSON value. |
+| `rift_flow_state_delete` | `int rift_flow_state_delete(RiftHandle* h, uint16_t port, const char* flow_id, const char* key)` | `0` on success, `-1` on error. |
+| `rift_space_add_stub` | `int rift_space_add_stub(RiftHandle* h, uint16_t port, const char* flow_id, const char* stub_json)` | `0` on success, `-1` on error. The stub's `space` is set from `flow_id`. |
+| `rift_space_list_stubs` | `char* rift_space_list_stubs(RiftHandle* h, uint16_t port, const char* flow_id)` | JSON `{"space","stubs":[…]}` (**caller frees**), or `NULL` on error. |
+| `rift_space_delete` | `int rift_space_delete(RiftHandle* h, uint16_t port, const char* flow_id)` | `0` on success, `-1` on error. One-call per-space teardown (scoped stubs + recorded + scenario state). |
+| `rift_space_recorded` | `char* rift_space_recorded(RiftHandle* h, uint16_t port, const char* flow_id)` | The requests recorded for that space (header-filtered `received`) as a JSON array (**caller frees**), or `NULL` on error. |
+
+`rift_flow_state_get` returns `NULL` both when the key is absent and on error — check
+`rift_last_error` (it reads `flow-state key not found` for a genuine absence) before treating a
+`NULL` as "unset".
+
+Errors set `rift_last_error` like the data-plane functions. Together with the data plane
+(`rift_create_imposter`/`rift_replace_stubs`/`rift_recorded`/`rift_delete_imposter`), these cover the
+whole SPI over C-ABI — an embedded consumer needs no admin HTTP server and no loopback client.
+
+## In-process admin plane (optional)
 
 `rift_serve_admin` starts the **real** admin API (and, if `metricsPort` is set, the metrics server)
 on the handle's runtime, serving the handle's manager — so external tooling can talk to an embedded
-Rift over HTTP.
+Rift over HTTP. It is **optional**: the direct C-ABI above already covers the admin long tail; use
+`rift_serve_admin` only when you want an actual HTTP admin surface.
 
 ```c
 char* result = rift_serve_admin(h, "{\"port\":0}");


### PR DESCRIPTION
Exposes 7 new librift_ffi entry points (rift_flow_state_get/put/delete, rift_space_add_stub/list_stubs/delete/recorded) that directly wrap the ImposterManager/Imposter methods the admin HTTP handlers call. Embedded consumers can now drive the full admin plane over FFI with zero loopback HTTP; rift_serve_admin becomes optional.

Updates cbindgen-generated C header and documents the new bindings in docs/embedding/ffi.md.

Closes #411
Milestone: embedded-FFI admin long tail (companion to #410)