### PR TITLE
feat(ffi): expose the intercept listener + control plane over librift_ffi (embedded half of #394)

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -142,6 +142,67 @@ int32_t rift_space_delete(RiftHandle *h, uint16_t port, const char *flow_id);
 char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
 
 /**
+ * Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
+ * intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://127.0.0.1:<port>"}`
+ * the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
+ * started — one listener per handle). `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 =
+ * OS-assigned); pass null or `{}` for defaults.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+ */
+char *rift_start_intercept(RiftHandle *h, const char *options_json);
+
+/**
+ * Add one intercept rule (a bare object) or many (a JSON array) — same shape the
+ * `/intercept/rules` admin route accepts. Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `rules_json` must be null or a valid C string.
+ */
+int32_t rift_intercept_add_rules(RiftHandle *h, const char *rules_json);
+
+/**
+ * Remove all intercept rules. Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+int32_t rift_intercept_clear_rules(RiftHandle *h);
+
+/**
+ * List the current intercept rules as a JSON array the caller frees with [`rift_free`], or null
+ * on error (null handle, intercept not started, or encode failure).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+char *rift_intercept_list_rules(RiftHandle *h);
+
+/**
+ * The intercept CA certificate as PEM, the caller frees with [`rift_free`], or null on error
+ * (null handle, or intercept not started).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+char *rift_intercept_ca_pem(RiftHandle *h);
+
+/**
+ * Write a truststore for the intercept CA to `out_path` — a truststore is binary, so it is
+ * written to a file (the format a JVM `trustStore` consumes directly) rather than returned as a
+ * C string. `format` is `"pkcs12"` or `"jks"`; `password` may be null for the default
+ * `"changeit"`. Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+ */
+int32_t rift_intercept_export_truststore(RiftHandle *h,
+                                         const char *format,
+                                         const char *password,
+                                         const char *out_path);
+
+/**
  * Start the real admin API (and, if `metricsPort` is given, the metrics server) in-process on
  * this handle's runtime, serving over this handle's manager (issue #343).
  *

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -29,8 +29,12 @@
 //! records the reason in [`rift_last_error`], and emits a `tracing` event.
 
 use rift_core::imposter::{ApplyReport, ImposterConfig, ImposterManager, Stub};
+use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
+use rift_core::proxy::truststore::{TrustStorePassword, ca_pem, export_jks, export_pkcs12};
 use rift_http_proxy::admin_api::{AdminApiServer, RunningAdminApi};
 use rift_http_proxy::config_loader::{self, ConfigSource};
+use rift_http_proxy::intercept::InterceptListener;
+use rift_http_proxy::intercept_rules::{InterceptRule, InterceptRules, InterceptState};
 use rift_http_proxy::server::{RunningMetrics, bind_metrics_server};
 use serde_json::{Value, json};
 use std::cell::RefCell;
@@ -70,12 +74,20 @@ pub struct RiftHandle {
     runtime: Runtime,
     manager: Arc<ImposterManager>,
     admin: Mutex<Option<AdminPlane>>,
+    intercept: Mutex<Option<InterceptPlane>>,
 }
 
 /// The admin API (and optional metrics server) serving in-process for a handle (issue #343).
 struct AdminPlane {
     admin: RunningAdminApi,
     metrics: Option<RunningMetrics>,
+}
+
+/// The intercept/TLS-MITM listener serving in-process for a handle, plus the shared
+/// [`InterceptState`] (rule store + CA) its control-plane functions mutate/export (issue #410).
+struct InterceptPlane {
+    listener: InterceptListener,
+    state: InterceptState,
 }
 
 /// Borrow the handle from a raw pointer, or `None` if null.
@@ -141,6 +153,7 @@ pub extern "C" fn rift_start() -> *mut RiftHandle {
             runtime,
             manager: Arc::new(ImposterManager::new()),
             admin: Mutex::new(None),
+            intercept: Mutex::new(None),
         })),
         Err(e) => {
             set_last_error(format!("rift_start: runtime creation failed: {e}"));
@@ -575,6 +588,301 @@ pub unsafe extern "C" fn rift_space_recorded(
     }
 }
 
+// ── Intercept/TLS-MITM listener + control plane over FFI (issue #410) ────────────────────────────
+// Start an intercept forward-proxy on the handle's runtime and drive its rule store + CA export
+// entirely over C-ABI — no loopback HTTP admin plane needed. One listener per handle.
+
+/// `rift_start_intercept` options (all optional): the bind host and port.
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct InterceptOptions {
+    host: Option<String>,
+    port: Option<u16>,
+}
+
+/// A single rule or a batch — `rift_intercept_add_rules` accepts either shape.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum RuleOrRules {
+    One(InterceptRule),
+    Many(Vec<InterceptRule>),
+}
+
+/// Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
+/// intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://127.0.0.1:<port>"}`
+/// the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
+/// started — one listener per handle). `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 =
+/// OS-assigned); pass null or `{}` for defaults.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_start_intercept(
+    h: *mut RiftHandle,
+    options_json: *const c_char,
+) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_start_intercept: null handle");
+            return std::ptr::null_mut();
+        };
+        let opts: InterceptOptions = if options_json.is_null() {
+            InterceptOptions::default()
+        } else {
+            match c_str(options_json) {
+                Some(s) => match serde_json::from_str(s) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        set_last_error(format!("rift_start_intercept: invalid options JSON: {e}"));
+                        return std::ptr::null_mut();
+                    }
+                },
+                None => {
+                    set_last_error("rift_start_intercept: options is not valid UTF-8");
+                    return std::ptr::null_mut();
+                }
+            }
+        };
+
+        // Hold the slot across build+set so a concurrent call can't race two listeners into
+        // existence (one intercept listener per handle).
+        let mut slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        if slot.is_some() {
+            set_last_error(
+                "rift_start_intercept: already started (one intercept listener per handle)",
+            );
+            return std::ptr::null_mut();
+        }
+
+        let host = opts.host.as_deref().unwrap_or("127.0.0.1");
+        let addr: std::net::SocketAddr = match format!("{host}:{}", opts.port.unwrap_or(0)).parse()
+        {
+            Ok(a) => a,
+            Err(e) => {
+                set_last_error(format!("rift_start_intercept: invalid host/port: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        let ca = match CertificateAuthority::generate() {
+            Ok(ca) => Arc::new(ca),
+            Err(e) => {
+                set_last_error(format!("rift_start_intercept: CA generation failed: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        let rules = InterceptRules::new();
+        let resolver = Arc::new(SniCertResolver::new(ca.clone()));
+        let listener =
+            match handle
+                .runtime
+                .block_on(InterceptListener::bind(addr, resolver, rules.clone()))
+            {
+                Ok(l) => l,
+                Err(e) => {
+                    set_last_error(format!("rift_start_intercept: bind failed: {e}"));
+                    warn!(error = %e, "rift_start_intercept: bind failed");
+                    return std::ptr::null_mut();
+                }
+            };
+        let intercept_port = listener.local_addr().port();
+        let response = json!({
+            "interceptPort": intercept_port,
+            "interceptUrl": format!("http://127.0.0.1:{intercept_port}"),
+        })
+        .to_string();
+        *slot = Some(InterceptPlane {
+            listener,
+            state: InterceptState { rules, ca },
+        });
+        into_c_string(response)
+    }
+}
+
+/// Add one intercept rule (a bare object) or many (a JSON array) — same shape the
+/// `/intercept/rules` admin route accepts. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `rules_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_intercept_add_rules(
+    h: *mut RiftHandle,
+    rules_json: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(rules_json)) = (handle(h), c_str(rules_json)) else {
+            set_last_error("rift_intercept_add_rules: null handle or rules pointer");
+            return -1;
+        };
+        let parsed: RuleOrRules = match serde_json::from_str(rules_json) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("rift_intercept_add_rules: invalid rule JSON: {e}"));
+                return -1;
+            }
+        };
+        let slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        let Some(plane) = slot.as_ref() else {
+            set_last_error("rift_intercept_add_rules: intercept not started");
+            return -1;
+        };
+        match parsed {
+            RuleOrRules::One(rule) => plane.state.rules.add(rule),
+            RuleOrRules::Many(rules) => {
+                for rule in rules {
+                    plane.state.rules.add(rule);
+                }
+            }
+        }
+        0
+    }
+}
+
+/// Remove all intercept rules. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_intercept_clear_rules(h: *mut RiftHandle) -> i32 {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_intercept_clear_rules: null handle");
+            return -1;
+        };
+        let slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        let Some(plane) = slot.as_ref() else {
+            set_last_error("rift_intercept_clear_rules: intercept not started");
+            return -1;
+        };
+        plane.state.rules.clear();
+        0
+    }
+}
+
+/// List the current intercept rules as a JSON array the caller frees with [`rift_free`], or null
+/// on error (null handle, intercept not started, or encode failure).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_intercept_list_rules(h: *mut RiftHandle) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_intercept_list_rules: null handle");
+            return std::ptr::null_mut();
+        };
+        let slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        let Some(plane) = slot.as_ref() else {
+            set_last_error("rift_intercept_list_rules: intercept not started");
+            return std::ptr::null_mut();
+        };
+        match serde_json::to_string(&plane.state.rules.list()) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_intercept_list_rules: encode failed: {e}"));
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// The intercept CA certificate as PEM, the caller frees with [`rift_free`], or null on error
+/// (null handle, or intercept not started).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_intercept_ca_pem(h: *mut RiftHandle) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_intercept_ca_pem: null handle");
+            return std::ptr::null_mut();
+        };
+        let slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        let Some(plane) = slot.as_ref() else {
+            set_last_error("rift_intercept_ca_pem: intercept not started");
+            return std::ptr::null_mut();
+        };
+        into_c_string(ca_pem(&plane.state.ca))
+    }
+}
+
+/// Write a truststore for the intercept CA to `out_path` — a truststore is binary, so it is
+/// written to a file (the format a JVM `trustStore` consumes directly) rather than returned as a
+/// C string. `format` is `"pkcs12"` or `"jks"`; `password` may be null for the default
+/// `"changeit"`. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); the string pointers must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_intercept_export_truststore(
+    h: *mut RiftHandle,
+    format: *const c_char,
+    password: *const c_char,
+    out_path: *const c_char,
+) -> i32 {
+    unsafe {
+        clear_last_error();
+        let (Some(handle), Some(format), Some(out_path)) =
+            (handle(h), c_str(format), c_str(out_path))
+        else {
+            set_last_error("rift_intercept_export_truststore: null handle or string pointer");
+            return -1;
+        };
+        // Null password -> the default; a present-but-invalid one is an error, not a silent default.
+        let password = if password.is_null() {
+            "changeit"
+        } else {
+            match c_str(password) {
+                Some(p) => p,
+                None => {
+                    set_last_error("rift_intercept_export_truststore: password is not valid UTF-8");
+                    return -1;
+                }
+            }
+        };
+        let slot = handle.intercept.lock().expect("intercept mutex poisoned");
+        let Some(plane) = slot.as_ref() else {
+            set_last_error("rift_intercept_export_truststore: intercept not started");
+            return -1;
+        };
+        let pw = TrustStorePassword::new(password);
+        let bytes = match format {
+            "pkcs12" => export_pkcs12(&plane.state.ca, &pw),
+            "jks" => export_jks(&plane.state.ca, &pw),
+            other => {
+                set_last_error(format!(
+                    "rift_intercept_export_truststore: unknown format '{other}' (want pkcs12/jks)"
+                ));
+                return -1;
+            }
+        };
+        let bytes = match bytes {
+            Ok(b) => b,
+            Err(e) => {
+                set_last_error(format!(
+                    "rift_intercept_export_truststore: export failed: {e}"
+                ));
+                return -1;
+            }
+        };
+        match std::fs::write(out_path, bytes) {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!(
+                    "rift_intercept_export_truststore: writing {out_path}: {e}"
+                ));
+                warn!(error = %e, out_path, "rift_intercept_export_truststore: write failed");
+                -1
+            }
+        }
+    }
+}
+
 /// Start the real admin API (and, if `metricsPort` is given, the metrics server) in-process on
 /// this handle's runtime, serving over this handle's manager (issue #343).
 ///
@@ -880,14 +1188,23 @@ pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
             return;
         }
         let handle = Box::from_raw(h);
-        // Ordering (issue #343): admin/metrics listeners down first, then the manager.
+        // Ordering (issue #343/#410): admin/metrics + intercept listeners down first, then the
+        // manager.
         let plane = handle.admin.lock().expect("admin mutex poisoned").take();
+        let intercept = handle
+            .intercept
+            .lock()
+            .expect("intercept mutex poisoned")
+            .take();
         handle.runtime.block_on(async {
             if let Some(plane) = plane {
                 plane.admin.shutdown().await;
                 if let Some(metrics) = plane.metrics {
                     metrics.shutdown().await;
                 }
+            }
+            if let Some(intercept) = intercept {
+                intercept.listener.shutdown().await;
             }
             handle.manager.shutdown().await;
         });

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -918,3 +918,197 @@ fn ffi_admin_plane_error_paths() {
         rift_stop(h);
     }
 }
+
+/// Issue #410: the intercept listener + control plane entirely over FFI — start the listener,
+/// add serve + forward rules, fetch the CA, and drive an HTTPS client (trusting only that CA)
+/// through the intercept port to both a served stub and a forwarded FFI imposter.
+#[test]
+fn ffi_intercept_serve_and_forward() {
+    unsafe {
+        let h = rift_start();
+
+        // An FFI-created imposter is the target of the `forward` rule.
+        let upstream = cstr(
+            r#"{ "port": 19993, "protocol": "http",
+                 "stubs": [{ "responses": [{ "is": { "statusCode": 200, "body": "forwarded" } }] }] }"#,
+        );
+        assert_eq!(rift_create_imposter(h, upstream.as_ptr()), 19993);
+
+        // Start the intercept listener on an OS-assigned port; learn interceptPort.
+        let started = take_json(rift_start_intercept(h, cstr(r#"{"port":0}"#).as_ptr()));
+        let started: serde_json::Value = serde_json::from_str(&started).unwrap();
+        let intercept_port = started["interceptPort"].as_u64().expect("interceptPort") as u16;
+        assert!(intercept_port > 0);
+
+        // Fetch the CA (needed to trust the minted leaves).
+        let ca_pem = take_json(rift_intercept_ca_pem(h));
+        assert!(ca_pem.starts_with("-----BEGIN CERTIFICATE-----"));
+
+        // Add a serve rule and a forward rule over FFI (batch).
+        let rules = cstr(
+            r#"[ { "host": "cdn.example.com", "action": { "serve": { "statusCode": 418, "body": "served" } } },
+                 { "host": "fwd.example.com", "action": { "forward": { "port": 19993 } } } ]"#,
+        );
+        assert_eq!(rift_intercept_add_rules(h, rules.as_ptr()), 0);
+
+        // list reflects the added rules (Read completes the CRUD surface, all over FFI).
+        let listed: serde_json::Value =
+            serde_json::from_str(&take_json(rift_intercept_list_rules(h))).unwrap();
+        assert_eq!(
+            listed.as_array().unwrap().len(),
+            2,
+            "both rules are listed over FFI"
+        );
+
+        // Drive HTTPS through the intercept port with a client trusting only the intercept CA.
+        rt().block_on(async {
+            let client = reqwest::Client::builder()
+                .proxy(reqwest::Proxy::https(format!("http://127.0.0.1:{intercept_port}")).unwrap())
+                .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+                .build()
+                .unwrap();
+
+            let served = client
+                .get("https://cdn.example.com/x")
+                .send()
+                .await
+                .expect("served");
+            assert_eq!(served.status(), 418);
+            assert_eq!(served.text().await.unwrap(), "served");
+
+            let forwarded = client
+                .get("https://fwd.example.com/y")
+                .send()
+                .await
+                .expect("forwarded");
+            assert_eq!(forwarded.status(), 200);
+            assert_eq!(forwarded.text().await.unwrap(), "forwarded");
+        });
+
+        rift_stop(h);
+    }
+}
+
+/// Export a truststore over FFI to a temp path, assert success, and return the written bytes.
+unsafe fn export_truststore_bytes(
+    h: *mut RiftHandle,
+    format: &str,
+    password: *const c_char,
+) -> Vec<u8> {
+    unsafe {
+        let path_buf =
+            std::env::temp_dir().join(format!("rift410-{}-{format}.store", std::process::id()));
+        let path = cstr(path_buf.to_str().unwrap());
+        let fmt = cstr(format);
+        assert_eq!(
+            rift_intercept_export_truststore(h, fmt.as_ptr(), password, path.as_ptr()),
+            0,
+            "export {format} succeeds"
+        );
+        let bytes = std::fs::read(&path_buf).unwrap();
+        let _ = std::fs::remove_file(&path_buf);
+        bytes
+    }
+}
+
+/// Issue #410 (AC3): truststore export writes structurally-valid PKCS#12 and JKS for the CA,
+/// with the default and a caller-supplied password; an unknown format is rejected.
+#[test]
+fn ffi_intercept_truststore_export() {
+    unsafe {
+        let h = rift_start();
+        take_json(rift_start_intercept(h, std::ptr::null()));
+
+        // PKCS#12 (default password) is DER — starts with a SEQUENCE tag.
+        let p12 = export_truststore_bytes(h, "pkcs12", std::ptr::null());
+        assert_eq!(
+            p12.first(),
+            Some(&0x30),
+            "PKCS#12 begins with a DER SEQUENCE"
+        );
+
+        // JKS (a caller-supplied password) starts with the JKS magic 0xFEEDFEED.
+        let pw = cstr("hunter2");
+        let jks = export_truststore_bytes(h, "jks", pw.as_ptr());
+        assert_eq!(jks[..4], [0xFE, 0xED, 0xFE, 0xED], "JKS magic 0xFEEDFEED");
+
+        // An unknown format is a clear error, not a silent write.
+        let bad = cstr("pem");
+        let out = cstr(
+            std::env::temp_dir()
+                .join("rift410-unused")
+                .to_str()
+                .unwrap(),
+        );
+        assert_eq!(
+            rift_intercept_export_truststore(h, bad.as_ptr(), std::ptr::null(), out.as_ptr()),
+            -1,
+            "unknown truststore format -> -1"
+        );
+
+        assert_eq!(rift_intercept_clear_rules(h), 0);
+        rift_stop(h);
+    }
+}
+
+/// Issue #410 (AC4): rift_stop shuts the intercept listener down and frees its port (no orphan),
+/// and the start response's interceptUrl matches the bound port (AC1).
+#[test]
+fn ffi_stop_shuts_down_intercept() {
+    unsafe {
+        let h = rift_start();
+        let started: serde_json::Value =
+            serde_json::from_str(&take_json(rift_start_intercept(h, std::ptr::null()))).unwrap();
+        let port = started["interceptPort"].as_u64().unwrap() as u16;
+        assert_eq!(
+            started["interceptUrl"].as_str().unwrap(),
+            format!("http://127.0.0.1:{port}")
+        );
+        rift_stop(h);
+        assert!(
+            rt().block_on(admin_refused(port)),
+            "intercept port is freed after rift_stop (no orphaned listener)"
+        );
+    }
+}
+
+/// Issue #410: opt-in — a handle that never started intercept rejects control calls (not started),
+/// and the data plane is unaffected.
+#[test]
+fn ffi_intercept_optin_not_started() {
+    unsafe {
+        let h = rift_start();
+        assert!(
+            rift_intercept_ca_pem(h).is_null(),
+            "ca_pem before start -> null"
+        );
+        assert!(
+            rift_intercept_list_rules(h).is_null(),
+            "list before start -> null"
+        );
+        assert_eq!(
+            rift_intercept_add_rules(h, cstr("[]").as_ptr()),
+            -1,
+            "add_rules before start -> -1"
+        );
+        assert_eq!(rift_intercept_clear_rules(h), -1);
+        let out = cstr("/tmp/rift410-never");
+        assert_eq!(
+            rift_intercept_export_truststore(
+                h,
+                cstr("jks").as_ptr(),
+                std::ptr::null(),
+                out.as_ptr()
+            ),
+            -1,
+            "export before start -> -1"
+        );
+        let last = rift_last_error();
+        assert!(!last.is_null(), "not-started failure records last_error");
+        rift_free(last);
+        // Data plane still works with intercept never started.
+        let cfg = cstr(r#"{ "port": 19994, "protocol": "http", "stubs": [] }"#);
+        assert_eq!(rift_create_imposter(h, cfg.as_ptr()), 19994);
+        rift_stop(h);
+    }
+}

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -89,6 +89,27 @@ rift_free(result);
 - **Returns** (caller frees): `{"adminPort":...,"adminUrl":"...","metricsPort":...}`, or `NULL` on
   error (bad JSON, bind failure, or already serving — one admin plane per handle).
 
+## Intercept proxy over FFI
+
+Start the [intercept/TLS-MITM proxy]({{ site.baseurl }}/features/intercept-proxy/) on the handle and
+drive its whole control plane over C-ABI — no in-process admin HTTP needed. One intercept listener
+per handle; `rift_stop` shuts it down.
+
+| Function | Signature | Returns |
+|---|---|---|
+| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, already started). Generates an intercept CA. `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. |
+| `rift_intercept_add_rules` | `int rift_intercept_add_rules(RiftHandle* h, const char* rules_json)` | `0`/`-1`. One rule (object) or many (array), same shape as `/intercept/rules`. |
+| `rift_intercept_list_rules` | `char* rift_intercept_list_rules(RiftHandle* h)` | The current rules as a JSON array (**caller frees**), or `NULL` on error. |
+| `rift_intercept_clear_rules` | `int rift_intercept_clear_rules(RiftHandle* h)` | `0`/`-1`. |
+| `rift_intercept_ca_pem` | `char* rift_intercept_ca_pem(RiftHandle* h)` | The CA cert PEM (**caller frees**), or `NULL` on error. |
+| `rift_intercept_export_truststore` | `int rift_intercept_export_truststore(RiftHandle* h, const char* format, const char* password, const char* out_path)` | Writes a truststore to `out_path` (`format` = `"pkcs12"`/`"jks"`, `password` may be `NULL` → `"changeit"`). `0`/`-1`. A truststore is binary, so it is written to a file — the form a JVM `trustStore` consumes directly. |
+
+An embedder calls `rift_start_intercept`, reads `interceptPort`, adds rules and fetches the CA /
+truststore (all over FFI), then points a CA-trusting SUT's HTTPS proxy at `interceptPort` — with no
+loopback HTTP. `Forward { port }` rules reach any imposter on that localhost port, including
+FFI-created ones. Errors set `rift_last_error`. A handle that never calls `rift_start_intercept` is
+unaffected.
+
 ## Build identity
 
 `rift_build_info` is a **static** JSON string (never freed) — probe it to detect a v2 library and read


### PR DESCRIPTION
Exposes FFI functions for starting the intercept proxy and managing its rules, CA certificate, and truststore export — no loopback HTTP required for embedded consumers.

The FFI half of epic #394 that unblocks zio-bdd#219.

Closes #410