### PR TITLE
feat(ffi): give rift_flow_state_get an unambiguous 'not found' signal

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -71,14 +71,19 @@ int32_t rift_delete_imposter(RiftHandle *h, uint16_t port);
 char *rift_recorded(RiftHandle *h, uint16_t port);
 
 /**
- * Get a scenario/flow-state value as JSON `{"flowId","key","value"}` the caller frees with
- * [`rift_free`]. Returns null if the handle/port is unknown, the key is absent, or encoding
- * fails (reason in `rift_last_error`).
+ * Get a scenario/flow-state value as a JSON envelope `{"found","flowId","key","value"}` the caller
+ * frees with [`rift_free`]. `found` disambiguates an absent key from a failure: a missing key is a
+ * non-error outcome (`{"found":false,"value":null}`), while a null pointer is returned **only** on a
+ * genuine error (unknown handle/port or encode failure, reason in `rift_last_error`) — matching
+ * [`rift_recorded`] and the rc-returning calls, where null/`-1` means error alone.
  *
  * # Safety
  * `h` must be a live handle (or null); `flow_id`/`key` must be null or valid C strings.
  */
-char *rift_flow_state_get(RiftHandle *h, uint16_t port, const char *flow_id, const char *key);
+char *rift_flow_state_get(RiftHandle *h,
+                          uint16_t port,
+                          const char *flow_id,
+                          const char *key);
 
 /**
  * Set a scenario/flow-state value from a bare JSON value (`value_json`). Returns `0` on success,

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -112,11 +112,18 @@ unsafe fn c_str<'a>(p: *const c_char) -> Option<&'a str> {
 }
 
 /// Move a `String` across the boundary as an owned `*mut c_char` the caller frees with
-/// [`rift_free`]. Returns null if the string contains an interior NUL.
+/// [`rift_free`]. Returns null if the string contains an interior NUL, recording the reason in
+/// `rift_last_error` so a null return always carries a diagnostic — the contract every
+/// string-returning entry point advertises (null means error, reason in `rift_last_error`).
 fn into_c_string(s: String) -> *mut c_char {
     match CString::new(s) {
         Ok(c) => c.into_raw(),
-        Err(_) => std::ptr::null_mut(),
+        Err(e) => {
+            set_last_error(format!(
+                "internal error: response contained an interior NUL byte ({e})"
+            ));
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -318,9 +325,11 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
 // and returns the same JSON, so an embedder can drive scenario state and correlated spaces with
 // zero loopback HTTP (no `rift_serve_admin` needed).
 
-/// Get a scenario/flow-state value as JSON `{"flowId","key","value"}` the caller frees with
-/// [`rift_free`]. Returns null if the handle/port is unknown, the key is absent, or encoding
-/// fails (reason in `rift_last_error`).
+/// Get a scenario/flow-state value as a JSON envelope `{"found","flowId","key","value"}` the caller
+/// frees with [`rift_free`]. `found` disambiguates an absent key from a failure: a missing key is a
+/// non-error outcome (`{"found":false,"value":null}`), while a null pointer is returned **only** on a
+/// genuine error (unknown handle/port or encode failure, reason in `rift_last_error`) — matching
+/// [`rift_recorded`] and the rc-returning calls, where null/`-1` means error alone.
 ///
 /// # Safety
 /// `h` must be a live handle (or null); `flow_id`/`key` must be null or valid C strings.
@@ -346,13 +355,12 @@ pub unsafe extern "C" fn rift_flow_state_get(
             }
         };
         match imposter.flow_get(flow_id, key) {
-            Ok(Some(value)) => {
-                into_c_string(json!({ "flowId": flow_id, "key": key, "value": value }).to_string())
-            }
-            Ok(None) => {
-                set_last_error("rift_flow_state_get: flow-state key not found");
-                std::ptr::null_mut()
-            }
+            // An absent key is a first-class result (`found:false`), not an error — `value` is a
+            // bare JSON value or null (an `Option<Value>` serializes to the value or JSON null).
+            Ok(value) => into_c_string(
+                json!({ "found": value.is_some(), "flowId": flow_id, "key": key, "value": value })
+                    .to_string(),
+            ),
             Err(e) => {
                 set_last_error(format!("rift_flow_state_get: {e}"));
                 warn!(error = %e, port, "rift_flow_state_get failed");

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -788,6 +788,7 @@ fn ffi_admin_plane_round_trip() {
             key.as_ptr(),
         )))
         .unwrap();
+        assert_eq!(got["found"], true);
         assert_eq!(got["flowId"], "flow-1");
         assert_eq!(got["key"], "state");
         assert_eq!(got["value"], "paid");
@@ -795,10 +796,18 @@ fn ffi_admin_plane_round_trip() {
             rift_flow_state_delete(h, port, flow.as_ptr(), key.as_ptr()),
             0
         );
-        assert!(
-            rift_flow_state_get(h, port, flow.as_ptr(), key.as_ptr()).is_null(),
-            "get after delete returns null (not found)"
+        let after_del: serde_json::Value = serde_json::from_str(&take_json(rift_flow_state_get(
+            h,
+            port,
+            flow.as_ptr(),
+            key.as_ptr(),
+        )))
+        .unwrap();
+        assert_eq!(
+            after_del["found"], false,
+            "get after delete -> found:false (absent), not a null/error"
         );
+        assert!(after_del["value"].is_null());
 
         // --- correlated space stubs: add -> list ({space,stubs}) -> delete -> list(empty) ---
         let space = cstr("space-a");
@@ -915,6 +924,92 @@ fn ffi_admin_plane_error_paths() {
         let err2 = rift_last_error();
         assert!(!err2.is_null(), "unknown-port failure records last_error");
         rift_free(err2);
+        rift_stop(h);
+    }
+}
+
+/// Issue #415: `rift_flow_state_get` gives an unambiguous "not found" signal — an absent key is a
+/// first-class value (`{"found":false}`), distinct from a genuine error (null pointer). Covers all
+/// three outcomes without parsing `rift_last_error`.
+#[test]
+fn ffi_flow_state_get_absent_vs_error() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null());
+        let config = cstr(
+            r#"{ "port": 19994, "protocol": "http",
+                 "_rift": { "flowState": { "backend": "inmemory" } }, "stubs": [] }"#,
+        );
+        let port = rift_create_imposter(h, config.as_ptr());
+        assert_eq!(port, 19994);
+
+        let flow = cstr("flow-x");
+        let present = cstr("present");
+        let absent = cstr("absent");
+        let val = cstr(r#""ready""#);
+
+        // present key -> found:true carrying the value.
+        assert_eq!(
+            rift_flow_state_put(h, port, flow.as_ptr(), present.as_ptr(), val.as_ptr()),
+            0
+        );
+        let hit: serde_json::Value = serde_json::from_str(&take_json(rift_flow_state_get(
+            h,
+            port,
+            flow.as_ptr(),
+            present.as_ptr(),
+        )))
+        .unwrap();
+        assert_eq!(hit["found"], true);
+        assert_eq!(hit["value"], "ready");
+
+        // a *stored* JSON null is found:true with value null — distinct from an absent key. This is
+        // the exact ambiguity the `found` field exists to resolve.
+        let null_key = cstr("null-value");
+        assert_eq!(
+            rift_flow_state_put(
+                h,
+                port,
+                flow.as_ptr(),
+                null_key.as_ptr(),
+                cstr("null").as_ptr()
+            ),
+            0
+        );
+        let stored_null: serde_json::Value = serde_json::from_str(&take_json(rift_flow_state_get(
+            h,
+            port,
+            flow.as_ptr(),
+            null_key.as_ptr(),
+        )))
+        .unwrap();
+        assert_eq!(
+            stored_null["found"], true,
+            "a stored null is present, not absent"
+        );
+        assert!(stored_null["value"].is_null());
+
+        // absent key -> found:false, value null, and NOT an error (no null pointer, last_error clear).
+        let ptr = rift_flow_state_get(h, port, flow.as_ptr(), absent.as_ptr());
+        assert!(!ptr.is_null(), "an absent key is a value, not a null/error");
+        let miss: serde_json::Value = serde_json::from_str(&take_json(ptr)).unwrap();
+        assert_eq!(miss["found"], false);
+        assert!(miss["value"].is_null());
+        assert!(
+            rift_last_error().is_null(),
+            "an absent key must not record last_error"
+        );
+
+        // bad port -> genuine error -> null pointer, and last_error recorded.
+        assert!(
+            rift_flow_state_get(h, 65001, flow.as_ptr(), absent.as_ptr()).is_null(),
+            "an unknown port is a genuine error -> null"
+        );
+        let err = rift_last_error();
+        assert!(!err.is_null(), "the error path records last_error");
+        rift_free(err);
+
+        assert_eq!(rift_delete_all(h), 0);
         rift_stop(h);
     }
 }

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -53,7 +53,7 @@ Each mirrors the corresponding admin-HTTP handler exactly (same `ImposterManager
 
 | Function | Signature | Returns |
 |---|---|---|
-| `rift_flow_state_get` | `char* rift_flow_state_get(RiftHandle* h, uint16_t port, const char* flow_id, const char* key)` | JSON `{"flowId","key","value"}` (**caller frees**), or `NULL` if unknown/absent. |
+| `rift_flow_state_get` | `char* rift_flow_state_get(RiftHandle* h, uint16_t port, const char* flow_id, const char* key)` | JSON envelope `{"found","flowId","key","value"}` (**caller frees**); `found:false` (with `value:null`) is an absent key, `NULL` is returned **only** on error. |
 | `rift_flow_state_put` | `int rift_flow_state_put(RiftHandle* h, uint16_t port, const char* flow_id, const char* key, const char* value_json)` | `0` on success, `-1` on error. `value_json` is the bare JSON value. |
 | `rift_flow_state_delete` | `int rift_flow_state_delete(RiftHandle* h, uint16_t port, const char* flow_id, const char* key)` | `0` on success, `-1` on error. |
 | `rift_space_add_stub` | `int rift_space_add_stub(RiftHandle* h, uint16_t port, const char* flow_id, const char* stub_json)` | `0` on success, `-1` on error. The stub's `space` is set from `flow_id`. |
@@ -61,9 +61,10 @@ Each mirrors the corresponding admin-HTTP handler exactly (same `ImposterManager
 | `rift_space_delete` | `int rift_space_delete(RiftHandle* h, uint16_t port, const char* flow_id)` | `0` on success, `-1` on error. One-call per-space teardown (scoped stubs + recorded + scenario state). |
 | `rift_space_recorded` | `char* rift_space_recorded(RiftHandle* h, uint16_t port, const char* flow_id)` | The requests recorded for that space (header-filtered `received`) as a JSON array (**caller frees**), or `NULL` on error. |
 
-`rift_flow_state_get` returns `NULL` both when the key is absent and on error — check
-`rift_last_error` (it reads `flow-state key not found` for a genuine absence) before treating a
-`NULL` as "unset".
+`rift_flow_state_get` never conflates "absent" with "failed": an absent key returns the envelope
+with `found:false` (a normal outcome, `rift_last_error` untouched), and `NULL` is reserved strictly
+for a genuine error — so a consumer treats `found:false` as "unset" and `NULL` as a read failure,
+with no need to parse `rift_last_error`.
 
 Errors set `rift_last_error` like the data-plane functions. Together with the data plane
 (`rift_create_imposter`/`rift_replace_stubs`/`rift_recorded`/`rift_delete_imposter`), these cover the


### PR DESCRIPTION
The call previously returned null for BOTH an absent key and a genuine error, making it impossible for FFI consumers to distinguish "not found" from "call failed" without parsing free-text rift_last_error. 

It now returns a JSON envelope {found,flowId,key,value} (found:false = absent) and reserves null strictly for errors, matching rift_recorded. into_c_string now records last_error on failure to guarantee the null-implies-last_error contract for every string-returning entry point. cbindgen header and docs/embedding/ffi.md regenerated.

Closes #415
Milestone: MockControl SPI / embedded (FFI ergonomics follow-up to #412)