### PR TITLE
fix(ffi): interceptUrl reflects the actual bind host, not hardcoded 127.0.0.1

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -148,10 +148,12 @@ char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
 
 /**
  * Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
- * intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://127.0.0.1:<port>"}`
+ * intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}`
  * the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
- * started — one listener per handle). `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 =
- * OS-assigned); pass null or `{}` for defaults.
+ * started — one listener per handle). `interceptUrl` reflects the bound address (the configured
+ * `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so dial a concrete interface).
+ * `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); pass null or `{}` for
+ * defaults.
  *
  * # Safety
  * `h` must be a live handle (or null); `options_json` must be null or a valid C string.

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -617,10 +617,12 @@ enum RuleOrRules {
 }
 
 /// Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
-/// intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://127.0.0.1:<port>"}`
+/// intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}`
 /// the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
-/// started — one listener per handle). `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 =
-/// OS-assigned); pass null or `{}` for defaults.
+/// started — one listener per handle). `interceptUrl` reflects the bound address (the configured
+/// `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so dial a concrete interface).
+/// `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); pass null or `{}` for
+/// defaults.
 ///
 /// # Safety
 /// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
@@ -693,10 +695,12 @@ pub unsafe extern "C" fn rift_start_intercept(
                     return std::ptr::null_mut();
                 }
             };
-        let intercept_port = listener.local_addr().port();
+        // Derive both fields from the real bound address so the URL reflects the actual host
+        // (and OS-assigned port), not a hardcoded loopback.
+        let local_addr = listener.local_addr();
         let response = json!({
-            "interceptPort": intercept_port,
-            "interceptUrl": format!("http://127.0.0.1:{intercept_port}"),
+            "interceptPort": local_addr.port(),
+            "interceptUrl": format!("http://{local_addr}"),
         })
         .to_string();
         *slot = Some(InterceptPlane {

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1167,6 +1167,43 @@ fn ffi_stop_shuts_down_intercept() {
     }
 }
 
+/// Issue #425: the start response's interceptUrl reflects the ACTUAL bound host, not a hardcoded
+/// 127.0.0.1. A non-loopback bind (0.0.0.0) must surface as the bound address; the loopback default
+/// is unchanged.
+#[test]
+fn ffi_intercept_url_reflects_bind_host() {
+    unsafe {
+        // Non-loopback bind (0.0.0.0 wildcard, OS-assigned port) -> URL reflects the bound host.
+        let h = rift_start();
+        let started: serde_json::Value = serde_json::from_str(&take_json(rift_start_intercept(
+            h,
+            cstr(r#"{"host":"0.0.0.0","port":0}"#).as_ptr(),
+        )))
+        .unwrap();
+        let port = started["interceptPort"].as_u64().expect("interceptPort");
+        assert!(port > 0, "OS-assigned port is surfaced");
+        assert_eq!(
+            started["interceptUrl"].as_str().expect("interceptUrl"),
+            format!("http://0.0.0.0:{port}"),
+            "interceptUrl reflects the bound host, not a hardcoded 127.0.0.1"
+        );
+        rift_stop(h);
+
+        // Loopback default (AC2) is unchanged.
+        let h2 = rift_start();
+        let d: serde_json::Value =
+            serde_json::from_str(&take_json(rift_start_intercept(h2, cstr("{}").as_ptr())))
+                .unwrap();
+        let p2 = d["interceptPort"].as_u64().expect("interceptPort");
+        assert_eq!(
+            d["interceptUrl"].as_str().unwrap(),
+            format!("http://127.0.0.1:{p2}"),
+            "loopback default unchanged"
+        );
+        rift_stop(h2);
+    }
+}
+
 /// Issue #410: opt-in — a handle that never started intercept rejects control calls (not started),
 /// and the data plane is unaffected.
 #[test]


### PR DESCRIPTION
rift_start_intercept honored a caller-supplied bind host but always returned interceptUrl as http://127.0.0.1:{port}, misreporting the endpoint as loopback for a non-loopback bind. Derive both interceptPort and interceptUrl from listener.local_addr() so the returned URL reflects the real bound address and OS-assigned port.

Closes #425

Standalone FFI fix (no milestone).