### PR TITLE
ci: run Homebrew formula update automatically on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,3 +582,20 @@ jobs:
     with:
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     secrets: inherit
+
+  # =============================================================================
+  # Update Homebrew formula
+  # =============================================================================
+  # Invoked here (not via update-homebrew.yml's `release:` trigger) because a release created by
+  # this workflow's GITHUB_TOKEN does not emit `release: published`. Runs after `release` so the
+  # tap formula points at assets that already exist.
+  publish-homebrew:
+    name: Update Homebrew Formula
+    needs: release
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    permissions:
+      contents: read
+    uses: ./.github/workflows/update-homebrew.yml
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -9,9 +9,19 @@
 name: Update Homebrew Formula
 
 on:
+  # Note: a release created by release.yml's default GITHUB_TOKEN does NOT emit the
+  # `release: published` event (GitHub suppresses it to prevent workflow recursion), so this
+  # trigger only fires for a release published manually via the web UI. The reliable path is the
+  # `workflow_call` below, invoked by release.yml after the release job uploads the assets.
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.1.0)'
+        required: true
+        type: string
+  workflow_call:
     inputs:
       tag:
         description: 'Release tag (e.g., v0.1.0)'
@@ -30,7 +40,9 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # `inputs.tag` is set for both workflow_dispatch and workflow_call; for a manual
+          # web-UI release publish there is no input, so fall back to the release payload's tag.
+          if [ -n "${{ inputs.tag }}" ]; then
             VERSION="${{ inputs.tag }}"
           else
             VERSION="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Problem

The Homebrew tap (`EtaCassiopeia/homebrew-rift`) was not updated automatically by any release. `update-homebrew.yml` triggers on `release: published`, but a release created by `release.yml`'s default `GITHUB_TOKEN` does **not** emit that event (GitHub suppresses it to prevent workflow recursion). Result: the workflow had **zero run history** and the tap had to be bumped manually with `gh workflow run update-homebrew.yml -f tag=vX.Y.Z` after every release (as just happened for 0.11.1/0.11.2).

## Fix

Wire it the same way `docker-publish` is already wired:
- `update-homebrew.yml` gains a `workflow_call` trigger (keeps `workflow_dispatch` and the `release:` trigger for manual web-UI publishes).
- `release.yml` gains a `publish-homebrew` job (`needs: release`, `uses: ./.github/workflows/update-homebrew.yml`, `secrets: inherit`) that runs after assets are uploaded.
- The version step now reads `inputs.tag` (set for both `workflow_call` and `workflow_dispatch`) and falls back to the release payload tag for a manual UI publish — necessary because under `workflow_call` `github.event_name` is the caller's `push`.

No double-run: the `GITHUB_TOKEN`-created release still emits no event, so only the `workflow_call` path fires on a normal tag-push release.

Milestone: none (release automation fix).