### PR TITLE
rift-ffi: rift_start_intercept should accept a caller-provided CA (caCertPath/caKeyPath), not only generate one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,6 +3424,7 @@ dependencies = [
 name = "rift-ffi"
 version = "0.1.0"
 dependencies = [
+ "rcgen",
  "reqwest",
  "rift-core",
  "rift-http-proxy",

--- a/crates/rift-core/src/proxy/intercept_ca.rs
+++ b/crates/rift-core/src/proxy/intercept_ca.rs
@@ -9,8 +9,10 @@
 //! `rift-http-proxy` crate.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use anyhow::Context;
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
     KeyPair, KeyUsagePurpose,
@@ -90,6 +92,30 @@ impl CertificateAuthority {
             cert_pem: cert_pem.to_string(),
             cert_der,
         })
+    }
+
+    /// Load the CA from PEM files when both paths are supplied, generate a fresh one when neither
+    /// is, and reject a half-configured pair (both-or-neither). This is the single implementation
+    /// shared by the container adapter (`--intercept-ca-cert`/`--intercept-ca-key`) and the
+    /// embedded FFI (`caCertPath`/`caKeyPath`), so both surfaces agree on load-or-generate
+    /// semantics and error.
+    pub fn load_or_generate(
+        cert_path: Option<&Path>,
+        key_path: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        match (cert_path, key_path) {
+            (Some(cert), Some(key)) => {
+                let cert_pem = std::fs::read_to_string(cert)
+                    .with_context(|| format!("reading intercept CA cert {}", cert.display()))?;
+                let key_pem = std::fs::read_to_string(key)
+                    .with_context(|| format!("reading intercept CA key {}", key.display()))?;
+                Self::load_pem(&cert_pem, &key_pem)
+            }
+            (None, None) => Self::generate(),
+            _ => anyhow::bail!(
+                "intercept CA cert and key must be provided together (or both omitted to generate a CA)"
+            ),
+        }
     }
 
     /// The CA certificate as PEM.

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -36,6 +36,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true
+# Mint a committed CA (cert+key PEM) on disk in the intercept CA-reuse gate test (issue #429).
+rcgen = "0.13"
 
 [features]
 default = ["redis-backend", "lua", "javascript"]

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -147,13 +147,16 @@ int32_t rift_space_delete(RiftHandle *h, uint16_t port, const char *flow_id);
 char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
 
 /**
- * Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
- * intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}`
- * the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
- * started — one listener per handle). `interceptUrl` reflects the bound address (the configured
- * `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so dial a concrete interface).
- * `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); pass null or `{}` for
- * defaults.
+ * Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime. The intercept CA
+ * is loaded from `caCertPath`/`caKeyPath` when both are supplied (letting independent instances
+ * share a committed trust anchor), and generated fresh otherwise. Returns JSON
+ * `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}` the caller frees with
+ * [`rift_free`], or null on error (bad JSON, half-configured CA pair, CA load failure, bind
+ * failure, or already started — one listener per handle). `interceptUrl` reflects the bound
+ * address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
+ * dial a concrete interface). `options_json`:
+ * `{"host":"127.0.0.1","port":0,"caCertPath":"ca.pem","caKeyPath":"ca.key"}` (port 0 =
+ * OS-assigned; CA paths optional, both-or-neither); pass null or `{}` for defaults.
  *
  * # Safety
  * `h` must be a live handle (or null); `options_json` must be null or a valid C string.

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -40,7 +40,7 @@ use serde_json::{Value, json};
 use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_char};
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
 use tracing::warn;
@@ -600,12 +600,17 @@ pub unsafe extern "C" fn rift_space_recorded(
 // Start an intercept forward-proxy on the handle's runtime and drive its rule store + CA export
 // entirely over C-ABI — no loopback HTTP admin plane needed. One listener per handle.
 
-/// `rift_start_intercept` options (all optional): the bind host and port.
+/// `rift_start_intercept` options (all optional): the bind host and port, plus an optional
+/// caller-provided intercept CA (`caCertPath`/`caKeyPath`, PEM file paths — both or neither).
+/// `deny_unknown_fields` so a misspelled key (e.g. `caCertpath`) is a hard error, not a silent
+/// fallback to a fresh ephemeral CA that would defeat the caller's intended CA reuse.
 #[derive(serde::Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct InterceptOptions {
     host: Option<String>,
     port: Option<u16>,
+    ca_cert_path: Option<String>,
+    ca_key_path: Option<String>,
 }
 
 /// A single rule or a batch — `rift_intercept_add_rules` accepts either shape.
@@ -616,13 +621,16 @@ enum RuleOrRules {
     Many(Vec<InterceptRule>),
 }
 
-/// Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime, generating an
-/// intercept CA. Returns JSON `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}`
-/// the caller frees with [`rift_free`], or null on error (bad JSON, bind failure, or already
-/// started — one listener per handle). `interceptUrl` reflects the bound address (the configured
-/// `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so dial a concrete interface).
-/// `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); pass null or `{}` for
-/// defaults.
+/// Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime. The intercept CA
+/// is loaded from `caCertPath`/`caKeyPath` when both are supplied (letting independent instances
+/// share a committed trust anchor), and generated fresh otherwise. Returns JSON
+/// `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}` the caller frees with
+/// [`rift_free`], or null on error (bad JSON, half-configured CA pair, CA load failure, bind
+/// failure, or already started — one listener per handle). `interceptUrl` reflects the bound
+/// address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
+/// dial a concrete interface). `options_json`:
+/// `{"host":"127.0.0.1","port":0,"caCertPath":"ca.pem","caKeyPath":"ca.key"}` (port 0 =
+/// OS-assigned; CA paths optional, both-or-neither); pass null or `{}` for defaults.
 ///
 /// # Safety
 /// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
@@ -674,10 +682,16 @@ pub unsafe extern "C" fn rift_start_intercept(
                 return std::ptr::null_mut();
             }
         };
-        let ca = match CertificateAuthority::generate() {
+        let ca = match CertificateAuthority::load_or_generate(
+            opts.ca_cert_path.as_deref().map(Path::new),
+            opts.ca_key_path.as_deref().map(Path::new),
+        ) {
             Ok(ca) => Arc::new(ca),
             Err(e) => {
-                set_last_error(format!("rift_start_intercept: CA generation failed: {e}"));
+                // `{e:#}` so the chained cause (missing file, bad PEM, mismatched pair) reaches the
+                // caller — `rift_last_error` is their only diagnostic channel.
+                set_last_error(format!("rift_start_intercept: CA setup failed: {e:#}"));
+                warn!(error = %e, "rift_start_intercept: CA setup failed");
                 return std::ptr::null_mut();
             }
         };

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1244,3 +1244,150 @@ fn ffi_intercept_optin_not_started() {
         rift_stop(h);
     }
 }
+
+/// Mint a committed CA (cert + key PEM) to two temp files and return their paths, mirroring the
+/// certificate shape `CertificateAuthority::generate()` produces so loaded leaves validate.
+fn write_committed_ca(tag: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
+    let key = KeyPair::generate().expect("generate CA key");
+    let mut params = CertificateParams::new(Vec::<String>::new()).expect("CA params");
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Rift Test Committed CA");
+    let cert = params.self_signed(&key).expect("self-sign CA");
+    let dir = std::env::temp_dir();
+    let cert_path = dir.join(format!("rift429-{}-{tag}-ca.pem", std::process::id()));
+    let key_path = dir.join(format!("rift429-{}-{tag}-ca.key", std::process::id()));
+    std::fs::write(&cert_path, cert.pem()).expect("write CA cert");
+    std::fs::write(&key_path, key.serialize_pem()).expect("write CA key");
+    (cert_path, key_path)
+}
+
+/// Issue #429 (AC1/AC4): two `rift_start_intercept` instances started with the SAME committed CA
+/// present mutually-trusted leaves — a truststore holding instance A's exported CA validates the
+/// TLS instance B intercepts. Both instances expose the committed CA verbatim (loaded, not
+/// regenerated).
+#[test]
+fn ffi_intercept_reuses_committed_ca() {
+    unsafe {
+        let (cert_path, key_path) = write_committed_ca("reuse");
+        let committed = std::fs::read_to_string(&cert_path).unwrap();
+
+        let opts = serde_json::json!({
+            "port": 0,
+            "caCertPath": cert_path.to_str().unwrap(),
+            "caKeyPath": key_path.to_str().unwrap(),
+        })
+        .to_string();
+
+        // Instance A and instance B both load the same committed CA.
+        let ha = rift_start();
+        take_json(rift_start_intercept(ha, cstr(&opts).as_ptr()));
+        let hb = rift_start();
+        let started_b: serde_json::Value =
+            serde_json::from_str(&take_json(rift_start_intercept(hb, cstr(&opts).as_ptr())))
+                .unwrap();
+        let port_b = started_b["interceptPort"].as_u64().expect("interceptPort") as u16;
+
+        // Both expose the committed CA verbatim — loaded, not regenerated.
+        let ca_a = take_json(rift_intercept_ca_pem(ha));
+        let ca_b = take_json(rift_intercept_ca_pem(hb));
+        assert_eq!(ca_a, ca_b, "both instances expose the same CA");
+        assert_eq!(
+            ca_a.trim(),
+            committed.trim(),
+            "instance A exposes the committed CA, not a fresh one"
+        );
+
+        // Instance B intercepts and serves a host.
+        let rules = cstr(
+            r#"[{ "host": "reuse.example.com",
+                  "action": { "serve": { "statusCode": 200, "body": "served-by-b" } } }]"#,
+        );
+        assert_eq!(rift_intercept_add_rules(hb, rules.as_ptr()), 0);
+
+        // A client trusting ONLY instance A's exported CA validates instance B's intercepted TLS —
+        // proving the committed CA is a shared trust anchor across independent instances.
+        rt().block_on(async {
+            let client = reqwest::Client::builder()
+                .proxy(reqwest::Proxy::https(format!("http://127.0.0.1:{port_b}")).unwrap())
+                .add_root_certificate(reqwest::Certificate::from_pem(ca_a.as_bytes()).unwrap())
+                .build()
+                .unwrap();
+            let resp = client
+                .get("https://reuse.example.com/x")
+                .send()
+                .await
+                .expect("A's truststore validates B's intercepted leaf");
+            assert_eq!(resp.status(), 200);
+            assert_eq!(resp.text().await.unwrap(), "served-by-b");
+        });
+
+        rift_stop(ha);
+        rift_stop(hb);
+        let _ = std::fs::remove_file(&cert_path);
+        let _ = std::fs::remove_file(&key_path);
+    }
+}
+
+/// Read and free `rift_last_error`, asserting it is present.
+unsafe fn take_last_error() -> String {
+    unsafe {
+        let p = rift_last_error();
+        assert!(!p.is_null(), "expected a recorded last_error");
+        let s = CStr::from_ptr(p).to_str().expect("utf8").to_owned();
+        rift_free(p);
+        s
+    }
+}
+
+/// Issue #429 (AC2): a half-configured CA pair is rejected — in either direction — with a clear
+/// both-or-neither error rather than silently generating an ephemeral CA.
+#[test]
+fn ffi_intercept_ca_both_or_neither() {
+    unsafe {
+        // caCertPath without caKeyPath.
+        let h = rift_start();
+        let cert_only = serde_json::json!({ "port": 0, "caCertPath": "/nonexistent/ca.pem" });
+        assert!(
+            rift_start_intercept(h, cstr(&cert_only.to_string()).as_ptr()).is_null(),
+            "caCertPath alone -> rejected, not a silent ephemeral CA"
+        );
+        assert!(
+            take_last_error().contains("provided together"),
+            "the error names the both-or-neither rule"
+        );
+
+        // caKeyPath without caCertPath (the mirror direction).
+        let key_only = serde_json::json!({ "port": 0, "caKeyPath": "/nonexistent/ca.key" });
+        assert!(
+            rift_start_intercept(h, cstr(&key_only.to_string()).as_ptr()).is_null(),
+            "caKeyPath alone -> rejected"
+        );
+        assert!(take_last_error().contains("provided together"));
+
+        rift_stop(h);
+    }
+}
+
+/// Issue #429: a misspelled CA option key is a hard error (deny_unknown_fields), never a silent
+/// fallback to a fresh ephemeral CA that would quietly defeat the caller's intended CA reuse.
+#[test]
+fn ffi_intercept_rejects_unknown_ca_option() {
+    unsafe {
+        let h = rift_start();
+        let typo = serde_json::json!({ "port": 0, "caCertpath": "/some/ca.pem" });
+        assert!(
+            rift_start_intercept(h, cstr(&typo.to_string()).as_ptr()).is_null(),
+            "a typo'd CA option key is rejected, not silently ignored"
+        );
+        assert!(!take_last_error().is_empty(), "records why it was rejected");
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -10,7 +10,6 @@ use crate::extensions::metrics;
 use crate::imposter::{ImposterConfig, ImposterManager, TlsDefaults};
 use crate::intercept::InterceptListener;
 use crate::intercept_rules::{InterceptRules, InterceptState};
-use anyhow::Context;
 use clap::{Parser, Subcommand};
 use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
 use std::net::SocketAddr;
@@ -310,9 +309,9 @@ impl ServerBuilder {
         // the admin server so `/intercept/*` verbs configure the same listener.
         let intercept = match cli.intercept_port {
             Some(intercept_port) => {
-                let ca = Arc::new(load_or_generate_ca(
-                    cli.intercept_ca_cert.as_ref(),
-                    cli.intercept_ca_key.as_ref(),
+                let ca = Arc::new(CertificateAuthority::load_or_generate(
+                    cli.intercept_ca_cert.as_deref(),
+                    cli.intercept_ca_key.as_deref(),
                 )?);
                 let rules = InterceptRules::new();
                 server = server.with_intercept(Arc::new(InterceptState {
@@ -350,27 +349,6 @@ impl ServerBuilder {
             metrics,
             intercept,
         })
-    }
-}
-
-/// Build the intercept CA: load it from PEM when both cert and key are given, generate one when
-/// neither is, and reject a half-configured pair.
-fn load_or_generate_ca(
-    cert: Option<&PathBuf>,
-    key: Option<&PathBuf>,
-) -> anyhow::Result<CertificateAuthority> {
-    match (cert, key) {
-        (Some(cert), Some(key)) => {
-            let cert_pem = std::fs::read_to_string(cert)
-                .with_context(|| format!("reading --intercept-ca-cert {cert:?}"))?;
-            let key_pem = std::fs::read_to_string(key)
-                .with_context(|| format!("reading --intercept-ca-key {key:?}"))?;
-            CertificateAuthority::load_pem(&cert_pem, &key_pem)
-        }
-        (None, None) => CertificateAuthority::generate(),
-        _ => anyhow::bail!(
-            "--intercept-ca-cert and --intercept-ca-key must be provided together (or both omitted to generate a CA)"
-        ),
     }
 }
 
@@ -656,13 +634,13 @@ mod tests {
 
     #[test]
     fn load_or_generate_ca_rules() {
-        use std::path::PathBuf;
+        use std::path::Path;
         // Neither cert nor key: a CA is generated.
-        assert!(load_or_generate_ca(None, None).is_ok());
+        assert!(CertificateAuthority::load_or_generate(None, None).is_ok());
         // A half-configured pair is rejected rather than silently generating.
-        let cert = PathBuf::from("ca.pem");
-        assert!(load_or_generate_ca(Some(&cert), None).is_err());
-        assert!(load_or_generate_ca(None, Some(&cert)).is_err());
+        let cert = Path::new("ca.pem");
+        assert!(CertificateAuthority::load_or_generate(Some(cert), None).is_err());
+        assert!(CertificateAuthority::load_or_generate(None, Some(cert)).is_err());
     }
 
     #[test]
@@ -681,9 +659,9 @@ mod tests {
         key_file.write_all(key.serialize_pem().as_bytes()).unwrap();
 
         // ...is loaded, not regenerated: the CA exposes the supplied certificate.
-        let cert_path = cert_file.path().to_path_buf();
-        let key_path = key_file.path().to_path_buf();
-        let ca = load_or_generate_ca(Some(&cert_path), Some(&key_path)).expect("load supplied CA");
+        let ca =
+            CertificateAuthority::load_or_generate(Some(cert_file.path()), Some(key_file.path()))
+                .expect("load supplied CA");
         assert_eq!(ca.ca_cert_pem(), cert.pem().as_str());
     }
 


### PR DESCRIPTION
Accept optional caller-provided intercept CA (caCertPath/caKeyPath) in rift_start_intercept, with both-or-neither validation and shared load-or-generate logic across FFI and container adapter surfaces. Enables independent embedded instances to share a committed trust anchor.

Closes #429