### PR TITLE
docs: record 0.11.3 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ record.
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-07-08
+
+### Added
+- **`rift_start_intercept` accepts a caller-provided intercept CA** (#429). New optional
+  `caCertPath`/`caKeyPath` options load a committed CA (via `CertificateAuthority::load_pem`)
+  instead of only minting a fresh ephemeral one, so independent embedded instances can share a
+  committed trust anchor — a long-lived containerized SUT can trust a CA that pre-exists its JVM
+  startup. A half-configured pair (only one of the two) is rejected with a clear both-or-neither
+  error; omitting both generates a CA exactly as before (unchanged default). The load-or-generate
+  logic is now shared with the container adapter's `--intercept-ca-cert`/`--intercept-ca-key`.
+
 ## [0.11.2] - 2026-07-08
 
 ### Fixed
@@ -174,7 +185,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/EtaCassiopeia/rift/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/EtaCassiopeia/rift/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/EtaCassiopeia/rift/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/EtaCassiopeia/rift/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
Records the #429 `rift_start_intercept` caller-provided CA feature under a new `## [0.11.3]` section, ahead of tagging the v0.11.3 release.

Docs-only; no code changes.