### PR TITLE
docs: reconcile documentation gaps against v0.11.3 (audit refresh) — single multi-commit PR

### DIFF
--- a/crates/rift-core/src/config/scripting.rs
+++ b/crates/rift-core/src/config/scripting.rs
@@ -23,7 +23,7 @@ impl Default for ScriptEngineConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FlowStateConfig {
     #[serde(default = "default_backend_type")]
-    pub backend: String, // "inmemory", "redis", "valkey"
+    pub backend: String, // "inmemory", "redis"
     #[serde(default = "default_ttl_seconds")]
     pub ttl_seconds: i64,
     #[serde(default)]

--- a/crates/rift-core/src/extensions/metrics.rs
+++ b/crates/rift-core/src/extensions/metrics.rs
@@ -64,7 +64,7 @@ lazy_static! {
     pub static ref ACTIVE_FLOWS: GaugeVec = register_gauge_vec!(
         "rift_active_flows",
         "Number of active flows being tracked in flow state",
-        &["backend"]  // backend: inmemory|redis|valkey
+        &["backend"]  // backend: inmemory|redis
     )
     .unwrap();
 
@@ -342,7 +342,7 @@ mod tests {
     fn test_set_active_flows_backends() {
         set_active_flows("inmemory", 100);
         set_active_flows("redis", 200);
-        set_active_flows("valkey", 150);
+        set_active_flows("redis", 150);
 
         let metrics = collect_metrics();
         assert!(metrics.contains("rift_active_flows"));

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -34,7 +34,7 @@ search:
   button: false
 
 # Footer
-footer_content: "Copyright &copy; 2024-2025 Rift Contributors. Distributed under the <a href=\"https://github.com/EtaCassiopeia/rift/blob/master/LICENSE\">Apache License 2.0</a>. Docs current as of <a href=\"https://github.com/EtaCassiopeia/rift/releases/tag/v0.8.0\">v0.8.0</a>."
+footer_content: "Copyright &copy; 2024-2025 Rift Contributors. Distributed under the <a href=\"https://github.com/EtaCassiopeia/rift/blob/master/LICENSE\">Apache License 2.0</a>. Docs current as of <a href=\"https://github.com/EtaCassiopeia/rift/releases/tag/v0.11.3\">v0.11.3</a>."
 
 # Back to top link
 back_to_top: true

--- a/docs/_data/sync.yml
+++ b/docs/_data/sync.yml
@@ -5,7 +5,7 @@
 #        git log --oneline --merges <commit>..origin/master
 #   2. Update the affected pages.
 #   3. Bump this file AND the version in _config.yml footer_content in the same PR.
-release: v0.8.0
-commit: 912e23c198243af81a18960ad0d409ef49964bef
-date: 2026-07-04
+release: v0.11.3
+commit: f5902f3548784d977a2be8c656f348cea99c8c97
+date: 2026-07-08
 tracking_issue: 280

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -137,6 +137,7 @@ Environment variables override CLI defaults:
 | `RIFT_DISABLE_HTTP2` | Force HTTP/1-only listeners, disabling HTTP/2 & h2c auto-negotiation (truthy: `1`/`true`/`yes`/`on`) | off |
 | `RIFT_TCP_BACKLOG` | Listen backlog for the accept loop (positive integer) | `1024` |
 | `RIFT_TCP_NODELAY` | `TCP_NODELAY` on accepted sockets; set `false`/`0`/`off` to disable | on |
+| `RIFT_STRICT_BEHAVIORS` | Force strict mode process-wide (truthy: `1`/`true`/`yes`/`on`): a `decorate`/`shellTransform`/binary-base64-decode failure returns `500` instead of the lenient fallback body | off |
 | `NO_COLOR` | Suppress ANSI color and the decorative banner in `rift-verify` / `rift-lint` output | |
 | `RUST_LOG` | Detailed log configuration | `info` |
 
@@ -144,6 +145,13 @@ Environment variables override CLI defaults:
 [HTTP/2 and h2c]({{ site.baseurl }}/mountebank/imposters/#http2-and-h2c). `RIFT_TCP_BACKLOG` and
 `RIFT_TCP_NODELAY` are socket-tuning knobs covered under
 [Performance → Runtime socket tuning]({{ site.baseurl }}/performance/#runtime-socket-tuning).
+
+`RIFT_STRICT_BEHAVIORS` and the per-imposter `strictBehaviors` field combine with **OR** — either
+being set enables strict mode. It is orthogonal to `RIFT_STRICT_FLOW_STORE`
+([Scripting]({{ site.baseurl }}/features/scripting/)): the two env vars gate unrelated failure
+paths (response behaviors vs. flow-store script errors), and neither implies the other. See
+[Rift Extensions → Strict Behaviors]({{ site.baseurl }}/configuration/native/#strict-behaviors-strictbehaviors)
+for the full semantics.
 
 ### Docker Example
 
@@ -331,6 +339,7 @@ Options:
   -o, --output <FMT>      Output format: text (default), json
       --dry-run           Show what would be tested without making requests
       --skip-dynamic      Skip stubs with inject/proxy/script responses
+      --verify-dynamic    Opt-in: assert dynamic stubs instead of skipping them
       --status-only       Only verify status codes (ignore body/headers)
       --demo              Run demo showing enhanced error output
   -h, --help              Print help
@@ -352,6 +361,9 @@ rift-verify --dry-run --verbose
 # Skip dynamic stubs (proxy, inject, script)
 rift-verify --skip-dynamic
 
+# Assert dynamic stubs instead of skipping them
+rift-verify --verify-dynamic
+
 # Status-only mode for cycling responses
 rift-verify --status-only
 
@@ -364,7 +376,19 @@ With `-o json`, `rift-verify` writes a single summary object to stdout —
 banner output to stderr, so it pipes cleanly into other tools. Color and the decorative banner are
 also suppressed automatically when stdout is not a TTY (piped) or when `NO_COLOR` is set.
 
-See [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) for details.
+By default, `rift-verify` SKIPs stubs whose response is dynamic (proxy/inject/script/cycling/faults)
+because their output isn't a static function of the stub — `--skip-dynamic` makes that skip explicit.
+`--verify-dynamic` is the opt-in complement: it asserts those stubs instead of skipping them, using
+three mechanisms — an embedded mock upstream for `proxy` stubs (verifying the proxied response and,
+when `predicateGenerators` is set, the recorded-stub prepend); a `_verify` expectation sequence
+(see below) run against a freshly recreated imposter for inject/script/decorate/cycling/stateful
+stubs; and deterministic (`probability: 1.0` or unset) `_rift.fault` assertions for latency/error/tcp
+faults. Each check runs against a throwaway imposter that is torn down afterward, so it never mutates
+the imposters under test. A dynamic stub with none of these assertable markers is still surfaced as a
+visible `SKIP` in the output rather than silently ignored.
+
+See [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) for details, including the `_verify`
+annotation schema.
 
 ### rift-lint
 

--- a/docs/configuration/native.md
+++ b/docs/configuration/native.md
@@ -57,6 +57,14 @@ Enable stateful testing scenarios with flow state:
 | `ttlSeconds` | integer | `300` | Time-to-live for state entries (5 minutes) |
 | `redis` | object | - | Redis-specific configuration (required for redis backend) |
 
+**Fail-loud backend errors**: an unknown `backend` string, or a `redis` backend that can't be
+created (missing `redis` config, a connection/pool failure, or a binary built without the
+`redis-backend` feature), fails imposter creation with `400 Bad Request` rather than silently
+degrading to a no-op store. See
+[Flow State → Backend configuration is fail-loud]({{ site.baseurl }}/features/flow-state/#backend-configuration-is-fail-loud)
+for details. Only the *implicit* case — no `flowState` block at all — stays silent, using a no-op
+store.
+
 ### Redis Configuration
 
 When using `redis` backend:
@@ -184,6 +192,45 @@ Defaults for `_rift.script` execution.
 |:------|:-----|:--------|:------|
 | `defaultEngine` | string | `"rhai"` | Engine used when a script omits `engine`. |
 | `timeoutMs` | integer | `5000` | Per-script wall-clock timeout. |
+
+---
+
+## Strict Behaviors (`strictBehaviors`)
+
+`strictBehaviors` is a top-level imposter field — a sibling of `protocol`/`stubs`, not nested under
+`_rift` — that controls whether a failing response behavior degrades quietly or fails loudly.
+
+| Field | Type | Default | Description |
+|:------|:-----|:--------|:-------------|
+| `strictBehaviors` | boolean | `false` | When `true`, a `decorate`/`shellTransform`/binary-base64-decode failure returns `500` instead of silently serving the fallback body. |
+
+```json
+{
+  "port": 4545,
+  "protocol": "http",
+  "strictBehaviors": true,
+  "stubs": [{
+    "responses": [{
+      "is": {"statusCode": 200, "body": "Hello"},
+      "_behaviors": {"decorate": "function(request, response) { throw new Error('boom'); }"}
+    }]
+  }]
+}
+```
+
+By default (`strictBehaviors: false`), a throwing `decorate`/`shellTransform`, or a `_mode: "binary"`
+response whose body isn't valid base64, still serves the stub's fallback body and only signals the
+failure via an `x-rift-<behavior>-error` header. With `strictBehaviors` on, the same failure returns
+`500` (still carrying that header) instead.
+
+Strict mode can also be forced process-wide with the `RIFT_STRICT_BEHAVIORS` environment variable
+(see [CLI Reference]({{ site.baseurl }}/configuration/cli/)) — the per-imposter flag **or** the env
+var enables it. This is orthogonal to `RIFT_STRICT_FLOW_STORE` ([Scripting]({{ site.baseurl
+}}/features/scripting/)): neither implies the other, since one governs response behaviors and the
+other governs flow-store script errors.
+
+See [Mountebank Behaviors → Error Semantics]({{ site.baseurl }}/mountebank/behaviors/#error-semantics)
+for the full walkthrough of `decorate`/`shellTransform`/binary failures under strict mode.
 
 ---
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -251,6 +251,15 @@ docker build -t my-rift:latest .
 docker run -p 2525:2525 -p 4545:4545 my-rift:latest
 ```
 
+### Feature flags for a custom build
+
+`crates/rift-http-proxy/Dockerfile` builds with `ARG FEATURES=lua,javascript,redis-backend` by
+default. If you're building a slimmer image (or embedding Rift as a `cdylib` instead of running the
+container), see the Cargo feature table in [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/#cargo-features)
+and the [Embedding & SPI]({{ site.baseurl }}/embedding/) overview — the same features gate both the
+binary and the `rift-ffi` cdylib, and `cargo build --no-default-features` (plus an explicit
+`--features` list) drops the scripting engines and Redis backend you don't need.
+
 ---
 
 ## Common Operations

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -98,7 +98,7 @@ per handle; `rift_stop` shuts it down.
 
 | Function | Signature | Returns |
 |---|---|---|
-| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, already started). Generates an intercept CA. `options_json`: `{"host":"127.0.0.1","port":0}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. |
+| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. |
 | `rift_intercept_add_rules` | `int rift_intercept_add_rules(RiftHandle* h, const char* rules_json)` | `0`/`-1`. One rule (object) or many (array), same shape as `/intercept/rules`. |
 | `rift_intercept_list_rules` | `char* rift_intercept_list_rules(RiftHandle* h)` | The current rules as a JSON array (**caller frees**), or `NULL` on error. |
 | `rift_intercept_clear_rules` | `int rift_intercept_clear_rules(RiftHandle* h)` | `0`/`-1`. |
@@ -111,6 +111,17 @@ loopback HTTP. `Forward { port }` rules reach any imposter on that localhost por
 FFI-created ones. Errors set `rift_last_error`. A handle that never calls `rift_start_intercept` is
 unaffected.
 
+By default (no `caCertPath`/`caKeyPath`) `rift_start_intercept` generates a fresh ephemeral intercept
+CA, unchanged from earlier releases. As of v0.11.3 (#429), passing both `caCertPath` and `caKeyPath`
+(PEM file paths) loads that committed CA instead — letting independent embedded instances share one
+trust anchor rather than each minting its own. Passing only one of the pair is a hard error (both or
+neither).
+
+`interceptUrl`/`interceptPort` in the response are derived from the listener's **actual bound
+address** (v0.11.2, #425/#426) — not hardcoded to `127.0.0.1`. A loopback `host` (the default)
+reports loopback as before; a `0.0.0.0` (or other non-loopback) bind surfaces that address verbatim,
+so dial a concrete interface rather than assuming `127.0.0.1`.
+
 ## Build identity
 
 `rift_build_info` is a **static** JSON string (never freed) — probe it to detect a v2 library and read
@@ -118,7 +129,7 @@ which engines are compiled in:
 
 ```c
 const char* info = rift_build_info();
-// {"version":"0.8.0","commit":"<sha>|null","builtAt":"<iso8601>|null","features":["redis-backend","lua","javascript"]}
+// {"version":"0.11.3","commit":"<sha>|null","builtAt":"<iso8601>|null","features":["redis-backend","lua","javascript"]}
 // Do NOT call rift_free on this pointer.
 ```
 

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -212,6 +212,11 @@ fault strings are the same set as `_rift.fault.tcp` above (`CONNECTION_RESET_BY_
 `EMPTY_RESPONSE`, `RANDOM_DATA_THEN_CLOSE`, `MALFORMED_RESPONSE_CHUNK`, plus their aliases). An
 unrecognized fault string is a configuration error and yields `500 Unknown fault: <value>`.
 
+Like `_rift.fault.tcp`, a bare top-level `fault` also forces the whole imposter onto **HTTP/1
+only**: it is a connection-level event, and aborting a socket mid-stream is incompatible with
+HTTP/2 multiplexing — so an imposter with even one stub returning a top-level `fault` never
+negotiates HTTP/2, regardless of what its other stubs do.
+
 > **Behavior change:** before v0.8.0 a top-level `fault` returned a framed HTTP `502`. It now
 > performs a real connection reset/close, matching Mountebank's transport-fault semantics.
 
@@ -227,6 +232,16 @@ this order:
 
 So `latency` + `tcp` is a *delay-then-drop*, and a configured `tcp` fault always wins over an
 `error` fault rather than being silently dropped.
+
+### Response-type precedence
+
+`_rift.fault` and a top-level `fault` string live on different response shapes, and a single stub
+response can only render as one shape. When a response carries more than one recognized type, Rift
+picks in this order: **`is` > `proxy` > `inject` > `fault`**. This response-type precedence means a
+stub combining an `is` block (with `_rift.fault` inside it) *and* a top-level `"fault"` string on
+the same response silently drops the top-level `fault` — `is` wins and the fault string is never
+evaluated. If you want the top-level transport fault, the response must be a bare `fault` with no
+`is`/`proxy`/`inject` alongside it.
 
 ---
 

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -116,3 +116,8 @@ curl -X DELETE http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts
 
 Note: an imposter gets a real store only when `_rift.flowState` is configured (or it declares
 scenario stubs); otherwise a no-op store is used and values never persist.
+
+> **Embedding over the C-ABI (non-Rust)**: a non-Rust host can read, write, and delete flow-state
+> keys with zero loopback HTTP via [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/#admin-long-tail-over-ffi-scenario-state--correlated-spaces) —
+> `rift_flow_state_get` / `rift_flow_state_put` / `rift_flow_state_delete` mirror the admin-API
+> calls above exactly (same `ImposterManager` calls, same JSON shapes).

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -76,6 +76,15 @@ rift --intercept-port 8443 --intercept-ca-cert ca.pem --intercept-ca-key ca.key
 
 (Equivalently `RIFT_INTERCEPT_PORT` / `RIFT_INTERCEPT_CA_CERT` / `RIFT_INTERCEPT_CA_KEY`.)
 
+### Embedding over the C-ABI (non-Rust)
+
+> A non-Rust host (JVM, Node, Go, Python, …) can start and drive the intercept listener with **no
+> loopback HTTP and no Rust code** — see [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/#intercept-proxy-over-ffi).
+> `rift_start_intercept` starts the listener, and the `rift_intercept_*` control-plane functions —
+> `rift_intercept_add_rules`, `rift_intercept_list_rules`, `rift_intercept_clear_rules`,
+> `rift_intercept_export_truststore`, and `rift_intercept_ca_pem` — add rules, list them, export a
+> truststore, and fetch the CA PEM, all over C-ABI.
+
 ---
 
 ## Configuring rules (admin API)
@@ -137,6 +146,15 @@ echoing the password used (default `changeit`, override with `?password=`).
 
 ```
 -Djavax.net.ssl.trustStore=ts.jks -Djavax.net.ssl.trustStorePassword=changeit \
+-Dhttps.proxyHost=<rift-host> -Dhttps.proxyPort=<intercept-port>
+```
+
+The JKS store above is `-Djavax.net.ssl.trustStoreType=JKS` (the JVM default); a PKCS#12 store also
+loads as a JVM trust anchor by adding the type:
+
+```
+-Djavax.net.ssl.trustStore=ts.p12 -Djavax.net.ssl.trustStoreType=PKCS12 \
+-Djavax.net.ssl.trustStorePassword=changeit \
 -Dhttps.proxyHost=<rift-host> -Dhttps.proxyPort=<intercept-port>
 ```
 

--- a/docs/features/scenarios.md
+++ b/docs/features/scenarios.md
@@ -21,6 +21,10 @@ state after it responds.
 | `requiredScenarioState` | The stub is only eligible when the scenario is in this state. |
 | `newScenarioState` | After the stub responds, the scenario transitions to this state. |
 
+`newScenarioState` is optional. If a matched stub omits `newScenarioState`, the scenario remains in
+its current state — no transition happens. That lets a stub gate on state without ever advancing
+it, which is how you model a repeatable step in the middle of a flow.
+
 The implicit initial state is **`Started`**. State is tracked per flow id (see
 [Spaces]({{ site.baseurl }}/features/spaces/)); by default that is the imposter port, so a single
 imposter has one scenario timeline.
@@ -58,6 +62,54 @@ second stub and return `200`.
 curl -i http://localhost:4602/pay   # 402 payment required  (now in state "paid")
 curl -i http://localhost:4602/pay   # 200 fulfilled
 ```
+
+---
+
+## Parallel callers, independent timelines
+
+By default all callers share one scenario timeline (the flow id defaults to the imposter port). To
+let two callers advance the *same* `scenarioName` independently, scope the flow id to a request
+header — e.g. `flowIdSource: "header:X-Mock-Space"` — so each caller's `X-Mock-Space` value gets its
+own state:
+
+```json
+{
+  "port": 4602,
+  "protocol": "http",
+  "_rift": {
+    "flowState": { "flowIdSource": "header:X-Mock-Space" }
+  },
+  "stubs": [
+    {
+      "scenarioName": "checkout",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "paid",
+      "predicates": [{ "equals": { "path": "/pay" } }],
+      "responses": [{ "is": { "statusCode": 402, "body": "payment required" } }]
+    },
+    {
+      "scenarioName": "checkout",
+      "requiredScenarioState": "paid",
+      "predicates": [{ "equals": { "path": "/pay" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "fulfilled" } }]
+    }
+  ]
+}
+```
+
+Alice and bob each drive the `checkout` scenario at their own pace — one being mid-flow doesn't
+gate or advance the other's state:
+
+```bash
+curl -i -H 'X-Mock-Space: alice' http://localhost:4602/pay   # 402  (alice: Started -> paid)
+curl -i -H 'X-Mock-Space: bob'   http://localhost:4602/pay   # 402  (bob: Started -> paid, independent of alice)
+curl -i -H 'X-Mock-Space: alice' http://localhost:4602/pay   # 200  (alice already paid)
+curl http://localhost:2525/imposters/4602/scenarios?flowId=bob
+# -> {"flowId":"bob","scenarios":[{"name":"checkout","state":"paid"}]}
+```
+
+See [Correlated Isolation (Spaces)]({{ site.baseurl }}/features/spaces/) for how `flowIdSource` is
+resolved.
 
 ---
 

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -103,7 +103,6 @@ request.method          // String: "GET", "POST", etc.
 request.path            // String: "/api/users"
 request.headers         // Map: access via request.headers["header-name"]
 request.query           // Map: access via request.query["param"]
-request.pathParams      // Map: access via request.pathParams["id"]
 request.body            // Parsed JSON body
 
 // Helper functions
@@ -203,7 +202,6 @@ request.method          -- String
 request.path            -- String
 request.headers         -- Table: request.headers["header-name"]
 request.query           -- Table: request.query["param"]
-request.pathParams      -- Table: request.pathParams["id"]
 request.body            -- Parsed body (table or string)
 
 -- Standard Lua functions
@@ -377,6 +375,18 @@ return {
 {
   "_rift": {
     "scriptEngine": { "timeoutMs": 2000 }
+  }
+}
+```
+
+`_rift.scriptEngine.defaultEngine` sets which engine runs a `_rift.script` block when the block
+itself omits `engine`: `"rhai"` (default), `"lua"`, or `"javascript"`. A per-script `engine` field
+always takes precedence over `defaultEngine`.
+
+```json
+{
+  "_rift": {
+    "scriptEngine": { "defaultEngine": "lua" }
   }
 }
 ```

--- a/docs/features/spaces.md
+++ b/docs/features/spaces.md
@@ -69,6 +69,22 @@ curl http://localhost:4510/health                          # OK  (global stub)
 
 ---
 
+## Recorded requests, scoped to a space
+
+With `recordRequests: true`, `GET /imposters/{port}/savedRequests` accepts a `match=flow_id=<value>`
+query parameter (see the [API Reference]({{ site.baseurl }}/api/#requests)) to read or clear only
+one space's requests, leaving other spaces and the imposter itself untouched:
+
+```bash
+# Read only alice's recorded requests
+curl 'http://localhost:2525/imposters/4510/savedRequests?match=flow_id=alice'
+
+# Clear only alice's recorded requests (bob's and the port's own are unaffected)
+curl -X DELETE 'http://localhost:2525/imposters/4510/savedRequests?match=flow_id=alice'
+```
+
+---
+
 ## Managing spaces at runtime
 
 Instead of declaring `space` inline, you can add stubs to a space through the admin API and tear the
@@ -82,5 +98,19 @@ curl http://localhost:2525/imposters/4510/spaces/alice        # inspect the spac
 curl -X DELETE http://localhost:2525/imposters/4510/spaces/alice   # teardown
 ```
 
+Spaces are addressed by a known flow id — there is no bare `GET /imposters/{port}/spaces` route to
+list or discover which spaces currently exist under an imposter. If you need an inventory of active
+flow ids, track them on the caller side (or derive them from recorded requests / stub `space`
+fields); the admin API only ever answers "what does *this* flow id look like."
+
 Spaces build on the same store as [Flow State]({{ site.baseurl }}/features/flow-state/) and
 [Scenarios]({{ site.baseurl }}/features/scenarios/), which are likewise partitioned by flow id.
+
+---
+
+## Embedding over the C-ABI
+
+Everything above is also reachable with zero loopback HTTP from an embedded Rift: the FFI exposes
+`rift_space_add_stub`, `rift_space_list_stubs`, `rift_space_delete`, and `rift_space_recorded`,
+each mirroring the corresponding admin-HTTP handler exactly. See
+[FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/) for signatures and ownership rules.

--- a/docs/features/stub-analysis.md
+++ b/docs/features/stub-analysis.md
@@ -320,6 +320,71 @@ Stubs with the same path but different methods don't conflict:
 
 ---
 
+## The `_verify` annotation
+
+`rift-verify` normally SKIPs stubs whose response is dynamic (`inject`, `proxy`, `script`, cycling,
+`_rift.fault`) because their output isn't a static function of the stub, and `--skip-dynamic` makes
+that skip explicit. Passing `--verify-dynamic` instead asserts those stubs, using whichever of three
+mechanisms applies:
+
+1. **`proxy` stubs** — an embedded mock upstream is stood up and the proxy stub is recreated pointing
+   at it; the verifier asserts the proxied response comes back, and (when the stub's `proxy` config
+   sets `predicateGenerators`) that a recorded stub is prepended.
+2. **`_verify`-annotated stubs** — the stub is recreated on a fresh throwaway imposter (clean
+   cyclic/FSM state) and the declared request/expectation `sequence` is driven against it. This is
+   the mechanism for `inject`/`script`/`decorate`/`copy`/`lookup`/cycling/repeat/stateful stubs, none
+   of which the verifier can infer an expected response for on its own.
+3. **Deterministic `_rift.fault` stubs** — a fault whose `probability` is `1.0` or unset always
+   fires, so the verifier can assert it directly: `tcp` as a transport-level reset, `latency` as an
+   elapsed time at or above the configured delay, `error` as the configured status code.
+
+A dynamic stub that carries none of these markers is still surfaced as a visible `SKIP` in the
+output — it is never silently dropped.
+
+`_verify` is a stub-level annotation (a sibling of `predicates`/`responses`) that declares a sequence
+of requests and expected outcomes to drive against a fresh copy of the imposter:
+
+```json
+{
+  "predicates": [{ "equals": { "path": "/orders/77" } }],
+  "responses": [{
+    "_rift": {
+      "script": {
+        "engine": "rhai",
+        "code": "fn should_inject(request, flow_store) { let n = flow_store.increment(\"77\", \"attempts\"); if n <= 1 { #{ inject: true, fault: \"error\", status: 503 } } else { #{ inject: true, fault: \"error\", status: 200, body: `order 77 ready` } } }"
+      }
+    }
+  }],
+  "_verify": {
+    "sequence": [
+      { "request": { "method": "GET", "path": "/orders/77" }, "expect": { "status": 503 } },
+      { "request": { "path": "/orders/77" }, "expect": { "status": 200, "bodyContains": "ready" } }
+    ]
+  }
+}
+```
+
+Fields:
+
+| Field | Default | Notes |
+|:------|:--------|:------|
+| `sequence` | `[]` | Ordered list of `{ request, expect }` steps, driven one after another against the same fresh imposter. |
+| `request.method` | `"GET"` | HTTP method for the step. |
+| `request.path` | required | Request path. |
+| `request.body` | — | Optional request body. |
+| `request.headers` | `{}` | Optional request headers. |
+| `expect.status` | — | Expected status code; omit to ignore status. |
+| `expect.bodyContains` | — | Substring the response body must contain. |
+| `expect.bodyEquals` | — | Exact response body match. |
+
+An `expect` with no fields set matches any response. A malformed `_verify` block (e.g. a step missing
+`request`) fails that stub's check rather than being silently skipped.
+
+See [CLI Reference → `rift-verify`]({{ site.baseurl }}/configuration/cli/#rift-verify) for
+`--skip-dynamic` and `--verify-dynamic`.
+
+---
+
 ## Mountebank Compatibility
 
 | Feature | Mountebank | Rift |

--- a/docs/mountebank/responses.md
+++ b/docs/mountebank/responses.md
@@ -151,7 +151,6 @@ substitutes them into the response **body** and **header values** before any beh
 | `${request.body}` | Raw request body |
 | `${request.query.<name>}` | Query parameter `<name>` |
 | `${request.headers.<name>}` | Request header `<name>` (case-insensitive) |
-| `${request.pathParams.<name>}` | Path parameter `<name>` |
 
 ```json
 {


### PR DESCRIPTION
Reconciles the documentation with the v0.11.3 implementation, closing the re-verified gap checklist in #432: removes dead/false claims (\`request.pathParams\` docs, \`valkey\` backend comments), fills CLI/config reference gaps (\`--verify-dynamic\`/\`_verify\`, \`strictBehaviors\`, \`flowState\` fail-loud, \`defaultEngine\`), tightens spaces/scenarios/fault precision, adds embedding/FFI cross-links + the new v0.11.x intercept CA options (#429) and bound-host \`interceptUrl\` (#425/#426), and bumps the stale v0.8.0 docs version stamp to v0.11.3.

Delivered as one PR with 5 grouped commits (one CI run). \`request.pathParams\` implementation is tracked separately in #433.

Closes #432.