### PR TITLE
feat: implement request.pathParams extraction (route-pattern stub field) and restore its docs

### DIFF
--- a/crates/rift-core/src/extensions/stub_analysis.rs
+++ b/crates/rift-core/src/extensions/stub_analysis.rs
@@ -414,6 +414,7 @@ mod tests {
         let predicates = predicates_from_jsons(predicates);
         Stub {
             id: None,
+            route_pattern: None,
             predicates,
             responses: vec![],
             scenario_name: None,
@@ -429,6 +430,7 @@ mod tests {
         let predicates = predicates_from_jsons(predicates);
         Stub {
             id: Some(id.to_string()),
+            route_pattern: None,
             predicates,
             responses: vec![],
             scenario_name: None,

--- a/crates/rift-core/src/extensions/template.rs
+++ b/crates/rift-core/src/extensions/template.rs
@@ -82,6 +82,17 @@ impl RequestData {
         }
     }
 
+    /// Populate `path_params` by matching the request path against a route `pattern` (issue #433),
+    /// e.g. `/users/:id`. A `None` pattern — or one whose shape doesn't match the path — leaves the
+    /// map empty (the unchanged default), so callers can pass a stub's optional pattern directly.
+    #[must_use]
+    pub fn with_route_pattern(mut self, pattern: Option<&str>) -> Self {
+        if let Some(pattern) = pattern {
+            self.path_params = extract_path_params(pattern, &self.path);
+        }
+        self
+    }
+
     /// Get a value by dotted path (e.g., "query.name", "headers.content-type")
     pub fn get(&self, path: &str) -> Option<String> {
         let parts: Vec<&str> = path.splitn(2, '.').collect();
@@ -98,9 +109,9 @@ impl RequestData {
     }
 }
 
-/// Extract path parameters from a route pattern and actual path (used in tests)
-#[cfg(test)]
-fn extract_path_params(pattern: &str, path: &str) -> HashMap<String, String> {
+/// Extract path parameters from a route `pattern` (`:name` segments) and the actual request
+/// `path`. Returns an empty map when the segment counts differ or a literal segment doesn't match.
+pub(crate) fn extract_path_params(pattern: &str, path: &str) -> HashMap<String, String> {
     let mut params = HashMap::new();
 
     let pattern_parts: Vec<&str> = pattern.split('/').collect();
@@ -248,6 +259,22 @@ mod tests {
     fn test_extract_path_params_no_match() {
         let params = extract_path_params("/users/:id", "/posts/123");
         assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_with_route_pattern_builder() {
+        let headers = hyper::HeaderMap::new();
+        // A matching pattern populates path_params from the request path.
+        let data = RequestData::new("GET", "/users/42", None, &headers, None)
+            .with_route_pattern(Some("/users/:id"));
+        assert_eq!(data.get("pathParams.id"), Some("42".to_string()));
+        // No pattern (and a non-matching pattern) leave the map empty.
+        let none =
+            RequestData::new("GET", "/users/42", None, &headers, None).with_route_pattern(None);
+        assert!(none.path_params.is_empty());
+        let mismatch = RequestData::new("GET", "/orders/42", None, &headers, None)
+            .with_route_pattern(Some("/users/:id"));
+        assert!(mismatch.path_params.is_empty());
     }
 
     #[test]

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -411,7 +411,13 @@ async fn handle_request_inner(
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or(serde_json::Value::Null),
                 query: parse_query_string(&query_str),
-                path_params: HashMap::new(),
+                // Issue #433: populate path params from the matched stub's route pattern, if any.
+                path_params: stub_state
+                    .stub
+                    .route_pattern
+                    .as_deref()
+                    .map(|pattern| crate::extensions::template::extract_path_params(pattern, &path))
+                    .unwrap_or_default(),
             };
 
             // Execute the script off the async worker under a wall-clock deadline (issue
@@ -548,7 +554,8 @@ async fn handle_request_inner(
                         query_opt,
                         &headers_for_context,
                         body_string.as_deref(),
-                    );
+                    )
+                    .with_route_pattern(stub_state.stub.route_pattern.as_deref());
                     if need_body {
                         body = process_template(&body, &request_data);
                     }

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -260,6 +260,7 @@ pub fn create_stub_from_proxy_response(
         .collect();
     super::types::Stub {
         id: None,
+        route_pattern: None,
         predicates,
         responses: vec![StubResponse::Is {
             is: is_response,

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -40,6 +40,7 @@ fn test_imposter_config_no_port() {
 fn test_predicate_matching() {
     let stub = Stub {
         id: None,
+        route_pattern: None,
         predicates: predicates_from_jsons(vec![serde_json::json!({
             "equals": {
                 "method": "GET",
@@ -138,6 +139,7 @@ fn test_execute_stub() {
 
     let stub = Stub {
         id: None,
+        route_pattern: None,
         predicates: vec![],
         responses: vec![StubResponse::Is {
             is: IsResponse {
@@ -2427,6 +2429,7 @@ async fn test_cors_headers_on_stub_response() {
     let manager = ImposterManager::new();
     let stub = Stub {
         id: None,
+        route_pattern: None,
         predicates: predicates_from_jsons(vec![serde_json::json!({
             "equals": {"method": "GET", "path": "/test"}
         })]),
@@ -3766,4 +3769,222 @@ mod cas_transitions {
             "an ungated transition keeps today's unconditional overwrite semantics"
         );
     }
+}
+
+// Issue #433: a stub-level `routePattern` populates `request.pathParams.<name>` for both response
+// templates and every script engine; absent a pattern the map stays empty (unchanged default).
+#[tokio::test]
+async fn test_path_params_template_end_to_end() {
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19741,
+        "protocol": "http",
+        "stubs": [{
+            "routePattern": "/users/:id",
+            "predicates": [{ "equals": { "path": "/users/123" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "${request.pathParams.id}" } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19741/users/123")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19741).await;
+
+    assert_eq!(
+        body, "123",
+        "routePattern must populate ${{request.pathParams.id}} in the response template, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_path_params_script_rhai() {
+    let script = "fn should_inject(request, flow_store) { \
+         let id = request.pathParams[\"id\"]; if id == () { id = \"MISS\"; } \
+         #{ inject: true, fault: \"error\", status: 200, body: id } }";
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19742,
+        "protocol": "http",
+        "stubs": [{
+            "routePattern": "/users/:id",
+            "predicates": [{ "equals": { "path": "/users/123" } }],
+            "responses": [{ "_rift": { "script": { "engine": "rhai", "code": script } } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19742/users/123")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19742).await;
+
+    assert_eq!(
+        body, "123",
+        "rhai script must read a populated request.pathParams.id, got: {body}"
+    );
+}
+
+#[cfg(feature = "lua")]
+#[tokio::test]
+async fn test_path_params_script_lua() {
+    let script = "function should_inject(request, flow_store) \
+         return { inject = true, fault = \"error\", status = 200, body = request.pathParams.id } end";
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19743,
+        "protocol": "http",
+        "stubs": [{
+            "routePattern": "/users/:id",
+            "predicates": [{ "equals": { "path": "/users/123" } }],
+            "responses": [{ "_rift": { "script": { "engine": "lua", "code": script } } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19743/users/123")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19743).await;
+
+    assert_eq!(
+        body, "123",
+        "lua script must read a populated request.pathParams.id, got: {body}"
+    );
+}
+
+#[cfg(feature = "javascript")]
+#[tokio::test]
+async fn test_path_params_script_js() {
+    let script = "function should_inject(request, flow_store) { \
+         return { inject: true, fault: \"error\", status: 200, body: request.pathParams.id }; }";
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19744,
+        "protocol": "http",
+        "stubs": [{
+            "routePattern": "/users/:id",
+            "predicates": [{ "equals": { "path": "/users/123" } }],
+            "responses": [{ "_rift": { "script": { "engine": "javascript", "code": script } } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19744/users/123")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19744).await;
+
+    assert_eq!(
+        body, "123",
+        "js script must read a populated request.pathParams.id, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_path_params_absent_pattern_is_empty() {
+    // No routePattern → pathParams stays empty and nothing errors (unchanged default). The `[]`
+    // wrapper makes the empty substitution observable.
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19745,
+        "protocol": "http",
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/users/456" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "[${request.pathParams.id}]" } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19745/users/456")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19745).await;
+
+    assert_eq!(
+        body, "[]",
+        "without routePattern, request.pathParams.id resolves to empty, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_path_params_non_matching_pattern_is_empty() {
+    // routePattern is set but structurally does not match the request path (segment counts differ):
+    // the predicate still matches, so the stub is served, but pathParams must be empty (no error).
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19746,
+        "protocol": "http",
+        "stubs": [{
+            "routePattern": "/users/:id",
+            "predicates": [{ "equals": { "path": "/users/123/profile" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "[${request.pathParams.id}]" } }]
+        }]
+    }))
+    .expect("config");
+
+    let manager = ImposterManager::new();
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter");
+    let body = reqwest::Client::new()
+        .get("http://127.0.0.1:19746/users/123/profile")
+        .send()
+        .await
+        .expect("GET failed")
+        .text()
+        .await
+        .expect("body");
+    let _ = manager.delete_imposter(19746).await;
+
+    assert_eq!(
+        body, "[]",
+        "a routePattern that doesn't match the path shape yields empty pathParams, got: {body}"
+    );
 }

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -183,6 +183,12 @@ pub struct Stub {
     /// Useful for targeting specific stubs for updates/deletion without relying on index
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Route pattern for path-parameter extraction (issue #433, Rift extension), e.g.
+    /// `/users/:id`. When set and the request path matches its shape, each `:name` segment
+    /// populates `request.pathParams.<name>` for response templates and scripts. Absent ⇒ no path
+    /// params (unchanged default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route_pattern: Option<String>,
     #[serde(default)]
     pub predicates: Vec<Predicate>,
     #[serde(default)]
@@ -214,6 +220,8 @@ struct StubRaw {
     space: Option<String>,
     #[serde(default)]
     id: Option<String>,
+    #[serde(default)]
+    route_pattern: Option<String>,
     #[serde(default)]
     predicates: Vec<Predicate>,
     /// Alternative field name "rules" used instead of "predicates" in some recorded formats
@@ -281,6 +289,7 @@ impl From<StubRaw> for Stub {
             new_scenario_state: raw.new_scenario_state,
             space: raw.space,
             id: raw.id,
+            route_pattern: raw.route_pattern,
             predicates,
             responses,
             recorded_from: raw.recorded_from,

--- a/crates/rift-core/src/scripting/stub_validator.rs
+++ b/crates/rift-core/src/scripting/stub_validator.rs
@@ -260,6 +260,7 @@ mod tests {
     fn make_rift_script_stub(engine: &str, code: &str) -> Stub {
         Stub {
             id: Some("test-stub".to_string()),
+            route_pattern: None,
             predicates: vec![],
             responses: vec![StubResponse::RiftScript {
                 rift: RiftResponseExtension {
@@ -282,6 +283,7 @@ mod tests {
     fn make_inject_stub(code: &str) -> Stub {
         Stub {
             id: Some("inject-stub".to_string()),
+            route_pattern: None,
             predicates: vec![],
             responses: vec![StubResponse::Inject {
                 inject: code.to_string(),
@@ -364,6 +366,7 @@ mod tests {
         let stubs = vec![
             Stub {
                 id: None, // No id, will use stub[0]
+                route_pattern: None,
                 predicates: vec![],
                 responses: vec![StubResponse::RiftScript {
                     rift: RiftResponseExtension {
@@ -384,6 +387,7 @@ mod tests {
             },
             Stub {
                 id: None, // No id, will use stub[1]
+                route_pattern: None,
                 predicates: vec![],
                 responses: vec![StubResponse::RiftScript {
                     rift: RiftResponseExtension {

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -446,13 +446,14 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
                 None
             } else {
                 Some(crate::imposter::Stub {
-                    id: stub.id,
-                    predicates: stub.predicates,
-                    responses: non_proxy_responses,
                     scenario_name: stub.scenario_name,
                     required_scenario_state: stub.required_scenario_state,
                     new_scenario_state: stub.new_scenario_state,
                     space: stub.space,
+                    id: stub.id,
+                    route_pattern: stub.route_pattern,
+                    predicates: stub.predicates,
+                    responses: non_proxy_responses,
                     recorded_from: stub.recorded_from,
                     verify: stub.verify,
                 })

--- a/docs/configuration/native.md
+++ b/docs/configuration/native.md
@@ -234,6 +234,39 @@ for the full walkthrough of `decorate`/`shellTransform`/binary failures under st
 
 ---
 
+## Route Patterns (`routePattern`)
+
+`routePattern` is a **top-level stub field** — a sibling of `predicates`/`responses`/`id`/
+`scenarioName`, **not** nested under `_rift` — that declares a path shape (e.g. `/users/:id`) for
+extracting named path parameters from the request.
+
+| Field | Type | Default | Description |
+|:------|:-----|:--------|:-------------|
+| `routePattern` | string | — | Path shape with `:name` segments to capture as path parameters. |
+
+When the request path has the same number of `/`-separated segments as the pattern, each literal
+segment must match exactly and each `:name` segment captures the corresponding path segment. The
+captured values are exposed as:
+
+- `${request.pathParams.<name>}` in response templates (see
+  [Request Interpolation]({{ site.baseurl }}/mountebank/responses/#request-interpolation)).
+- `request.pathParams.<name>` in scripts, for every engine (see
+  [Scripting]({{ site.baseurl }}/features/scripting/)).
+
+If `routePattern` is absent, or the request path doesn't match its segment shape, `pathParams` is
+simply empty — nothing errors. Extraction is `:name`-segment matching only; there's no regex or
+glob support.
+
+```json
+{
+  "routePattern": "/users/:id",
+  "predicates": [{ "matches": { "path": "^/users/[^/]+$" } }],
+  "responses": [{ "is": { "statusCode": 200, "body": "user ${request.pathParams.id}" } }]
+}
+```
+
+---
+
 ## Fault Injection
 
 Add probabilistic fault injection to responses:

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -45,6 +45,8 @@ config.request.headers     // { "content-type": "application/json" }
 config.request.body        // Request body (string or parsed object)
 ```
 
+> Path parameters (`request.pathParams`, from a stub's [`routePattern`](../configuration/native/#route-patterns-routepattern)) are exposed to the `_rift.script` engines — Rhai, Lua, and JavaScript — not to this Mountebank `inject` `config.request` object.
+
 ### State Object
 
 Persist data across requests within the same imposter:
@@ -103,6 +105,7 @@ request.method          // String: "GET", "POST", etc.
 request.path            // String: "/api/users"
 request.headers         // Map: access via request.headers["header-name"]
 request.query           // Map: access via request.query["param"]
+request.pathParams      // Map: access via request.pathParams["name"] (populated from the stub's routePattern)
 request.body            // Parsed JSON body
 
 // Helper functions
@@ -202,6 +205,7 @@ request.method          -- String
 request.path            -- String
 request.headers         -- Table: request.headers["header-name"]
 request.query           -- Table: request.query["param"]
+request.pathParams      -- Table: request.pathParams["name"]
 request.body            -- Parsed body (table or string)
 
 -- Standard Lua functions

--- a/docs/mountebank/responses.md
+++ b/docs/mountebank/responses.md
@@ -151,6 +151,11 @@ substitutes them into the response **body** and **header values** before any beh
 | `${request.body}` | Raw request body |
 | `${request.query.<name>}` | Query parameter `<name>` |
 | `${request.headers.<name>}` | Request header `<name>` (case-insensitive) |
+| `${request.pathParams.<name>}` | Path parameter `<name>` captured from the stub's `routePattern` |
+
+`${request.pathParams.<name>}` only resolves when the stub declares a top-level `routePattern`
+(e.g. `/users/:id`) whose shape matches the request path — see
+[Route patterns]({{ site.baseurl }}/configuration/native/#route-patterns-routepattern).
 
 ```json
 {


### PR DESCRIPTION
A stub can declare a top-level routePattern (e.g. /users/:id); matching :name segments populate request.pathParams.<name> for response templates and the _rift.script engines (rhai/lua/js). Absent/non-matching pattern results in empty pathParams (unchanged default). Restores the pathParams docs removed in #432.

Closes #433