### PR TITLE
docs: add front-matter so the demo set appears in site nav (#280)

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Demos
+nav_order: 9.5
+permalink: /demo/
+---
+
 # Rift Demo
 
 Quick-start demos for Rift in different modes.


### PR DESCRIPTION
`docs/demo/README.md` had no Jekyll front-matter, so just-the-docs excluded the working demo corpus from the published site nav. Adds `title`/`nav_order`/`permalink: /demo/` to integrate it.

Addresses the **section D** demo-nav residual of #280 — does **not** close the umbrella; the example-execution gate (section E2) remains open as #436.