### PR TITLE
feat(scripting): P1 fidelity bundle — MB v2 config convention (dual-convention, zero breakage), real script logger, JS timeouts + Boa RuntimeLimits, enforce --allowInjection, MB error parity, execute wait fns, EJS stringify()

### DIFF
--- a/crates/rift-core/src/behaviors/wait.rs
+++ b/crates/rift-core/src/behaviors/wait.rs
@@ -31,19 +31,83 @@ impl WaitBehavior {
             WaitBehavior::Function(js_func) => {
                 // Parse JavaScript function and execute
                 // Format: "function() { return Math.floor(Math.random() * 100) + 50; }"
-                Self::execute_js_wait_function(js_func).unwrap_or(100)
+                // A failed/unusable wait function falls back to 100ms — but loudly, so it is
+                // distinguishable from a genuine 100ms wait (B4, issue #355).
+                Self::execute_js_wait_function(js_func).unwrap_or_else(|| {
+                    tracing::warn!(
+                        target: "rift::script",
+                        "wait function produced no usable delay; falling back to 100ms"
+                    );
+                    100
+                })
             }
         }
     }
 
-    /// Execute a JavaScript wait function
+    /// Execute a JavaScript wait function.
+    ///
+    /// When the `javascript` feature is enabled, this actually runs the function body on a
+    /// bounded Boa `Context` (issue #355 Item 6) rather than pattern-matching a couple of known
+    /// `Math.random` shapes — so any wait function (not just the ones the old regex recognized)
+    /// produces a correct value. Without the feature, falls back to the original regex-based
+    /// extraction so `--no-default-features` still builds and works for the common patterns.
     fn execute_js_wait_function(js_func: &str) -> Option<u64> {
-        // Extract the function body
         let trimmed = js_func.trim();
         if !trimmed.starts_with("function") {
             return None;
         }
 
+        #[cfg(feature = "javascript")]
+        {
+            if let Some(ms) = Self::execute_js_wait_function_boa(trimmed) {
+                return Some(ms);
+            }
+        }
+
+        Self::execute_js_wait_function_regex(trimmed)
+    }
+
+    /// Run the wait function body for real on a bounded Boa `Context`: evaluate `(<js_func>)()`
+    /// and coerce the numeric result to a `u64` delay, floored and capped at 60s so a
+    /// pathological/negative/huge result can't turn into an enormous or nonsensical sleep.
+    #[cfg(feature = "javascript")]
+    fn execute_js_wait_function_boa(js_func: &str) -> Option<u64> {
+        const MAX_WAIT_MS: u64 = 60_000;
+        let mut context = crate::scripting::bounded_js_context();
+        let wrapped = format!("({js_func})()");
+        // A script/runtime error must not be swallowed silently (B4, issue #355): log it, then
+        // return None so the caller's regex safety net / 100ms fallback still applies.
+        let result = match context.eval(boa_engine::Source::from_bytes(wrapped.as_bytes())) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(target: "rift::script", "wait function script error: {e}");
+                return None;
+            }
+        };
+        let n = match result.to_number(&mut context) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    target: "rift::script",
+                    "wait function returned a non-numeric result: {e}"
+                );
+                return None;
+            }
+        };
+        if !n.is_finite() {
+            tracing::warn!(
+                target: "rift::script",
+                "wait function returned a non-finite number: {n}"
+            );
+            return None;
+        }
+        let ms = n.max(0.0).floor() as u64;
+        Some(ms.min(MAX_WAIT_MS))
+    }
+
+    /// Regex-based fallback: used as the sole path when the `javascript` feature is disabled,
+    /// and as a safety net if the Boa path above fails to produce a value while it's enabled.
+    fn execute_js_wait_function_regex(trimmed: &str) -> Option<u64> {
         if let Some(body) = extract_function_body(trimmed) {
             // Handle Solo pattern:
             // var min = Math.ceil(N); var max = Math.floor(M); var num = Math.floor(Math.random() * (max - min + 1)); var wait = (num + min); return wait;
@@ -199,5 +263,28 @@ mod tests {
                 "Duration {duration} not in range 50-150"
             );
         }
+    }
+
+    // Issue #355 Item 6: the wait function body is actually EXECUTED (not regex-scraped), so a
+    // function that isn't one of the previously-recognized `Math.random` shapes still works.
+    #[test]
+    fn wait_function_executes_js() {
+        let wait = WaitBehavior::Function("function() { return 42; }".to_string());
+        assert_eq!(wait.get_duration_ms(), 42);
+    }
+
+    // A negative return value must not become an enormous u64 delay (underflow) or a negative
+    // sleep; it clamps to 0.
+    #[test]
+    fn wait_function_negative_clamps_to_zero() {
+        let wait = WaitBehavior::Function("function() { return -5; }".to_string());
+        assert_eq!(wait.get_duration_ms(), 0);
+    }
+
+    // A huge return value is capped rather than producing an unbounded sleep.
+    #[test]
+    fn wait_function_huge_value_is_capped() {
+        let wait = WaitBehavior::Function("function() { return 999999999; }".to_string());
+        assert_eq!(wait.get_duration_ms(), 60_000);
     }
 }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -349,6 +349,7 @@ async fn handle_request_inner(
                 &inject_fn,
                 &mb_request,
                 imposter.config.port.unwrap_or(0),
+                stub_state.stub.id.as_deref(),
             ) {
                 Ok(inject_response) => {
                     // Advance the cycler for this inject response
@@ -376,10 +377,21 @@ async fn handle_request_inner(
                 }
                 Err(e) => {
                     warn!("Inject function failed: {}", e);
+                    // Mountebank-shaped error parity (issue #355 Item 5): a failing inject is a
+                    // 400 with `{"errors":[{"code":"invalid injection","message":"..."}]}`, not a
+                    // bare 500 — the script failed to produce a valid response, which is a client
+                    // (config) problem, not a server fault.
+                    let body = serde_json::json!({
+                        "errors": [{
+                            "code": "invalid injection",
+                            "message": format!("{e}"),
+                        }]
+                    })
+                    .to_string();
                     return Ok(build_response_with_headers(
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::BAD_REQUEST,
                         [("x-rift-imposter", "true"), ("x-rift-inject-error", "true")],
-                        format!(r#"{{"error": "Inject error: {e}"}}"#),
+                        body,
                     ));
                 }
             }
@@ -641,6 +653,8 @@ async fn handle_request_inner(
                             &body,
                             status,
                             &mut single,
+                            imposter.config.port.unwrap_or(0),
+                            stub_state.stub.id.as_deref(),
                         ) {
                             Ok((new_body, new_status)) => {
                                 body = new_body;

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -276,14 +276,26 @@ pub fn create_stub_from_proxy_response(
     }
 }
 
-/// Apply decorate behavior - handles both JavaScript and Rhai scripts
+/// Apply decorate behavior - handles both JavaScript and Rhai scripts.
+///
+/// `imposter_port` identifies the per-imposter state shared with predicate injects and response
+/// injects for the same imposter (issue #355 Item 0) — decorate reads and writes the same
+/// persisted state rather than a throwaway object. `stub_id` tags the script logger's tracing
+/// events with the owning stub, when known (issue #355 AC1).
 pub fn apply_js_or_rhai_decorate(
     script: &str,
     request: &RequestContext,
     body: &str,
     status: u16,
     headers: &mut HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<&str>,
 ) -> Result<(String, u16), DecorateError> {
+    // Only the JS engine call sites below consume `imposter_port`/`stub_id`; without the feature
+    // the parameters would otherwise be unused.
+    #[cfg(not(feature = "javascript"))]
+    let _ = (imposter_port, stub_id);
+
     // Mountebank's JS `config =>` convention (issue #191): rewrite simple field access onto the
     // Rhai request/response maps. Checked before the `function` route since arrow scripts don't
     // start with "function" and `function(config)` uses the config model, not (request, response).
@@ -309,6 +321,8 @@ pub fn apply_js_or_rhai_decorate(
                 body,
                 status,
                 headers,
+                imposter_port,
+                stub_id,
             ) {
                 Ok(result) => {
                     for (k, v) in result.headers {
@@ -343,6 +357,8 @@ pub fn apply_js_or_rhai_decorate(
                 body,
                 status,
                 headers,
+                imposter_port,
+                stub_id,
             ) {
                 Ok(result) => {
                     // Update headers from the result
@@ -377,6 +393,14 @@ pub fn apply_js_or_rhai_decorate(
 mod tests {
     use super::*;
 
+    // Allocates a fresh port per test so parallel tests never share `IMPOSTER_STATE` (disjoint
+    // from the range used by `rift-core/src/scripting/js_engine.rs`'s own tests in this binary).
+    fn test_port() -> u16 {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static NEXT: AtomicU32 = AtomicU32::new(41_100);
+        NEXT.fetch_add(1, Ordering::Relaxed) as u16
+    }
+
     // Issue #191: the JS `config =>` decorate convention runs (rewritten to Rhai) end-to-end.
     fn decorate_req() -> RequestContext {
         RequestContext {
@@ -397,6 +421,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(body, "hello");
@@ -412,6 +438,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(body, "REQ-BODY");
@@ -437,8 +465,15 @@ mod tests {
             module.display()
         );
         let mut headers = std::collections::HashMap::new();
-        let result =
-            apply_js_or_rhai_decorate(&script, &decorate_req(), "original", 200, &mut headers);
+        let result = apply_js_or_rhai_decorate(
+            &script,
+            &decorate_req(),
+            "original",
+            200,
+            &mut headers,
+            test_port(),
+            None,
+        );
         let _ = std::fs::remove_file(&module);
         let (body, _) = result.expect("require-based config decorate should run");
         assert_eq!(body, "REQUIRE-RAN");
@@ -453,6 +488,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(status, 404);
@@ -469,6 +506,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(body, "fn");
@@ -485,6 +524,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(body, "bare");
@@ -499,6 +540,8 @@ mod tests {
             "original",
             200,
             &mut headers,
+            test_port(),
+            None,
         )
         .unwrap();
         assert_eq!(body, "/orders", "existing Rhai decorate must be unchanged");

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -222,6 +222,35 @@ fn execute_js_script(
 /// interrupt mechanism that 0.20 lacks.
 const JS_SCRIPT_LOOP_ITERATION_LIMIT: u64 = 10_000_000;
 
+/// Recursion depth cap applied to every bounded Boa `Context` (issue #355 Item 3). Boa's own
+/// default is already 512; set explicitly so the contract doesn't silently drift if Boa's default
+/// ever changes.
+const JS_SCRIPT_RECURSION_LIMIT: usize = 512;
+
+/// Stack size cap (bytes) applied to every bounded Boa `Context` (issue #355 Item 3), mirroring
+/// Boa's own default (10 * 1024).
+const JS_SCRIPT_STACK_SIZE_LIMIT: usize = 10 * 1024;
+
+/// Build a `Context` with the interpreter-level guards every Mountebank JS hook (inject response,
+/// predicate inject, `predicateGenerators.inject`, decorate) must run under (issue #355 Items 2/3).
+///
+/// Boa 0.20 has no per-instruction wall-clock interrupt, so these MB hooks — which execute
+/// synchronously, inline in the request path, with no `spawn_blocking` wrapper — can't honor a
+/// wall-clock deadline the way `_rift.script` does (see `bounded.rs::should_inject_bounded`).
+/// The loop-iteration cap is what makes a `while(true){}` throw instead of hanging its thread; the
+/// recursion/stack-size limits catch runaway recursion the same way. This is the enforcement layer
+/// that stands in for the `_rift.script` wall-clock budget (`bounded::DEFAULT_SCRIPT_TIMEOUT_MS`)
+/// for these sync call sites — every one of them must build its `Context` through this helper
+/// rather than `Context::default()`.
+pub(crate) fn bounded_js_context() -> Context {
+    let mut context = Context::default();
+    let limits = context.runtime_limits_mut();
+    limits.set_loop_iteration_limit(JS_SCRIPT_LOOP_ITERATION_LIMIT);
+    limits.set_recursion_limit(JS_SCRIPT_RECURSION_LIMIT);
+    limits.set_stack_size_limit(JS_SCRIPT_STACK_SIZE_LIMIT);
+    context
+}
+
 /// Inner function that does the actual JavaScript execution
 fn execute_js_script_inner(
     script: &str,
@@ -559,6 +588,186 @@ fn create_flow_store_object(context: &mut Context) -> Result<JsValue> {
     Ok(obj.into())
 }
 
+// =============================================================================
+// Mountebank v2 `config` calling convention support (issue #355 Item 0)
+// =============================================================================
+
+/// Flatten every field of a Mountebank request object onto `config` itself
+/// (`config.method`, `config.path`, `config.query`, `config.headers`, `config.body`), mirroring
+/// Mountebank v2's `downcastInjectionConfig`. This is why `function(config){config.request.path}`,
+/// `function(request){request.path}` (with `config` passed positionally where `request` used to
+/// be), and `function(config){config.path}` all address the same data.
+fn flatten_request_onto(
+    config_obj: &JsObject,
+    request_obj: &JsValue,
+    context: &mut Context,
+) -> Result<()> {
+    let Some(req) = request_obj.as_object() else {
+        return Ok(());
+    };
+    for key in ["method", "path", "query", "headers", "body"] {
+        let val = req
+            .get(js_string!(key), context)
+            .map_err(|e| anyhow!("Failed to read request.{key} for config flattening: {e}"))?;
+        config_obj
+            .set(js_string!(key), val, false, context)
+            .map_err(|e| anyhow!("Failed to flatten config.{key}: {e}"))?;
+    }
+    Ok(())
+}
+
+// =============================================================================
+// Native logger (issue #355 Item 1)
+// =============================================================================
+
+/// Log one Mountebank script `logger.<level>(...)` call at target `"rift::script"`, tagging the
+/// event with the imposter port and (where available) the stub id. All arguments are best-effort
+/// stringified and joined with a space, mirroring a console-style logger call.
+fn log_script_event(
+    level: tracing::Level,
+    port: u16,
+    stub_id: Option<&str>,
+    args: &[JsValue],
+    context: &mut Context,
+) {
+    let message: String = args
+        .iter()
+        .map(|v| js_value_to_log_string(context, v))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let stub_id = stub_id.unwrap_or("");
+    match level {
+        tracing::Level::ERROR => {
+            tracing::error!(target: "rift::script", port, stub_id, "{message}")
+        }
+        tracing::Level::WARN => {
+            tracing::warn!(target: "rift::script", port, stub_id, "{message}")
+        }
+        tracing::Level::INFO => {
+            tracing::info!(target: "rift::script", port, stub_id, "{message}")
+        }
+        tracing::Level::DEBUG => {
+            tracing::debug!(target: "rift::script", port, stub_id, "{message}")
+        }
+        tracing::Level::TRACE => {
+            tracing::trace!(target: "rift::script", port, stub_id, "{message}")
+        }
+    }
+}
+
+/// Best-effort stringify of a single logger argument: strings pass through; objects are
+/// JSON-stringified; everything else uses JS `display()`.
+fn js_value_to_log_string(context: &mut Context, value: &JsValue) -> String {
+    if let Some(s) = value.as_string() {
+        return s.to_std_string_escaped();
+    }
+    if value.is_object() {
+        let json = js_to_json(context, value).unwrap_or(Value::Null);
+        return serde_json::to_string(&json).unwrap_or_default();
+    }
+    value.display().to_string()
+}
+
+/// Captures shared by every native logger method registered on one script's `logger` object:
+/// the imposter port and (where the caller has one) the stub id.
+type LoggerCaptures = (u16, Option<String>);
+
+fn logger_debug(
+    _this: &JsValue,
+    args: &[JsValue],
+    captures: &LoggerCaptures,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    log_script_event(
+        tracing::Level::DEBUG,
+        captures.0,
+        captures.1.as_deref(),
+        args,
+        context,
+    );
+    Ok(JsValue::undefined())
+}
+
+fn logger_info(
+    _this: &JsValue,
+    args: &[JsValue],
+    captures: &LoggerCaptures,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    log_script_event(
+        tracing::Level::INFO,
+        captures.0,
+        captures.1.as_deref(),
+        args,
+        context,
+    );
+    Ok(JsValue::undefined())
+}
+
+fn logger_warn(
+    _this: &JsValue,
+    args: &[JsValue],
+    captures: &LoggerCaptures,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    log_script_event(
+        tracing::Level::WARN,
+        captures.0,
+        captures.1.as_deref(),
+        args,
+        context,
+    );
+    Ok(JsValue::undefined())
+}
+
+fn logger_error(
+    _this: &JsValue,
+    args: &[JsValue],
+    captures: &LoggerCaptures,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    log_script_event(
+        tracing::Level::ERROR,
+        captures.0,
+        captures.1.as_deref(),
+        args,
+        context,
+    );
+    Ok(JsValue::undefined())
+}
+
+/// Build a native `logger` object (`debug`/`info`/`warn`/`error`) that routes to `tracing` at
+/// target `"rift::script"`, tagged with the imposter port and, where available, the stub id
+/// (issue #355 Item 1). A real native object — not a JS no-op shim — so script log calls actually
+/// reach the process's tracing subscriber.
+/// Function pointer type shared by every native logger method (see [`create_script_logger_object`]).
+type LoggerMethodFn = fn(&JsValue, &[JsValue], &LoggerCaptures, &mut Context) -> JsResult<JsValue>;
+
+fn create_script_logger_object(
+    context: &mut Context,
+    port: u16,
+    stub_id: Option<String>,
+) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    let captures: LoggerCaptures = (port, stub_id);
+
+    let methods: [(&str, LoggerMethodFn); 4] = [
+        ("debug", logger_debug),
+        ("info", logger_info),
+        ("warn", logger_warn),
+        ("error", logger_error),
+    ];
+
+    for (name, func) in methods {
+        let native_fn = NativeFunction::from_copy_closure_with_captures(func, captures.clone())
+            .to_js_function(context.realm());
+        obj.set(js_string!(name), native_fn, false, context)
+            .map_err(|e| anyhow!("Failed to set logger.{name}: {e}"))?;
+    }
+
+    Ok(obj.into())
+}
+
 /// Parse fault decision from JavaScript result
 fn parse_fault_decision(
     context: &mut Context,
@@ -801,65 +1010,111 @@ pub fn clear_imposter_state(port: u16) {
     states.remove(&port);
 }
 
-/// Execute a Mountebank-style inject function
+/// Execute a Mountebank-style inject function.
 ///
-/// Mountebank inject functions have the signature:
-/// - `function(request) { return response; }`
+/// Implements Mountebank v2's `config`-first calling convention (issue #355 Item 0), built like
+/// Mountebank's `downcastInjectionConfig`: a `config` object (`{ request, state, logger,
+/// callback }`) with every request field ALSO flattened onto `config` itself, so
+/// `function(config){config.request.path}`, `function(request){request.path}` (legacy — `config`
+/// is passed where `request` used to be, and works because of the flattening), and
+/// `function(config){config.path}` all resolve the same data. Legacy positional args follow
+/// `config` unchanged, so old scripts keep working:
+///
+/// - `function(config) { return response; }` (v2)
+/// - `function(request) { return response; }` (legacy, `config` stands in for `request`)
 /// - `function(request, state) { return response; }`
 /// - `function(request, state, logger, callback) { callback(response); }`
+///
+/// Full call signature: `fn(config, injectState, logger, done, imposterState)`. `injectState`
+/// (arg 2) and `imposterState` (arg 5) are the SAME object as `config.state` — the per-imposter
+/// state persisted across calls via `get_imposter_state`/`save_imposter_state`, shared with
+/// predicate injects and decorate for the same imposter port. `done` (arg 4, aliased as
+/// `config.callback`) is the async-style callback; if the function returns `undefined` its
+/// invocation is used instead (this engine is fully synchronous, so "waiting" for `done` just
+/// means checking whether it was called during the synchronous call).
 ///
 /// Where response is: `{ statusCode: number, headers: object?, body: string }`
 pub fn execute_mountebank_inject(
     inject_fn: &str,
     request: &MountebankRequest,
     imposter_port: u16,
+    stub_id: Option<&str>,
 ) -> Result<MountebankInjectResponse> {
-    let mut context = Context::default();
+    let mut context = bounded_js_context();
 
     // Create request object
     let request_obj = create_mountebank_request_object(&mut context, request)?;
 
-    // Get current state for this imposter
+    // Get current (persisted, per-port) state for this imposter — shared across predicate
+    // injects, response injects, and decorate for the same imposter (issue #355 Item 0).
     let state_map = get_imposter_state(imposter_port);
     let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
 
-    // Set global variables
-    let global = context.global_object();
-    global
+    let logger_obj =
+        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+
+    // Build config = { request, state, logger } and flatten request fields onto config itself.
+    let config_obj = create_js_object(&context);
+    config_obj
         .set(
-            js_string!("__request"),
+            js_string!("request"),
             request_obj.clone(),
             false,
             &mut context,
         )
-        .map_err(|e| anyhow!("Failed to set request: {e}"))?;
+        .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
+    config_obj
+        .set(js_string!("state"), state_obj.clone(), false, &mut context)
+        .map_err(|e| anyhow!("Failed to set config.state: {e}"))?;
+    config_obj
+        .set(
+            js_string!("logger"),
+            logger_obj.clone(),
+            false,
+            &mut context,
+        )
+        .map_err(|e| anyhow!("Failed to set config.logger: {e}"))?;
+    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
+
+    // Set global variables consumed by the wrapper script below.
+    let global = context.global_object();
+    global
+        .set(js_string!("__config"), config_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set config: {e}"))?;
+    global
+        .set(js_string!("__logger"), logger_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set logger: {e}"))?;
+    // injectState and imposterState are the SAME shared, persisted state object as config.state.
     global
         .set(
-            js_string!("__state"),
+            js_string!("__injectState"),
             state_obj.clone(),
             false,
             &mut context,
         )
-        .map_err(|e| anyhow!("Failed to set state: {e}"))?;
+        .map_err(|e| anyhow!("Failed to set injectState: {e}"))?;
+    global
+        .set(
+            js_string!("__imposterState"),
+            state_obj,
+            false,
+            &mut context,
+        )
+        .map_err(|e| anyhow!("Failed to set imposterState: {e}"))?;
 
-    // Wrap the inject function to call it with our arguments
-    // Support both sync and callback styles
-    // For callback style, we capture the result in __callbackResult
+    // Wrap the inject function to call it with (config, injectState, logger, done, imposterState).
+    // `config.callback` aliases `done` so scripts using either the positional callback or the
+    // config field convention both work. If the function returns undefined, use whatever `done`/
+    // `config.callback` was invoked with instead (synchronous stand-in for MB's async wait).
     let wrapper_script = format!(
         r#"
-        var __injectFn = {inject_fn};
         var __callbackResult = null;
-        var __logger = function() {{}};  // No-op logger
-        var __callback = function(r) {{ __callbackResult = r; }};
-        var __directResult;
-
-        if (__injectFn.length >= 4) {{
-            // Callback style: function(request, state, logger, callback)
-            __injectFn(__request, __state, __logger, __callback);
+        var __done = function(r) {{ __callbackResult = r; }};
+        __config.callback = __done;
+        var __injectFn = {inject_fn};
+        var __directResult = __injectFn(__config, __injectState, __logger, __done, __imposterState);
+        if (__directResult === undefined) {{
             __directResult = __callbackResult;
-        }} else {{
-            // Sync style: function(request) or function(request, state)
-            __directResult = __injectFn(__request, __state, __logger);
         }}
         __directResult;
         "#
@@ -870,9 +1125,9 @@ pub fn execute_mountebank_inject(
         .eval(Source::from_bytes(wrapper_script.as_bytes()))
         .map_err(|e| anyhow!("Failed to execute inject function: {e}"))?;
 
-    // Save updated state back
+    // Save updated state back (config.state/injectState/imposterState all alias the same object).
     let updated_state = global
-        .get(js_string!("__state"), &mut context)
+        .get(js_string!("__imposterState"), &mut context)
         .map_err(|e| anyhow!("Failed to get updated state: {e}"))?;
 
     if let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state) {
@@ -884,14 +1139,18 @@ pub fn execute_mountebank_inject(
 }
 
 /// Execute a Mountebank-style predicate inject function.
-/// The function signature is: `function(request, logger, imposterState) { return bool; }`
-/// Returns `true` if the predicate matches, `false` otherwise.
+///
+/// v2 `config`-first calling convention (issue #355 Item 0): full signature
+/// `fn(config, logger, imposterState) { return bool; }`, where `config` also stands in for the
+/// legacy `request` positional argument (request fields are flattened onto `config`), and
+/// `imposterState` aliases `config.state` — the same per-port state shared with response injects
+/// and decorate for the same imposter. Returns `true` if the predicate matches, `false` otherwise.
 pub fn execute_predicate_inject(
     inject_fn: &str,
     request: &MountebankRequest,
     imposter_port: u16,
 ) -> bool {
-    let mut context = Context::default();
+    let mut context = bounded_js_context();
 
     let request_obj = match create_mountebank_request_object(&mut context, request) {
         Ok(obj) => obj,
@@ -910,15 +1169,57 @@ pub fn execute_predicate_inject(
         }
     };
 
+    // stub_id is left None here: predicate matching operates on a `PredicateOperation` tree and
+    // the owning stub's id is not threaded through the matcher without an invasive change to the
+    // predicate-matching signatures (issue #355 AC1 note).
+    let logger_obj = match create_script_logger_object(&mut context, imposter_port, None) {
+        Ok(obj) => obj,
+        Err(e) => {
+            tracing::warn!("inject predicate: failed to build logger object: {e}");
+            return false;
+        }
+    };
+
+    let config_obj = create_js_object(&context);
+    if config_obj
+        .set(
+            js_string!("request"),
+            request_obj.clone(),
+            false,
+            &mut context,
+        )
+        .is_err()
+        || config_obj
+            .set(js_string!("state"), state_obj.clone(), false, &mut context)
+            .is_err()
+        || config_obj
+            .set(
+                js_string!("logger"),
+                logger_obj.clone(),
+                false,
+                &mut context,
+            )
+            .is_err()
+        || flatten_request_onto(&config_obj, &request_obj, &mut context).is_err()
+    {
+        tracing::warn!("inject predicate: failed to build config object");
+        return false;
+    }
+
     let global = context.global_object();
-    let _ = global.set(js_string!("__request"), request_obj, false, &mut context);
-    let _ = global.set(js_string!("__state"), state_obj, false, &mut context);
+    let _ = global.set(js_string!("__config"), config_obj, false, &mut context);
+    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut context);
+    let _ = global.set(
+        js_string!("__imposterState"),
+        state_obj,
+        false,
+        &mut context,
+    );
 
     let wrapper_script = format!(
         r#"
         var __injectFn = {inject_fn};
-        var __logger = {{ debug: function() {{}}, info: function() {{}}, warn: function() {{}}, error: function() {{}} }};
-        var __result = __injectFn(__request, __logger, __state);
+        var __result = __injectFn(__config, __logger, __imposterState);
         Boolean(__result);
         "#
     );
@@ -931,8 +1232,8 @@ pub fn execute_predicate_inject(
         }
     };
 
-    // Update state
-    if let Ok(updated_state) = global.get(js_string!("__state"), &mut context)
+    // Update the persisted, shared per-port state.
+    if let Ok(updated_state) = global.get(js_string!("__imposterState"), &mut context)
         && let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state)
     {
         save_imposter_state(imposter_port, map);
@@ -951,7 +1252,7 @@ pub fn execute_predicate_generator_inject(
     request: &MountebankRequest,
     existing_predicates: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
-    let mut context = Context::default();
+    let mut context = bounded_js_context();
 
     let request_obj = match create_mountebank_request_object(&mut context, request) {
         Ok(obj) => obj,
@@ -970,8 +1271,19 @@ pub fn execute_predicate_generator_inject(
         }
     };
 
+    // No imposter is running yet during proxy recording, so there is no per-port state to tag
+    // the logger with (port 0 placeholder) and no stub id exists yet (stub_id left None).
+    let logger_obj = match create_script_logger_object(&mut context, 0, None) {
+        Ok(obj) => obj,
+        Err(e) => {
+            tracing::warn!("predicateGenerator inject: failed to build logger object: {e}");
+            return Vec::new();
+        }
+    };
+
     let global = context.global_object();
     let _ = global.set(js_string!("__request"), request_obj, false, &mut context);
+    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut context);
     let _ = global.set(
         js_string!("__predicates"),
         predicates_val,
@@ -983,7 +1295,6 @@ pub fn execute_predicate_generator_inject(
         r#"
         var __injectFn = {inject_fn};
         var __config = {{ request: __request }};
-        var __logger = {{ debug: function() {{}}, info: function() {{}}, warn: function() {{}}, error: function(){{}} }};
         var __result = __injectFn(__config, __logger, __predicates);
         JSON.stringify(__result);
         "#
@@ -1300,16 +1611,21 @@ fn register_require(context: &mut Context) -> Result<()> {
 }
 
 /// Execute a Mountebank `config => {...}` / `function(config)` decorate in Boa, exposing a
-/// `config` object ({ request, response, path }) and a CommonJS `require()` so a decorate can
-/// load an external `.cjs`/`.js` module (issue #305). Returns the mutated response.
+/// `config` object ({ request, response, path, state, logger }) — with every request field also
+/// flattened onto `config` itself (issue #355 Item 0) — and a CommonJS `require()` so a decorate
+/// can load an external `.cjs`/`.js` module (issue #305). `config.state` is the per-port state
+/// persisted via `get_imposter_state`/`save_imposter_state`, shared with predicate injects and
+/// response injects for the same imposter. Returns the mutated response.
 pub fn execute_mountebank_config_decorate(
     decorate_fn: &str,
     request: &MountebankRequest,
     response_body: &str,
     response_status: u16,
     response_headers: &std::collections::HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<&str>,
 ) -> Result<MountebankDecorateResponse> {
-    let mut context = Context::default();
+    let mut context = bounded_js_context();
 
     // Create request object
     let request_obj = create_mountebank_request_object(&mut context, request)?;
@@ -1351,10 +1667,22 @@ pub fn execute_mountebank_config_decorate(
         .set(js_string!("headers"), headers_obj, false, &mut context)
         .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
 
-    // Build the config object: { request, response, path }
+    // Get current (persisted, per-port) state for this imposter — shared with predicate/response
+    // injects for the same imposter (issue #355 Item 0).
+    let state_map = get_imposter_state(imposter_port);
+    let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
+    let logger_obj =
+        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+
+    // Build the config object: { request, response, path, state, logger } + flattened request.
     let config_obj = create_js_object(&context);
     config_obj
-        .set(js_string!("request"), request_obj, false, &mut context)
+        .set(
+            js_string!("request"),
+            request_obj.clone(),
+            false,
+            &mut context,
+        )
         .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
     config_obj
         .set(
@@ -1372,6 +1700,13 @@ pub fn execute_mountebank_config_decorate(
             &mut context,
         )
         .map_err(|e| anyhow!("Failed to set config.path: {e}"))?;
+    config_obj
+        .set(js_string!("state"), state_obj.clone(), false, &mut context)
+        .map_err(|e| anyhow!("Failed to set config.state: {e}"))?;
+    config_obj
+        .set(js_string!("logger"), logger_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set config.logger: {e}"))?;
+    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
 
     // Register the CommonJS `require()` global before evaluating the decorate so it (and any
     // module it loads) can use it.
@@ -1454,6 +1789,11 @@ pub fn execute_mountebank_config_decorate(
         })
         .unwrap_or_else(|| response_body.to_string());
 
+    // Persist any mutation the decorate made to the shared, per-port state.
+    if let Ok(Value::Object(map)) = js_to_json(&mut context, &state_obj) {
+        save_imposter_state(imposter_port, map);
+    }
+
     Ok(MountebankDecorateResponse {
         status_code,
         headers,
@@ -1461,16 +1801,25 @@ pub fn execute_mountebank_config_decorate(
     })
 }
 
-/// Execute a Mountebank-style decorate behavior function
-/// Format: function(request, response) { ... modifies response ... }
+/// Execute a Mountebank-style decorate behavior function.
+///
+/// Full call signature (issue #355 Item 0): `fn(config, response, logger, state)`, where `config`
+/// stands in for the legacy `request` positional argument (request fields flattened onto
+/// `config`), and `state` is the per-port state persisted via `get_imposter_state`/
+/// `save_imposter_state` — shared with predicate injects and response injects for the same
+/// imposter (previously this was a throwaway `{}` per call).
+/// Legacy forms: `function(request, response) { ... }`, `function(request, response, logger)`,
+/// `function(request, response, logger, state)`.
 pub fn execute_mountebank_decorate(
     decorate_fn: &str,
     request: &MountebankRequest,
     response_body: &str,
     response_status: u16,
     response_headers: &std::collections::HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<&str>,
 ) -> Result<MountebankDecorateResponse> {
-    let mut context = Context::default();
+    let mut context = bounded_js_context();
 
     // Create request object
     let request_obj = create_mountebank_request_object(&mut context, request)?;
@@ -1512,16 +1861,36 @@ pub fn execute_mountebank_decorate(
         .set(js_string!("headers"), headers_obj, false, &mut context)
         .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
 
-    // Set global variables
-    let global = context.global_object();
-    global
+    // Config-first convention (issue #355 Item 0): config stands in for the legacy `request` arg,
+    // with request fields flattened onto it, and carries the shared per-port state + native
+    // logger. Built even though this entrypoint's legacy convention doesn't take a `config`
+    // param, so `function(config, response, ...)`-style scripts also work through this path.
+    let config_obj = create_js_object(&context);
+    config_obj
         .set(
-            js_string!("__request"),
+            js_string!("request"),
             request_obj.clone(),
             false,
             &mut context,
         )
+        .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
+    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
+
+    // Get current (persisted, per-port) state for this imposter — shared with predicate/response
+    // injects for the same imposter (previously a throwaway `{}` per call; issue #355 Item 0).
+    let state_map = get_imposter_state(imposter_port);
+    let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
+    let logger_obj =
+        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+
+    // Set global variables
+    let global = context.global_object();
+    global
+        .set(js_string!("__request"), request_obj, false, &mut context)
         .map_err(|e| anyhow!("Failed to set request: {e}"))?;
+    global
+        .set(js_string!("__config"), config_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set config: {e}"))?;
     global
         .set(
             js_string!("__response"),
@@ -1530,16 +1899,25 @@ pub fn execute_mountebank_decorate(
             &mut context,
         )
         .map_err(|e| anyhow!("Failed to set response: {e}"))?;
+    global
+        .set(js_string!("__logger"), logger_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set logger: {e}"))?;
+    global
+        .set(
+            js_string!("__state"),
+            state_obj.clone(),
+            false,
+            &mut context,
+        )
+        .map_err(|e| anyhow!("Failed to set state: {e}"))?;
 
-    // Wrap the decorate function to call it with our arguments.
-    // Provide a no-op logger (Mountebank's 3rd arg) and empty state (4th arg) so
-    // scripts that reference logger.info(...) or state.counter don't throw ReferenceError.
+    // Wrap the decorate function to call it with (config, response, logger, state). `config`
+    // stands in for the legacy `request` positional arg (request fields flattened onto it), so
+    // both `function(request, response, ...)` and `function(config, response, ...)` scripts work.
     let wrapper_script = format!(
         r#"
         var __decorateFn = {decorate_fn};
-        var __logger = {{ debug: function() {{}}, info: function() {{}}, warn: function() {{}}, error: function() {{}} }};
-        var __state = {{}};
-        __decorateFn(__request, __response, __logger, __state);
+        __decorateFn(__config, __response, __logger, __state);
         __response;
         "#
     );
@@ -1548,6 +1926,11 @@ pub fn execute_mountebank_decorate(
     let result = context
         .eval(Source::from_bytes(wrapper_script.as_bytes()))
         .map_err(|e| anyhow!("Failed to execute decorate function: {e}"))?;
+
+    // Persist any mutation the decorate made to the shared, per-port state.
+    if let Ok(Value::Object(map)) = js_to_json(&mut context, &state_obj) {
+        save_imposter_state(imposter_port, map);
+    }
 
     // Parse the modified response
     let obj = result
@@ -2177,6 +2560,14 @@ function should_inject(request, flow_store) {
         }
     }
 
+    // Allocates a fresh, never-reused port number for each test that touches the process-global
+    // `IMPOSTER_STATE` map, so parallel tests never see each other's persisted state.
+    fn test_port() -> u16 {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static NEXT: AtomicU32 = AtomicU32::new(40_100);
+        NEXT.fetch_add(1, Ordering::Relaxed) as u16
+    }
+
     #[test]
     fn test_decorate_with_logger_arg() {
         let request = MountebankRequest {
@@ -2190,7 +2581,15 @@ function should_inject(request, flow_store) {
 
         // Script that uses logger as 3rd argument — must not throw ReferenceError
         let script = r#"function(request, response, logger) { logger.info("decorating"); response.body = "logged"; }"#;
-        let result = execute_mountebank_decorate(script, &request, "original", 200, &headers);
+        let result = execute_mountebank_decorate(
+            script,
+            &request,
+            "original",
+            200,
+            &headers,
+            test_port(),
+            None,
+        );
         assert!(
             result.is_ok(),
             "logger arg should not throw: {:?}",
@@ -2212,7 +2611,15 @@ function should_inject(request, flow_store) {
 
         // Script that uses state as 4th argument — must not throw ReferenceError
         let script = r#"function(request, response, logger, state) { state.count = 1; response.body = "state ok"; }"#;
-        let result = execute_mountebank_decorate(script, &request, "original", 200, &headers);
+        let result = execute_mountebank_decorate(
+            script,
+            &request,
+            "original",
+            200,
+            &headers,
+            test_port(),
+            None,
+        );
         assert!(
             result.is_ok(),
             "state arg should not throw: {:?}",
@@ -2260,6 +2667,8 @@ function should_inject(request, flow_store) {
             "orig",
             200,
             &HashMap::new(),
+            test_port(),
+            None,
         );
         let _ = std::fs::remove_file(&module);
         let resp = result.expect("require decorate should run");
@@ -2274,9 +2683,16 @@ function should_inject(request, flow_store) {
     #[test]
     fn test_config_decorate_direct_field_access() {
         let script = "config => { config.response.body = 'DIRECT'; }";
-        let resp =
-            execute_mountebank_config_decorate(script, &config_req(), "orig", 200, &HashMap::new())
-                .expect("direct config decorate should run");
+        let resp = execute_mountebank_config_decorate(
+            script,
+            &config_req(),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("direct config decorate should run");
         assert_eq!(resp.body, "DIRECT");
     }
 
@@ -2284,9 +2700,16 @@ function should_inject(request, flow_store) {
     #[test]
     fn test_config_decorate_reads_request_body() {
         let script = "config => { config.response.body = config.request.body; }";
-        let resp =
-            execute_mountebank_config_decorate(script, &config_req(), "orig", 200, &HashMap::new())
-                .expect("config.request decorate should run");
+        let resp = execute_mountebank_config_decorate(
+            script,
+            &config_req(),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("config.request decorate should run");
         assert_eq!(resp.body, "REQ-BODY");
     }
 
@@ -2332,6 +2755,8 @@ function should_inject(request, flow_store) {
             "orig",
             200,
             &HashMap::new(),
+            test_port(),
+            None,
         );
         let _ = std::fs::remove_file(&path_a);
         let _ = std::fs::remove_file(&path_b);
@@ -2347,11 +2772,393 @@ function should_inject(request, flow_store) {
     #[test]
     fn test_config_decorate_require_missing_errors() {
         let script = "config => { const s = require('/no/such/rift305/module.cjs'); s(config); }";
-        let result =
-            execute_mountebank_config_decorate(script, &config_req(), "orig", 200, &HashMap::new());
+        let result = execute_mountebank_config_decorate(
+            script,
+            &config_req(),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        );
         assert!(
             result.is_err(),
             "a missing require() must surface as Err, not silently no-op"
+        );
+    }
+
+    // =========================================================================================
+    // Issue #355 Item 0: Mountebank v2 `config` calling convention (dual-convention, zero
+    // breakage) for response inject, predicate inject, and decorate.
+    // =========================================================================================
+
+    fn mb_req(method: &str, path: &str) -> MountebankRequest {
+        MountebankRequest {
+            method: method.to_string(),
+            path: path.to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        }
+    }
+
+    // (a) v2 config convention: function(config) { ...config.request.path... }
+    #[test]
+    fn inject_v2_config_request_path() {
+        let script =
+            r#"function(config) { return { statusCode: 200, body: config.request.path }; }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/a-path"), test_port(), None)
+            .expect("v2 config convention should run");
+        assert_eq!(resp.body, "/a-path");
+    }
+
+    // (b) legacy positional: function(request, state, logger) { ...request.path... }
+    #[test]
+    fn inject_legacy_positional_request_path() {
+        let script = r#"function(request, state, logger) { return { statusCode: 200, body: request.path }; }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/legacy"), test_port(), None)
+            .expect("legacy positional convention should run");
+        assert_eq!(resp.body, "/legacy");
+    }
+
+    // (c) flattened: function(config) { ...config.path... } (no config.request access)
+    #[test]
+    fn inject_flattened_config_path() {
+        let script = r#"function(config) { return { statusCode: 200, body: config.path + " " + config.method }; }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("POST", "/flat"), test_port(), None)
+            .expect("flattened config fields should be readable");
+        assert_eq!(resp.body, "/flat POST");
+    }
+
+    // (d) the `var req = config.request || config;` shim used by scripts written to run under
+    // either the old or new convention.
+    #[test]
+    fn inject_request_or_config_shim() {
+        let script = r#"function(config) {
+            var req = config.request || config;
+            return { statusCode: 200, body: req.path };
+        }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/shim"), test_port(), None)
+            .expect("request-or-config shim should run");
+        assert_eq!(resp.body, "/shim");
+    }
+
+    // (e) hybrid: function(config, state) { ... } — a script naming the 2nd positional param
+    // "state" (matching Mountebank's legacy name) still works positionally.
+    #[test]
+    fn inject_hybrid_config_state() {
+        let script = r#"function(config, state) {
+            state.hits = (state.hits || 0) + 1;
+            return { statusCode: 200, body: "hits:" + state.hits };
+        }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/hybrid"), test_port(), None)
+            .expect("hybrid config+state signature should run");
+        assert_eq!(resp.body, "hits:1");
+    }
+
+    // The async-callback convention: `done` (arg 4) is called instead of returning a value;
+    // `config.callback` is an alias of the same function, so either spelling works.
+    #[test]
+    fn inject_callback_style_done() {
+        let script = r#"function(config, injectState, logger, done) {
+            done({ statusCode: 200, body: "via-done" });
+        }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/cb"), test_port(), None)
+            .expect("callback-style inject should run");
+        assert_eq!(resp.body, "via-done");
+    }
+
+    #[test]
+    fn inject_callback_style_config_callback_alias() {
+        let script = r#"function(config) {
+            config.callback({ statusCode: 200, body: "via-config-callback" });
+        }"#;
+        let resp = execute_mountebank_inject(script, &mb_req("GET", "/cb2"), test_port(), None)
+            .expect("config.callback alias should run");
+        assert_eq!(resp.body, "via-config-callback");
+    }
+
+    // Predicate inject: same five conventions, adapted to a boolean-returning function.
+    #[test]
+    fn predicate_v2_config_request_path() {
+        let script = r#"function(config) { return config.request.path === "/match"; }"#;
+        assert!(execute_predicate_inject(
+            script,
+            &mb_req("GET", "/match"),
+            test_port()
+        ));
+    }
+
+    #[test]
+    fn predicate_legacy_positional() {
+        let script = r#"function(request, logger, state) { return request.path === "/match"; }"#;
+        assert!(execute_predicate_inject(
+            script,
+            &mb_req("GET", "/match"),
+            test_port()
+        ));
+    }
+
+    #[test]
+    fn predicate_flattened_config_path() {
+        let script = r#"function(config) { return config.path === "/match"; }"#;
+        assert!(execute_predicate_inject(
+            script,
+            &mb_req("GET", "/match"),
+            test_port()
+        ));
+    }
+
+    #[test]
+    fn predicate_request_or_config_shim() {
+        let script = r#"function(config) {
+            var req = config.request || config;
+            return req.path === "/match";
+        }"#;
+        assert!(execute_predicate_inject(
+            script,
+            &mb_req("GET", "/match"),
+            test_port()
+        ));
+    }
+
+    #[test]
+    fn predicate_hybrid_config_state() {
+        let script = r#"function(config, state) {
+            state.checked = true;
+            return config.method === "GET";
+        }"#;
+        assert!(execute_predicate_inject(
+            script,
+            &mb_req("GET", "/match"),
+            test_port()
+        ));
+    }
+
+    // Decorate: same five conventions.
+    #[test]
+    fn decorate_v2_config_request_path() {
+        let script = r#"function(config, response) { response.body = config.request.path; }"#;
+        let resp = execute_mountebank_decorate(
+            script,
+            &mb_req("GET", "/dec-a"),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("v2 config decorate should run");
+        assert_eq!(resp.body, "/dec-a");
+    }
+
+    #[test]
+    fn decorate_legacy_positional() {
+        let script = r#"function(request, response, logger) { response.body = request.path; }"#;
+        let resp = execute_mountebank_decorate(
+            script,
+            &mb_req("GET", "/dec-legacy"),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("legacy positional decorate should run");
+        assert_eq!(resp.body, "/dec-legacy");
+    }
+
+    #[test]
+    fn decorate_flattened_config_path() {
+        let script = r#"function(config, response) { response.body = config.path; }"#;
+        let resp = execute_mountebank_decorate(
+            script,
+            &mb_req("GET", "/dec-flat"),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("flattened config decorate should run");
+        assert_eq!(resp.body, "/dec-flat");
+    }
+
+    #[test]
+    fn decorate_request_or_config_shim() {
+        let script = r#"function(config, response) {
+            var req = config.request || config;
+            response.body = req.path;
+        }"#;
+        let resp = execute_mountebank_decorate(
+            script,
+            &mb_req("GET", "/dec-shim"),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("request-or-config shim decorate should run");
+        assert_eq!(resp.body, "/dec-shim");
+    }
+
+    #[test]
+    fn decorate_hybrid_config_state() {
+        let script = r#"function(config, response, logger, state) {
+            state.decorated = true;
+            response.body = "decorated:" + config.method;
+        }"#;
+        let resp = execute_mountebank_decorate(
+            script,
+            &mb_req("GET", "/dec-hybrid"),
+            "orig",
+            200,
+            &HashMap::new(),
+            test_port(),
+            None,
+        )
+        .expect("hybrid config+state decorate should run");
+        assert_eq!(resp.body, "decorated:GET");
+    }
+
+    // State written by a predicate inject must be visible to a later response inject on the same
+    // imposter port (issue #355 Item 0: config.state / imposterState is shared per-port).
+    #[test]
+    fn state_shared_between_predicate_and_response_inject() {
+        let port = test_port();
+        let predicate_script =
+            r#"function(config) { config.state.seen = "from-predicate"; return true; }"#;
+        assert!(execute_predicate_inject(
+            predicate_script,
+            &mb_req("GET", "/shared"),
+            port
+        ));
+
+        let inject_script = r#"function(config) { return { statusCode: 200, body: config.state.seen || "missing" }; }"#;
+        let resp = execute_mountebank_inject(inject_script, &mb_req("GET", "/shared"), port, None)
+            .expect("response inject should run");
+        assert_eq!(
+            resp.body, "from-predicate",
+            "state written by a predicate inject must be visible to a later response inject \
+             on the same imposter port"
+        );
+    }
+
+    // =========================================================================================
+    // Issue #355 Item 1: native logger routes to `tracing`.
+    // =========================================================================================
+
+    /// Minimal capturing `tracing::Subscriber` (no external test-capture crate needed): records
+    /// every event's target + fields as one formatted string per event.
+    struct CapturingSubscriber {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl tracing::Subscriber for CapturingSubscriber {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct Visitor(String);
+            impl tracing::field::Visit for Visitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    self.0.push_str(&format!("{}={:?} ", field.name(), value));
+                }
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    self.0.push_str(&format!("{}={} ", field.name(), value));
+                }
+            }
+            let mut visitor = Visitor(format!("target={} ", event.metadata().target()));
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(visitor.0);
+        }
+        fn enter(&self, _span: &tracing::span::Id) {}
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    // The native logger's methods are callable without throwing, AND the messages actually reach
+    // the process's tracing subscriber at target "rift::script", tagged with the imposter port and
+    // — when the caller provides one — the stub id (issue #355 Item 1 + AC1).
+    #[test]
+    fn mb_logger_routes_to_tracing() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = CapturingSubscriber {
+            events: Arc::clone(&events),
+        };
+        let port = test_port();
+
+        let script = r#"function(config) {
+            config.logger.debug("dbg-msg");
+            config.logger.info("hello-from-script");
+            config.logger.warn("warn-msg");
+            config.logger.error("err-msg");
+            return { statusCode: 200, body: "logged" };
+        }"#;
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            execute_mountebank_inject(script, &mb_req("GET", "/log"), port, Some("stub-log-42"))
+        });
+
+        assert!(
+            result.is_ok(),
+            "logger calls must not throw: {:?}",
+            result.err()
+        );
+
+        let logs = events.lock().unwrap();
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("rift::script") && l.contains("hello-from-script")),
+            "expected an info event carrying the script's message, got: {logs:?}"
+        );
+        assert!(
+            logs.iter().any(|l| l.contains(&port.to_string())),
+            "expected the imposter port to be tagged on a logged event, got: {logs:?}"
+        );
+        assert!(
+            logs.iter().any(|l| l.contains("stub-log-42")),
+            "expected the stub id to be tagged on a logged event when provided, got: {logs:?}"
+        );
+    }
+
+    // =========================================================================================
+    // Issue #355 Item 3: Boa RuntimeLimits on every MB JS hook Context.
+    // =========================================================================================
+
+    // An inject fn with a genuine infinite loop must terminate (Err), not hang, because
+    // `bounded_js_context()` caps loop iterations on every Context these hooks build.
+    #[test]
+    fn mb_inject_infinite_loop_terminates() {
+        let script = r#"function(config) { while (true) {} }"#;
+        let result = execute_mountebank_inject(script, &mb_req("GET", "/loop"), test_port(), None);
+        assert!(
+            result.is_err(),
+            "an infinite loop in an inject fn must terminate with an error, not hang"
+        );
+    }
+
+    // =========================================================================================
+    // Issue #355 Item 5 (AC5): a throwing inject fn surfaces as an Err (the handler maps this to
+    // a Mountebank-shaped 400 — see issue_355_inject_error_parity.rs for the end-to-end assertion).
+    // =========================================================================================
+    #[test]
+    fn mb_inject_throwing_returns_err() {
+        let script = r#"function(config) { throw new Error('boom-inject'); }"#;
+        let result = execute_mountebank_inject(script, &mb_req("GET", "/throw"), test_port(), None);
+        let err = result.expect_err("a throwing inject must surface as Err, not silently succeed");
+        assert!(
+            err.to_string().contains("boom-inject"),
+            "the error must carry the script's failure message, got: {err}"
         );
     }
 }

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -27,6 +27,11 @@ pub use lua_engine::{LuaEngine, compile_to_bytecode};
 
 #[cfg(feature = "javascript")]
 mod js_engine;
+/// Exposed so other modules (e.g. `behaviors::wait`) that run a standalone JS snippet outside the
+/// MB inject/predicate/decorate hooks still get the same interpreter-level guards (issue #355
+/// Items 3/6) rather than an unbounded `Context::default()`.
+#[cfg(feature = "javascript")]
+pub(crate) use js_engine::bounded_js_context;
 #[cfg(feature = "javascript")]
 pub use js_engine::{
     JsEngine, MountebankRequest, clear_imposter_state, compile_js_to_bytecode,

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -3,13 +3,14 @@
 use crate::admin_api::request_filter::{parse_match_clauses, request_matches};
 use crate::admin_api::types::{
     ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
-    RiftImposterExtensions, StubWithLinks, collect_body, error_response, json_response,
-    make_imposter_links, make_stub_links,
+    RiftImposterExtensions, StubWithLinks, build_response_with_headers, collect_body,
+    error_response, json_response, make_imposter_links, make_stub_links,
 };
 use crate::extensions::decorate::backend_error_response;
 use crate::extensions::stub_analysis::analyze_stubs;
 use crate::imposter::{
-    Imposter, ImposterConfig, ImposterError, ImposterManager, RecordedRequest, StubResponse,
+    Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
+    RecordedRequest, Stub, StubResponse,
 };
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
@@ -20,11 +21,113 @@ use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
+/// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`
+/// (issue #355 Item 4): an inject response, a decorate behavior (`_behaviors.decorate` / a
+/// proxy's `addDecorateBehavior`), a `_behaviors.shellTransform` (runs a host shell command),
+/// a `wait` behavior expressed as a JS function (which this engine now executes on Boa), a
+/// predicate `inject`, a `predicateGenerators.inject`, or `_rift.script`. Mirrors Mountebank's
+/// `allowInjection` gate.
+fn stubs_contain_script_surface(stubs: &[Stub]) -> bool {
+    stubs.iter().any(|stub| {
+        stub.predicates.iter().any(predicate_has_inject)
+            || stub.responses.iter().any(response_has_script_surface)
+    })
+}
+
+/// True if `predicate` (or anything nested under a `not`/`or`/`and`) is an `inject` predicate.
+fn predicate_has_inject(predicate: &Predicate) -> bool {
+    match &predicate.operation {
+        PredicateOperation::Inject(_) => true,
+        PredicateOperation::Not(inner) => predicate_has_inject(inner),
+        PredicateOperation::Or(preds) | PredicateOperation::And(preds) => {
+            preds.iter().any(predicate_has_inject)
+        }
+        _ => false,
+    }
+}
+
+/// True if `response` uses any script surface: an inject response, a decorate behavior, a
+/// shellTransform behavior, a JS-function `wait` behavior, or `_rift.script`.
+fn response_has_script_surface(response: &StubResponse) -> bool {
+    match response {
+        StubResponse::Inject { .. } => true,
+        StubResponse::RiftScript { rift } => rift.script.is_some(),
+        StubResponse::Is {
+            behaviors, rift, ..
+        } => {
+            let behavior_is_scripted = behaviors
+                .as_ref()
+                .and_then(|b| {
+                    serde_json::from_value::<crate::behaviors::ResponseBehaviors>(b.clone()).ok()
+                })
+                .is_some_and(|b| behaviors_contain_script_surface(&b));
+            behavior_is_scripted || rift.as_ref().is_some_and(|r| r.script.is_some())
+        }
+        StubResponse::Proxy { proxy } => {
+            proxy.add_decorate_behavior.is_some()
+                || proxy
+                    .predicate_generators
+                    .iter()
+                    .any(|g| g.get("inject").and_then(|v| v.as_str()).is_some())
+        }
+        StubResponse::Fault { .. } => false,
+    }
+}
+
+/// True if the parsed `_behaviors` block carries a scripting surface: `decorate` (JS/Rhai),
+/// `shellTransform` (runs a host shell command — B1), or a `wait` expressed as a JS function
+/// (executed on Boa since issue #355 Item 6 — B2). A numeric `wait` (`Fixed`/`Range`) is NOT a
+/// scripting surface and stays allowed.
+fn behaviors_contain_script_surface(behaviors: &crate::behaviors::ResponseBehaviors) -> bool {
+    behaviors.decorate.is_some()
+        || !behaviors.shell_transform.is_empty()
+        || matches!(
+            behaviors.wait,
+            Some(crate::behaviors::WaitBehavior::Function(_))
+        )
+}
+
+/// Reject a set of stubs carrying a Mountebank scripting surface when `--allowInjection` is off,
+/// mirroring Mountebank's gate (issue #355 Item 4). `None` when the stubs are allowed through.
+/// Shared by the imposter CRUD handlers and the stub sub-resource handlers (B3) so the gate can't
+/// be bypassed by adding a script-bearing stub through `POST/PUT /imposters/:port/stubs[...]`.
+pub(crate) fn reject_stubs_if_injection_disallowed(
+    stubs: &[Stub],
+    allow_injection: bool,
+) -> Option<Response<Full<Bytes>>> {
+    if allow_injection || !stubs_contain_script_surface(stubs) {
+        return None;
+    }
+    let body = serde_json::json!({
+        "errors": [{
+            "code": "invalid injection",
+            "message": "inject requires --allowInjection to be set. See \
+                        http://www.mbtest.org/docs/api/injection for more information.",
+        }]
+    })
+    .to_string();
+    Some(build_response_with_headers(
+        StatusCode::BAD_REQUEST,
+        [("Content-Type", "application/json")],
+        body,
+    ))
+}
+
+/// Reject a whole imposter config when its stubs carry a scripting surface and `--allowInjection`
+/// is off. Delegates to [`reject_stubs_if_injection_disallowed`].
+fn reject_if_injection_disallowed(
+    config: &ImposterConfig,
+    allow_injection: bool,
+) -> Option<Response<Full<Bytes>>> {
+    reject_stubs_if_injection_disallowed(&config.stubs, allow_injection)
+}
+
 /// POST /imposters - Create a new imposter
 pub async fn handle_create(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -40,6 +143,10 @@ pub async fn handle_create(
             );
         }
     };
+
+    if let Some(rejection) = reject_if_injection_disallowed(&config, allow_injection) {
+        return rejection;
+    }
 
     // Validate all scripts in stubs before creating the imposter
     let validation_result = validate_stubs(&config.stubs);
@@ -131,6 +238,7 @@ pub async fn handle_replace_all(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -148,6 +256,14 @@ pub async fn handle_replace_all(
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid batch JSON: {e}"));
         }
     };
+
+    // Reject the whole batch (before making any changes) if any imposter carries a script
+    // surface and --allowInjection is off (issue #355 Item 4).
+    for config in &batch.imposters {
+        if let Some(rejection) = reject_if_injection_disallowed(config, allow_injection) {
+            return rejection;
+        }
+    }
 
     // Validate all scripts in all imposters before making any changes
     for (idx, config) in batch.imposters.iter().enumerate() {
@@ -460,6 +576,230 @@ fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter:
             }
         })
         .collect()
+}
+
+// Issue #355 Item 4: `--allowInjection` gates any Mountebank scripting surface on
+// POST/PUT /imposters. Exercised at the `reject_if_injection_disallowed` level (the exact
+// decision `handle_create`/`handle_replace_all` apply) rather than through a live HTTP request,
+// since building a real `hyper::body::Incoming` outside a running server is impractical in a
+// `--lib` unit test; the handlers above are a thin `if let Some(rejection) = ... { return }`
+// wrapper around this function.
+#[cfg(test)]
+mod allow_injection_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cfg(value: serde_json::Value) -> ImposterConfig {
+        serde_json::from_value(value).expect("test imposter config")
+    }
+
+    #[test]
+    fn non_script_imposter_always_accepted() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "equals": { "path": "/ok" } }],
+                "responses": [{ "is": { "statusCode": 200, "body": "fine" } }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_none());
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    #[test]
+    fn inject_response_rejected_when_disallowed_allowed_when_enabled() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{ "inject": "function(config) { return { statusCode: 200 }; }" }]
+            }]
+        }));
+        let rejection = reject_if_injection_disallowed(&config, false)
+            .expect("inject response must be rejected when allowInjection is off");
+        assert_eq!(rejection.status(), StatusCode::BAD_REQUEST);
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    #[test]
+    fn decorate_behavior_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200, "body": "x" },
+                    "_behaviors": { "decorate": "function(config) { }" }
+                }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    #[test]
+    fn proxy_add_decorate_behavior_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "proxy": { "to": "http://example.com", "addDecorateBehavior": "function(config) {}" }
+                }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+    }
+
+    #[test]
+    fn predicate_inject_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "inject": "function(config) { return true; }" }],
+                "responses": [{ "is": { "statusCode": 200 } }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    #[test]
+    fn predicate_inject_nested_under_not_is_still_detected() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "predicates": [{ "not": { "inject": "function(config) { return true; }" } }],
+                "responses": [{ "is": { "statusCode": 200 } }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+    }
+
+    #[test]
+    fn predicate_generator_inject_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "proxy": {
+                        "to": "http://example.com",
+                        "predicateGenerators": [{ "inject": "function(config, logger, preds) { return preds; }" }]
+                    }
+                }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    #[test]
+    fn rift_script_response_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": { "script": { "engine": "javascript", "code": "function f(){}" } }
+                }]
+            }]
+        }));
+        assert!(reject_if_injection_disallowed(&config, false).is_some());
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    // B1: shellTransform runs a host shell command and MUST be gated.
+    #[test]
+    fn shell_transform_rejected_when_disallowed_allowed_when_enabled() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200, "body": "x" },
+                    "_behaviors": { "shellTransform": "cat" }
+                }]
+            }]
+        }));
+        assert!(
+            reject_if_injection_disallowed(&config, false).is_some(),
+            "shellTransform is a host-command execution surface and must be gated"
+        );
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    // B2: a `wait` expressed as a JS function is now executed on Boa, so it's an injection surface.
+    #[test]
+    fn wait_function_rejected_when_disallowed() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200, "body": "x" },
+                    "_behaviors": { "wait": "function() { return 10; }" }
+                }]
+            }]
+        }));
+        assert!(
+            reject_if_injection_disallowed(&config, false).is_some(),
+            "a JS-function wait is executed on Boa and must be gated"
+        );
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    // B2: a numeric wait (Fixed/Range) is NOT a scripting surface and must stay allowed.
+    #[test]
+    fn numeric_wait_always_allowed() {
+        let fixed = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200, "body": "x" },
+                    "_behaviors": { "wait": 250 }
+                }]
+            }]
+        }));
+        assert!(
+            reject_if_injection_disallowed(&fixed, false).is_none(),
+            "a numeric (Fixed) wait must never be gated"
+        );
+
+        let range = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200, "body": "x" },
+                    "_behaviors": { "wait": { "min": 100, "max": 200 } }
+                }]
+            }]
+        }));
+        assert!(
+            reject_if_injection_disallowed(&range, false).is_none(),
+            "a numeric (Range) wait must never be gated"
+        );
+    }
+
+    // B3: the shared stub-slice gate rejects a script-bearing single stub when off, and the same
+    // gate the stub sub-resource handlers call.
+    #[test]
+    fn reject_stubs_gate_rejects_script_bearing_slice() {
+        let config = cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{ "inject": "function(config) { return { statusCode: 200 }; }" }]
+            }]
+        }));
+        let stubs = &config.stubs;
+        assert!(
+            reject_stubs_if_injection_disallowed(stubs, false).is_some(),
+            "the shared stub-slice gate must reject a script-bearing stub when injection is off"
+        );
+        assert!(reject_stubs_if_injection_disallowed(stubs, true).is_none());
+
+        let clean = cfg(json!({
+            "protocol": "http",
+            "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+        }));
+        assert!(
+            reject_stubs_if_injection_disallowed(&clean.stubs, false).is_none(),
+            "a non-script stub slice is always allowed"
+        );
+    }
 }
 
 // Issue #201: filter recorded requests by header / flow_id via

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -4,6 +4,7 @@
 //! partitioned by `flow_id`. When a `flowId` is not supplied, the imposter's default
 //! flow (`resolve_flow_id` with no headers ⇒ the `imposter_port` flow) is used.
 
+use crate::admin_api::handlers::imposters::reject_stubs_if_injection_disallowed;
 use crate::admin_api::types::{collect_body, error_response, json_response};
 use crate::extensions::decorate::backend_error_response;
 use crate::imposter::{Imposter, ImposterManager, Stub};
@@ -212,6 +213,7 @@ pub async fn handle_add_space_stub(
     flow_id: &str,
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let payload = match parse_json_body(req).await {
         Ok(v) => v,
@@ -221,6 +223,12 @@ pub async fn handle_add_space_stub(
         Ok(s) => s,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub: {e}")),
     };
+    // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
+    if let Some(rejection) =
+        reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
+    {
+        return rejection;
+    }
     // The path `:flowId` is the source of truth for the scope; ignore any `space` in the body.
     stub.space = Some(flow_id.to_string());
     match manager.add_stub(port, stub, None).await {

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -1,6 +1,7 @@
 //! Stub management handlers.
 
 use crate::admin_api::handlers::imposters::handle_get as handle_get_imposter;
+use crate::admin_api::handlers::imposters::reject_stubs_if_injection_disallowed;
 use crate::admin_api::types::{
     AddStubRequest, ReplaceStubsRequest, StubWithLinks, collect_body, error_response,
     json_response, make_stub_links,
@@ -21,6 +22,7 @@ pub async fn handle_add(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -33,6 +35,13 @@ pub async fn handle_add(
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
+
+    // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
+    if let Some(rejection) =
+        reject_stubs_if_injection_disallowed(std::slice::from_ref(&add_req.stub), allow_injection)
+    {
+        return rejection;
+    }
 
     // Issue #202: honor a caller-supplied `id`, but generate a stable one if absent so every
     // stub is addressable via the by-id endpoints.
@@ -94,6 +103,7 @@ pub async fn handle_replace_all(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -106,6 +116,13 @@ pub async fn handle_replace_all(
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stubs JSON: {e}"));
         }
     };
+
+    // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
+    if let Some(rejection) =
+        reject_stubs_if_injection_disallowed(&replace_req.stubs, allow_injection)
+    {
+        return rejection;
+    }
 
     // Validate all scripts in stubs before replacing
     let validation_result = validate_stubs(&replace_req.stubs);
@@ -189,6 +206,7 @@ pub async fn handle_replace(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -201,6 +219,13 @@ pub async fn handle_replace(
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
+
+    // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
+    if let Some(rejection) =
+        reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
+    {
+        return rejection;
+    }
 
     // Validate scripts in the stub before replacing
     let validation_result = validate_stub(&stub, index);
@@ -254,6 +279,7 @@ pub async fn handle_replace_by_id(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -265,6 +291,12 @@ pub async fn handle_replace_by_id(
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
         }
     };
+    // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
+    if let Some(rejection) =
+        reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
+    {
+        return rejection;
+    }
     let validation_result = validate_stub(&stub, 0);
     if !validation_result.is_valid() {
         return error_response(

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -188,8 +188,10 @@ async fn route_by_path(
     if path == "/imposters" {
         return match *method {
             Method::GET => imposters::handle_list(manager, query, base_url).await,
-            Method::POST => imposters::handle_create(req, base_url, manager).await,
-            Method::PUT => imposters::handle_replace_all(req, base_url, manager).await,
+            Method::POST => imposters::handle_create(req, base_url, manager, allow_injection).await,
+            Method::PUT => {
+                imposters::handle_replace_all(req, base_url, manager, allow_injection).await
+            }
             Method::DELETE => imposters::handle_delete_all(manager, base_url).await,
             _ => not_found(),
         };
@@ -202,7 +204,7 @@ async fn route_by_path(
 
     // Individual imposter routes
     if let Some(rest) = path.strip_prefix("/imposters/") {
-        return route_imposter(method, rest, query, req, base_url, manager).await;
+        return route_imposter(method, rest, query, req, base_url, manager, allow_injection).await;
     }
 
     not_found()
@@ -237,6 +239,7 @@ async fn route_admin_flow_state(
 }
 
 /// Route imposter-specific requests
+#[allow(clippy::too_many_arguments)]
 async fn route_imposter(
     method: &Method,
     path: &str,
@@ -244,6 +247,7 @@ async fn route_imposter(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     // Parse: port/remaining/path
     let segments: Vec<&str> = path.split('/').collect();
@@ -278,10 +282,10 @@ async fn route_imposter(
             stubs::handle_get_all(port, base_url, manager).await
         }
         (&Method::POST, ImposterRoute::Stubs) => {
-            stubs::handle_add(port, req, base_url, manager).await
+            stubs::handle_add(port, req, base_url, manager, allow_injection).await
         }
         (&Method::PUT, ImposterRoute::Stubs) => {
-            stubs::handle_replace_all(port, req, base_url, manager).await
+            stubs::handle_replace_all(port, req, base_url, manager, allow_injection).await
         }
 
         // /imposters/:port/stubs/:index
@@ -289,7 +293,7 @@ async fn route_imposter(
             stubs::handle_get(port, index, base_url, manager).await
         }
         (&Method::PUT, ImposterRoute::StubByIndex(index)) => {
-            stubs::handle_replace(port, index, req, base_url, manager).await
+            stubs::handle_replace(port, index, req, base_url, manager, allow_injection).await
         }
         (&Method::DELETE, ImposterRoute::StubByIndex(index)) => {
             stubs::handle_delete(port, index, base_url, manager).await
@@ -300,7 +304,7 @@ async fn route_imposter(
             stubs::handle_get_by_id(port, &id, manager).await
         }
         (&Method::PUT, ImposterRoute::StubById(id)) => {
-            stubs::handle_replace_by_id(port, &id, req, base_url, manager).await
+            stubs::handle_replace_by_id(port, &id, req, base_url, manager, allow_injection).await
         }
         (&Method::DELETE, ImposterRoute::StubById(id)) => {
             stubs::handle_delete_by_id(port, &id, base_url, manager).await
@@ -336,7 +340,7 @@ async fn route_imposter(
 
         // /imposters/:port/spaces/:flowId — Correlated isolation (issue #223)
         (&Method::POST, ImposterRoute::SpaceStubs(flow_id)) => {
-            scenarios::handle_add_space_stub(port, &flow_id, req, manager).await
+            scenarios::handle_add_space_stub(port, &flow_id, req, manager, allow_injection).await
         }
         (&Method::GET, ImposterRoute::SpaceStubs(flow_id)) => {
             scenarios::handle_list_space_stubs(port, &flow_id, manager).await

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -105,6 +105,41 @@ fn preprocess_ejs(content: &str, config_path: &Path) -> anyhow::Result<String> {
     result.push_str(&content[last..]);
     let content = result;
 
+    // Process `<%- stringify('relative/path') %>` (issue #355 Item 7): inline the referenced
+    // file's contents as a JSON-string-safe body. Must run BEFORE the final `<% ... %>` strip
+    // below — that catch-all matches `<%[^=].*?%>`, which would otherwise eat `<%-` tokens too.
+    // `<%-` is EJS's "unescaped output" tag; here the template already supplies the surrounding
+    // quotes (e.g. `"inject": "<%- stringify('inject.js') %>"`), so only the escaped INNER
+    // content is substituted — `serde_json::to_string` then stripping its own wrapping quotes —
+    // keeping the surrounding JSON valid.
+    let stringify_re =
+        regex::Regex::new(r#"<%-\s*stringify\(\s*['"]([^'"]+)['"]\s*\)\s*%>"#).unwrap();
+    let mut result = String::new();
+    let mut last = 0;
+    for cap in stringify_re.captures_iter(&content) {
+        let full = cap.get(0).unwrap();
+        let rel_path = cap.get(1).unwrap().as_str();
+        result.push_str(&content[last..full.start()]);
+        let abs_path = config_dir.join(rel_path);
+        let file_contents = std::fs::read_to_string(&abs_path).map_err(|e| {
+            anyhow::anyhow!(
+                "EJS stringify file '{}' not found ({}): {}",
+                rel_path,
+                abs_path.display(),
+                e
+            )
+        })?;
+        let json_quoted = serde_json::to_string(&file_contents).map_err(|e| {
+            anyhow::anyhow!("failed to JSON-encode stringify file '{rel_path}': {e}")
+        })?;
+        // Strip the wrapping quotes serde_json added; the template's own quotes surround the tag.
+        let inner = &json_quoted[1..json_quoted.len() - 1];
+        result.push_str(inner);
+        last = full.end();
+    }
+    result.push_str(&content[last..]);
+    let content = result;
+
     // Process expression tags: `<%= expr %>`
     let expr_re = regex::Regex::new(r"<%=\s*(.*?)\s*%>").unwrap();
     let env_var_re = regex::Regex::new(
@@ -290,6 +325,57 @@ mod tests {
         assert!(result.is_err(), "missing include file should return Err");
         assert!(
             result.unwrap_err().to_string().contains("nonexistent.json"),
+            "error message should name the missing file"
+        );
+    }
+
+    // Issue #355 Item 7: `<%- stringify('path') %>` inlines a file's contents as a JSON-string-
+    // safe body, producing the same parsed config as writing the script inline.
+    #[test]
+    fn ejs_stringify_inlines_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("inject.js"),
+            "function (config) {\n  return { statusCode: 200, body: 'hi' };\n}",
+        )
+        .unwrap();
+        let content = r#"{"port": 9000, "protocol": "http", "stubs": [{"responses": [{"inject": "<%- stringify('inject.js') %>"}]}]}"#;
+        let config_path = dir.path().join("config.ejs");
+        let processed = preprocess_ejs(content, &config_path).unwrap();
+
+        // The substituted content must keep the surrounding JSON valid.
+        let processed_value: serde_json::Value =
+            serde_json::from_str(&processed).expect("stringify output must stay valid JSON");
+
+        let inlined = serde_json::json!({
+            "port": 9000, "protocol": "http",
+            "stubs": [{"responses": [{
+                "inject": "function (config) {\n  return { statusCode: 200, body: 'hi' };\n}"
+            }]}]
+        });
+        assert_eq!(
+            processed_value["stubs"][0]["responses"][0]["inject"],
+            inlined["stubs"][0]["responses"][0]["inject"],
+            "stringify output must match the inline-string equivalent"
+        );
+
+        let processed_config: ImposterConfig = serde_json::from_value(processed_value).unwrap();
+        let inlined_config: ImposterConfig = serde_json::from_value(inlined).unwrap();
+        assert_eq!(
+            serde_json::to_value(&processed_config).unwrap(),
+            serde_json::to_value(&inlined_config).unwrap(),
+            "the stringify'd config must parse identically to the inlined-string version"
+        );
+    }
+
+    #[test]
+    fn ejs_stringify_missing_file_is_fatal_error() {
+        let content = r#"{"inject": "<%- stringify('nope-355.js') %>"}"#;
+        let path = PathBuf::from("config.json");
+        let result = preprocess_ejs(content, &path);
+        assert!(result.is_err(), "missing stringify file should return Err");
+        assert!(
+            result.unwrap_err().to_string().contains("nope-355.js"),
             "error message should name the missing file"
         );
     }

--- a/crates/rift-http-proxy/tests/issue_355_inject_error_parity.rs
+++ b/crates/rift-http-proxy/tests/issue_355_inject_error_parity.rs
@@ -1,0 +1,56 @@
+//! Issue #355 Item 5 (AC5): a Mountebank `inject` response function that THROWS must yield a
+//! Mountebank-shaped 400 error — `{"errors":[{"code":"invalid injection","message":...}]}` — not
+//! a bare 500. The script failing to produce a valid response is a config problem (client error),
+//! matching Mountebank's error parity.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+// A throwing inject response returns HTTP 400 with the Mountebank error body shape, and keeps the
+// x-rift-imposter / x-rift-inject-error headers.
+#[tokio::test]
+async fn throwing_inject_returns_mountebank_400() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19895, "protocol": "http", "stubs": [
+            { "responses": [{ "inject": "function (config) { throw new Error('boom-inject'); }" }] }
+        ]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19895/x")
+        .send()
+        .await
+        .expect("send");
+
+    assert_eq!(
+        resp.status(),
+        400,
+        "a throwing inject must return 400 (Mountebank error parity), not 500"
+    );
+    assert!(
+        resp.headers().contains_key("x-rift-imposter"),
+        "the imposter marker header must be preserved"
+    );
+    assert!(
+        resp.headers().contains_key("x-rift-inject-error"),
+        "the inject-error marker header must be present"
+    );
+
+    let body: serde_json::Value = resp.json().await.expect("json body");
+    assert_eq!(
+        body["errors"][0]["code"], "invalid injection",
+        "error code must be Mountebank's 'invalid injection', got: {body}"
+    );
+    assert!(
+        body["errors"][0]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("boom-inject")),
+        "the error message must surface the script failure, got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19895).await;
+}


### PR DESCRIPTION
Implements 7 fidelity fixes for scripting P1 fidelity:
- MB v2 config convention (dual-convention, zero breakage)
- Real script logger with runtime info
- JS timeouts via Boa RuntimeLimits
- Enforce --allowInjection access control
- MB error parity for typed errors
- Execute wait fns in script context
- EJS stringify() support

Review-time hardening closed --allowInjection bypasses: shellTransform, stub sub-resource endpoints, wait-as-function.

Closes #355
Part of epic #354
Milestone: scripting DX (P1)