### PR TITLE
feat(scripting): P2 authoring — script file: references, named script library (ref:), bless YAML configs

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -403,10 +403,23 @@ async fn handle_request_inner(
             Err(e) => return Ok(backend_error_response(&e)),
         };
         if let Some(script_config) = script_config {
-            debug!(
-                "Handling Rift script response (engine: {})",
-                script_config.engine
-            );
+            // `code` is populated by the config-time resolve-scripts pass (issue #356), which
+            // runs before an imposter carrying `file:`/`ref:` scripts is ever created. A `None`
+            // here means that pass was skipped (e.g. a stub added through a sub-resource
+            // endpoint that doesn't resolve scripts) — surface it as a clear error instead of
+            // silently running an empty script.
+            let Some(code) = script_config.code.clone() else {
+                return Ok(build_response_with_headers(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
+                    r#"{"error": "script not resolved: `file:`/`ref:` sources must be resolved before serving"}"#,
+                ));
+            };
+            let engine = script_config
+                .engine
+                .clone()
+                .unwrap_or_else(|| "rhai".to_string());
+            debug!("Handling Rift script response (engine: {})", engine);
 
             // Build script request. Expose headers with lowercase keys so scripts can read
             // them case-insensitively (e.g. `request.headers["x-flow-id"]`) regardless of the
@@ -438,8 +451,8 @@ async fn handle_request_inner(
             let timeout_ms = resolve_script_timeout_ms(&imposter.config);
             let flow_store = imposter.flow_store.clone();
             match should_inject_bounded(
-                script_config.engine.clone(),
-                script_config.code.clone(),
+                engine.clone(),
+                code,
                 format!("rift_script_{stub_index}"),
                 script_request,
                 flow_store,
@@ -462,7 +475,7 @@ async fn handle_request_inner(
                         response = response.header(k, v);
                     }
                     response = response.header("x-rift-imposter", "true");
-                    response = response.header("x-rift-script", &script_config.engine);
+                    response = response.header("x-rift-script", &engine);
 
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
@@ -484,7 +497,7 @@ async fn handle_request_inner(
                         StatusCode::OK,
                         [
                             ("x-rift-imposter", "true"),
-                            ("x-rift-script", &script_config.engine),
+                            ("x-rift-script", &engine),
                             ("x-rift-latency-ms", &duration_ms.to_string()),
                         ],
                         Bytes::new(),
@@ -500,7 +513,7 @@ async fn handle_request_inner(
                         StatusCode::OK,
                         [
                             ("x-rift-imposter", "true"),
-                            ("x-rift-script", script_config.engine.as_str()),
+                            ("x-rift-script", engine.as_str()),
                         ],
                         Bytes::new(),
                     ));

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -23,6 +23,7 @@ mod manager;
 mod predicates;
 mod reconcile;
 mod response;
+mod script_resolve;
 mod types;
 
 #[cfg(test)]
@@ -38,6 +39,11 @@ pub use types::{
     RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig, RiftRedisConfig,
     RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig, RiftUpstreamConfig, Stub,
     StubResponse,
+};
+
+// Re-export script `file:`/`ref:` resolution (issue #356)
+pub use script_resolve::{
+    ScriptBaseDir, ScriptResolveError, resolve_scripts, resolve_stub_scripts,
 };
 
 // Re-export core imposter

--- a/crates/rift-core/src/imposter/script_resolve.rs
+++ b/crates/rift-core/src/imposter/script_resolve.rs
@@ -1,0 +1,659 @@
+//! Config-time resolution for `_rift.script` `file:`/`ref:` sources (issue #356).
+//!
+//! A `RiftScriptConfig` may specify its script via inline `code`, a `file` path, or a `ref` into
+//! the imposter's `_rift.scripts` named registry. This module walks a freshly-parsed
+//! `ImposterConfig`, validates that every script config carries exactly one source, and resolves
+//! `file`/`ref` down to a populated `code` + `engine` — so everything downstream (validation,
+//! execution, the compiled-script cache) only ever sees plain inline scripts.
+//!
+//! Resolution happens once, at config-load time (`--configfile`/`--datadir`, admin API create,
+//! and `/admin/reload`), never per-request.
+
+use super::types::{ImposterConfig, RiftScriptConfig, Stub, StubResponse};
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+
+/// Errors from resolving `file:`/`ref:` script sources.
+#[derive(Debug, thiserror::Error)]
+pub enum ScriptResolveError {
+    #[error("script config must specify exactly one of `code`, `file`, or `ref` (found {found})")]
+    InvalidSourceCount { found: usize },
+    #[error("unknown script ref '{0}': no entry named '{0}' in `_rift.scripts`")]
+    UnknownRef(String),
+    #[error("_rift.scripts entry '{0}' may not itself use `ref` — ref chains are not allowed")]
+    RefChain(String),
+    #[error("failed to read script file '{path}': {source}")]
+    FileRead {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("script file path '{0}' escapes the scripts root")]
+    PathEscape(String),
+    #[error(
+        "script file '{0}' cannot be resolved: no --scripts-dir is configured for the admin API"
+    )]
+    ScriptsDirNotConfigured(String),
+}
+
+/// Where `file:` script paths resolve relative to, and whether escaping that root is rejected.
+#[derive(Debug, Clone)]
+pub enum ScriptBaseDir {
+    /// Explicit `--configfile` single-file load: relative to the config file's own directory. No
+    /// escape restriction — a human author who can write the configfile already has filesystem
+    /// access, so an absolute path or `..` is honored verbatim (matches EJS `include`).
+    ConfigRelative(PathBuf),
+    /// `--datadir` load (including the persisted `{port}.json` files written by the admin API):
+    /// relative to the datadir root, with the SAME escape rules as [`ScriptBaseDir::ScriptsDir`].
+    /// These files can be network-authored (a stub POSTed through the admin API is persisted
+    /// here), so an absolute path or a `..`/symlink escape is rejected — never read (issue #356
+    /// B1/B2 defense-in-depth against a datadir re-resolution reading `/etc/passwd`).
+    DatadirRelative(PathBuf),
+    /// Admin-API-created imposters: relative to `--scripts-dir`. A resolved path that would
+    /// escape this root is rejected outright (never read).
+    ScriptsDir(PathBuf),
+    /// The admin API has no `--scripts-dir` configured: any `file:` reference is rejected.
+    Unconfigured,
+}
+
+/// Resolve every `_rift.script` in `config` — the named registry first, then each stub response
+/// — mutating `code`/`engine` in place. Returns the first error encountered; on error `config`
+/// may be partially mutated and must not be used (the caller returns the error to the client /
+/// aborts the load without applying anything).
+pub fn resolve_scripts(
+    config: &mut ImposterConfig,
+    base: &ScriptBaseDir,
+) -> Result<(), ScriptResolveError> {
+    // Resolve the named registry first so response-level `ref:` lookups see fully-resolved
+    // entries (populated `code` + `engine`, never another `ref`).
+    if let Some(rift) = &mut config.rift {
+        for (name, script) in rift.scripts.iter_mut() {
+            if script.ref_name.is_some() {
+                return Err(ScriptResolveError::RefChain(name.clone()));
+            }
+            validate_source_count(script)?;
+            resolve_leaf(script, base)?;
+        }
+    }
+
+    // Snapshot the resolved registry (small, config-time only) so per-response resolution can
+    // look up `ref:` targets without holding a borrow of `config.rift` across the stub loop.
+    let registry: HashMap<String, RiftScriptConfig> = config
+        .rift
+        .as_ref()
+        .map(|r| r.scripts.clone())
+        .unwrap_or_default();
+
+    resolve_stub_scripts(&mut config.stubs, &registry, base)
+}
+
+/// Resolve `_rift.script` sources in a set of stubs against an already-resolved `registry`
+/// (issue #356). Used by the admin-API stub sub-resource endpoints (`POST/PUT .../stubs[...]`,
+/// space stubs), which add stubs to an existing imposter and must resolve — and therefore
+/// escape-check — `file:`/`ref:` at WRITE time, before persisting, exactly like whole-imposter
+/// create. `registry` is the target imposter's `_rift.scripts` (its entries must themselves be
+/// already resolved — `code` populated, `file`/`ref` cleared — which they are once the imposter
+/// was created).
+pub fn resolve_stub_scripts(
+    stubs: &mut [Stub],
+    registry: &HashMap<String, RiftScriptConfig>,
+    base: &ScriptBaseDir,
+) -> Result<(), ScriptResolveError> {
+    for stub in stubs {
+        for response in &mut stub.responses {
+            if let Some(script) = response_script_mut(response) {
+                resolve_response_script(script, registry, base)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Borrow the `_rift.script` config out of a stub response, if it has one — covers both the
+/// `is` response's optional `_rift` extension and the script-only `RiftScript` response.
+fn response_script_mut(response: &mut StubResponse) -> Option<&mut RiftScriptConfig> {
+    match response {
+        StubResponse::Is {
+            rift: Some(rift), ..
+        } => rift.script.as_mut(),
+        StubResponse::RiftScript { rift } => rift.script.as_mut(),
+        _ => None,
+    }
+}
+
+fn validate_source_count(script: &RiftScriptConfig) -> Result<(), ScriptResolveError> {
+    if script.has_valid_source() {
+        Ok(())
+    } else {
+        Err(ScriptResolveError::InvalidSourceCount {
+            found: script.source_count(),
+        })
+    }
+}
+
+/// Resolve a single response-level script: validate its source count, then either follow `ref:`
+/// into the (already-resolved) registry or resolve it as a leaf (`code:`/`file:`).
+fn resolve_response_script(
+    script: &mut RiftScriptConfig,
+    registry: &HashMap<String, RiftScriptConfig>,
+    base: &ScriptBaseDir,
+) -> Result<(), ScriptResolveError> {
+    validate_source_count(script)?;
+    if let Some(ref_name) = script.ref_name.clone() {
+        let target = registry
+            .get(&ref_name)
+            .ok_or_else(|| ScriptResolveError::UnknownRef(ref_name.clone()))?;
+        script.code = target.code.clone();
+        script.engine = target.engine.clone();
+        // `ref` fully collapses into `code`/`engine` — clearing it keeps `source_count() == 1`
+        // for any post-resolution re-check (e.g. `validate_stubs`, run after resolution in the
+        // admin-API handlers) and matches the resolved leaf's shape below.
+        script.ref_name = None;
+        return Ok(());
+    }
+    resolve_leaf(script, base)
+}
+
+/// Resolve a leaf script config (`code:` or `file:`, never `ref:`): load `file:` content into
+/// `code` if needed, then normalize `engine` to the effective value (explicit, else inferred
+/// from the file extension, else the legacy "rhai" default).
+///
+/// `file` is cleared once its content is loaded into `code` — resolution is meant to collapse
+/// every source down to a plain `code`/`engine` pair, so everything downstream (validation,
+/// execution, the compiled-script cache) only ever sees an inline script, and a repeated
+/// `source_count()` check (post-resolution) still sees exactly one source.
+fn resolve_leaf(
+    script: &mut RiftScriptConfig,
+    base: &ScriptBaseDir,
+) -> Result<(), ScriptResolveError> {
+    if script.engine.is_none() {
+        script.engine = Some(infer_engine(script.file.as_deref()));
+    }
+    if let Some(file) = script.file.take() {
+        script.code = Some(read_script_file(&file, base)?);
+    }
+    Ok(())
+}
+
+/// Infer the engine from a `file:` path's extension; `.rhai`/`.lua`/`.js` map to their engines,
+/// anything else (or no `file`, i.e. inline `code:`) falls back to the legacy "rhai" default.
+fn infer_engine(file: Option<&str>) -> String {
+    let ext = file
+        .and_then(|f| Path::new(f).extension())
+        .and_then(|e| e.to_str());
+    match ext {
+        Some("rhai") => "rhai",
+        Some("lua") => "lua",
+        Some("js") => "javascript",
+        _ => "rhai",
+    }
+    .to_string()
+}
+
+/// Read a `file:` script's content per `base`. For the escape-checked roots (`ScriptsDir` /
+/// `DatadirRelative`) the path is resolved AND canonicalized-under-root BEFORE any read (issue
+/// #356 B5), so a symlink inside the root that points outside is rejected without its target ever
+/// being read, and a canonicalize failure fails closed (reject) rather than open.
+fn read_script_file(file: &str, base: &ScriptBaseDir) -> Result<String, ScriptResolveError> {
+    match base {
+        ScriptBaseDir::Unconfigured => Err(ScriptResolveError::ScriptsDirNotConfigured(
+            file.to_string(),
+        )),
+        // Explicit --configfile: human-authored, any path allowed (no escape check).
+        ScriptBaseDir::ConfigRelative(dir) => {
+            let path = dir.join(file);
+            std::fs::read_to_string(&path).map_err(|source| ScriptResolveError::FileRead {
+                path: file.to_string(),
+                source,
+            })
+        }
+        // Escape-checked roots: resolve strictly under `root`, then read the vetted path.
+        ScriptBaseDir::ScriptsDir(root) | ScriptBaseDir::DatadirRelative(root) => {
+            let vetted = resolve_within_root(root, file)?;
+            std::fs::read_to_string(&vetted).map_err(|source| ScriptResolveError::FileRead {
+                path: file.to_string(),
+                source,
+            })
+        }
+    }
+}
+
+/// Resolve `file` strictly under `root`, returning the vetted on-disk path to read, or an error —
+/// WITHOUT reading the file (issue #356 B5, fail-closed). In order:
+///  1. lexically reject an absolute path or a `..` that climbs above `root` ([`safe_join`]);
+///  2. canonicalize the candidate and require it to stay under the canonical `root` — this
+///     follows symlinks, so a link inside the root pointing outside resolves outside and is
+///     rejected before its target is read;
+///  3. if canonicalization fails, distinguish a genuinely-missing file (its parent still resolves
+///     under the root → surface a `FileRead` so the message names the missing file) from anything
+///     else (a broken/escaping symlink, an unreadable parent) → reject as `PathEscape`. Either way
+///     the target is never read here.
+fn resolve_within_root(root: &Path, file: &str) -> Result<PathBuf, ScriptResolveError> {
+    let candidate = safe_join(root, file)?;
+    let canon_root = root
+        .canonicalize()
+        .map_err(|source| ScriptResolveError::FileRead {
+            path: file.to_string(),
+            source,
+        })?;
+    match candidate.canonicalize() {
+        Ok(canon_candidate) => {
+            if canon_candidate.starts_with(&canon_root) {
+                Ok(canon_candidate)
+            } else {
+                Err(ScriptResolveError::PathEscape(file.to_string()))
+            }
+        }
+        Err(source) => {
+            // The candidate itself doesn't resolve. If its PARENT canonicalizes under the root
+            // it's simply a missing file (safe to report as such); otherwise fail closed.
+            let parent_ok = candidate
+                .parent()
+                .and_then(|p| p.canonicalize().ok())
+                .is_some_and(|cp| cp.starts_with(&canon_root));
+            if parent_ok {
+                Err(ScriptResolveError::FileRead {
+                    path: file.to_string(),
+                    source,
+                })
+            } else {
+                Err(ScriptResolveError::PathEscape(file.to_string()))
+            }
+        }
+    }
+}
+
+/// Lexically join `root` with `rel`, rejecting any absolute path or `..` component that would
+/// climb above `root` — computed purely from path components (no filesystem access), so an
+/// escaping reference is rejected before the file is ever opened.
+fn safe_join(root: &Path, rel: &str) -> Result<PathBuf, ScriptResolveError> {
+    let mut joined = root.to_path_buf();
+    let mut depth: i32 = 0;
+    for component in Path::new(rel).components() {
+        match component {
+            Component::Normal(part) => {
+                joined.push(part);
+                depth += 1;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return Err(ScriptResolveError::PathEscape(rel.to_string()));
+                }
+                joined.pop();
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(ScriptResolveError::PathEscape(rel.to_string()));
+            }
+        }
+    }
+    Ok(joined)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imposter::types::{RiftConfig, RiftResponseExtension, Stub};
+
+    fn script(code: Option<&str>, file: Option<&str>, ref_name: Option<&str>) -> RiftScriptConfig {
+        RiftScriptConfig {
+            engine: None,
+            code: code.map(str::to_string),
+            file: file.map(str::to_string),
+            ref_name: ref_name.map(str::to_string),
+        }
+    }
+
+    fn stub_with_script(script_config: RiftScriptConfig) -> Stub {
+        Stub {
+            id: None,
+            route_pattern: None,
+            predicates: vec![],
+            responses: vec![StubResponse::RiftScript {
+                rift: RiftResponseExtension {
+                    fault: None,
+                    script: Some(script_config),
+                },
+            }],
+            scenario_name: None,
+            required_scenario_state: None,
+            new_scenario_state: None,
+            space: None,
+            recorded_from: None,
+            verify: None,
+        }
+    }
+
+    fn extract_script(config: &ImposterConfig) -> &RiftScriptConfig {
+        match &config.stubs[0].responses[0] {
+            StubResponse::RiftScript { rift } => rift.script.as_ref().unwrap(),
+            other => panic!("expected RiftScript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inline_code_resolves_with_default_engine() {
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(
+                Some("fn should_inject() {}"),
+                None,
+                None,
+            ))],
+            ..Default::default()
+        };
+        resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap();
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code.as_deref(), Some("fn should_inject() {}"));
+        assert_eq!(resolved.engine.as_deref(), Some("rhai"));
+    }
+
+    #[test]
+    fn zero_sources_is_rejected() {
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, None, None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap_err();
+        assert!(matches!(
+            err,
+            ScriptResolveError::InvalidSourceCount { found: 0 }
+        ));
+    }
+
+    #[test]
+    fn multiple_sources_is_rejected() {
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(Some("x"), Some("y.rhai"), None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap_err();
+        assert!(matches!(
+            err,
+            ScriptResolveError::InvalidSourceCount { found: 2 }
+        ));
+    }
+
+    #[test]
+    fn file_resolves_relative_to_config_dir_and_infers_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("script.lua"), "return {inject=false}").unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("script.lua"), None))],
+            ..Default::default()
+        };
+        resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::ConfigRelative(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code.as_deref(), Some("return {inject=false}"));
+        assert_eq!(resolved.engine.as_deref(), Some("lua"));
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("nope.rhai"), None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::ConfigRelative(dir.path().to_path_buf()),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ScriptResolveError::FileRead { .. }));
+    }
+
+    #[test]
+    fn scripts_dir_unconfigured_rejects_file_reference() {
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("a.rhai"), None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap_err();
+        assert!(matches!(
+            err,
+            ScriptResolveError::ScriptsDirNotConfigured(_)
+        ));
+    }
+
+    #[test]
+    fn scripts_dir_escape_is_rejected_without_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        // A real file that a naive join would successfully read if the escape check were
+        // skipped — its presence proves the rejection is the `..` check, not a missing file.
+        std::fs::write(dir.path().join("secret.rhai"), "SECRET").unwrap();
+        let root = dir.path().join("scripts");
+        std::fs::create_dir(&root).unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("../secret.rhai"), None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::ScriptsDir(root)).unwrap_err();
+        assert!(matches!(err, ScriptResolveError::PathEscape(_)));
+    }
+
+    #[test]
+    fn scripts_dir_within_root_is_read() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ok.rhai"), "fn should_inject() {}").unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("ok.rhai"), None))],
+            ..Default::default()
+        };
+        resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::ScriptsDir(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code.as_deref(), Some("fn should_inject() {}"));
+    }
+
+    #[test]
+    fn ref_resolves_from_registry() {
+        let mut scripts = HashMap::new();
+        scripts.insert(
+            "failTwice".to_string(),
+            script(Some("fn should_inject() {}"), None, None),
+        );
+        let mut config = ImposterConfig {
+            rift: Some(RiftConfig {
+                scripts,
+                ..Default::default()
+            }),
+            stubs: vec![stub_with_script(script(None, None, Some("failTwice")))],
+            ..Default::default()
+        };
+        resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap();
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code.as_deref(), Some("fn should_inject() {}"));
+        assert_eq!(resolved.engine.as_deref(), Some("rhai"));
+    }
+
+    #[test]
+    fn ref_resolves_a_file_backed_registry_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("fail-twice.rhai"), "fn should_inject() {}").unwrap();
+        let mut scripts = HashMap::new();
+        scripts.insert(
+            "failTwice".to_string(),
+            script(None, Some("scripts/fail-twice.rhai"), None),
+        );
+        // Registry file paths resolve the same way as response-level file paths.
+        std::fs::create_dir(dir.path().join("scripts")).unwrap();
+        std::fs::write(
+            dir.path().join("scripts").join("fail-twice.rhai"),
+            "fn should_inject() {}",
+        )
+        .unwrap();
+        let mut config = ImposterConfig {
+            rift: Some(RiftConfig {
+                scripts,
+                ..Default::default()
+            }),
+            stubs: vec![stub_with_script(script(None, None, Some("failTwice")))],
+            ..Default::default()
+        };
+        resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::ConfigRelative(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code.as_deref(), Some("fn should_inject() {}"));
+        assert_eq!(resolved.engine.as_deref(), Some("rhai"));
+    }
+
+    #[test]
+    fn unknown_ref_is_an_error() {
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, None, Some("nope")))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap_err();
+        assert!(matches!(err, ScriptResolveError::UnknownRef(name) if name == "nope"));
+    }
+
+    #[test]
+    fn ref_to_ref_is_rejected() {
+        let mut scripts = HashMap::new();
+        scripts.insert("a".to_string(), script(None, None, Some("b")));
+        scripts.insert("b".to_string(), script(Some("code"), None, None));
+        let mut config = ImposterConfig {
+            rift: Some(RiftConfig {
+                scripts,
+                ..Default::default()
+            }),
+            stubs: vec![stub_with_script(script(None, None, Some("a")))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::Unconfigured).unwrap_err();
+        assert!(matches!(err, ScriptResolveError::RefChain(name) if name == "a"));
+    }
+
+    // Issue #356 B5: an ABSOLUTE `file:` path under a `--scripts-dir` root is rejected lexically
+    // (the RootDir component in `safe_join`) before any read — `/etc/passwd` never opened.
+    #[test]
+    fn scripts_dir_absolute_path_is_rejected_without_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        // A real, readable absolute target outside the root — proves the rejection is the
+        // absolute-path check, not a missing file.
+        let secret = dir.path().join("secret.rhai");
+        std::fs::write(&secret, "SECRET").unwrap();
+        let root = dir.path().join("scripts");
+        std::fs::create_dir(&root).unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(
+                None,
+                Some(secret.to_str().unwrap()),
+                None,
+            ))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::ScriptsDir(root)).unwrap_err();
+        assert!(
+            matches!(err, ScriptResolveError::PathEscape(_)),
+            "absolute path must be PathEscape, got {err:?}"
+        );
+        // Nothing was loaded into `code`.
+        assert_eq!(extract_script(&config).code, None);
+    }
+
+    // Issue #356 B5: a symlink INSIDE the root pointing OUTSIDE it is rejected (fail-closed) and
+    // its target's content is never returned — the canonicalize-before-read guard.
+    #[cfg(unix)]
+    #[test]
+    fn scripts_dir_symlink_escape_is_rejected_without_reading() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = dir.path().join("secret.rhai");
+        std::fs::write(&secret, "SUPER-SECRET-CONTENTS").unwrap();
+        let root = dir.path().join("scripts");
+        std::fs::create_dir(&root).unwrap();
+        // scripts/leak.rhai -> ../secret.rhai (target is real and outside the root).
+        std::os::unix::fs::symlink(&secret, root.join("leak.rhai")).unwrap();
+
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("leak.rhai"), None))],
+            ..Default::default()
+        };
+        let err = resolve_scripts(&mut config, &ScriptBaseDir::ScriptsDir(root)).unwrap_err();
+        assert!(
+            matches!(err, ScriptResolveError::PathEscape(_)),
+            "symlink escape must be PathEscape, got {err:?}"
+        );
+        // The secret's content must NOT have been read into `code`.
+        let resolved = extract_script(&config);
+        assert_eq!(resolved.code, None);
+    }
+
+    // Issue #356 B2: the datadir base applies the SAME escape rules as `--scripts-dir` — a
+    // network-authored `{port}.json` cannot read an absolute or `..`-escaping path.
+    #[test]
+    fn datadir_relative_rejects_absolute_and_parent_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("secret.rhai"), "SECRET").unwrap();
+        let root = dir.path().join("data");
+        std::fs::create_dir(&root).unwrap();
+
+        for bad in ["/etc/passwd", "../secret.rhai"] {
+            let mut config = ImposterConfig {
+                stubs: vec![stub_with_script(script(None, Some(bad), None))],
+                ..Default::default()
+            };
+            let err = resolve_scripts(&mut config, &ScriptBaseDir::DatadirRelative(root.clone()))
+                .unwrap_err();
+            assert!(
+                matches!(err, ScriptResolveError::PathEscape(_)),
+                "datadir `{bad}` must be PathEscape, got {err:?}"
+            );
+            assert_eq!(extract_script(&config).code, None);
+        }
+    }
+
+    #[test]
+    fn datadir_relative_within_root_is_read() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("ok.rhai"), "fn should_inject() {}").unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("ok.rhai"), None))],
+            ..Default::default()
+        };
+        resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::DatadirRelative(root.path().to_path_buf()),
+        )
+        .unwrap();
+        assert_eq!(
+            extract_script(&config).code.as_deref(),
+            Some("fn should_inject() {}")
+        );
+    }
+
+    // Issue #356: a `.js` file infers the "javascript" engine.
+    #[test]
+    fn js_file_extension_infers_javascript_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("script.js"),
+            "function should_inject() { return { inject: false }; }",
+        )
+        .unwrap();
+        let mut config = ImposterConfig {
+            stubs: vec![stub_with_script(script(None, Some("script.js"), None))],
+            ..Default::default()
+        };
+        resolve_scripts(
+            &mut config,
+            &ScriptBaseDir::ConfigRelative(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        assert_eq!(
+            extract_script(&config).engine.as_deref(),
+            Some("javascript")
+        );
+    }
+}

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -835,6 +835,11 @@ pub struct RiftConfig {
     /// Global script engine configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub script_engine: Option<RiftScriptEngineConfig>,
+    /// Named script registry (issue #356): a response script can reference an entry here via
+    /// `{ "ref": "name" }` instead of inlining `code`/`file`. Each entry is itself a `code:` or
+    /// `file:` script — not `ref:` (no chains).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub scripts: HashMap<String, RiftScriptConfig>,
 }
 
 /// Flow state configuration for Rift extensions
@@ -1049,15 +1054,53 @@ fn default_error_status() -> u16 {
     503
 }
 
-/// Script configuration for response generation
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Script configuration for response generation.
+///
+/// Exactly one of `code`, `file`, or `ref` must be set (issue #356). This is enforced by the
+/// config-time script-resolution pass (`imposter::script_resolve`) rather than at deserialize
+/// time, so a validation error can name the offending stub/registry entry instead of a generic
+/// serde failure — and so existing configs using only `code` keep deserializing unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RiftScriptConfig {
-    /// Script engine: "rhai", "lua", or "javascript"
-    #[serde(default = "default_script_engine")]
-    pub engine: String,
-    /// Inline script code
-    pub code: String,
+    /// Script engine: "rhai", "lua", or "javascript". When absent, the resolver infers it from
+    /// `file`'s extension (`.rhai`/`.lua`/`.js`), falling back to "rhai" — the legacy default —
+    /// when neither `engine` nor an inferable extension is present (back-compat with `code:`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    /// Inline script code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    /// Path to a script file. Resolved relative to the config file's directory for
+    /// `--configfile`/`--datadir` loads, or to `--scripts-dir` for admin-API-created imposters
+    /// (a path that escapes `--scripts-dir` is rejected rather than read).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// Name of a `_rift.scripts` registry entry (see [`RiftConfig::scripts`]) to resolve this
+    /// script from. The referenced entry must itself use `code` or `file` — a `ref` chain is a
+    /// validation error.
+    #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub ref_name: Option<String>,
+}
+
+impl RiftScriptConfig {
+    /// How many of `code`/`file`/`ref` are set. Exactly one is valid; used by both the resolver
+    /// and rift-lint to report "missing source" vs. "multiple sources" distinctly.
+    pub fn source_count(&self) -> usize {
+        [
+            self.code.is_some(),
+            self.file.is_some(),
+            self.ref_name.is_some(),
+        ]
+        .into_iter()
+        .filter(|set| *set)
+        .count()
+    }
+
+    /// True when exactly one of `code`/`file`/`ref` is set.
+    pub fn has_valid_source(&self) -> bool {
+        self.source_count() == 1
+    }
 }
 
 // ============================================================================
@@ -1109,6 +1152,88 @@ mod tests {
         assert_eq!(
             out.get("flowIdSource").and_then(|v| v.as_str()),
             Some("header:X-Mock-Space")
+        );
+    }
+
+    // Issue #356: `code`/`file`/`ref` all deserialize into the right field; `engine` stays
+    // optional (resolution — not deserialize — fills it in).
+    #[test]
+    fn script_config_deserializes_code_file_and_ref_variants() {
+        let code: RiftScriptConfig =
+            serde_json::from_value(json!({ "code": "fn should_inject() {}" })).unwrap();
+        assert_eq!(code.code.as_deref(), Some("fn should_inject() {}"));
+        assert_eq!(code.file, None);
+        assert_eq!(code.ref_name, None);
+        assert_eq!(
+            code.engine, None,
+            "engine is not defaulted at deserialize time"
+        );
+
+        let file: RiftScriptConfig =
+            serde_json::from_value(json!({ "file": "scripts/a.rhai" })).unwrap();
+        assert_eq!(file.file.as_deref(), Some("scripts/a.rhai"));
+        assert_eq!(file.code, None);
+
+        let by_ref: RiftScriptConfig =
+            serde_json::from_value(json!({ "ref": "failTwice" })).unwrap();
+        assert_eq!(by_ref.ref_name.as_deref(), Some("failTwice"));
+        assert_eq!(by_ref.code, None);
+    }
+
+    // Issue #356: back-compat — a pre-existing `{ "engine": ..., "code": ... }` config (the shape
+    // before `file`/`ref` existed) still deserializes unchanged.
+    #[test]
+    fn script_config_back_compat_engine_and_code() {
+        let cfg: RiftScriptConfig = serde_json::from_value(json!({
+            "engine": "lua",
+            "code": "function should_inject() end"
+        }))
+        .unwrap();
+        assert_eq!(cfg.engine.as_deref(), Some("lua"));
+        assert_eq!(cfg.code.as_deref(), Some("function should_inject() end"));
+        assert!(cfg.has_valid_source());
+    }
+
+    // Issue #356: exactly one of `code`/`file`/`ref` is valid; zero or multiple is not.
+    #[test]
+    fn script_config_source_count_invariant() {
+        let none = RiftScriptConfig::default();
+        assert_eq!(none.source_count(), 0);
+        assert!(!none.has_valid_source());
+
+        let one = RiftScriptConfig {
+            code: Some("x".to_string()),
+            ..Default::default()
+        };
+        assert!(one.has_valid_source());
+
+        let two = RiftScriptConfig {
+            code: Some("x".to_string()),
+            file: Some("y.rhai".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(two.source_count(), 2);
+        assert!(!two.has_valid_source());
+    }
+
+    // Issue #356: `_rift.scripts` registry round-trips and defaults to empty/omitted.
+    #[test]
+    fn rift_config_scripts_registry_round_trips() {
+        let cfg: RiftConfig = serde_json::from_value(json!({
+            "scripts": { "failTwice": { "file": "fail-twice.rhai" } }
+        }))
+        .unwrap();
+        assert_eq!(
+            cfg.scripts.get("failTwice").and_then(|s| s.file.as_deref()),
+            Some("fail-twice.rhai")
+        );
+
+        let empty = RiftConfig::default();
+        assert!(empty.scripts.is_empty());
+        let out = serde_json::to_value(&empty).unwrap();
+        assert!(
+            out.get("scripts").is_none(),
+            "empty registry must be omitted on serialize"
         );
     }
 

--- a/crates/rift-core/src/scripting/compiled_cache.rs
+++ b/crates/rift-core/src/scripting/compiled_cache.rs
@@ -1,0 +1,194 @@
+//! Content-addressed compiled-script cache for the imposter `_rift.script` path (issue #356).
+//!
+//! `file:`/`ref:` script resolution (`imposter::script_resolve`) funnels every script down to a
+//! plain `code` string before it reaches execution, so two responses that reference the same
+//! file — directly, or both via `ref:` — end up with byte-identical `code`. Caching the compiled
+//! Rhai AST by that content (rather than by path or rule id) lets them share one compiled entry,
+//! and means editing the file changes the content and therefore the cache key, busting the entry
+//! automatically — no explicit invalidation needed.
+//!
+//! The cache is **bounded** (issue #356 B3): without a cap, every distinct script content — every
+//! hot-reload edit included — would leak one `Arc<AST>` for the process lifetime. On reaching
+//! capacity the cache is cleared wholesale before the next insert (a simple, adequate policy; a
+//! full LRU is overkill for a config-scale working set). Each entry also stores its source string
+//! and verifies it on a hit (issue #356 B4): a `u64` hash collision would otherwise silently
+//! return the WRONG compiled AST, so a mismatch recompiles instead.
+
+use anyhow::{Result, anyhow};
+use rhai::AST;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Maximum number of distinct compiled scripts retained. Comfortably above any realistic
+/// imposter/config working set, while bounding memory against an adversarial or churny workload
+/// (e.g. repeated hot-reload edits).
+const DEFAULT_CAPACITY: usize = 512;
+
+fn content_key(code: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    code.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A bounded, content-addressed cache of compiled Rhai ASTs. Each entry stores the source string
+/// alongside the compiled `Arc<AST>` so a hit can verify the source matches (collision guard).
+struct CompiledCache {
+    entries: HashMap<u64, (String, Arc<AST>)>,
+    capacity: usize,
+}
+
+impl CompiledCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            capacity,
+        }
+    }
+
+    /// Return the cached AST for `code` only when an entry under its key exists AND its stored
+    /// source matches `code` — so a hash collision (same key, different source) is a miss, never a
+    /// wrong-AST hit (B4).
+    fn get_verified(&self, key: u64, code: &str) -> Option<Arc<AST>> {
+        self.entries
+            .get(&key)
+            .and_then(|(source, ast)| (source == code).then(|| Arc::clone(ast)))
+    }
+
+    /// Return the cached AST for `code`, compiling and inserting it on a (verified) miss. Enforces
+    /// the capacity bound: when inserting a NEW key would exceed `capacity`, the cache is cleared
+    /// first (B3).
+    fn get_or_compile(&mut self, key: u64, code: &str) -> Result<Arc<AST>> {
+        if let Some(ast) = self.get_verified(key, code) {
+            return Ok(ast);
+        }
+        let engine = rhai::Engine::new();
+        let ast = Arc::new(
+            engine
+                .compile(code)
+                .map_err(|e| anyhow!("Failed to compile script: {e}"))?,
+        );
+        // Only a brand-new key grows the map; replacing a same-key entry (a collision, or an
+        // edited script re-hashed to the same slot) does not, so no clear is needed there.
+        if !self.entries.contains_key(&key) && self.entries.len() >= self.capacity {
+            self.entries.clear();
+        }
+        self.entries
+            .insert(key, (code.to_string(), Arc::clone(&ast)));
+        Ok(ast)
+    }
+}
+
+fn rhai_cache() -> &'static RwLock<CompiledCache> {
+    static CACHE: OnceLock<RwLock<CompiledCache>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(CompiledCache::new(DEFAULT_CAPACITY)))
+}
+
+/// Get a compiled Rhai AST for `code`, compiling and caching it on first use. A later call with
+/// byte-identical content returns the same cached `Arc` without recompiling; different content
+/// (e.g. an edited file) hashes to a different key and compiles fresh. Bounded and
+/// collision-guarded — see the module docs.
+pub(crate) fn cached_rhai_ast(code: &str) -> Result<Arc<AST>> {
+    let key = content_key(code);
+    // Fast path: a shared read lock is enough for a verified hit.
+    {
+        let cache = rhai_cache()
+            .read()
+            .map_err(|_| anyhow!("rhai script cache lock poisoned"))?;
+        if let Some(ast) = cache.get_verified(key, code) {
+            return Ok(ast);
+        }
+    }
+    // Slow path: compile + insert under a write lock (get_or_compile re-checks for a hit first, so
+    // a concurrent insert between the two locks does not double-compile a stored entry).
+    let mut cache = rhai_cache()
+        .write()
+        .map_err(|_| anyhow!("rhai script cache lock poisoned"))?;
+    cache.get_or_compile(key, code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_content_shares_one_compiled_entry() {
+        let code = "fn should_inject(request, flow_store) { #{ inject: false } }";
+        let a = cached_rhai_ast(code).unwrap();
+        let b = cached_rhai_ast(code).unwrap();
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "byte-identical content must return the same cached AST"
+        );
+    }
+
+    #[test]
+    fn different_content_compiles_a_distinct_entry() {
+        let a = cached_rhai_ast("fn should_inject(request, flow_store) { #{ inject: false } }")
+            .unwrap();
+        let b = cached_rhai_ast("fn should_inject(request, flow_store) { #{ inject: true, fault: `latency`, duration_ms: 1 } }")
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "different content must not share a cache entry"
+        );
+    }
+
+    #[test]
+    fn editing_content_busts_the_cache_key() {
+        // Simulates "edit the file, reload": the resolved `code` string changes, so the second
+        // call recompiles instead of reusing the first (stale) AST.
+        let original =
+            cached_rhai_ast("fn should_inject(request, flow_store) { #{ inject: false } }")
+                .unwrap();
+        let edited = cached_rhai_ast("fn should_inject(request, flow_store) { #{ inject: true, fault: `latency`, duration_ms: 2 } }").unwrap();
+        assert!(!Arc::ptr_eq(&original, &edited));
+    }
+
+    // B3: the cache never grows past its capacity — inserting more distinct scripts than the cap
+    // triggers a wholesale clear rather than unbounded growth. Uses an isolated cache instance so
+    // it doesn't perturb (or get perturbed by) the process-global cache other tests share.
+    #[test]
+    fn cache_does_not_grow_past_capacity() {
+        let cap = 8;
+        let mut cache = CompiledCache::new(cap);
+        for i in 0..(cap * 4) {
+            let code =
+                format!("fn should_inject(request, flow_store) {{ #{{ inject: false, n: {i} }} }}");
+            let key = content_key(&code);
+            cache.get_or_compile(key, &code).unwrap();
+            assert!(
+                cache.entries.len() <= cap,
+                "cache size {} exceeded cap {cap} after {} inserts",
+                cache.entries.len(),
+                i + 1
+            );
+        }
+    }
+
+    // B4: a hit is only returned when the STORED SOURCE matches — a same-key/different-source
+    // collision compiles fresh and replaces, never returns the wrong AST. Drives the key
+    // explicitly (a real 64-bit collision is infeasible to construct) to exercise the guard.
+    #[test]
+    fn collision_guard_never_returns_wrong_ast() {
+        let mut cache = CompiledCache::new(16);
+        let src_a = "fn should_inject(request, flow_store) { #{ inject: false, tag: 1 } }";
+        let src_b = "fn should_inject(request, flow_store) { #{ inject: false, tag: 2 } }";
+        let forced_key = 0xC0FFEE_u64;
+
+        let a = cache.get_or_compile(forced_key, src_a).unwrap();
+        // Same key, different source: must recompile B, not return A.
+        let b = cache.get_or_compile(forced_key, src_b).unwrap();
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "collision must not return A's AST for B"
+        );
+
+        // The verified lookup only matches the currently-stored source (B), not the evicted A.
+        assert!(cache.get_verified(forced_key, src_b).is_some());
+        assert!(
+            cache.get_verified(forced_key, src_a).is_none(),
+            "a source that doesn't match the stored entry is a miss, not a wrong-AST hit"
+        );
+    }
+}

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 // Engine modules (only used by proxy.rs for compilation)
 mod bounded;
+mod compiled_cache;
 mod rhai_engine;
 pub use bounded::{DEFAULT_SCRIPT_TIMEOUT_MS, resolve_script_timeout_ms, should_inject_bounded};
 

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -550,6 +550,10 @@ pub(super) fn dynamic_to_json(value: Dynamic) -> Value {
 /// evaluates, Rhai calls the registered `on_progress` callback periodically; when `abort`
 /// is set (by the caller's deadline), it returns `Some(_)`, terminating execution with an
 /// error — the same mechanism the pooled path uses (#172).
+///
+/// The AST is compiled through the content-addressed cache (issue #356): repeated requests for
+/// the same `code` (e.g. several stubs `ref:`-ing the same registry entry, or repeated requests
+/// against the same stub) reuse the compiled AST instead of recompiling every call.
 pub fn run_should_inject_with_abort_rhai(
     code: &str,
     rule_id: &str,
@@ -557,7 +561,7 @@ pub fn run_should_inject_with_abort_rhai(
     flow_store: Arc<dyn FlowStore>,
     abort: &Arc<AtomicBool>,
 ) -> Result<FaultDecision> {
-    let compiled = RhaiEngine::new(code, rule_id)?;
+    let ast = super::compiled_cache::cached_rhai_ast(code)?;
     let mut engine = RhaiEngine::create_engine();
     let flag = Arc::clone(abort);
     engine.on_progress(move |_ops| {
@@ -567,7 +571,7 @@ pub fn run_should_inject_with_abort_rhai(
             None
         }
     });
-    execute_rhai_with_engine(&engine, compiled.ast(), request, flow_store, rule_id)
+    execute_rhai_with_engine(&engine, &ast, request, flow_store, rule_id)
 }
 
 #[cfg(test)]

--- a/crates/rift-core/src/scripting/stub_validator.rs
+++ b/crates/rift-core/src/scripting/stub_validator.rs
@@ -5,7 +5,7 @@
 //! rather than at request time.
 
 use super::validator::ScriptValidator;
-use crate::imposter::{Stub, StubResponse};
+use crate::imposter::{RiftScriptConfig, Stub, StubResponse};
 use std::fmt;
 
 /// Error type for stub script validation
@@ -105,40 +105,45 @@ fn validate_response(
 ) -> Option<StubValidationError> {
     match response {
         // Rift script responses (_rift.script)
-        StubResponse::RiftScript { rift } => {
-            if let Some(ref script_config) = rift.script {
-                validate_rift_script(
-                    &script_config.engine,
-                    &script_config.code,
-                    stub_id,
-                    response_index,
-                )
-            } else {
-                None
-            }
-        }
+        StubResponse::RiftScript { rift } => rift.script.as_ref().and_then(|script_config| {
+            validate_rift_script_config(script_config, stub_id, response_index)
+        }),
         // Is responses with optional _rift extension
-        StubResponse::Is { rift, .. } => {
-            if let Some(rift_ext) = rift {
-                if let Some(ref script_config) = rift_ext.script {
-                    validate_rift_script(
-                        &script_config.engine,
-                        &script_config.code,
-                        stub_id,
-                        response_index,
-                    )
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
+        StubResponse::Is { rift, .. } => rift.as_ref().and_then(|rift_ext| {
+            rift_ext.script.as_ref().and_then(|script_config| {
+                validate_rift_script_config(script_config, stub_id, response_index)
+            })
+        }),
         // JavaScript inject responses
         StubResponse::Inject { inject } => validate_inject_script(inject, stub_id, response_index),
         // Proxy and Fault responses don't have inline scripts to validate
         StubResponse::Proxy { .. } | StubResponse::Fault { .. } => None,
     }
+}
+
+/// Validates a single `_rift.script` config. `code`/`file`/`ref` exactly-one is checked
+/// unconditionally; the syntax check only runs against `code` — a `file`/`ref` source is
+/// unresolved here (that happens in the config-time resolve-scripts pass, issue #356) so an
+/// unresolved script is structurally checked but not syntax-checked by this call site.
+fn validate_rift_script_config(
+    script_config: &RiftScriptConfig,
+    stub_id: &str,
+    response_index: usize,
+) -> Option<StubValidationError> {
+    if !script_config.has_valid_source() {
+        return Some(StubValidationError {
+            stub_id: stub_id.to_string(),
+            response_index,
+            engine: script_config.engine.clone().unwrap_or_default(),
+            message: format!(
+                "script must specify exactly one of `code`, `file`, or `ref` (found {})",
+                script_config.source_count()
+            ),
+        });
+    }
+    let code = script_config.code.as_deref()?;
+    let engine = script_config.engine.as_deref().unwrap_or("rhai");
+    validate_rift_script(engine, code, stub_id, response_index)
 }
 
 /// Validates a Rift script (_rift.script) using the appropriate validator
@@ -266,8 +271,10 @@ mod tests {
                 rift: RiftResponseExtension {
                     fault: None,
                     script: Some(RiftScriptConfig {
-                        engine: engine.to_string(),
-                        code: code.to_string(),
+                        engine: Some(engine.to_string()),
+                        code: Some(code.to_string()),
+                        file: None,
+                        ref_name: None,
                     }),
                 },
             }],
@@ -372,9 +379,13 @@ mod tests {
                     rift: RiftResponseExtension {
                         fault: None,
                         script: Some(RiftScriptConfig {
-                            engine: "rhai".to_string(),
-                            code: r#"fn should_inject(request, flow_store) { #{ inject: false } }"#
-                                .to_string(),
+                            engine: Some("rhai".to_string()),
+                            code: Some(
+                                r#"fn should_inject(request, flow_store) { #{ inject: false } }"#
+                                    .to_string(),
+                            ),
+                            file: None,
+                            ref_name: None,
                         }),
                     },
                 }],
@@ -393,9 +404,13 @@ mod tests {
                     rift: RiftResponseExtension {
                         fault: None,
                         script: Some(RiftScriptConfig {
-                            engine: "rhai".to_string(),
-                            code: r#"fn should_inject(request, flow_store) { #{ inject: "#
-                                .to_string(), // Invalid
+                            engine: Some("rhai".to_string()),
+                            code: Some(
+                                r#"fn should_inject(request, flow_store) { #{ inject: "#
+                                    .to_string(), // Invalid
+                            ),
+                            file: None,
+                            ref_name: None,
                         }),
                     },
                 }],

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -10,7 +10,7 @@ use crate::extensions::decorate::backend_error_response;
 use crate::extensions::stub_analysis::analyze_stubs;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
-    RecordedRequest, Stub, StubResponse,
+    RecordedRequest, ScriptBaseDir, Stub, StubResponse, resolve_scripts,
 };
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
@@ -18,8 +18,34 @@ use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
 use serde::Deserialize;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{error, info, warn};
+
+/// The `ScriptBaseDir` a `--scripts-dir`-carrying admin API resolves `file:` scripts under;
+/// `Unconfigured` when the flag was never set. Shared by the imposter CRUD handlers and the stub
+/// sub-resource handlers (issue #356 B1) so a `file:`/`ref:` script added through ANY admin-API
+/// write path is resolved & escape-checked under the same root before it is persisted.
+pub(crate) fn admin_script_base(scripts_dir: &Option<Arc<PathBuf>>) -> ScriptBaseDir {
+    match scripts_dir {
+        Some(dir) => ScriptBaseDir::ScriptsDir(dir.as_ref().clone()),
+        None => ScriptBaseDir::Unconfigured,
+    }
+}
+
+/// The `_rift.scripts` registry of the imposter on `port` (already resolved when the imposter was
+/// created), for resolving a newly-added stub's `{ "ref": "name" }` against. Empty when the
+/// imposter doesn't exist or declares no registry.
+pub(crate) fn imposter_script_registry(
+    manager: &ImposterManager,
+    port: u16,
+) -> std::collections::HashMap<String, crate::imposter::RiftScriptConfig> {
+    manager
+        .get_imposter(port)
+        .ok()
+        .and_then(|imposter| imposter.config.rift.as_ref().map(|r| r.scripts.clone()))
+        .unwrap_or_default()
+}
 
 /// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`
 /// (issue #355 Item 4): an inject response, a decorate behavior (`_behaviors.decorate` / a
@@ -128,13 +154,14 @@ pub async fn handle_create(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
     };
 
-    let config: ImposterConfig = match serde_json::from_slice(&body) {
+    let mut config: ImposterConfig = match serde_json::from_slice(&body) {
         Ok(c) => c,
         Err(e) => {
             return error_response(
@@ -146,6 +173,16 @@ pub async fn handle_create(
 
     if let Some(rejection) = reject_if_injection_disallowed(&config, allow_injection) {
         return rejection;
+    }
+
+    // Resolve `_rift.script` `file:`/`ref:` sources (issue #356) before validating/creating —
+    // a `file:` outside `--scripts-dir` (or with no `--scripts-dir` configured at all) is
+    // rejected here, never read.
+    if let Err(e) = resolve_scripts(&mut config, &admin_script_base(&scripts_dir)) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("Script resolution failed: {e}"),
+        );
     }
 
     // Validate all scripts in stubs before creating the imposter
@@ -239,6 +276,7 @@ pub async fn handle_replace_all(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -250,7 +288,7 @@ pub async fn handle_replace_all(
         imposters: Vec<ImposterConfig>,
     }
 
-    let batch: BatchRequest = match serde_json::from_slice(&body) {
+    let mut batch: BatchRequest = match serde_json::from_slice(&body) {
         Ok(b) => b,
         Err(e) => {
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid batch JSON: {e}"));
@@ -262,6 +300,21 @@ pub async fn handle_replace_all(
     for config in &batch.imposters {
         if let Some(rejection) = reject_if_injection_disallowed(config, allow_injection) {
             return rejection;
+        }
+    }
+
+    // Resolve `_rift.script` `file:`/`ref:` sources (issue #356) for every imposter before
+    // making any changes — same rejection rules as `handle_create`.
+    let base = admin_script_base(&scripts_dir);
+    for (idx, config) in batch.imposters.iter_mut().enumerate() {
+        if let Err(e) = resolve_scripts(config, &base) {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!(
+                    "Script resolution failed in imposter[{idx}] (port {:?}): {e}",
+                    config.port
+                ),
+            );
         }
     }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -4,15 +4,18 @@
 //! partitioned by `flow_id`. When a `flowId` is not supplied, the imposter's default
 //! flow (`resolve_flow_id` with no headers ⇒ the `imposter_port` flow) is used.
 
-use crate::admin_api::handlers::imposters::reject_stubs_if_injection_disallowed;
+use crate::admin_api::handlers::imposters::{
+    admin_script_base, imposter_script_registry, reject_stubs_if_injection_disallowed,
+};
 use crate::admin_api::types::{collect_body, error_response, json_response};
 use crate::extensions::decorate::backend_error_response;
-use crate::imposter::{Imposter, ImposterManager, Stub};
+use crate::imposter::{Imposter, ImposterManager, Stub, resolve_stub_scripts};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 fn default_flow_id(imposter: &Imposter) -> String {
@@ -214,6 +217,7 @@ pub async fn handle_add_space_stub(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let payload = match parse_json_body(req).await {
         Ok(v) => v,
@@ -228,6 +232,18 @@ pub async fn handle_add_space_stub(
         reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
     {
         return rejection;
+    }
+    // Resolve `_rift.script` `file:`/`ref:` sources before persisting (issue #356 B1): escape /
+    // unknown-ref / unconfigured `file:` → 400, nothing unresolved is ever stored.
+    {
+        let registry = imposter_script_registry(&manager, port);
+        let base = admin_script_base(&scripts_dir);
+        if let Err(e) = resolve_stub_scripts(std::slice::from_mut(&mut stub), &registry, &base) {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("Script resolution failed: {e}"),
+            );
+        }
     }
     // The path `:flowId` is the source of truth for the scope; ignore any `space` in the body.
     stub.space = Some(flow_id.to_string());

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -1,20 +1,44 @@
 //! Stub management handlers.
 
 use crate::admin_api::handlers::imposters::handle_get as handle_get_imposter;
-use crate::admin_api::handlers::imposters::reject_stubs_if_injection_disallowed;
+use crate::admin_api::handlers::imposters::{
+    admin_script_base, imposter_script_registry, reject_stubs_if_injection_disallowed,
+};
 use crate::admin_api::types::{
     AddStubRequest, ReplaceStubsRequest, StubWithLinks, collect_body, error_response,
     json_response, make_stub_links,
 };
 use crate::extensions::stub_analysis::{analyze_new_stub, analyze_stubs};
-use crate::imposter::{ImposterManager, Stub};
+use crate::imposter::{ImposterManager, Stub, resolve_stub_scripts};
 use crate::scripting::{validate_stub, validate_stubs};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::warn;
+
+/// Resolve `_rift.script` `file:`/`ref:` sources in admin-API-supplied stubs at WRITE time (issue
+/// #356 B1), under the same `--scripts-dir` root as whole-imposter create, before the stubs are
+/// persisted. Returns a `400` on any escape / unknown-ref / unconfigured-`file:` error so nothing
+/// unresolved (`file`/`ref` still set) is ever written to the datadir. `None` on success.
+fn resolve_admin_stubs(
+    stubs: &mut [Stub],
+    manager: &ImposterManager,
+    port: u16,
+    scripts_dir: &Option<Arc<PathBuf>>,
+) -> Option<Response<Full<Bytes>>> {
+    let registry = imposter_script_registry(manager, port);
+    let base = admin_script_base(scripts_dir);
+    match resolve_stub_scripts(stubs, &registry, &base) {
+        Ok(()) => None,
+        Err(e) => Some(error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("Script resolution failed: {e}"),
+        )),
+    }
+}
 
 /// POST /imposters/:port/stubs - Add a stub
 pub async fn handle_add(
@@ -23,6 +47,7 @@ pub async fn handle_add(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
@@ -40,6 +65,17 @@ pub async fn handle_add(
     if let Some(rejection) =
         reject_stubs_if_injection_disallowed(std::slice::from_ref(&add_req.stub), allow_injection)
     {
+        return rejection;
+    }
+
+    // Resolve `_rift.script` `file:`/`ref:` sources before persisting (issue #356 B1): an escape /
+    // unknown-ref / unconfigured `file:` is a 400, and nothing unresolved is ever stored.
+    if let Some(rejection) = resolve_admin_stubs(
+        std::slice::from_mut(&mut add_req.stub),
+        &manager,
+        port,
+        &scripts_dir,
+    ) {
         return rejection;
     }
 
@@ -104,13 +140,14 @@ pub async fn handle_replace_all(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
     };
 
-    let replace_req: ReplaceStubsRequest = match serde_json::from_slice(&body) {
+    let mut replace_req: ReplaceStubsRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stubs JSON: {e}"));
@@ -120,6 +157,13 @@ pub async fn handle_replace_all(
     // Gate any scripting surface behind --allowInjection before mutating state (B3, issue #355).
     if let Some(rejection) =
         reject_stubs_if_injection_disallowed(&replace_req.stubs, allow_injection)
+    {
+        return rejection;
+    }
+
+    // Resolve `_rift.script` `file:`/`ref:` sources before persisting (issue #356 B1).
+    if let Some(rejection) =
+        resolve_admin_stubs(&mut replace_req.stubs, &manager, port, &scripts_dir)
     {
         return rejection;
     }
@@ -207,13 +251,14 @@ pub async fn handle_replace(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
     };
 
-    let stub: Stub = match serde_json::from_slice(&body) {
+    let mut stub: Stub = match serde_json::from_slice(&body) {
         Ok(s) => s,
         Err(e) => {
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
@@ -224,6 +269,16 @@ pub async fn handle_replace(
     if let Some(rejection) =
         reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
     {
+        return rejection;
+    }
+
+    // Resolve `_rift.script` `file:`/`ref:` sources before persisting (issue #356 B1).
+    if let Some(rejection) = resolve_admin_stubs(
+        std::slice::from_mut(&mut stub),
+        &manager,
+        port,
+        &scripts_dir,
+    ) {
         return rejection;
     }
 
@@ -280,12 +335,13 @@ pub async fn handle_replace_by_id(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
     };
-    let stub: Stub = match serde_json::from_slice(&body) {
+    let mut stub: Stub = match serde_json::from_slice(&body) {
         Ok(s) => s,
         Err(e) => {
             return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub JSON: {e}"));
@@ -295,6 +351,15 @@ pub async fn handle_replace_by_id(
     if let Some(rejection) =
         reject_stubs_if_injection_disallowed(std::slice::from_ref(&stub), allow_injection)
     {
+        return rejection;
+    }
+    // Resolve `_rift.script` `file:`/`ref:` sources before persisting (issue #356 B1).
+    if let Some(rejection) = resolve_admin_stubs(
+        std::slice::from_mut(&mut stub),
+        &manager,
+        port,
+        &scripts_dir,
+    ) {
         return rejection;
     }
     let validation_result = validate_stub(&stub, 0);

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -323,6 +323,75 @@ mod tests {
         manager.delete_all().await;
     }
 
+    // Issue #356: editing a `file:`-referenced script and reloading must pick up the new
+    // content — the resolve-scripts pass has to re-run on every reload (it does, since reload
+    // re-reads the config source from scratch via `config_loader::load_configs`, which resolves
+    // scripts as part of parsing), not just once at startup.
+    #[tokio::test]
+    async fn test_handle_reload_picks_up_edited_file_referenced_script() {
+        use crate::imposter::StubResponse;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script_path = dir.path().join("should_inject.rhai");
+        std::fs::write(
+            &script_path,
+            r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "v1" } }"#,
+        )
+        .expect("write script v1");
+
+        let config_path = dir.path().join("imposter.json");
+        std::fs::write(
+            &config_path,
+            r#"{"port":19479,"protocol":"http","stubs":[{"responses":[{"_rift":{"script":{"file":"should_inject.rhai"}}}]}]}"#,
+        )
+        .expect("write config");
+
+        let source = Arc::new(crate::config_loader::ConfigSource::File {
+            path: config_path,
+            no_parse: false,
+        });
+
+        let manager = Arc::new(ImposterManager::new());
+
+        // Initial reload creates the imposter with the v1 script content resolved.
+        let resp = handle_reload(manager.clone(), Some(source.clone())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let script_code = |manager: &ImposterManager| {
+            let imposter = manager.get_imposter(19479).expect("imposter exists");
+            let stubs = imposter.get_stubs();
+            match &stubs[0].responses[0] {
+                StubResponse::RiftScript { rift } => {
+                    rift.script.as_ref().and_then(|s| s.code.clone())
+                }
+                other => panic!("expected RiftScript response, got {other:?}"),
+            }
+        };
+        assert_eq!(
+            script_code(&manager).as_deref(),
+            Some(
+                r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "v1" } }"#
+            )
+        );
+
+        // Edit the referenced file (the configfile itself is untouched) and reload again.
+        std::fs::write(
+            &script_path,
+            r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "v2" } }"#,
+        )
+        .expect("write script v2");
+        let resp = handle_reload(manager.clone(), Some(source)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            script_code(&manager).as_deref(),
+            Some(
+                r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "v2" } }"#
+            ),
+            "reload must pick up the edited file content"
+        );
+
+        manager.delete_all().await;
+    }
+
     #[test]
     fn test_handle_logs_no_query() {
         let resp = handle_logs(None);

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
 use hyper::{Method, Request, Response, StatusCode};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -74,6 +75,7 @@ pub async fn route_request(
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
     intercept: Option<Arc<InterceptState>>,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
@@ -105,6 +107,7 @@ pub async fn route_request(
         manager,
         config_source,
         allow_injection,
+        scripts_dir,
     )
     .await;
     Ok(response)
@@ -164,6 +167,7 @@ async fn route_by_path(
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     // Single-port gateway (issue #212): `/__rift/:port/<path>` dispatches to that imposter,
     // so a containerized Rift only needs the one admin port published.
@@ -188,9 +192,12 @@ async fn route_by_path(
     if path == "/imposters" {
         return match *method {
             Method::GET => imposters::handle_list(manager, query, base_url).await,
-            Method::POST => imposters::handle_create(req, base_url, manager, allow_injection).await,
+            Method::POST => {
+                imposters::handle_create(req, base_url, manager, allow_injection, scripts_dir).await
+            }
             Method::PUT => {
-                imposters::handle_replace_all(req, base_url, manager, allow_injection).await
+                imposters::handle_replace_all(req, base_url, manager, allow_injection, scripts_dir)
+                    .await
             }
             Method::DELETE => imposters::handle_delete_all(manager, base_url).await,
             _ => not_found(),
@@ -204,7 +211,17 @@ async fn route_by_path(
 
     // Individual imposter routes
     if let Some(rest) = path.strip_prefix("/imposters/") {
-        return route_imposter(method, rest, query, req, base_url, manager, allow_injection).await;
+        return route_imposter(
+            method,
+            rest,
+            query,
+            req,
+            base_url,
+            manager,
+            allow_injection,
+            scripts_dir,
+        )
+        .await;
     }
 
     not_found()
@@ -248,6 +265,7 @@ async fn route_imposter(
     base_url: &str,
     manager: Arc<ImposterManager>,
     allow_injection: bool,
+    scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {
     // Parse: port/remaining/path
     let segments: Vec<&str> = path.split('/').collect();
@@ -282,10 +300,11 @@ async fn route_imposter(
             stubs::handle_get_all(port, base_url, manager).await
         }
         (&Method::POST, ImposterRoute::Stubs) => {
-            stubs::handle_add(port, req, base_url, manager, allow_injection).await
+            stubs::handle_add(port, req, base_url, manager, allow_injection, scripts_dir).await
         }
         (&Method::PUT, ImposterRoute::Stubs) => {
-            stubs::handle_replace_all(port, req, base_url, manager, allow_injection).await
+            stubs::handle_replace_all(port, req, base_url, manager, allow_injection, scripts_dir)
+                .await
         }
 
         // /imposters/:port/stubs/:index
@@ -293,7 +312,16 @@ async fn route_imposter(
             stubs::handle_get(port, index, base_url, manager).await
         }
         (&Method::PUT, ImposterRoute::StubByIndex(index)) => {
-            stubs::handle_replace(port, index, req, base_url, manager, allow_injection).await
+            stubs::handle_replace(
+                port,
+                index,
+                req,
+                base_url,
+                manager,
+                allow_injection,
+                scripts_dir,
+            )
+            .await
         }
         (&Method::DELETE, ImposterRoute::StubByIndex(index)) => {
             stubs::handle_delete(port, index, base_url, manager).await
@@ -304,7 +332,16 @@ async fn route_imposter(
             stubs::handle_get_by_id(port, &id, manager).await
         }
         (&Method::PUT, ImposterRoute::StubById(id)) => {
-            stubs::handle_replace_by_id(port, &id, req, base_url, manager, allow_injection).await
+            stubs::handle_replace_by_id(
+                port,
+                &id,
+                req,
+                base_url,
+                manager,
+                allow_injection,
+                scripts_dir,
+            )
+            .await
         }
         (&Method::DELETE, ImposterRoute::StubById(id)) => {
             stubs::handle_delete_by_id(port, &id, base_url, manager).await
@@ -340,7 +377,15 @@ async fn route_imposter(
 
         // /imposters/:port/spaces/:flowId — Correlated isolation (issue #223)
         (&Method::POST, ImposterRoute::SpaceStubs(flow_id)) => {
-            scenarios::handle_add_space_stub(port, &flow_id, req, manager, allow_injection).await
+            scenarios::handle_add_space_stub(
+                port,
+                &flow_id,
+                req,
+                manager,
+                allow_injection,
+                scripts_dir,
+            )
+            .await
         }
         (&Method::GET, ImposterRoute::SpaceStubs(flow_id)) => {
             scenarios::handle_list_space_stubs(port, &flow_id, manager).await

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -11,6 +11,7 @@ use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -30,6 +31,7 @@ pub struct AdminApiServer {
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
     intercept: Option<Arc<InterceptState>>,
+    scripts_dir: Option<Arc<PathBuf>>,
 }
 
 impl AdminApiServer {
@@ -42,6 +44,7 @@ impl AdminApiServer {
             config_source: None,
             allow_injection: false,
             intercept: None,
+            scripts_dir: None,
         }
     }
 
@@ -70,6 +73,15 @@ impl AdminApiServer {
         self
     }
 
+    /// Set the root directory `_rift.script` `file:` references resolve under for imposters
+    /// created through the admin API (issue #356). Without it, admin-API `file:` references are
+    /// rejected — see `imposter::ScriptBaseDir::Unconfigured`.
+    #[must_use]
+    pub fn with_scripts_dir(mut self, dir: PathBuf) -> Self {
+        self.scripts_dir = Some(Arc::new(dir));
+        self
+    }
+
     /// Bind the listener (`:0` is fine) and start serving on the current runtime, returning a
     /// handle that reports the bound address and can be shut down gracefully (issue #342).
     pub async fn bind(self) -> anyhow::Result<RunningAdminApi> {
@@ -95,6 +107,7 @@ impl AdminApiServer {
                 self.config_source,
                 self.allow_injection,
                 self.intercept,
+                self.scripts_dir,
                 loop_cancel,
                 loop_tracker,
             )
@@ -190,6 +203,7 @@ async fn accept_loop(
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
     intercept: Option<Arc<InterceptState>>,
+    scripts_dir: Option<Arc<PathBuf>>,
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
@@ -203,6 +217,7 @@ async fn accept_loop(
         let api_key = api_key.clone();
         let config_source = config_source.clone();
         let intercept = intercept.clone();
+        let scripts_dir = scripts_dir.clone();
         let conn_cancel = cancel.clone();
 
         tracker.spawn(async move {
@@ -211,6 +226,7 @@ async fn accept_loop(
                 let api_key = api_key.clone();
                 let config_source = config_source.clone();
                 let intercept = intercept.clone();
+                let scripts_dir = scripts_dir.clone();
                 async move {
                     // Per-request annotation scope + response decorator (issue #318):
                     // every response through this listener — including the `/__rift/`
@@ -235,7 +251,15 @@ async fn accept_loop(
                                 return Ok::<_, hyper::Error>(unauthorized_response());
                             }
                         }
-                        route_request(req, manager, config_source, allow_injection, intercept).await
+                        route_request(
+                            req,
+                            manager,
+                            config_source,
+                            allow_injection,
+                            intercept,
+                            scripts_dir,
+                        )
+                        .await
                     })
                     .await;
                     let mut response = result?;

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -2,7 +2,7 @@
 //! by startup and the `POST /admin/reload` hot-reload endpoint (issue #197). Parsing is pure (no
 //! running state is touched), so a parse error is returned rather than applied.
 
-use crate::imposter::ImposterConfig;
+use crate::imposter::{ImposterConfig, ScriptBaseDir, resolve_scripts};
 use std::path::{Path, PathBuf};
 use tracing::warn;
 
@@ -33,7 +33,7 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>>
     };
 
     let trimmed = content.trim_start();
-    let configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
+    let mut configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
         // Single imposter, or a `{ "imposters": [...] }` wrapper (Mountebank format).
         let value: serde_json::Value = serde_json::from_str(&content)?;
         match value.get("imposters") {
@@ -45,6 +45,19 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>>
     } else {
         serde_yaml::from_str(&content)?
     };
+
+    // Resolve `_rift.script` `file:`/`ref:` sources (issue #356) relative to the config file's
+    // own directory, before the configs are handed to the caller — so a parse error and a
+    // resolve error are both surfaced up front, and hot-reload (which re-runs this loader)
+    // automatically picks up edits to referenced script files.
+    let base = ScriptBaseDir::ConfigRelative(
+        path.parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf(),
+    );
+    for config in &mut configs {
+        resolve_scripts(config, &base)?;
+    }
     Ok(configs)
 }
 
@@ -52,12 +65,18 @@ fn load_dir(dir: &Path) -> anyhow::Result<Vec<ImposterConfig>> {
     if !dir.exists() {
         return Ok(Vec::new());
     }
+    // Datadir `{port}.json` files can be network-authored (a stub POSTed through the admin API is
+    // persisted here), so `file:` references are escape-checked — an absolute path or a `..`
+    // escape is rejected, never read (issue #356 B1/B2 defense-in-depth).
+    let base = ScriptBaseDir::DatadirRelative(dir.to_path_buf());
     let mut configs = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let path = entry?.path();
         if path.extension().map(|e| e == "json").unwrap_or(false) {
             let content = std::fs::read_to_string(&path)?;
-            configs.push(serde_json::from_str::<ImposterConfig>(&content)?);
+            let mut config: ImposterConfig = serde_json::from_str(&content)?;
+            resolve_scripts(&mut config, &base)?;
+            configs.push(config);
         }
     }
     Ok(configs)
@@ -244,6 +263,37 @@ mod tests {
             load_configs(&ConfigSource::Dir(dir.path().to_path_buf())).is_err(),
             "a malformed file makes the whole reload fail (no partial apply)"
         );
+    }
+
+    // Issue #356 B1 (security regression): a persisted datadir `{port}.json` carrying an absolute
+    // or `..`-escaping `_rift.script.file:` is REJECTED on load — never read. This is the proof
+    // that a stub POSTed through the admin API and persisted here cannot turn a later
+    // reload/restart into an arbitrary file read (`/etc/passwd`).
+    #[test]
+    fn datadir_rejects_escaping_file_script_without_reading() {
+        for bad in ["/etc/passwd", "../secret.rhai"] {
+            let dir = tempfile::tempdir().unwrap();
+            // A real secret adjacent to the datadir that a naive resolver would read.
+            std::fs::write(dir.path().join("secret.rhai"), "SUPER-SECRET").unwrap();
+            let datadir = dir.path().join("data");
+            std::fs::create_dir(&datadir).unwrap();
+            let cfg = format!(
+                r#"{{"port":8300,"protocol":"http","stubs":[{{"responses":[{{"_rift":{{"script":{{"file":"{bad}"}}}}}}]}}]}}"#
+            );
+            write(&datadir, "8300.json", &cfg);
+
+            let result = load_configs(&ConfigSource::Dir(datadir));
+            let err = result.expect_err("escaping datadir file: must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("escapes"),
+                "datadir `{bad}` should be a path-escape error, got: {msg}"
+            );
+            assert!(
+                !msg.contains("SUPER-SECRET"),
+                "the secret's content must never appear (it must not be read): {msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -7,7 +7,9 @@
 use crate::admin_api::{AdminApiServer, DEFAULT_ADMIN_PORT, RunningAdminApi};
 use crate::config_loader::{self, ConfigSource};
 use crate::extensions::metrics;
-use crate::imposter::{ImposterConfig, ImposterManager, TlsDefaults};
+use crate::imposter::{
+    ImposterConfig, ImposterManager, ScriptBaseDir, TlsDefaults, resolve_scripts,
+};
 use crate::intercept::InterceptListener;
 use crate::intercept_rules::{InterceptRules, InterceptState};
 use clap::{Parser, Subcommand};
@@ -53,6 +55,13 @@ pub struct Cli {
     /// Directory for persistent imposter storage
     #[arg(long, value_name = "DIR", env = "MB_DATADIR")]
     pub datadir: Option<PathBuf>,
+
+    /// Root directory `_rift.script` `file:` references resolve under for admin-API-created
+    /// imposters (issue #356). A resolved path that escapes this root is rejected. Without it,
+    /// admin-API `file:` script references are rejected outright (`--configfile`/`--datadir`
+    /// loads are unaffected — those resolve relative to the config's own directory).
+    #[arg(long, value_name = "DIR", env = "RIFT_SCRIPTS_DIR")]
+    pub scripts_dir: Option<PathBuf>,
 
     /// Allow JavaScript injection in responses (for inject and decorate)
     #[arg(long, visible_alias = "allowInjection", env = "MB_ALLOW_INJECTION")]
@@ -296,6 +305,9 @@ impl ServerBuilder {
         // Injection gating is threaded explicitly (issue #342) rather than read from env.
         let mut server = AdminApiServer::new(addr, manager, cli.api_key)
             .with_allow_injection(cli.allow_injection);
+        if let Some(scripts_dir) = cli.scripts_dir {
+            server = server.with_scripts_dir(scripts_dir);
+        }
         if let Some(configfile) = cli.configfile {
             server = server.with_config_source(ConfigSource::File {
                 path: configfile,
@@ -595,18 +607,30 @@ async fn load_imposters_from_datadir(
         return Ok(());
     }
 
+    // `file:`/`ref:` scripts in a datadir-loaded imposter resolve relative to the datadir itself,
+    // escape-checked: these `{port}.json` files can be network-authored (persisted from an
+    // admin-API POST), so an absolute path or `..` escape is rejected, never read (issue #356
+    // B1/B2 defense-in-depth against a datadir re-resolution reading `/etc/passwd`).
+    let base = ScriptBaseDir::DatadirRelative(datadir.clone());
     for entry in std::fs::read_dir(datadir)? {
         let entry = entry?;
         let path = entry.path();
 
         if path.extension().map(|e| e == "json").unwrap_or(false) {
             let content = std::fs::read_to_string(&path)?;
-            if let Ok(config) = serde_json::from_str::<ImposterConfig>(&content) {
-                info!("Loading imposter on port {:?} from {:?}", config.port, path);
-                match manager.create_imposter(config).await {
-                    Ok(port) => info!("Created imposter on port {} from {:?}", port, path),
-                    Err(e) => error!("Failed to create imposter from {:?}: {}", path, e),
+            match serde_json::from_str::<ImposterConfig>(&content) {
+                Ok(mut config) => {
+                    if let Err(e) = resolve_scripts(&mut config, &base) {
+                        error!("Failed to resolve scripts for {:?}: {}", path, e);
+                        continue;
+                    }
+                    info!("Loading imposter on port {:?} from {:?}", config.port, path);
+                    match manager.create_imposter(config).await {
+                        Ok(port) => info!("Created imposter on port {} from {:?}", port, path),
+                        Err(e) => error!("Failed to create imposter from {:?}: {}", path, e),
+                    }
                 }
+                Err(e) => warn!("Skipping invalid imposter file {:?}: {}", path, e),
             }
         }
     }
@@ -630,6 +654,18 @@ mod tests {
         assert_eq!(cli.intercept_port, Some(9000));
         let none = Cli::try_parse_from(["rift"]).expect("parse");
         assert_eq!(none.intercept_port, None);
+    }
+
+    // Issue #356: `--scripts-dir` is the admin-API `file:` script resolution root.
+    #[test]
+    fn scripts_dir_flag_parses() {
+        let cli = Cli::try_parse_from(["rift", "--scripts-dir", "/tmp/scripts"]).expect("parse");
+        assert_eq!(
+            cli.scripts_dir,
+            Some(std::path::PathBuf::from("/tmp/scripts"))
+        );
+        let none = Cli::try_parse_from(["rift"]).expect("parse");
+        assert_eq!(none.scripts_dir, None);
     }
 
     #[test]

--- a/crates/rift-http-proxy/tests/issue_356_scripts_dir.rs
+++ b/crates/rift-http-proxy/tests/issue_356_scripts_dir.rs
@@ -1,0 +1,380 @@
+//! Issue #356: admin-API-created imposters resolve `_rift.script.file:` under `--scripts-dir`,
+//! rejecting any path that escapes the root (never reading it), and rejecting `file:` outright
+//! when no `--scripts-dir` was configured.
+
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::imposter::ImposterManager;
+use std::sync::Arc;
+
+async fn wait_for_http(url: &str) {
+    for _ in 0..50 {
+        if reqwest::get(url).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("server at {url} did not come up");
+}
+
+fn config_with_file_script(port: u16, file: &str) -> serde_json::Value {
+    serde_json::json!({
+        "port": port,
+        "protocol": "http",
+        "stubs": [{
+            "responses": [{ "_rift": { "script": { "file": file } } }]
+        }]
+    })
+}
+
+#[tokio::test]
+async fn file_script_within_scripts_dir_is_accepted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("should_inject.rhai"),
+        r#"fn should_inject(request, flow_store) { #{ inject: false } }"#,
+    )
+    .unwrap();
+
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .with_scripts_dir(dir.path().to_path_buf())
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&config_with_file_script(19551, "should_inject.rhai"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 201, "in-root file: must be accepted");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn file_script_escaping_scripts_dir_is_rejected_without_reading() {
+    let root_parent = tempfile::tempdir().expect("tempdir");
+    // A real, readable file OUTSIDE the scripts root — proves rejection is the `..` escape
+    // check, not merely a missing file.
+    std::fs::write(root_parent.path().join("secret.rhai"), "SECRET").unwrap();
+    let scripts_dir = root_parent.path().join("scripts");
+    std::fs::create_dir(&scripts_dir).unwrap();
+
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .with_scripts_dir(scripts_dir)
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&config_with_file_script(19552, "../secret.rhai"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        400,
+        "a file: path escaping --scripts-dir must be rejected"
+    );
+    let body: serde_json::Value = resp.json().await.expect("json body");
+    let message = body["errors"][0]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("escapes"),
+        "error should explain the escape, got: {message}"
+    );
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn file_script_without_scripts_dir_configured_is_rejected() {
+    let manager = Arc::new(ImposterManager::new());
+    // No `.with_scripts_dir(...)` — admin-API file: references have nowhere to resolve.
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&config_with_file_script(19553, "should_inject.rhai"))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn ref_to_unknown_registry_entry_is_rejected() {
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let config = serde_json::json!({
+        "port": 19554,
+        "protocol": "http",
+        "stubs": [{
+            "responses": [{ "_rift": { "script": { "ref": "doesNotExist" } } }]
+        }]
+    });
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&config)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn named_registry_ref_resolves_end_to_end() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("fail-twice.rhai"),
+        r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "nope" } }"#,
+    )
+    .unwrap();
+
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .with_scripts_dir(dir.path().to_path_buf())
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let config = serde_json::json!({
+        "port": 19555,
+        "protocol": "http",
+        "_rift": { "scripts": { "failTwice": { "file": "fail-twice.rhai" } } },
+        "stubs": [{
+            "responses": [{ "_rift": { "script": { "ref": "failTwice" } } }]
+        }]
+    });
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&config)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        201,
+        "ref: to a file-backed registry entry must resolve"
+    );
+
+    let imposter_resp = client
+        .get("http://127.0.0.1:19555/anything")
+        .send()
+        .await
+        .expect("hit the imposter");
+    assert_eq!(
+        imposter_resp.status(),
+        503,
+        "the resolved script must actually run"
+    );
+
+    running.shutdown().await;
+}
+
+// Issue #356 B1: the stub sub-resource endpoints resolve & escape-check `file:` at WRITE time,
+// exactly like whole-imposter create — so a network-authored `file:` escape is a 400 (never
+// persisted), and an in-root file resolves and actually runs at request time (no unresolved 500).
+#[tokio::test]
+async fn stub_add_endpoint_rejects_escaping_file_and_resolves_in_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("secret.rhai"), "SECRET").unwrap();
+    let root = dir.path().join("scripts");
+    std::fs::create_dir(&root).unwrap();
+    std::fs::write(
+        root.join("boom.rhai"),
+        r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 503, body: "boom" } }"#,
+    )
+    .unwrap();
+
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .with_scripts_dir(root)
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let client = reqwest::Client::new();
+    // Create the target imposter (no stubs yet).
+    let create = client
+        .post(format!("http://{addr}/imposters"))
+        .json(&serde_json::json!({ "port": 19556, "protocol": "http", "stubs": [] }))
+        .send()
+        .await
+        .expect("create");
+    assert_eq!(create.status(), 201);
+
+    // POST a stub whose `file:` escapes the scripts root → 400, and the escaping stub is NOT
+    // persisted (the imposter still has zero stubs).
+    let escaping = client
+        .post(format!("http://{addr}/imposters/19556/stubs"))
+        .json(&serde_json::json!({
+            "stub": { "responses": [{ "_rift": { "script": { "file": "../secret.rhai" } } }] }
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        escaping.status(),
+        400,
+        "escaping file: via stub add must 400"
+    );
+    let stubs_now: serde_json::Value = client
+        .get(format!("http://{addr}/imposters/19556/stubs"))
+        .send()
+        .await
+        .expect("get stubs")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(
+        stubs_now["stubs"].as_array().map(|a| a.len()),
+        Some(0),
+        "the rejected stub must not have been persisted"
+    );
+
+    // POST a stub with an in-root `file:` → accepted, resolved, and it actually runs.
+    let ok = client
+        .post(format!("http://{addr}/imposters/19556/stubs"))
+        .json(&serde_json::json!({
+            "stub": { "responses": [{ "_rift": { "script": { "file": "boom.rhai" } } }] }
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert!(
+        ok.status().is_success(),
+        "in-root file: via stub add must be accepted, got {}",
+        ok.status()
+    );
+    let served = client
+        .get("http://127.0.0.1:19556/anything")
+        .send()
+        .await
+        .expect("hit imposter");
+    assert_eq!(
+        served.status(),
+        503,
+        "the file-resolved script must run (no unresolved 500)"
+    );
+
+    running.shutdown().await;
+}
+
+// Issue #356 B1: PUT .../stubs (replace-all) is escape-checked too.
+#[tokio::test]
+async fn stub_replace_all_endpoint_rejects_escaping_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("scripts");
+    std::fs::create_dir(&root).unwrap();
+
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_allow_injection(true)
+        .with_scripts_dir(root)
+        .bind()
+        .await
+        .expect("bind admin");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let client = reqwest::Client::new();
+    client
+        .post(format!("http://{addr}/imposters"))
+        .json(&serde_json::json!({ "port": 19557, "protocol": "http", "stubs": [] }))
+        .send()
+        .await
+        .expect("create");
+
+    let resp = client
+        .put(format!("http://{addr}/imposters/19557/stubs"))
+        .json(&serde_json::json!({
+            "stubs": [{ "responses": [{ "_rift": { "script": { "file": "/etc/passwd" } } }] }]
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        400,
+        "absolute file: via replace-all must 400"
+    );
+
+    running.shutdown().await;
+}
+
+// Issue #356: if an UNRESOLVED script (a `file:` never resolved into `code`) somehow reaches the
+// serve path — a defense-in-depth invariant, since every write path now resolves — the handler
+// must return a clear 500 with `x-rift-script-error`, not silently run an empty script. Built by
+// creating the imposter directly through the manager (bypassing the resolving admin handlers).
+#[tokio::test]
+async fn unresolved_script_at_serve_time_returns_500() {
+    // `file` set, `code` absent — the shape a resolve pass would have collapsed but here never ran.
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19558,
+        "protocol": "http",
+        "stubs": [{ "responses": [{ "_rift": { "script": { "file": "unresolved.rhai" } } }] }]
+    }))
+    .expect("deserialize config");
+
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(config)
+        .await
+        .expect("create imposter directly (no resolve pass)");
+
+    let resp = reqwest::get("http://127.0.0.1:19558/anything")
+        .await
+        .expect("hit imposter");
+    assert_eq!(
+        resp.status(),
+        500,
+        "an unresolved file:/ref: script must be a 500, not a silent empty run"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-rift-script-error")
+            .and_then(|v| v.to_str().ok()),
+        Some("true"),
+        "the 500 must carry x-rift-script-error"
+    );
+
+    manager.delete_all().await;
+}

--- a/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
+++ b/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
@@ -1,0 +1,168 @@
+//! Issue #356: a YAML configfile using `_rift.script.file:` must resolve to the same effective
+//! `ImposterConfig` as the equivalent JSON configfile using inline `code:` — the "06-stateful-retry"
+//! sample rewritten to source its script from a file instead of a JSON-escaped one-liner.
+//!
+//! This is a *behavioral* parity assertion, not string equality of the two source files: the
+//! JSON's `_rift.script` carries `code` directly while the YAML's carries `file` (the bookkeeping
+//! that names the source differs by design), so the two resolved `RiftScriptConfig`s are compared
+//! field-by-field on what actually matters at runtime (`engine`, and the resolved `code` content),
+//! and — the real proof of "same effective config" — both scripts are executed through the Rhai
+//! engine against an identical request/flow-store sequence and must produce identical decisions.
+
+use rift_http_proxy::backends::InMemoryFlowStore;
+use rift_http_proxy::config_loader::{ConfigSource, load_configs};
+use rift_http_proxy::imposter::StubResponse;
+use rift_http_proxy::scripting::{FaultDecision, RhaiEngine, ScriptRequest};
+use std::sync::Arc;
+
+/// The retry-until-success Rhai script: fails (503) the first two attempts per `x-flow-id`, then
+/// succeeds. Kept as one constant so the JSON-inline and file-sourced configs carry byte-identical
+/// script content — proving the two authoring styles resolve to the same effective config.
+const RETRY_SCRIPT: &str = r#"fn should_inject(request, flow_store) { let flow_id = request.headers["x-flow-id"]; if flow_id == () { flow_id = "default"; }; let attempts = flow_store.get(flow_id, "attempts"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, "attempts", attempts); if attempts <= 2 { #{inject: true, fault: "error", status: 503, body: `{"error":"Temporary failure","attempt":${attempts}}`, headers: #{"Content-Type": "application/json"}} } else { #{inject: false} } }"#;
+
+fn script_config(
+    config: &rift_http_proxy::imposter::ImposterConfig,
+) -> rift_http_proxy::imposter::RiftScriptConfig {
+    match &config.stubs[0].responses[0] {
+        StubResponse::RiftScript { rift } => rift.script.clone().expect("script present"),
+        other => panic!("expected a RiftScript response, got {other:?}"),
+    }
+}
+
+fn req(attempt_tag: &str) -> ScriptRequest {
+    let mut headers = std::collections::HashMap::new();
+    headers.insert("x-flow-id".to_string(), attempt_tag.to_string());
+    ScriptRequest {
+        method: "GET".to_string(),
+        path: "/retry".to_string(),
+        headers,
+        body: serde_json::Value::Null,
+        query: Default::default(),
+        path_params: Default::default(),
+    }
+}
+
+/// (status, body) for an `Error` decision, or `None` for `FaultDecision::None`. `Latency` isn't
+/// produced by this script so it's left unmatched (a test failure if it ever were).
+fn decision_summary(decision: &FaultDecision) -> Option<(u16, String)> {
+    match decision {
+        FaultDecision::None => None,
+        FaultDecision::Error { status, body, .. } => Some((*status, body.clone())),
+        FaultDecision::Latency { .. } => panic!("script never injects latency"),
+    }
+}
+
+#[test]
+fn yaml_file_config_behaves_like_json_inline_config() {
+    // JSON original: script inline as `code:` (matches docs/features/scripting.md's "Retry
+    // Simulation" example).
+    let json_dir = tempfile::tempdir().unwrap();
+    let json_config = serde_json::json!({
+        "port": 4545,
+        "protocol": "http",
+        "_rift": {
+            "flowState": {"backend": "inmemory", "ttlSeconds": 300}
+        },
+        "stubs": [{
+            "responses": [{
+                "_rift": {
+                    "script": {
+                        "engine": "rhai",
+                        "code": RETRY_SCRIPT,
+                    }
+                }
+            }]
+        }]
+    });
+    let json_path = json_dir.path().join("retry.json");
+    std::fs::write(&json_path, serde_json::to_string(&json_config).unwrap()).unwrap();
+
+    // YAML rewrite: the same script, but sourced from a companion file (issue #356 `file:`).
+    let yaml_dir = tempfile::tempdir().unwrap();
+    std::fs::write(yaml_dir.path().join("fail-twice.rhai"), RETRY_SCRIPT).unwrap();
+    // `config_loader::load_file` parses a bare (non `{`/`[`-prefixed) file as a YAML sequence of
+    // imposters, so the document root is a `- ` list even for a single imposter.
+    let yaml_config = "\
+- port: 4545
+  protocol: http
+  _rift:
+    flowState:
+      backend: inmemory
+      ttlSeconds: 300
+  stubs:
+    - responses:
+        - _rift:
+            script:
+              file: fail-twice.rhai
+";
+    let yaml_path = yaml_dir.path().join("retry.yaml");
+    std::fs::write(&yaml_path, yaml_config).unwrap();
+
+    let json_configs = load_configs(&ConfigSource::File {
+        path: json_path,
+        no_parse: false,
+    })
+    .expect("JSON config resolves");
+    let yaml_configs = load_configs(&ConfigSource::File {
+        path: yaml_path,
+        no_parse: false,
+    })
+    .expect("YAML+file config resolves");
+
+    assert_eq!(json_configs.len(), 1);
+    assert_eq!(yaml_configs.len(), 1);
+
+    // Everything outside the script's own source-of-truth bookkeeping matches exactly.
+    assert_eq!(json_configs[0].port, yaml_configs[0].port);
+    assert_eq!(json_configs[0].protocol, yaml_configs[0].protocol);
+    assert_eq!(json_configs[0].stubs.len(), yaml_configs[0].stubs.len());
+    assert_eq!(
+        json_configs[0].stubs[0].responses.len(),
+        yaml_configs[0].stubs[0].responses.len()
+    );
+
+    // The resolved script itself: `file:` must have populated `code` identically to the JSON's
+    // inline `code:`, and the engine must have been inferred to the same value that was explicit
+    // in the JSON.
+    let json_script = script_config(&json_configs[0]);
+    let yaml_script = script_config(&yaml_configs[0]);
+    assert_eq!(
+        json_script.code, yaml_script.code,
+        "resolved `code` must match"
+    );
+    assert_eq!(
+        json_script.engine.as_deref(),
+        Some("rhai"),
+        "JSON's explicit engine"
+    );
+    assert_eq!(
+        yaml_script.engine.as_deref(),
+        Some("rhai"),
+        "YAML's engine must be inferred from the .rhai extension to the same value"
+    );
+
+    // Behavioral parity: run both resolved scripts through the Rhai engine against an identical
+    // request/flow-store sequence (3 attempts on the same flow_id) and require identical
+    // decisions at every step — the actual proof that "sourced via file:" behaves like "inline".
+    let json_engine = RhaiEngine::new(&json_script.code.unwrap(), "json").unwrap();
+    let yaml_engine = RhaiEngine::new(&yaml_script.code.unwrap(), "yaml").unwrap();
+    let json_store: Arc<dyn rift_http_proxy::flow_state::FlowStore> =
+        Arc::new(InMemoryFlowStore::new(300));
+    let yaml_store: Arc<dyn rift_http_proxy::flow_state::FlowStore> =
+        Arc::new(InMemoryFlowStore::new(300));
+
+    for attempt in 1..=3 {
+        let request = req("parity-flow");
+        let json_decision = json_engine
+            .should_inject_fault(&request, json_store.clone())
+            .unwrap();
+        let yaml_decision = yaml_engine
+            .should_inject_fault(&request, yaml_store.clone())
+            .unwrap();
+        assert_eq!(
+            decision_summary(&json_decision),
+            decision_summary(&yaml_decision),
+            "attempt {attempt}: JSON-inline and YAML+file scripts must decide identically"
+        );
+    }
+}

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -61,10 +61,211 @@ pub fn validate_imposter(
     check_protocol(file, imposter, result);
     check_port_range(file, imposter, result);
 
+    // Named script registry (`_rift.scripts`, issue #356): validated once up front (each entry
+    // must be a `code:`/`file:` leaf, not a `ref:`), then handed to every response so a
+    // `{ "ref": "name" }` script can be resolved and validated the same way as inline `code:`.
+    let registry = imposter
+        .get("_rift")
+        .and_then(|r| r.get("scripts"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    validate_script_registry(file, &registry, result);
+
     if let Some(stubs) = imposter.get("stubs").and_then(|v| v.as_array()) {
         for (idx, stub) in stubs.iter().enumerate() {
-            validate_stub(file, stub, idx, result, options);
+            validate_stub(file, stub, idx, result, options, &registry);
         }
+    }
+}
+
+/// Infer a script's effective engine: explicit `engine`, else inferred from a `file` path's
+/// extension (`.rhai`/`.lua`/`.js`), else the "rhai" default — mirrors
+/// `rift_core::imposter::RiftScriptConfig`'s resolution rule.
+fn infer_script_engine(explicit: Option<&str>, file_field: Option<&str>) -> String {
+    if let Some(e) = explicit {
+        return e.to_string();
+    }
+    let ext = file_field
+        .and_then(|f| Path::new(f).extension())
+        .and_then(|e| e.to_str());
+    match ext {
+        Some("rhai") => "rhai",
+        Some("lua") => "lua",
+        Some("js") => "javascript",
+        _ => "rhai",
+    }
+    .to_string()
+}
+
+/// Read a `file:` script path relative to the linted config file's own directory.
+fn read_script_file_relative(config_file: &Path, rel: &str) -> std::io::Result<String> {
+    let dir = config_file.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::read_to_string(dir.join(rel))
+}
+
+/// Syntax-check a resolved script's content at the same level inline `code:` would get for its
+/// engine. Only "javascript" has an embedded syntax checker in this crate (`js_validator`,
+/// gated behind the `javascript` feature) — rhai/lua scripts get the structural checks above
+/// (exactly-one-source, ref resolution, file existence) but no deep syntax check here.
+fn check_script_syntax(
+    file: &Path,
+    code: &str,
+    engine: &str,
+    location: &str,
+    result: &mut LintResult,
+) {
+    if (engine == "javascript" || engine == "js")
+        && let Err(e) = js_validator::validate_javascript(code)
+    {
+        result.add_issue(
+            LintIssue::error(
+                "E040",
+                format!("JavaScript syntax error in _rift.script: {e}"),
+                file.to_path_buf(),
+            )
+            .with_location(location),
+        );
+    }
+}
+
+/// Validate one `_rift.script`-shaped object: `{ engine?, code?, file?, ref? }` (issue #356).
+/// Exactly one of `code`/`file`/`ref` must be present (E036). A `file:` is read relative to
+/// `config_file`'s own directory (E038 if unreadable); a `ref:` is resolved against `registry`
+/// (`Value::Null` when validating a registry entry itself, which cannot use `ref`) — E037 if the
+/// name is unknown. Whatever content is resolved gets the same syntax check inline `code:` would.
+fn validate_script_source(
+    config_file: &Path,
+    script: &Value,
+    location: &str,
+    result: &mut LintResult,
+    registry: &Value,
+) {
+    let code_field = script.get("code").and_then(|v| v.as_str());
+    let file_field = script.get("file").and_then(|v| v.as_str());
+    let ref_field = script.get("ref").and_then(|v| v.as_str());
+    let engine_field = script.get("engine").and_then(|v| v.as_str());
+
+    let source_count = [
+        code_field.is_some(),
+        file_field.is_some(),
+        ref_field.is_some(),
+    ]
+    .into_iter()
+    .filter(|set| *set)
+    .count();
+    if source_count != 1 {
+        result.add_issue(
+            LintIssue::error(
+                "E036",
+                format!(
+                    "script must specify exactly one of 'code', 'file', or 'ref' (found {source_count})"
+                ),
+                config_file.to_path_buf(),
+            )
+            .with_location(location)
+            .with_suggestion("Set exactly one of 'code', 'file', or 'ref'"),
+        );
+        return;
+    }
+
+    if let Some(ref_name) = ref_field {
+        let Some(target) = registry.get(ref_name) else {
+            result.add_issue(
+                LintIssue::error(
+                    "E037",
+                    format!(
+                        "Unknown script ref '{ref_name}': no entry named '{ref_name}' in _rift.scripts"
+                    ),
+                    config_file.to_path_buf(),
+                )
+                .with_location(location)
+                .with_suggestion("Add this name under _rift.scripts, or fix the typo"),
+            );
+            return;
+        };
+        // The target's own exactly-one-source / no-ref-chain checks already ran in
+        // `validate_script_registry`; here we only need its resolved code to syntax-check what
+        // this `ref:` actually points at.
+        let target_code = target.get("code").and_then(|v| v.as_str());
+        let target_file = target.get("file").and_then(|v| v.as_str());
+        let target_engine = target.get("engine").and_then(|v| v.as_str());
+        let resolved = match (target_code, target_file) {
+            (Some(c), _) => Some(c.to_string()),
+            (None, Some(f)) => match read_script_file_relative(config_file, f) {
+                Ok(content) => Some(content),
+                Err(e) => {
+                    result.add_issue(
+                        LintIssue::error(
+                            "E038",
+                            format!(
+                                "script file '{f}' (via ref '{ref_name}') could not be read: {e}"
+                            ),
+                            config_file.to_path_buf(),
+                        )
+                        .with_location(location),
+                    );
+                    return;
+                }
+            },
+            _ => None,
+        };
+        if let Some(code) = resolved {
+            let engine = infer_script_engine(target_engine, target_file);
+            check_script_syntax(config_file, &code, &engine, location, result);
+        }
+        return;
+    }
+
+    if let Some(f) = file_field {
+        match read_script_file_relative(config_file, f) {
+            Ok(content) => {
+                let engine = infer_script_engine(engine_field, Some(f));
+                check_script_syntax(config_file, &content, &engine, location, result);
+            }
+            Err(e) => {
+                result.add_issue(
+                    LintIssue::error(
+                        "E038",
+                        format!("script file '{f}' could not be read: {e}"),
+                        config_file.to_path_buf(),
+                    )
+                    .with_location(location)
+                    .with_suggestion("Check the path is relative to the config file"),
+                );
+            }
+        }
+        return;
+    }
+
+    if let Some(code) = code_field {
+        let engine = infer_script_engine(engine_field, None);
+        check_script_syntax(config_file, code, &engine, location, result);
+    }
+}
+
+/// Validate every entry in the `_rift.scripts` registry: each must be a `code:`/`file:` leaf
+/// script (never `ref:` — no chains), and its source resolved/checked exactly like an inline
+/// stub response script.
+fn validate_script_registry(file: &Path, registry: &Value, result: &mut LintResult) {
+    let Some(entries) = registry.as_object() else {
+        return;
+    };
+    for (name, entry) in entries {
+        let location = format!("_rift.scripts.{name}");
+        if entry.get("ref").and_then(|v| v.as_str()).is_some() {
+            result.add_issue(
+                LintIssue::error(
+                    "E039",
+                    format!(
+                        "_rift.scripts entry '{name}' may not itself use 'ref' (ref chains are not allowed)"
+                    ),
+                    file.to_path_buf(),
+                )
+                .with_location(location),
+            );
+            continue;
+        }
+        validate_script_source(file, entry, &location, result, &Value::Null);
     }
 }
 
@@ -146,6 +347,7 @@ pub fn validate_stub(
     idx: usize,
     result: &mut LintResult,
     options: &LintOptions,
+    registry: &Value,
 ) {
     let location = format!("stubs[{idx}]");
 
@@ -177,6 +379,7 @@ pub fn validate_stub(
                 &format!("{location}.responses[{resp_idx}]"),
                 result,
                 options,
+                registry,
             );
         }
     } else {
@@ -367,6 +570,7 @@ pub fn validate_response(
     location: &str,
     result: &mut LintResult,
     options: &LintOptions,
+    registry: &Value,
 ) {
     let has_is = response.get("is").is_some();
     let has_proxy = response
@@ -385,6 +589,18 @@ pub fn validate_response(
                 file.to_path_buf(),
             )
             .with_location(location),
+        );
+    }
+
+    // `_rift.script` `file:`/`ref:` sources are validated exactly like inline `code:` (issue
+    // #356): read/resolved, then syntax-checked at whatever level the engine supports.
+    if let Some(script) = response.get("_rift").and_then(|rift| rift.get("script")) {
+        validate_script_source(
+            file,
+            script,
+            &format!("{location}._rift.script"),
+            result,
+            registry,
         );
     }
 

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -1,5 +1,5 @@
 use rift_lint::{
-    LintOptions, LintResult, lint_directory, lint_json, lint_value, validate_behavior,
+    LintOptions, LintResult, lint_directory, lint_file, lint_json, lint_value, validate_behavior,
     validate_imposter, validate_is_response, validate_predicate, validate_proxy_response,
     validate_response, validate_stub,
 };
@@ -140,7 +140,7 @@ fn w001_not_fired_for_normal_port() {
 fn e006_stub_missing_responses() {
     let stub = json!({ "predicates": [] });
     let mut r = LintResult::new();
-    validate_stub(path(), &stub, 0, &mut r, &opts());
+    validate_stub(path(), &stub, 0, &mut r, &opts(), &serde_json::Value::Null);
     assert!(has_code(&r, "E006"));
 }
 
@@ -148,7 +148,7 @@ fn e006_stub_missing_responses() {
 fn w002_stub_empty_responses() {
     let stub = json!({ "responses": [] });
     let mut r = LintResult::new();
-    validate_stub(path(), &stub, 0, &mut r, &opts());
+    validate_stub(path(), &stub, 0, &mut r, &opts(), &serde_json::Value::Null);
     assert!(has_code(&r, "W002"));
 }
 
@@ -156,7 +156,7 @@ fn w002_stub_empty_responses() {
 fn w002_not_fired_with_response() {
     let stub = minimal_stub();
     let mut r = LintResult::new();
-    validate_stub(path(), &stub, 0, &mut r, &opts());
+    validate_stub(path(), &stub, 0, &mut r, &opts(), &serde_json::Value::Null);
     assert!(!has_code(&r, "W002"));
 }
 
@@ -248,7 +248,14 @@ fn e013_not_fired_for_valid_regex() {
 fn e014_response_no_type() {
     let resp = json!({ "behaviors": [] });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(has_code(&r, "E014"));
 }
 
@@ -256,7 +263,14 @@ fn e014_response_no_type() {
 fn e014_not_fired_for_is_response() {
     let resp = json!({ "is": { "statusCode": 200 } });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(!has_code(&r, "E014"), "unexpected E014: {:?}", codes(&r));
 }
 
@@ -264,7 +278,14 @@ fn e014_not_fired_for_is_response() {
 fn e014_not_fired_for_rift_response() {
     let resp = json!({ "_rift": { "script": "console.log('hi')" } });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         !has_code(&r, "E014"),
         "E014 should not fire for _rift response, got {:?}",
@@ -281,7 +302,14 @@ fn e014_not_fired_for_rift_response() {
 fn e014_not_fired_for_inject_response() {
     let resp = json!({ "inject": "function(req, state, logger, callback) { callback({statusCode: 200}); }" });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(!has_code(&r, "E014"));
 }
 
@@ -289,7 +317,14 @@ fn e014_not_fired_for_inject_response() {
 fn e014_not_fired_for_fault_response() {
     let resp = json!({ "fault": "CONNECTION_RESET_BY_PEER" });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(!has_code(&r, "E014"));
 }
 
@@ -300,7 +335,14 @@ fn w003_both_is_and_proxy() {
         "proxy": { "to": "http://example.com" }
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(has_code(&r, "W003"));
 }
 
@@ -672,7 +714,14 @@ fn e025_via_response_underscore_behaviors_object() {
         "_behaviors": { "wait": true }
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         has_code(&r, "E025"),
         "E025 must fire through _behaviors dispatch, got {:?}",
@@ -687,7 +736,14 @@ fn e025_not_fired_via_response_for_valid_wait_range() {
         "_behaviors": { "wait": { "min": 100, "max": 500 } }
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         !has_code(&r, "E025"),
         "E025 must not fire for {{min,max}} via _behaviors, got {:?}",
@@ -702,7 +758,14 @@ fn e035_via_response_underscore_behaviors_object() {
         "_behaviors": { "repeat": 0 }
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         has_code(&r, "E035"),
         "E035 must fire through _behaviors dispatch, got {:?}",
@@ -718,7 +781,14 @@ fn behaviors_array_format_still_dispatches() {
         "behaviors": [{ "wait": true }]
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         has_code(&r, "E025"),
         "E025 must fire through behaviors array dispatch, got {:?}",
@@ -735,7 +805,14 @@ fn underscore_behaviors_takes_priority_over_behaviors_array() {
         "behaviors": [{ "wait": true }]  // invalid, but should not be reached
     });
     let mut r = LintResult::new();
-    validate_response(path(), &resp, "loc", &mut r, &opts());
+    validate_response(
+        path(),
+        &resp,
+        "loc",
+        &mut r,
+        &opts(),
+        &serde_json::Value::Null,
+    );
     assert!(
         !has_code(&r, "E025"),
         "_behaviors (valid) should shadow behaviors array, got {:?}",
@@ -935,4 +1012,119 @@ fn w009_still_fired_for_non_function_wait_through_behavior() {
     let mut r = LintResult::new();
     validate_behavior(path(), &behavior, "loc", &mut r, &opts());
     assert!(has_code(&r, "W009"), "non-function wait should warn W009");
+}
+
+// ─── Issue #356: `_rift.script` file:/ref: validation ────────────────────────
+
+fn rift_script_stub(script: Value) -> Value {
+    json!({
+        "responses": [{ "_rift": { "script": script } }]
+    })
+}
+
+#[test]
+fn e036_zero_script_sources_is_an_error() {
+    let v = make_imposter(json!([rift_script_stub(json!({}))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E036"), "expected E036, got {:?}", codes(&r));
+}
+
+#[test]
+fn e036_multiple_script_sources_is_an_error() {
+    let v = make_imposter(json!([rift_script_stub(
+        json!({ "code": "fn should_inject() {}", "file": "x.rhai" })
+    )]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E036"), "expected E036, got {:?}", codes(&r));
+}
+
+#[test]
+fn inline_code_is_accepted_without_e036() {
+    let v = make_imposter(json!([rift_script_stub(
+        json!({ "code": "fn should_inject() {}" })
+    )]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E036"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e037_unknown_ref_is_an_error() {
+    let v = make_imposter(json!([rift_script_stub(json!({ "ref": "missing" }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E037"), "expected E037, got {:?}", codes(&r));
+}
+
+#[test]
+fn ref_resolves_against_the_registry_without_e037() {
+    let mut v = make_imposter(json!([rift_script_stub(json!({ "ref": "failTwice" }))]));
+    v["_rift"] = json!({ "scripts": { "failTwice": { "code": "fn should_inject() {}" } } });
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E037"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e039_registry_entry_cannot_itself_use_ref() {
+    let mut v = make_imposter(json!([minimal_stub()]));
+    v["_rift"] = json!({ "scripts": { "a": { "ref": "b" }, "b": { "code": "x" } } });
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E039"), "expected E039, got {:?}", codes(&r));
+}
+
+#[test]
+fn e038_missing_file_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = make_imposter(json!([rift_script_stub(
+        json!({ "file": "does-not-exist.rhai" })
+    )]));
+    let config_path = dir.path().join("imposter.json");
+    std::fs::write(&config_path, serde_json::to_string(&cfg).unwrap()).unwrap();
+
+    let r = lint_file(&config_path, &opts());
+    assert!(has_code(&r, "E038"), "expected E038, got {:?}", codes(&r));
+}
+
+#[test]
+fn file_resolves_relative_to_the_config_and_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("script.rhai"), "fn should_inject() {}").unwrap();
+    let cfg = make_imposter(json!([rift_script_stub(json!({ "file": "script.rhai" }))]));
+    let config_path = dir.path().join("imposter.json");
+    std::fs::write(&config_path, serde_json::to_string(&cfg).unwrap()).unwrap();
+
+    let r = lint_file(&config_path, &opts());
+    assert!(!has_code(&r, "E038"), "got {:?}", codes(&r));
+    assert!(!has_code(&r, "E036"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn ref_to_file_backed_registry_entry_resolves_relative_to_config() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("fail-twice.rhai"), "fn should_inject() {}").unwrap();
+    let mut cfg = make_imposter(json!([rift_script_stub(json!({ "ref": "failTwice" }))]));
+    cfg["_rift"] = json!({ "scripts": { "failTwice": { "file": "fail-twice.rhai" } } });
+    let config_path = dir.path().join("imposter.json");
+    std::fs::write(&config_path, serde_json::to_string(&cfg).unwrap()).unwrap();
+
+    let r = lint_file(&config_path, &opts());
+    assert!(!has_code(&r, "E037"), "got {:?}", codes(&r));
+    assert!(!has_code(&r, "E038"), "got {:?}", codes(&r));
+}
+
+#[cfg(feature = "javascript")]
+#[test]
+fn e040_invalid_javascript_file_syntax_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("bad.js"), "function should_inject( {").unwrap();
+    let cfg = make_imposter(json!([rift_script_stub(json!({ "file": "bad.js" }))]));
+    let config_path = dir.path().join("imposter.json");
+    std::fs::write(&config_path, serde_json::to_string(&cfg).unwrap()).unwrap();
+
+    let r = lint_file(&config_path, &opts());
+    assert!(has_code(&r, "E040"), "expected E040, got {:?}", codes(&r));
 }

--- a/crates/rift-tui/src/validation.rs
+++ b/crates/rift-tui/src/validation.rs
@@ -54,7 +54,15 @@ pub fn validate_stub_json(json: &str) -> ValidationReport {
         ..Default::default()
     };
     let path = PathBuf::from("<editor>");
-    validate_stub(&path, &value, 0, &mut lint_result, &options);
+    // A standalone stub has no imposter-level `_rift.scripts` registry to resolve `ref:` against.
+    validate_stub(
+        &path,
+        &value,
+        0,
+        &mut lint_result,
+        &options,
+        &serde_json::Value::Null,
+    );
 
     ValidationReport::from_lint_result(lint_result)
 }

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -314,6 +314,73 @@ return {
 }
 ```
 
+### Authoring Scripts: `file:` and `ref:` (YAML)
+
+The retry script above works fine as a single JSON-escaped line, but it stops being readable once
+a script grows past a few statements. `_rift.script` also accepts `file:` (load the script from a
+separate file) and `ref:` (resolve from a named entry under `_rift.scripts`) instead of inline
+`code:` — exactly one of `code`, `file`, or `ref` must be set. This is most useful in a YAML
+configfile, where a block scalar (`|`) lets you write the same script as normal multi-line Rhai.
+`rift --configfile config.yaml` expects a YAML *sequence* of imposters at the document root (a
+single imposter is still a one-element sequence):
+
+```yaml
+- port: 4545
+  protocol: http
+  _rift:
+    flowState: { backend: inmemory, ttlSeconds: 300 }
+  stubs:
+    - responses:
+        - _rift:
+            script:
+              engine: rhai
+              # Block scalar: the exact retry logic from the JSON example above, just readable.
+              code: |
+                fn should_inject(request, flow_store) {
+                  let flow_id = request.headers["x-flow-id"];
+                  if flow_id == () { flow_id = "default"; }
+                  let attempts = flow_store.get(flow_id, "attempts");
+                  if attempts == () { attempts = 0; }
+                  attempts += 1;
+                  flow_store.set(flow_id, "attempts", attempts);
+                  if attempts <= 2 {
+                    #{
+                      inject: true, fault: "error", status: 503,
+                      body: `{"error":"Temporary failure","attempt":${attempts}}`,
+                      headers: #{"Content-Type": "application/json"}
+                    }
+                  } else {
+                    #{ inject: false }
+                  }
+                }
+```
+
+For a script reused across stubs — or one you'd rather keep in its own file for editor
+syntax-highlighting and diffs — use `file:` instead, resolved relative to the configfile's own
+directory (`--datadir` files resolve the same way; admin-API-created imposters resolve under
+`--scripts-dir` instead, and reject any path that escapes it):
+
+```yaml
+- port: 4545
+  protocol: http
+  _rift:
+    flowState: { backend: inmemory, ttlSeconds: 300 }
+    # Named registry (issue #356): give a script a name once, `ref:` it from any response.
+    scripts:
+      failTwice:
+        file: scripts/fail-twice.rhai   # engine inferred from the extension: .rhai -> rhai
+  stubs:
+    - responses:
+        - _rift:
+            script:
+              ref: failTwice
+```
+
+`engine` is inferred from `file`'s extension (`.rhai` -> `rhai`, `.lua` -> `lua`, `.js` ->
+`javascript`) when omitted; a `ref:` may not itself point at another `ref:` (no chains), and an
+unknown `ref:` or a `file:` that can't be read is a config-time validation error — surfaced at
+`rift --configfile` load, at `POST /imposters` as a `400`, and by `rift-lint`.
+
 ### Counter with Multiple Endpoints
 
 ```json


### PR DESCRIPTION
Implement file:/ref: and ref: script sources resolved relative to config or --scripts-dir
with path-escape rejection. Add imposter-level named script registry with content-hashed
compiled cache. Enable YAML config authoring. Review-time hardening closed arbitrary-file-read
vulnerabilities via stub sub-resource endpoints with datadir re-resolution and bounded cache.

Closes #356
Part of epic #354
Milestone: scripting DX (P2)