### PR TITLE
feat(scripting): P3a Script API v2 — unified ctx object + http()/delay()/reset()/pass() result constructors

### DIFF
--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -329,6 +329,11 @@ impl Imposter {
     /// Whether any current stub can trigger a connection-level TCP fault (`_rift.fault.tcp`, or a
     /// Mountebank `fault` that maps to one). Such imposters must be served HTTP/1-only: a TCP fault
     /// aborts the whole socket, which is incompatible with HTTP/2 stream multiplexing (issue #295).
+    ///
+    /// A `_rift.script` (RiftScript) stub also counts (issue #357 B2): a script can dynamically
+    /// call `reset()` — the v2 connection-reset result constructor — which lowers to the same
+    /// transport-level abort as `_rift.fault.tcp`, so a script-bearing stub must likewise be
+    /// served HTTP/1-only even though its reset path isn't visible in the static config.
     pub(crate) fn uses_tcp_faults(&self) -> bool {
         use crate::imposter::fault_io::TcpFaultKind;
         let rift_has_tcp = |rift: &RiftResponseExtension| {
@@ -344,7 +349,8 @@ impl Imposter {
             .any(|resp| match resp {
                 StubResponse::Fault { fault } => TcpFaultKind::parse(fault).is_some(),
                 StubResponse::Is { rift: Some(r), .. } => rift_has_tcp(r),
-                StubResponse::RiftScript { rift } => rift_has_tcp(rift),
+                // A script may call `reset()` at runtime, so conservatively force H1-only.
+                StubResponse::RiftScript { .. } => true,
                 _ => false,
             })
     }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -18,7 +18,8 @@ use crate::extensions::decorate::{
 };
 use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::scripting::{
-    FaultDecision, ScriptRequest, resolve_script_timeout_ms, should_inject_bounded,
+    FaultDecision, ScriptCtxExtras, ScriptRequest, ScriptStubContext, resolve_script_timeout_ms,
+    should_inject_bounded_with_ctx,
 };
 #[cfg(feature = "javascript")]
 use crate::scripting::{MountebankRequest, execute_mountebank_inject};
@@ -425,6 +426,7 @@ async fn handle_request_inner(
             // them case-insensitively (e.g. `request.headers["x-flow-id"]`) regardless of the
             // wire casing; this matches the engine docs and HTTP header semantics.
             let script_request = ScriptRequest {
+                raw_body: Some(body_string.clone().unwrap_or_default()),
                 method: method.clone(),
                 path: path.clone(),
                 headers: headers_clone
@@ -450,13 +452,36 @@ async fn handle_request_inner(
             // (default 5s) instead of wedging the whole engine.
             let timeout_ms = resolve_script_timeout_ms(&imposter.config);
             let flow_store = imposter.flow_store.clone();
-            match should_inject_bounded(
+
+            // ctx.stub (issue #357 Item 1): thread the matched stub's identity through, resolving
+            // its current scenario state (if it belongs to a scenario) the same way the FSM gate
+            // already does. A backend failure here must surface, not silently drop to `None`
+            // (this epic's "nothing fails silently" principle).
+            let scenario_state = match &stub_state.stub.scenario_name {
+                Some(name) => match imposter.scenario_state(&scenario_flow_id, name) {
+                    Ok(s) => Some(s),
+                    Err(e) => return Ok(backend_error_response(&e)),
+                },
+                None => None,
+            };
+            let ctx_extra = ScriptCtxExtras {
+                flow_id: Some(scenario_flow_id.clone()),
+                stub: ScriptStubContext {
+                    scenario_name: stub_state.stub.scenario_name.clone(),
+                    scenario_state,
+                    stub_id: stub_state.stub.id.clone(),
+                },
+                port: imposter.config.port.unwrap_or(0),
+            };
+
+            match should_inject_bounded_with_ctx(
                 engine.clone(),
                 code,
                 format!("rift_script_{stub_index}"),
                 script_request,
                 flow_store,
                 Duration::from_millis(timeout_ms),
+                ctx_extra,
             )
             .await
             {
@@ -517,6 +542,29 @@ async fn handle_request_inner(
                         ],
                         Bytes::new(),
                     ));
+                }
+                Ok(FaultDecision::Reset { .. }) => {
+                    // v2 `reset()` result constructor (issue #357 Item 3): a connection reset,
+                    // applied the same real way as `_rift.fault.tcp` / a top-level `fault` (see
+                    // `handle_fault_response`) — attach the parsed TcpFaultKind as a response
+                    // extension; the serve loop's FaultIo aborts the connection before this
+                    // carrier response is ever sent, so its status/body are never observed.
+                    if let Err(e) = imposter.advance_cycler_for_rift_script(&stub_state) {
+                        return Ok(backend_error_response(&e));
+                    }
+
+                    let mut response = build_response_with_headers(
+                        StatusCode::BAD_GATEWAY,
+                        [
+                            ("x-rift-imposter", "true"),
+                            ("x-rift-script", engine.as_str()),
+                        ],
+                        Bytes::new(),
+                    );
+                    response
+                        .extensions_mut()
+                        .insert(super::fault_io::TcpFaultKind::Reset);
+                    return Ok(response);
                 }
                 Err(e) => {
                     warn!("Rift script execution failed: {}", e);

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -9,8 +9,12 @@ use super::types::{
 };
 use crate::behaviors::{
     DecorateError, HasRepeatBehavior, RequestContext, apply_decorate, is_js_config_decorate,
-    rewrite_js_config_to_rhai,
 };
+// Fallback-only (issue #357 Item 6): the real JS `config =>` decorate path is Boa
+// (`execute_mountebank_config_decorate`); this textual transpiler is used only when the
+// `javascript` feature is disabled and no JS engine is available.
+#[cfg(not(feature = "javascript"))]
+use crate::behaviors::rewrite_js_config_to_rhai;
 use crate::imposter::Predicate;
 use std::collections::HashMap;
 
@@ -296,18 +300,15 @@ pub fn apply_js_or_rhai_decorate(
     #[cfg(not(feature = "javascript"))]
     let _ = (imposter_port, stub_id);
 
-    // Mountebank's JS `config =>` convention (issue #191): rewrite simple field access onto the
-    // Rhai request/response maps. Checked before the `function` route since arrow scripts don't
-    // start with "function" and `function(config)` uses the config model, not (request, response).
+    // Mountebank's JS `config =>` convention (issue #191). Issue #357 Item 6: every such script
+    // now runs through REAL Boa execution (`execute_mountebank_config_decorate`, which already
+    // backed the `require()` case for issue #305) instead of the lossy textual JS→Rhai
+    // transpiler — one JS contract everywhere, so e.g. `JSON.parse` + real object mutation work.
+    // Checked before the `function` route since arrow scripts don't start with "function" and
+    // `function(config)` uses the config model, not (request, response).
     if is_js_config_decorate(script) {
-        // Issue #305: a `config =>` decorate that `require()`s an external CommonJS module
-        // can't be represented by the lossy Rhai rewrite below (it doesn't run real JS), so
-        // route it through the Boa engine instead, where `require()` actually works.
         #[cfg(feature = "javascript")]
-        // `require(` / `require (` → needs the real JS engine (not the lossy Rhai rewrite). A false
-        // positive only routes a simple decorate through Boa (still correct); a false negative would
-        // fail loudly at Rhai-eval, never silently.
-        if script.contains("require(") || script.contains("require (") {
+        {
             let mb_request = crate::scripting::MountebankRequest {
                 method: request.method.clone(),
                 path: request.path.clone(),
@@ -315,8 +316,29 @@ pub fn apply_js_or_rhai_decorate(
                 headers: request.headers.clone(),
                 body: request.body.clone(),
             };
+            // `execute_mountebank_config_decorate` calls `decorate_fn` as a function value
+            // (`{decorate_fn}(__config)`), so a bare body with no `function`/arrow wrapper (the
+            // "config.response.body = ...;" convention `is_js_config_decorate` also accepts)
+            // must be wrapped into one first.
+            //
+            // B4 (issue #357): detect "already a function value" via START-ANCHORED prefixes (the
+            // same wrapper forms `is_js_config_decorate` recognizes), NOT a substring `=>` test —
+            // a bare body can legitimately contain an inner arrow lambda, e.g.
+            // `config.response.body = JSON.stringify(items.map(x => x.id));`, and a `contains("=>")`
+            // check would then leave it unwrapped, producing `var __fn = <statement>` (a throw).
+            let trimmed = script.trim_start();
+            let already_function_value = trimmed.starts_with("function")
+                || trimmed.starts_with("config =>")
+                || trimmed.starts_with("config=>")
+                || trimmed.starts_with("(config) =>")
+                || trimmed.starts_with("(config)=>");
+            let wrapped_script = if already_function_value {
+                std::borrow::Cow::Borrowed(script)
+            } else {
+                std::borrow::Cow::Owned(format!("function(config) {{ {script} }}"))
+            };
             return match crate::scripting::execute_mountebank_config_decorate(
-                script,
+                &wrapped_script,
                 &mb_request,
                 body,
                 status,
@@ -334,8 +356,14 @@ pub fn apply_js_or_rhai_decorate(
             };
         }
 
-        let rhai_script = rewrite_js_config_to_rhai(script);
-        return apply_decorate(&rhai_script, request, body, status, headers);
+        // No JS engine compiled in (`--no-default-features`): fall back to the textual rewrite
+        // so simple field-access decorates still work, at the cost of real JS semantics
+        // (require(), JSON.parse/stringify on nested values, closures).
+        #[cfg(not(feature = "javascript"))]
+        {
+            let rhai_script = rewrite_js_config_to_rhai(script);
+            return apply_decorate(&rhai_script, request, body, status, headers);
+        }
     }
 
     // Check if it's a JavaScript function declaration
@@ -477,6 +505,78 @@ mod tests {
         let _ = std::fs::remove_file(&module);
         let (body, _) = result.expect("require-based config decorate should run");
         assert_eq!(body, "REQUIRE-RAN");
+    }
+
+    // Issue #357 Item 6: every `config =>` decorate now runs through real Boa execution, not the
+    // lossy textual JS→Rhai transpiler. Prove it with something the transpiler's regex-based
+    // `JSON.parse`/`JSON.stringify` handling could never do: parse a NESTED request body and
+    // mutate the resulting object before re-serializing it — `rewrite_js_config_to_rhai`'s
+    // `JSON_FN_RE` only handles a single, non-nested argument (see its doc comment), so this
+    // would previously have been left un-rewritten (`JSON.parse({"nested":...})`, a syntax error).
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn decorate_js_config_real_json_parse_and_mutation_runs_through_boa() {
+        let mut headers = std::collections::HashMap::new();
+        let request = RequestContext {
+            method: "POST".to_string(),
+            path: "/orders".to_string(),
+            query: std::collections::HashMap::new(),
+            headers: std::collections::HashMap::new(),
+            body: Some(r#"{"order": {"id": 42, "items": ["a", "b"]}}"#.to_string()),
+        };
+        let script = r#"config => {
+            var parsed = JSON.parse(config.request.body);
+            parsed.order.itemCount = parsed.order.items.length;
+            delete parsed.order.items;
+            config.response.body = JSON.stringify(parsed);
+        }"#;
+        let (body, _) = apply_js_or_rhai_decorate(
+            script,
+            &request,
+            "original",
+            200,
+            &mut headers,
+            test_port(),
+            None,
+        )
+        .expect("real JS JSON.parse/stringify decorate must execute via Boa");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["order"]["id"], 42);
+        assert_eq!(parsed["order"]["itemCount"], 2);
+        assert!(parsed["order"].get("items").is_none());
+    }
+
+    // B4 (issue #357): a BARE-BODY decorate (no `function`/arrow wrapper) that legitimately
+    // contains an INNER arrow lambda must still be wrapped and run — the old `contains("=>")`
+    // detection wrongly classified it as an already-wrapped function value and left it unwrapped,
+    // producing `var __fn = <statement>` (a throw).
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn decorate_bare_body_with_inner_arrow_runs_through_boa() {
+        let mut headers = std::collections::HashMap::new();
+        let request = RequestContext {
+            method: "GET".to_string(),
+            path: "/orders".to_string(),
+            query: std::collections::HashMap::new(),
+            headers: std::collections::HashMap::new(),
+            body: None,
+        };
+        // Bare body (starts with `config.response.`, detected via that prefix), containing an
+        // inner `.map(x => x.id)` arrow.
+        let script =
+            r#"config.response.body = JSON.stringify([{id:1},{id:2},{id:3}].map(x => x.id));"#;
+        let (body, _) = apply_js_or_rhai_decorate(
+            script,
+            &request,
+            "original",
+            200,
+            &mut headers,
+            test_port(),
+            None,
+        )
+        .expect("bare-body decorate with an inner arrow must execute via Boa");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed, serde_json::json!([1, 2, 3]));
     }
 
     #[test]

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -3988,3 +3988,38 @@ async fn test_path_params_non_matching_pattern_is_empty() {
         "a routePattern that doesn't match the path shape yields empty pathParams, got: {body}"
     );
 }
+
+// Issue #357 B2: a `_rift.script` stub can dynamically call `reset()` (the v2 connection-reset
+// result constructor), so `uses_tcp_faults()` must report true for it — forcing the imposter
+// HTTP/1-only, since a socket reset is incompatible with HTTP/2 stream multiplexing.
+#[test]
+fn script_bearing_stub_forces_http1_only() {
+    use crate::imposter::core::Imposter;
+
+    let with_script: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19507,
+        "protocol": "http",
+        "stubs": [{
+            "responses": [{ "_rift": { "script": { "engine": "rhai", "code": "fn respond(ctx) { reset() }" } } }]
+        }]
+    }))
+    .expect("config");
+    let imposter = Imposter::new(with_script).expect("test imposter");
+    assert!(
+        imposter.uses_tcp_faults(),
+        "a stub carrying a _rift.script (which may call reset()) must force HTTP/1-only"
+    );
+
+    // Control: a plain `is` stub with no script and no tcp fault stays HTTP/2-eligible.
+    let plain: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 19508,
+        "protocol": "http",
+        "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+    }))
+    .expect("config");
+    let plain_imposter = Imposter::new(plain).expect("test imposter");
+    assert!(
+        !plain_imposter.uses_tcp_faults(),
+        "a plain is-response stub must not be forced HTTP/1-only"
+    );
+}

--- a/crates/rift-core/src/proxy/handler.rs
+++ b/crates/rift-core/src/proxy/handler.rs
@@ -189,6 +189,7 @@ async fn handle_script_rules(
     let query_params = crate::predicate::parse_query_string(request_info.uri.query());
 
     let script_request = ScriptRequest {
+        raw_body: Some(String::from_utf8_lossy(&body_bytes).into_owned()),
         method: request_info.method.to_string(),
         path: request_info.uri.path().to_string(),
         headers: headers_map.clone(),
@@ -365,6 +366,31 @@ async fn handle_script_result(
             response.set_header_value(&X_RIFT_RULE_ID, &rule_id);
             response.set_header(&X_RIFT_SCRIPT, &VALUE_TRUE);
             response.set_header_value(&X_RIFT_LATENCY_MS, &duration_ms.to_string());
+            response.into_boxed()
+        }
+        Ok(ScriptFaultDecision::Reset { rule_id }) => {
+            // The proxy path has no transport-level reset hook (unlike the imposter serve loop's
+            // `FaultIo`), so `reset()` is simulated the same way a config-driven `TcpFault` is on
+            // this path: a synthesized 502 tagged with the tcp-fault headers.
+            warn!("Script injecting connection reset fault: rule={}", rule_id);
+
+            metrics::record_script_execution(&rule_id, script_duration, "inject");
+            metrics::record_script_fault("reset", &rule_id, None);
+            metrics::record_error_injection(&rule_id, 0);
+
+            let duration_ms = forwarding_ctx.start_time.elapsed().as_secs_f64() * 1000.0;
+            metrics::record_proxy_duration(request_info.method.as_str(), duration_ms, "script");
+
+            let mut response = create_error_response(
+                502,
+                r#"{"error": "Connection reset by peer"}"#.to_string(),
+                None,
+                None,
+            )
+            .unwrap();
+            response.set_header(&X_RIFT_FAULT, &VALUE_TCP);
+            response.set_header_value(&X_RIFT_RULE_ID, &rule_id);
+            response.set_header(&X_RIFT_SCRIPT, &VALUE_TRUE);
             response.into_boxed()
         }
         Ok(ScriptFaultDecision::None) => {

--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -6,7 +6,7 @@
 //! at a wall-clock deadline using the same abort-flag mechanism as the pooled path (#172):
 //! Rhai's `on_progress` callback, and a Lua instruction hook.
 
-use super::{FaultDecision, ScriptEngine, ScriptRequest};
+use super::{FaultDecision, ScriptCtxExtras, ScriptEngine, ScriptRequest};
 use crate::extensions::flow_state::FlowStore;
 use crate::imposter::ImposterConfig;
 use anyhow::Result;
@@ -45,6 +45,30 @@ pub async fn should_inject_bounded(
     flow_store: Arc<dyn FlowStore>,
     timeout: Duration,
 ) -> Result<FaultDecision> {
+    should_inject_bounded_with_ctx(
+        engine_type,
+        code,
+        rule_id,
+        request,
+        flow_store,
+        timeout,
+        ScriptCtxExtras::default(),
+    )
+    .await
+}
+
+/// As [`should_inject_bounded`], but threading real `ctx.flowId`/`ctx.stub` context (issue #357
+/// Item 1) through to the v2 `ctx` object — used by the imposter `_rift.script` hook, which knows
+/// the resolved flow id and matched stub.
+pub async fn should_inject_bounded_with_ctx(
+    engine_type: String,
+    code: String,
+    rule_id: String,
+    request: ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    timeout: Duration,
+    ctx_extra: ScriptCtxExtras,
+) -> Result<FaultDecision> {
     let abort = Arc::new(AtomicBool::new(false));
     let run_abort = Arc::clone(&abort);
     let handle = tokio::task::spawn_blocking(move || {
@@ -55,6 +79,7 @@ pub async fn should_inject_bounded(
             &request,
             flow_store,
             &run_abort,
+            &ctx_extra,
         )
     });
 
@@ -88,21 +113,22 @@ fn run_should_inject_with_abort(
     request: &ScriptRequest,
     flow_store: Arc<dyn FlowStore>,
     abort: &Arc<AtomicBool>,
+    ctx_extra: &ScriptCtxExtras,
 ) -> Result<FaultDecision> {
     // Start each execution with a clean last-flow-error slot so `flow_store.last_error()` can't
     // observe a stale error left by a previous script on this reused worker thread (issue #322).
     crate::extensions::flow_state::clear_last_flow_error();
     match engine_type {
         "rhai" => super::rhai_engine::run_should_inject_with_abort_rhai(
-            code, rule_id, request, flow_store, abort,
+            code, rule_id, request, flow_store, abort, ctx_extra,
         ),
         #[cfg(feature = "lua")]
         "lua" => super::lua_engine::run_should_inject_with_abort_lua(
-            code, rule_id, request, flow_store, abort,
+            code, rule_id, request, flow_store, abort, ctx_extra,
         ),
         other => {
             let engine = ScriptEngine::new(other, code, rule_id)?;
-            engine.should_inject_fault(request, flow_store)
+            engine.should_inject_fault_with_ctx(request, flow_store, ctx_extra)
         }
     }
 }
@@ -115,6 +141,7 @@ mod tests {
 
     fn req() -> ScriptRequest {
         ScriptRequest {
+            raw_body: None,
             method: "GET".into(),
             path: "/hang".into(),
             headers: Default::default(),
@@ -162,7 +189,15 @@ mod tests {
         });
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let res = run_should_inject_with_abort(engine, code, "t", &req(), store(), &abort);
+            let res = run_should_inject_with_abort(
+                engine,
+                code,
+                "t",
+                &req(),
+                store(),
+                &abort,
+                &ScriptCtxExtras::default(),
+            );
             let _ = tx.send(res.is_err());
         });
         match rx.recv_timeout(Duration::from_secs(5)) {

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,5 +1,8 @@
 use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
-use crate::scripting::{FaultDecision, ScriptRequest};
+use crate::scripting::{
+    FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptRequest, ScriptResponseContext,
+    ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
+};
 use anyhow::{Result, anyhow};
 use boa_engine::{
     Context, JsNativeError, JsObject, JsResult, JsValue, Source, js_string,
@@ -12,12 +15,23 @@ fn create_js_object(context: &Context) -> JsObject {
     JsObject::with_object_proto(context.intrinsics())
 }
 use serde_json::Value;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::Arc;
 
 // Thread-local storage for the flow store during script execution
 thread_local! {
     static CURRENT_FLOW_STORE: RefCell<Option<Arc<dyn FlowStore>>> = const { RefCell::new(None) };
+}
+
+// Thread-local registry backing the v2 result-constructor values (`http`/`delay`/`reset`/`pass`,
+// issue #357 Item 3). Boa's `JsObject` is a plain property bag with no easy way to embed an
+// opaque Rust value, so each constructor stashes its [`ScriptResult`] here under a fresh id and
+// hands the script a `{ __riftResultId: id }` object; `.header()` and the final conversion look
+// the value back up by id (mirroring the `CURRENT_FLOW_STORE` thread-local pattern above).
+thread_local! {
+    static SCRIPT_RESULT_REGISTRY: RefCell<std::collections::HashMap<u64, ScriptResult>> =
+        RefCell::new(std::collections::HashMap::new());
+    static SCRIPT_RESULT_NEXT_ID: Cell<u64> = const { Cell::new(0) };
 }
 
 /// Set the current flow store for thread-local access
@@ -126,21 +140,17 @@ pub struct JsEngine {
 
 impl JsEngine {
     pub fn new(script: &str, rule_id: &str) -> Result<Self> {
-        // Validate script compiles by evaluating it
+        // Validate the script PARSES — not that it runs. Issue #357 Item 2 legalizes bare-
+        // expression scripts, which reference a top-level `ctx` that only exists at real
+        // execution time (with `request`/`flow_store`/`ctx` globals bound); fully evaluating an
+        // unbound bare script here would spuriously fail with "ctx is not defined" and, for a
+        // wrapper-form script, would run its top-level side effects at construction time, not
+        // request time. `Script::parse` catches genuine syntax errors without executing anything
+        // (issue #357 Item 4 relaxes the old "must define should_inject" requirement the same way
+        // `RhaiEngine::new`, which only ever compiled, already did).
         let mut context = Context::default();
-        context
-            .eval(Source::from_bytes(script.as_bytes()))
+        boa_engine::Script::parse(Source::from_bytes(script.as_bytes()), None, &mut context)
             .map_err(|e| anyhow!("Failed to compile JavaScript script: {e}"))?;
-
-        // Check that should_inject function exists
-        let global = context.global_object();
-        let func = global.get(js_string!("should_inject"), &mut context);
-        match func {
-            Ok(val) if val.is_callable() => {}
-            _ => {
-                return Err(anyhow!("Script must define should_inject function"));
-            }
-        }
 
         Ok(Self {
             script: script.to_string(),
@@ -148,12 +158,27 @@ impl JsEngine {
         })
     }
 
+    /// Execute the script and determine if a fault should be injected. Auto-detects v1
+    /// (`should_inject(request, flow_store)`) vs v2 (`respond(ctx)` or bare) — see
+    /// [`crate::scripting::ScriptEngine::should_inject_fault`] for the full contract.
     pub fn should_inject(
         &self,
         request: &ScriptRequest,
         flow_store: Arc<dyn FlowStore>,
     ) -> Result<FaultDecision> {
-        execute_js_script(&self.script, request, flow_store, &self.rule_id)
+        self.should_inject_with_ctx(request, flow_store, &ScriptCtxExtras::default())
+    }
+
+    /// As [`Self::should_inject`], but with real `ctx.flowId`/`ctx.stub` context (issue #357
+    /// Item 1).
+    pub fn should_inject_with_ctx(
+        &self,
+        request: &ScriptRequest,
+        flow_store: Arc<dyn FlowStore>,
+        extra: &ScriptCtxExtras,
+    ) -> Result<FaultDecision> {
+        let ctx_input = extra.build_ctx_input(request);
+        execute_js_script(&self.script, request, flow_store, &self.rule_id, &ctx_input)
     }
 }
 
@@ -163,10 +188,10 @@ impl JsEngine {
 /// and validate it compiles
 // Used by proxy.rs but cross-module analysis doesn't see it
 pub fn compile_js_to_bytecode(script: &str) -> Result<Vec<u8>> {
-    // Validate the script compiles
+    // Validate the script PARSES (not that it runs) — see the comment on `JsEngine::new` for why
+    // a bare v2 script can't be blind-evaluated here (issue #357 Items 2/4).
     let mut context = Context::default();
-    context
-        .eval(Source::from_bytes(script.as_bytes()))
+    boa_engine::Script::parse(Source::from_bytes(script.as_bytes()), None, &mut context)
         .map_err(|e| anyhow!("Failed to compile JavaScript script: {e}"))?;
 
     // Store the source as "bytecode" since Boa doesn't support
@@ -184,7 +209,8 @@ pub fn execute_js_bytecode(
 ) -> Result<FaultDecision> {
     let script =
         std::str::from_utf8(bytecode).map_err(|e| anyhow!("Invalid UTF-8 in bytecode: {e}"))?;
-    execute_js_script(script, request, flow_store, rule_id)
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(request);
+    execute_js_script(script, request, flow_store, rule_id, &ctx_input)
 }
 
 /// Internal function to execute JavaScript script
@@ -193,12 +219,13 @@ fn execute_js_script(
     request: &ScriptRequest,
     flow_store: Arc<dyn FlowStore>,
     rule_id: &str,
+    ctx_input: &ScriptCtxInput,
 ) -> Result<FaultDecision> {
     // Set the flow store in thread-local storage for native functions to access
     set_current_flow_store(flow_store);
 
     // Ensure we clear the flow store when done (even on error)
-    let result = execute_js_script_inner(script, request, rule_id);
+    let result = execute_js_script_inner(script, request, rule_id, ctx_input);
 
     clear_current_flow_store();
 
@@ -256,72 +283,153 @@ fn execute_js_script_inner(
     script: &str,
     request: &ScriptRequest,
     rule_id: &str,
+    ctx_input: &ScriptCtxInput,
 ) -> Result<FaultDecision> {
-    execute_js_script_inner_bounded(script, request, rule_id, JS_SCRIPT_LOOP_ITERATION_LIMIT)
+    execute_js_script_inner_bounded(
+        script,
+        request,
+        rule_id,
+        ctx_input,
+        JS_SCRIPT_LOOP_ITERATION_LIMIT,
+    )
 }
 
 /// As [`execute_js_script_inner`], but with an explicit loop-iteration cap so tests can bound a
 /// runaway cheaply (issue #327).
+///
+/// Dispatch (issue #357 Items 2/4): the script is evaluated once with `request`/`flow_store`
+/// (v1 globals) and `ctx` (v2 global) already set — its completion value is the bare-expression
+/// result. Then: a global `should_inject` → v1 (call it with `(request, flow_store)`, parse the
+/// old `#{inject:, fault:}` map). Else a global `respond` → v2 named (call it with `ctx`). Else →
+/// v2 bare (the completion value from the single eval above).
 fn execute_js_script_inner_bounded(
     script: &str,
     request: &ScriptRequest,
     rule_id: &str,
+    ctx_input: &ScriptCtxInput,
     loop_iteration_limit: u64,
 ) -> Result<FaultDecision> {
+    // B3 (issue #357): clear any `ScriptResult` registry entries left over from a previous run on
+    // this reused `spawn_blocking` worker thread. Only the single RETURNED result's id is removed
+    // in `js_value_to_fault_decision`; constructor calls that aren't the returned value (a
+    // top-level `http(500)` completion, `var a = http(500); return pass();`, etc.) would otherwise
+    // leak an entry forever. Reset per execution, mirroring the per-task flow-store reset.
+    SCRIPT_RESULT_REGISTRY.with(|r| r.borrow_mut().clear());
+
     let mut context = Context::default();
     context
         .runtime_limits_mut()
         .set_loop_iteration_limit(loop_iteration_limit);
 
-    // Create request object
     let request_obj = create_request_object(&mut context, request)?;
-
-    // Create flow_store object with methods
     let flow_store_obj = create_flow_store_object(&mut context)?;
+    let ctx_obj = create_ctx_object(&mut context, ctx_input)?;
+    register_result_constructors(&mut context)?;
 
-    // Set global variables
     let global = context.global_object();
     global
-        .set(js_string!("request"), request_obj, false, &mut context)
+        .set(
+            js_string!("request"),
+            request_obj.clone(),
+            false,
+            &mut context,
+        )
         .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
     global
         .set(
             js_string!("flow_store"),
-            flow_store_obj,
+            flow_store_obj.clone(),
             false,
             &mut context,
         )
         .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
+    global
+        .set(js_string!("ctx"), ctx_obj.clone(), false, &mut context)
+        .map_err(|e| anyhow!("Failed to set ctx global: {e}"))?;
 
-    // Execute script to define the function
-    context
+    // Snapshot the global own-property names present BEFORE eval, so afterwards we can tell which
+    // function globals the SCRIPT itself declared (B1): Boa builtins plus the request/flow_store/
+    // ctx/http/delay/reset/pass globals we set above are all already present here.
+    let pre_existing: std::collections::HashSet<String> = global
+        .own_property_keys(&mut context)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|k| match k {
+            PropertyKey::String(s) => Some(s.to_std_string_escaped()),
+            _ => None,
+        })
+        .collect();
+
+    let bare_result = context
         .eval(Source::from_bytes(script.as_bytes()))
         .map_err(|e| anyhow!("Failed to execute script: {e}"))?;
 
-    // Call should_inject function
-    let func = global
-        .get(js_string!("should_inject"), &mut context)
-        .map_err(|e| anyhow!("Failed to get should_inject function: {e}"))?;
+    let should_inject_fn = global
+        .get(js_string!(entrypoints::SHOULD_INJECT), &mut context)
+        .ok()
+        .filter(JsValue::is_callable);
+    if let Some(func) = should_inject_fn {
+        let result = func
+            .as_callable()
+            .ok_or_else(|| anyhow!("should_inject is not a function"))?
+            .call(
+                &JsValue::undefined(),
+                &[request_obj, flow_store_obj],
+                &mut context,
+            )
+            .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
+        return parse_fault_decision(&mut context, result, rule_id);
+    }
 
-    let request_arg = global
-        .get(js_string!("request"), &mut context)
-        .map_err(|e| anyhow!("Failed to get request: {e}"))?;
-    let flow_store_arg = global
-        .get(js_string!("flow_store"), &mut context)
-        .map_err(|e| anyhow!("Failed to get flow_store: {e}"))?;
+    let respond_fn = global
+        .get(js_string!(entrypoints::RESPOND), &mut context)
+        .ok()
+        .filter(JsValue::is_callable);
+    let result = if let Some(func) = respond_fn {
+        func.as_callable()
+            .ok_or_else(|| anyhow!("respond is not a function"))?
+            .call(&JsValue::undefined(), &[ctx_obj], &mut context)
+            .map_err(|e| anyhow!("Failed to call respond(ctx): {e}"))?
+    } else {
+        // B1 (issue #357, "nothing fails silently"): if the script DECLARED a function global
+        // that isn't `respond` (nor `should_inject`) and produced no bare-expression value
+        // (undefined/null), it almost certainly has a MISNAMED entrypoint (e.g.
+        // `function respnod(ctx)`). Falling through to `bare_result` (→ `None`) would silently
+        // serve a normal response with no sign the script never ran. Surface it as an explicit
+        // error instead. A genuine bare expression is still fine: it either declared no new
+        // functions, or produced a non-undefined value.
+        if bare_result.is_undefined() || bare_result.is_null() {
+            let keys = global.own_property_keys(&mut context).unwrap_or_default();
+            let mut declared_a_function = false;
+            for key in keys {
+                let name = match &key {
+                    PropertyKey::String(s) => s.to_std_string_escaped(),
+                    _ => continue,
+                };
+                if pre_existing.contains(&name) {
+                    continue;
+                }
+                if global
+                    .get(key, &mut context)
+                    .ok()
+                    .filter(JsValue::is_callable)
+                    .is_some()
+                {
+                    declared_a_function = true;
+                    break;
+                }
+            }
+            if declared_a_function {
+                return Err(anyhow!(
+                    "script defines function(s) but none is the `respond` entrypoint \
+                     (and there is no bare expression to evaluate); did you mean `respond`?"
+                ));
+            }
+        }
+        bare_result
+    };
 
-    let result = func
-        .as_callable()
-        .ok_or_else(|| anyhow!("should_inject is not a function"))?
-        .call(
-            &JsValue::undefined(),
-            &[request_arg, flow_store_arg],
-            &mut context,
-        )
-        .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
-
-    // Parse result
-    parse_fault_decision(&mut context, result, rule_id)
+    js_value_to_fault_decision(&mut context, result, rule_id)
 }
 
 /// Create request object from ScriptRequest
@@ -586,6 +694,535 @@ fn create_flow_store_object(context: &mut Context) -> Result<JsValue> {
     register_method(&obj, "last_error", flow_store_last_error, context)?;
 
     Ok(obj.into())
+}
+
+// =============================================================================
+// v2 `ctx` API (issue #357 Items 1-4)
+// =============================================================================
+
+fn clamp_u16_f64(n: f64) -> u16 {
+    n.max(0.0).min(f64::from(u16::MAX)) as u16
+}
+
+fn parse_json_or_null(context: &mut Context, raw: &str) -> Result<JsValue> {
+    match serde_json::from_str::<Value>(raw) {
+        Ok(v) => json_to_js(context, &v),
+        Err(_) => Ok(JsValue::null()),
+    }
+}
+
+/// Captures for the `ctx.request`/`ctx.response` case-insensitive `header(name)` getter: the
+/// (non-lowercased) source headers, looked up case-insensitively at call time.
+type HeaderGetterCaptures = std::collections::HashMap<String, String>;
+
+fn header_getter(
+    _this: &JsValue,
+    args: &[JsValue],
+    captures: &HeaderGetterCaptures,
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    let name = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped());
+    let found = name.and_then(|n| {
+        captures
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(&n))
+            .map(|(_, v)| v.clone())
+    });
+    Ok(match found {
+        Some(v) => JsValue::from(js_string!(v)),
+        None => JsValue::null(),
+    })
+}
+
+fn set_header_getter(
+    obj: &JsObject,
+    headers: &std::collections::HashMap<String, String>,
+    context: &mut Context,
+) -> Result<()> {
+    let native_fn = NativeFunction::from_copy_closure_with_captures(header_getter, headers.clone())
+        .to_js_function(context.realm());
+    obj.set(js_string!("header"), native_fn, false, context)
+        .map(|_| ())
+        .map_err(|e| anyhow!("Failed to set header(): {e}"))
+}
+
+fn create_request_ctx_object(context: &mut Context, request: &ScriptRequest) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    obj.set(
+        js_string!("method"),
+        JsValue::from(js_string!(request.method.clone())),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.request.method: {e}"))?;
+    obj.set(
+        js_string!("path"),
+        JsValue::from(js_string!(request.path.clone())),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.request.path: {e}"))?;
+
+    let path_params_obj = create_js_object(context);
+    for (k, v) in &request.path_params {
+        path_params_obj
+            .set(
+                js_string!(k.clone()),
+                JsValue::from(js_string!(v.clone())),
+                false,
+                context,
+            )
+            .map_err(|e| anyhow!("Failed to set ctx.request.pathParams.{k}: {e}"))?;
+    }
+    obj.set(js_string!("pathParams"), path_params_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.request.pathParams: {e}"))?;
+
+    let query_obj = create_js_object(context);
+    for (k, v) in &request.query {
+        query_obj
+            .set(
+                js_string!(k.clone()),
+                JsValue::from(js_string!(v.clone())),
+                false,
+                context,
+            )
+            .map_err(|e| anyhow!("Failed to set ctx.request.query.{k}: {e}"))?;
+    }
+    obj.set(js_string!("query"), query_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.request.query: {e}"))?;
+
+    let headers_obj = create_js_object(context);
+    for (k, v) in &request.headers {
+        headers_obj
+            .set(
+                js_string!(k.to_ascii_lowercase()),
+                JsValue::from(js_string!(v.clone())),
+                false,
+                context,
+            )
+            .map_err(|e| anyhow!("Failed to set ctx.request.headers.{k}: {e}"))?;
+    }
+    obj.set(js_string!("headers"), headers_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.request.headers: {e}"))?;
+    set_header_getter(&obj, &request.headers, context)?;
+
+    // ctx.request.body is always the raw string (issue #357 Item 1); fall back to
+    // re-serializing the parsed `body` for callers that only populated that field.
+    let raw = request.raw_body.clone().unwrap_or_else(|| {
+        if request.body.is_null() {
+            String::new()
+        } else {
+            serde_json::to_string(&request.body).unwrap_or_default()
+        }
+    });
+    let json_val = parse_json_or_null(context, &raw)?;
+    obj.set(js_string!("json"), json_val, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.request.json: {e}"))?;
+    obj.set(
+        js_string!("body"),
+        JsValue::from(js_string!(raw)),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.request.body: {e}"))?;
+
+    Ok(obj.into())
+}
+
+fn create_response_ctx_object(
+    context: &mut Context,
+    response: &ScriptResponseContext,
+) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    obj.set(
+        js_string!("status"),
+        JsValue::from(f64::from(response.status)),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.response.status: {e}"))?;
+
+    let headers_obj = create_js_object(context);
+    for (k, v) in &response.headers {
+        headers_obj
+            .set(
+                js_string!(k.to_ascii_lowercase()),
+                JsValue::from(js_string!(v.clone())),
+                false,
+                context,
+            )
+            .map_err(|e| anyhow!("Failed to set ctx.response.headers.{k}: {e}"))?;
+    }
+    obj.set(js_string!("headers"), headers_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.response.headers: {e}"))?;
+    set_header_getter(&obj, &response.headers, context)?;
+
+    let json_val = parse_json_or_null(context, &response.body)?;
+    obj.set(js_string!("json"), json_val, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.response.json: {e}"))?;
+    obj.set(
+        js_string!("body"),
+        JsValue::from(js_string!(response.body.clone())),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.response.body: {e}"))?;
+
+    Ok(obj.into())
+}
+
+fn optional_string_to_js(value: &Option<String>) -> JsValue {
+    match value {
+        Some(s) => JsValue::from(js_string!(s.clone())),
+        None => JsValue::null(),
+    }
+}
+
+fn create_stub_ctx_object(context: &mut Context, stub: &ScriptStubContext) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    obj.set(
+        js_string!("scenarioName"),
+        optional_string_to_js(&stub.scenario_name),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.stub.scenarioName: {e}"))?;
+    obj.set(
+        js_string!("scenarioState"),
+        optional_string_to_js(&stub.scenario_state),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.stub.scenarioState: {e}"))?;
+    obj.set(
+        js_string!("id"),
+        optional_string_to_js(&stub.stub_id),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.stub.id: {e}"))?;
+    Ok(obj.into())
+}
+
+/// Captures for the `ctx.state` methods: the flow id they're bound to.
+type StateCaptures = String;
+
+fn state_get(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let outcome = with_current_flow_store(|store| flow_result("get", store.get(flow_id, &key)));
+    match outcome {
+        Some(Ok(Some(value))) => json_to_js_result(ctx, &value),
+        Some(Ok(None)) => Ok(JsValue::null()),
+        Some(Err(msg)) if strict_flow_store() => {
+            Err(JsNativeError::error().with_message(msg).into())
+        }
+        Some(Err(_)) | None => Ok(JsValue::null()),
+    }
+}
+
+fn state_set(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let value = args.get(1).cloned().unwrap_or(JsValue::null());
+    let json_value = js_to_json(ctx, &value)?;
+    let outcome = with_current_flow_store(|store| {
+        flow_result("set", store.set(flow_id, &key, json_value).map(|()| true))
+    });
+    js_flow_outcome(outcome, false)
+}
+
+fn state_incr(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let outcome =
+        with_current_flow_store(|store| flow_result("increment", store.increment(flow_id, &key)));
+    js_flow_outcome(outcome, 0i64)
+}
+
+fn state_exists(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let outcome =
+        with_current_flow_store(|store| flow_result("exists", store.exists(flow_id, &key)));
+    js_flow_outcome(outcome, false)
+}
+
+fn state_delete(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let outcome = with_current_flow_store(|store| {
+        flow_result("delete", store.delete(flow_id, &key).map(|()| true))
+    });
+    js_flow_outcome(outcome, false)
+}
+
+/// `ctx.state` — a flow-state handle bound to one flow id (issue #357 Item 1). Exposes the subset
+/// of `flow_store` that doesn't need a `flow_id` argument per call (full get_or/incr-with-args/cas
+/// is P3b, issue #358).
+type StateMethodFn = fn(&JsValue, &[JsValue], &StateCaptures, &mut Context) -> JsResult<JsValue>;
+
+fn create_state_object(context: &mut Context, flow_id: String) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    let methods: [(&str, StateMethodFn); 5] = [
+        ("get", state_get),
+        ("set", state_set),
+        ("incr", state_incr),
+        ("exists", state_exists),
+        ("delete", state_delete),
+    ];
+    for (name, func) in methods {
+        let native_fn = NativeFunction::from_copy_closure_with_captures(func, flow_id.clone())
+            .to_js_function(context.realm());
+        obj.set(js_string!(name), native_fn, false, context)
+            .map_err(|e| anyhow!("Failed to set ctx.state.{name}: {e}"))?;
+    }
+    Ok(obj.into())
+}
+
+fn store_flow_method(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    let flow_id = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("flow_id must be a string"))?;
+    create_state_object(ctx, flow_id)
+        .map_err(|e| JsNativeError::error().with_message(e.to_string()).into())
+}
+
+/// `ctx.store`: the flow-store escape hatch (issue #357 Item 1) — `.flow(id)` returns a handle
+/// scoped to an arbitrary flow id.
+fn create_store_object(context: &mut Context) -> Result<JsValue> {
+    let obj = create_js_object(context);
+    register_method(&obj, "flow", store_flow_method, context)?;
+    Ok(obj.into())
+}
+
+/// Build the v2 `ctx` object (issue #357 Item 1): identical field names/semantics across engines —
+/// see the doc comment on [`ScriptCtxInput`]. `ctx.logger` reuses P1's native logger (issue #355).
+fn create_ctx_object(context: &mut Context, input: &ScriptCtxInput) -> Result<JsValue> {
+    let obj = create_js_object(context);
+
+    let request_obj = create_request_ctx_object(context, input.request)?;
+    obj.set(js_string!("request"), request_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.request: {e}"))?;
+
+    if let Some(resp) = &input.response {
+        let response_obj = create_response_ctx_object(context, resp)?;
+        obj.set(js_string!("response"), response_obj, false, context)
+            .map_err(|e| anyhow!("Failed to set ctx.response: {e}"))?;
+    }
+
+    obj.set(
+        js_string!("flowId"),
+        JsValue::from(js_string!(input.flow_id.clone())),
+        false,
+        context,
+    )
+    .map_err(|e| anyhow!("Failed to set ctx.flowId: {e}"))?;
+
+    let stub_obj = create_stub_ctx_object(context, &input.stub)?;
+    obj.set(js_string!("stub"), stub_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.stub: {e}"))?;
+
+    let state_obj = create_state_object(context, input.flow_id.clone())?;
+    obj.set(js_string!("state"), state_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.state: {e}"))?;
+
+    let store_obj = create_store_object(context)?;
+    obj.set(js_string!("store"), store_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.store: {e}"))?;
+
+    let logger_obj = create_script_logger_object(context, input.port, input.stub.stub_id.clone())?;
+    obj.set(js_string!("logger"), logger_obj, false, context)
+        .map_err(|e| anyhow!("Failed to set ctx.logger: {e}"))?;
+
+    Ok(obj.into())
+}
+
+// =============================================================================
+// v2 result constructors: http()/delay()/reset()/pass() (issue #357 Item 3)
+// =============================================================================
+
+fn wrap_script_result(context: &mut Context, result: ScriptResult) -> JsResult<JsValue> {
+    let id = SCRIPT_RESULT_NEXT_ID.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    });
+    SCRIPT_RESULT_REGISTRY.with(|r| {
+        r.borrow_mut().insert(id, result);
+    });
+    let obj = create_js_object(context);
+    obj.set(
+        js_string!("__riftResultId"),
+        JsValue::from(id as f64),
+        false,
+        context,
+    )?;
+    obj.set(
+        PropertyKey::from(js_string!("header")),
+        NativeFunction::from_fn_ptr(script_result_header).to_js_function(context.realm()),
+        false,
+        context,
+    )?;
+    Ok(obj.into())
+}
+
+fn script_result_header(this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    let id = this
+        .as_object()
+        .and_then(|o| o.get(js_string!("__riftResultId"), ctx).ok())
+        .and_then(|v| v.as_number())
+        .map(|n| n as u64)
+        .ok_or_else(|| {
+            JsNativeError::typ().with_message("header() called on a non-result value")
+        })?;
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| {
+            JsNativeError::typ().with_message("header(name, value): name must be a string")
+        })?;
+    let value = args
+        .get(1)
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| {
+            JsNativeError::typ().with_message("header(name, value): value must be a string")
+        })?;
+    SCRIPT_RESULT_REGISTRY.with(|r| {
+        if let Some(res) = r.borrow_mut().get_mut(&id) {
+            res.add_header(key, value);
+        }
+    });
+    Ok(this.clone())
+}
+
+fn js_value_to_script_result_body(ctx: &mut Context, v: &JsValue) -> JsResult<ScriptResultBody> {
+    if let Some(s) = v.as_string() {
+        Ok(ScriptResultBody::Str(s.to_std_string_escaped()))
+    } else {
+        Ok(ScriptResultBody::Json(js_to_json(ctx, v)?))
+    }
+}
+
+fn ctor_http(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    let status = args.first().and_then(JsValue::as_number).unwrap_or(200.0);
+    let body = match args.get(1) {
+        None => None,
+        Some(v) if v.is_null() || v.is_undefined() => None,
+        Some(v) => Some(js_value_to_script_result_body(ctx, v)?),
+    };
+    wrap_script_result(ctx, ScriptResult::http(clamp_u16_f64(status), body))
+}
+
+fn ctor_delay(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    let ms = args.first().and_then(JsValue::as_number).unwrap_or(0.0);
+    wrap_script_result(ctx, ScriptResult::Delay(ms.max(0.0) as u64))
+}
+
+fn ctor_reset(_this: &JsValue, _args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    wrap_script_result(ctx, ScriptResult::Reset)
+}
+
+fn ctor_pass(_this: &JsValue, _args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    wrap_script_result(ctx, ScriptResult::Pass)
+}
+
+/// Register the v2 result constructors as globals. Cheap and idempotent, so it's called on every
+/// script run rather than requiring every `Context` creation site in this module to remember it.
+fn register_result_constructors(context: &mut Context) -> Result<()> {
+    let global = context.global_object();
+    for (name, func) in [
+        (
+            "http",
+            ctor_http as fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>,
+        ),
+        ("delay", ctor_delay),
+        ("reset", ctor_reset),
+        ("pass", ctor_pass),
+    ] {
+        global
+            .set(
+                js_string!(name),
+                NativeFunction::from_fn_ptr(func).to_js_function(context.realm()),
+                false,
+                context,
+            )
+            .map_err(|e| anyhow!("Failed to set global {name}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Convert a `respond(ctx)`/bare-expression return value into a [`FaultDecision`] (issue #357
+/// Item 3): `null`/`undefined` (or the script returning nothing) → `None`; an `http()`/`delay()`/
+/// `reset()`/`pass()` result → its own outcome; anything else is an error.
+fn js_value_to_fault_decision(
+    context: &mut Context,
+    value: JsValue,
+    rule_id: &str,
+) -> Result<FaultDecision> {
+    if value.is_null() || value.is_undefined() {
+        return Ok(FaultDecision::None);
+    }
+    let id = value
+        .as_object()
+        .and_then(|o| o.get(js_string!("__riftResultId"), context).ok())
+        .and_then(|v| v.as_number())
+        .map(|n| n as u64);
+    let Some(id) = id else {
+        return Err(anyhow!(
+            "respond(ctx) must return http(...)/delay(...)/reset()/pass() or nothing"
+        ));
+    };
+    let result = SCRIPT_RESULT_REGISTRY.with(|r| r.borrow_mut().remove(&id));
+    let result = result.ok_or_else(|| anyhow!("respond(ctx) result was already consumed"))?;
+    Ok(result.into_fault_decision(rule_id))
 }
 
 // =============================================================================
@@ -2010,7 +2647,10 @@ function should_inject(request, flow_store) {
     }
 
     #[test]
-    fn test_js_engine_missing_function() {
+    fn test_js_engine_without_should_inject_still_constructs() {
+        // Issue #357 Item 4: a script defining neither `should_inject` (v1) nor a v2 named
+        // entrypoint is now legal — it's a v2 bare-expression script (Item 2). Construction only
+        // validates that the script compiles.
         let script = r#"
 function some_other_function() {
     return true;
@@ -2018,8 +2658,21 @@ function some_other_function() {
 "#;
 
         let engine = JsEngine::new(script, "test-rule");
-        assert!(engine.is_err());
-        assert!(engine.unwrap_err().to_string().contains("should_inject"));
+        assert!(
+            engine.is_ok(),
+            "bare/helper-only scripts must construct: {:?}",
+            engine.err()
+        );
+    }
+
+    #[test]
+    fn test_js_engine_syntax_error_fails_construction() {
+        let script = "function should_inject(request, flow_store {  // missing paren";
+        let engine = JsEngine::new(script, "test-rule");
+        assert!(
+            engine.is_err(),
+            "a genuine syntax error must still fail construction"
+        );
     }
 
     #[test]
@@ -2045,6 +2698,7 @@ function should_inject(request, flow_store) {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -2071,6 +2725,7 @@ function should_inject(request, flow_store) {
     fn js_should_inject_loop_limit_terminates() {
         set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
             headers: HashMap::new(),
@@ -2079,7 +2734,8 @@ function should_inject(request, flow_store) {
             path_params: HashMap::new(),
         };
         let script = "function should_inject(request, flow_store) { while (true) {} }";
-        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        let ctx_input = ScriptCtxExtras::default().build_ctx_input(&request);
+        let result = execute_js_script_inner_bounded(script, &request, "rule", &ctx_input, 100_000);
         clear_current_flow_store();
         assert!(
             result.is_err(),
@@ -2091,6 +2747,7 @@ function should_inject(request, flow_store) {
     fn js_should_inject_under_limit_runs() {
         set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
             headers: HashMap::new(),
@@ -2099,7 +2756,8 @@ function should_inject(request, flow_store) {
             path_params: HashMap::new(),
         };
         let script = "function should_inject(request, flow_store) { let n = 0; for (let i = 0; i < 100; i++) { n++; } return { inject: n === 100, fault: 'latency', duration_ms: 1 }; }";
-        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        let ctx_input = ScriptCtxExtras::default().build_ctx_input(&request);
+        let result = execute_js_script_inner_bounded(script, &request, "rule", &ctx_input, 100_000);
         clear_current_flow_store();
         assert!(
             result.is_ok(),
@@ -2116,6 +2774,7 @@ function should_inject(request, flow_store) {
         let _ = take_last_flow_error();
         set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
             headers: HashMap::new(),
@@ -2130,7 +2789,8 @@ function should_inject(request, flow_store) {
             Err::<Option<i32>, _>(anyhow::anyhow!("js backend down")),
         );
         let script = "function should_inject(request, flow_store) { var e = flow_store.last_error(); return { inject: true, fault: 'latency', duration_ms: (e && e.indexOf('js backend down') >= 0) ? 999 : 1 }; }";
-        let result = execute_js_script_inner_bounded(script, &request, "rule", 100_000);
+        let ctx_input = ScriptCtxExtras::default().build_ctx_input(&request);
+        let result = execute_js_script_inner_bounded(script, &request, "rule", &ctx_input, 100_000);
         clear_current_flow_store();
         match result {
             Ok(FaultDecision::Latency { duration_ms, .. }) => assert_eq!(
@@ -2157,6 +2817,7 @@ function should_inject(request, flow_store) {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -2206,6 +2867,7 @@ function should_inject(request, flow_store) {
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -2263,6 +2925,7 @@ function should_inject(request, flow_store) {
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -2331,6 +2994,7 @@ function should_inject(request, flow_store) {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/bytecode".to_string(),
             headers,
@@ -2378,6 +3042,7 @@ function should_inject(request, flow_store) {
 
         // Test with high value
         let request1 = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -2404,6 +3069,7 @@ function should_inject(request, flow_store) {
 
         // Test with low value
         let request2 = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -2443,6 +3109,7 @@ function should_inject(request, flow_store) {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -2495,6 +3162,7 @@ function should_inject(request, flow_store) {
         query.insert("page".to_string(), "42".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -2541,6 +3209,7 @@ function should_inject(request, flow_store) {
         path_params.insert("action".to_string(), "update".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/users/123/update".to_string(),
             headers: HashMap::new(),
@@ -3160,5 +3829,275 @@ function should_inject(request, flow_store) {
             err.to_string().contains("boom-inject"),
             "the error must carry the script's failure message, got: {err}"
         );
+    }
+
+    // ============================================
+    // Issue #357: unified ctx, v2 respond entrypoint, result constructors (JS)
+    // ============================================
+    mod v2 {
+        use super::*;
+
+        fn req(headers: HashMap<String, String>, raw_body: Option<&str>) -> ScriptRequest {
+            ScriptRequest {
+                method: "POST".to_string(),
+                path: "/api/orders".to_string(),
+                headers,
+                body: json!(null),
+                query: HashMap::new(),
+                path_params: HashMap::new(),
+                raw_body: raw_body.map(|s| s.to_string()),
+            }
+        }
+
+        fn store() -> Arc<dyn FlowStore> {
+            Arc::new(InMemoryFlowStore::new(300))
+        }
+
+        fn run_respond(script: &str, request: &ScriptRequest) -> Result<FaultDecision> {
+            let engine = JsEngine::new(script, "v2-rule").unwrap();
+            engine.should_inject(request, store())
+        }
+
+        #[test]
+        fn respond_named_wrapper() {
+            let script = r#"
+                function respond(ctx) {
+                    return http(503, { error: "unavailable" });
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error {
+                    status,
+                    body,
+                    headers,
+                    ..
+                } => {
+                    assert_eq!(status, 503);
+                    assert!(body.contains("unavailable"));
+                    assert_eq!(
+                        headers.get("Content-Type").map(String::as_str),
+                        Some("application/json")
+                    );
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn respond_bare_expression() {
+            let script = r#"
+                (ctx.request.method === "POST") ? http(503, { error: "unavailable" }) : pass()
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        #[test]
+        fn ctx_request_header_case_insensitive_and_lowercased_map() {
+            let headers = HashMap::from([("X-Flow-Id".to_string(), "flow-9".to_string())]);
+            let script = r#"
+                function respond(ctx) {
+                    var byGetter = ctx.request.header("x-flow-id");
+                    var byMap = ctx.request.headers["x-flow-id"];
+                    return http(200, { getter: byGetter, map: byMap });
+                }
+            "#;
+            let decision = run_respond(script, &req(headers, None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("flow-9"));
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_json_lazy_parse() {
+            let script = r#"
+                function respond(ctx) {
+                    if (ctx.request.json === null) { return http(500); }
+                    return http(200, { n: ctx.request.json.n });
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), Some(r#"{"n": 7}"#))).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains('7'));
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+
+            let decision2 = run_respond(script, &req(HashMap::new(), Some("not json"))).unwrap();
+            assert!(matches!(
+                decision2,
+                FaultDecision::Error { status: 500, .. }
+            ));
+        }
+
+        #[test]
+        fn result_constructors_delay_reset_pass() {
+            let delay = run_respond(
+                "function respond(ctx) { return delay(42); }",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            match delay {
+                FaultDecision::Latency { duration_ms, .. } => assert_eq!(duration_ms, 42),
+                other => panic!("expected Latency, got {other:?}"),
+            }
+
+            let reset = run_respond(
+                "function respond(ctx) { return reset(); }",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            assert!(matches!(reset, FaultDecision::Reset { .. }));
+
+            let pass = run_respond(
+                "function respond(ctx) { return pass(); }",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            assert!(matches!(pass, FaultDecision::None));
+
+            let nothing =
+                run_respond("function respond(ctx) { }", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(nothing, FaultDecision::None));
+        }
+
+        #[test]
+        fn http_string_body_passes_through_verbatim() {
+            let script = r#"function respond(ctx) { return http(200, "hello world"); }"#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, headers, .. } => {
+                    assert_eq!(body, "hello world");
+                    assert!(!headers.contains_key("Content-Type"));
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        // v1 back-compat: `should_inject` still wins even when `respond`-shaped calls exist in
+        // the ambient globals (issue #357 Item 4).
+        #[test]
+        fn v1_should_inject_still_works_unchanged() {
+            let script = r#"
+                function should_inject(request, flow_store) {
+                    return { inject: true, fault: "error", status: 418, body: "teapot" };
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 418);
+                    assert_eq!(body, "teapot");
+                }
+                other => panic!("expected v1 Error decision, got {other:?}"),
+            }
+        }
+
+        // Retry example from the issue: ctx.state.incr + http() executes end-to-end.
+        #[test]
+        fn retry_example_end_to_end_with_ctx_state_incr() {
+            let script = r#"
+                function respond(ctx) {
+                    var n = ctx.state.incr("attempts");
+                    if (n <= 2) {
+                        return http(503, { error: "unavailable", attempt: n }).header("Retry-After", "1");
+                    }
+                    return http(200, { ok: true, succeededOnAttempt: n });
+                }
+            "#;
+            let engine = JsEngine::new(script, "retry-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d1, FaultDecision::Error { status: 503, .. }));
+
+            let d2 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d2, FaultDecision::Error { status: 503, .. }));
+
+            let d3 = engine.should_inject(&request, shared_store).unwrap();
+            match d3 {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("succeededOnAttempt"));
+                }
+                other => panic!("expected 200 on third attempt, got {other:?}"),
+            }
+        }
+
+        // B1 (issue #357): a script defining ONLY a misnamed entrypoint must Err, not None.
+        #[test]
+        fn misnamed_entrypoint_errors_not_none() {
+            let script = r#"
+                function respnod(ctx) {
+                    return http(500);
+                }
+            "#;
+            let result = JsEngine::new(script, "v2-rule")
+                .unwrap()
+                .should_inject(&req(HashMap::new(), None), store());
+            assert!(
+                result.is_err(),
+                "a misnamed entrypoint must surface an error, got {result:?}"
+            );
+        }
+
+        #[test]
+        fn genuine_bare_expression_still_ok_after_b1() {
+            let decision = run_respond("http(503)", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        // ctx.request.pathParams and ctx.request.query round-trip (mirrors the Rhai test).
+        #[test]
+        fn ctx_request_path_params_and_query() {
+            let mut request = req(HashMap::new(), None);
+            request
+                .path_params
+                .insert("id".to_string(), "42".to_string());
+            request.query.insert("page".to_string(), "2".to_string());
+            let script = r#"
+                function respond(ctx) {
+                    return http(200, { id: ctx.request.pathParams.id, page: ctx.request.query.page });
+                }
+            "#;
+            let decision = run_respond(script, &request).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("42"), "pathParams.id missing: {body}");
+                    assert!(body.contains('2'), "query.page missing: {body}");
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        // B3 (issue #357): the ScriptResult registry must not grow unbounded across runs on a
+        // reused worker thread. Each execution makes constructor calls that are NOT the returned
+        // value (an orphaned `http(999)` completion), yet the registry is reset per run, so its
+        // size stays bounded (here: empty at the start of each run, so <= 1 entry mid-run).
+        #[test]
+        fn script_result_registry_does_not_leak_across_runs() {
+            let script = "http(999); pass()"; // orphaned http(999), returns pass()
+            for _ in 0..25 {
+                let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+                assert!(matches!(decision, FaultDecision::None));
+            }
+            let leaked = SCRIPT_RESULT_REGISTRY.with(|r| r.borrow().len());
+            assert!(
+                leaked <= 1,
+                "registry leaked {leaked} entries across 25 runs; per-run reset is broken"
+            );
+        }
     }
 }

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1,5 +1,8 @@
 use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
-use crate::scripting::{FaultDecision, ScriptRequest};
+use crate::scripting::{
+    FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptRequest, ScriptResponseContext,
+    ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
+};
 use anyhow::{Result, anyhow};
 use mlua::prelude::*;
 use serde_json::Value;
@@ -93,18 +96,18 @@ pub struct LuaEngine {
 
 impl LuaEngine {
     pub fn new(script: &str, rule_id: &str) -> Result<Self> {
-        // Validate script compiles
+        // Validate the script COMPILES — not that it runs (`.into_function()` compiles without
+        // calling). Issue #357 Item 2 legalizes bare-expression scripts, which reference a
+        // top-level `ctx` global that only exists at real execution time (`request`/`flow_store`/
+        // `ctx` all bound); `.exec()`-ing an unbound bare script here would spuriously fail with
+        // "ctx is nil", and for a wrapper-form script would run its top-level side effects at
+        // construction time, not request time. A missing `should_inject` is also no longer a
+        // construction error (issue #357 Item 4), matching `RhaiEngine::new`, which never required
+        // it either.
         let lua = Lua::new();
         lua.load(script)
-            .exec()
+            .into_function()
             .map_err(|e| anyhow!("Failed to compile Lua script: {e}"))?;
-
-        // Check that should_inject function exists
-        let globals = lua.globals();
-        let func: LuaResult<LuaFunction> = globals.get("should_inject");
-        if func.is_err() {
-            return Err(anyhow!("Script must define should_inject function"));
-        }
 
         Ok(Self {
             script: script.to_string(),
@@ -112,10 +115,24 @@ impl LuaEngine {
         })
     }
 
+    /// Execute the script and determine if a fault should be injected. Auto-detects v1
+    /// (`should_inject(request, flow_store)`) vs v2 (`respond(ctx)` or bare) — see
+    /// [`crate::scripting::ScriptEngine::should_inject_fault`] for the full contract.
     pub fn should_inject(
         &self,
         request: &ScriptRequest,
         flow_store: Arc<dyn FlowStore>,
+    ) -> Result<FaultDecision> {
+        self.should_inject_with_ctx(request, flow_store, &ScriptCtxExtras::default())
+    }
+
+    /// As [`Self::should_inject`], but with real `ctx.flowId`/`ctx.stub` context (issue #357
+    /// Item 1).
+    pub fn should_inject_with_ctx(
+        &self,
+        request: &ScriptRequest,
+        flow_store: Arc<dyn FlowStore>,
+        extra: &ScriptCtxExtras,
     ) -> Result<FaultDecision> {
         // DEPRECATED: This method spawns a thread+runtime per execution (expensive!)
         // Script pool workers should use execute_lua_with_state() instead
@@ -123,6 +140,7 @@ impl LuaEngine {
         let script = self.script.clone();
         let request = request.clone();
         let rule_id = self.rule_id.clone();
+        let extra_owned = extra.clone();
         let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
@@ -130,7 +148,9 @@ impl LuaEngine {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
             let _guard = rt.enter();
 
-            let result = Self::execute_in_thread(script, request, flow_store, rule_id);
+            let ctx_input = extra_owned.build_ctx_input(&request);
+            let result =
+                Self::execute_respond_in_thread(script, &request, flow_store, rule_id, &ctx_input);
             let _ = tx.send(result);
         });
 
@@ -138,175 +158,21 @@ impl LuaEngine {
             .map_err(|_| anyhow!("Lua execution thread panicked"))?
     }
 
-    fn execute_in_thread(
+    /// Compile-and-run a script for `should_inject_with_ctx` — replaces the old duplicated
+    /// table-building (now shared via [`run_entrypoint_lua`]) with the v1/v2-aware dispatch.
+    fn execute_respond_in_thread(
         script: String,
-        request: ScriptRequest,
+        request: &ScriptRequest,
         flow_store: Arc<dyn FlowStore>,
         rule_id: String,
+        ctx_input: &ScriptCtxInput,
     ) -> Result<FaultDecision> {
         let lua = Lua::new();
-
-        // Create request table
-        let request_table = lua
-            .create_table()
-            .map_err(|e| anyhow!("Failed to create request table: {e}"))?;
-        request_table
-            .set("method", request.method.clone())
-            .map_err(|e| anyhow!("Failed to set method: {e}"))?;
-        request_table
-            .set("path", request.path.clone())
-            .map_err(|e| anyhow!("Failed to set path: {e}"))?;
-
-        // Create headers table
-        let headers_table = lua
-            .create_table()
-            .map_err(|e| anyhow!("Failed to create headers table: {e}"))?;
-        for (k, v) in &request.headers {
-            headers_table
-                .set(k.as_str(), v.as_str())
-                .map_err(|e| anyhow!("Failed to set header: {e}"))?;
-        }
-        request_table
-            .set("headers", headers_table)
-            .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
-
-        // Convert body JSON to Lua value
-        let body_value =
-            json_to_lua(&lua, &request.body).map_err(|e| anyhow!("Failed to convert body: {e}"))?;
-        request_table
-            .set("body", body_value)
-            .map_err(|e| anyhow!("Failed to set body: {e}"))?;
-
-        // Create query parameters table
-        let query_table = lua
-            .create_table()
-            .map_err(|e| anyhow!("Failed to create query table: {e}"))?;
-        for (k, v) in &request.query {
-            query_table
-                .set(k.as_str(), v.as_str())
-                .map_err(|e| anyhow!("Failed to set query param: {e}"))?;
-        }
-        request_table
-            .set("query", query_table)
-            .map_err(|e| anyhow!("Failed to set query: {e}"))?;
-
-        // Create path parameters table
-        let path_params_table = lua
-            .create_table()
-            .map_err(|e| anyhow!("Failed to create path_params table: {e}"))?;
-        for (k, v) in &request.path_params {
-            path_params_table
-                .set(k.as_str(), v.as_str())
-                .map_err(|e| anyhow!("Failed to set path param: {e}"))?;
-        }
-        request_table
-            .set("pathParams", path_params_table)
-            .map_err(|e| anyhow!("Failed to set pathParams: {e}"))?;
-
-        // Create flow_store userdata
-        let flow_store_ud = lua
-            .create_userdata(LuaFlowStore::new(flow_store))
-            .map_err(|e| anyhow!("Failed to create flow_store userdata: {e}"))?;
-
-        // Set global variables
-        let globals = lua.globals();
-        globals
-            .set("request", request_table)
-            .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
-        globals
-            .set("flow_store", flow_store_ud)
-            .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
-
-        // Load and execute script
-        lua.load(&script)
-            .exec()
-            .map_err(|e| anyhow!("Failed to execute script: {e}"))?;
-
-        // Call should_inject function
-        let should_inject: LuaFunction = globals
-            .get("should_inject")
-            .map_err(|e| anyhow!("Failed to get should_inject function: {e}"))?;
-        let request_arg: LuaTable = globals
-            .get("request")
-            .map_err(|e| anyhow!("Failed to get request: {e}"))?;
-        let flow_store_arg: LuaAnyUserData = globals
-            .get("flow_store")
-            .map_err(|e| anyhow!("Failed to get flow_store: {e}"))?;
-        let result: LuaTable = should_inject
-            .call((request_arg, flow_store_arg))
-            .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
-
-        // Parse result table
-        Self::parse_fault_decision(&lua, result, rule_id)
-    }
-
-    fn parse_fault_decision(
-        _lua: &Lua,
-        result: LuaTable,
-        rule_id: String,
-    ) -> Result<FaultDecision> {
-        let inject: bool = result.get("inject").unwrap_or(false);
-
-        if !inject {
-            return Ok(FaultDecision::None);
-        }
-
-        let fault_type: String = result.get("fault").unwrap_or_else(|_| "none".to_string());
-
-        match fault_type.as_str() {
-            "latency" => {
-                let duration_ms: u64 = result
-                    .get("duration_ms")
-                    .map_err(|_| anyhow!("latency fault requires duration_ms field"))?;
-                Ok(FaultDecision::Latency {
-                    duration_ms,
-                    rule_id,
-                })
-            }
-            "error" => {
-                let status: u16 = result
-                    .get("status")
-                    .map_err(|_| anyhow!("error fault requires status field"))?;
-                let body: String = result.get("body").unwrap_or_else(|_| "".to_string());
-
-                // Extract optional headers table
-                let mut headers = std::collections::HashMap::new();
-                if let Ok(headers_table) = result.get::<LuaTable>("headers") {
-                    for (key, value) in headers_table.pairs::<LuaValue, LuaValue>().flatten() {
-                        // Convert key to string
-                        let key_str = match key {
-                            LuaValue::String(s) => {
-                                s.to_str().map(|s| s.to_string()).unwrap_or_default()
-                            }
-                            LuaValue::Integer(i) => i.to_string(),
-                            LuaValue::Number(n) => n.to_string(),
-                            _ => continue, // Skip non-stringable keys
-                        };
-
-                        // Convert value to string
-                        let value_str = match value {
-                            LuaValue::String(s) => {
-                                s.to_str().map(|s| s.to_string()).unwrap_or_default()
-                            }
-                            LuaValue::Integer(i) => i.to_string(),
-                            LuaValue::Number(n) => n.to_string(),
-                            LuaValue::Boolean(b) => b.to_string(),
-                            _ => continue, // Skip non-stringable values
-                        };
-
-                        headers.insert(key_str, value_str);
-                    }
-                }
-
-                Ok(FaultDecision::Error {
-                    status,
-                    body,
-                    rule_id,
-                    headers,
-                })
-            }
-            _ => Ok(FaultDecision::None),
-        }
+        let chunk_fn = lua
+            .load(&script)
+            .into_function()
+            .map_err(|e| anyhow!("Failed to compile script: {e}"))?;
+        call_respond_lua(&lua, &chunk_fn, request, ctx_input, flow_store, &rule_id)
     }
 }
 
@@ -326,8 +192,9 @@ pub fn compile_to_bytecode(script: &str) -> Result<Vec<u8>> {
     Ok(bytecode)
 }
 
-/// Public function to execute Lua bytecode with a reusable Lua state (for script pool)
-/// This eliminates the expensive compilation overhead on each execution
+/// Public function to execute Lua bytecode with a reusable Lua state (for script pool). Routes
+/// through the shared v1/v2-aware [`call_respond_lua`] (issue #357 Item 4); `ctx` gets
+/// best-effort defaults since the pool has no imposter context here.
 pub fn execute_lua_bytecode(
     lua: &Lua,
     bytecode: &[u8],
@@ -335,102 +202,16 @@ pub fn execute_lua_bytecode(
     flow_store: Arc<dyn FlowStore>,
     rule_id: &str,
 ) -> Result<FaultDecision> {
-    // Create request table
-    let request_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create request table: {e}"))?;
-    request_table
-        .set("method", request.method.clone())
-        .map_err(|e| anyhow!("Failed to set method: {e}"))?;
-    request_table
-        .set("path", request.path.clone())
-        .map_err(|e| anyhow!("Failed to set path: {e}"))?;
-
-    // Create headers table
-    let headers_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create headers table: {e}"))?;
-    for (k, v) in &request.headers {
-        headers_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set header: {e}"))?;
-    }
-    request_table
-        .set("headers", headers_table)
-        .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
-
-    // Convert body JSON to Lua value
-    let body_value =
-        json_to_lua(lua, &request.body).map_err(|e| anyhow!("Failed to convert body: {e}"))?;
-    request_table
-        .set("body", body_value)
-        .map_err(|e| anyhow!("Failed to set body: {e}"))?;
-
-    // Create query parameters table
-    let query_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create query table: {e}"))?;
-    for (k, v) in &request.query {
-        query_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set query param: {e}"))?;
-    }
-    request_table
-        .set("query", query_table)
-        .map_err(|e| anyhow!("Failed to set query: {e}"))?;
-
-    // Create path parameters table
-    let path_params_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create path_params table: {e}"))?;
-    for (k, v) in &request.path_params {
-        path_params_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set path param: {e}"))?;
-    }
-    request_table
-        .set("pathParams", path_params_table)
-        .map_err(|e| anyhow!("Failed to set pathParams: {e}"))?;
-
-    // Create flow_store userdata
-    let flow_store_ud = lua
-        .create_userdata(LuaFlowStore::new(flow_store))
-        .map_err(|e| anyhow!("Failed to create flow_store userdata: {e}"))?;
-
-    // Set global variables
-    let globals = lua.globals();
-    globals
-        .set("request", request_table)
-        .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
-    globals
-        .set("flow_store", flow_store_ud)
-        .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
-
-    // Load and execute bytecode (MUCH faster than compiling from source)
-    lua.load(bytecode)
-        .exec()
-        .map_err(|e| anyhow!("Failed to execute bytecode: {e}"))?;
-
-    // Call should_inject function
-    let should_inject: LuaFunction = globals
-        .get("should_inject")
-        .map_err(|e| anyhow!("Failed to get should_inject function: {e}"))?;
-    let request_arg: LuaTable = globals
-        .get("request")
-        .map_err(|e| anyhow!("Failed to get request: {e}"))?;
-    let flow_store_arg: LuaAnyUserData = globals
-        .get("flow_store")
-        .map_err(|e| anyhow!("Failed to get flow_store: {e}"))?;
-    let result: LuaTable = should_inject
-        .call((request_arg, flow_store_arg))
-        .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
-
-    // Parse result table with rule_id parameter
-    parse_fault_decision_lua(lua, result, rule_id)
+    let chunk_fn = lua
+        .load(bytecode)
+        .into_function()
+        .map_err(|e| anyhow!("Failed to load bytecode: {e}"))?;
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(request);
+    call_respond_lua(lua, &chunk_fn, request, &ctx_input, flow_store, rule_id)
 }
 
-/// Public function to execute Lua script with a reusable Lua state (for script pool)
-/// This eliminates the expensive thread spawning and runtime creation overhead
+/// Public function to execute Lua script with a reusable Lua state (for script pool). As
+/// [`execute_lua_bytecode`], but compiling from source each call.
 pub fn execute_lua_with_state(
     lua: &Lua,
     script: &str,
@@ -438,98 +219,12 @@ pub fn execute_lua_with_state(
     flow_store: Arc<dyn FlowStore>,
     rule_id: &str,
 ) -> Result<FaultDecision> {
-    // Create request table
-    let request_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create request table: {e}"))?;
-    request_table
-        .set("method", request.method.clone())
-        .map_err(|e| anyhow!("Failed to set method: {e}"))?;
-    request_table
-        .set("path", request.path.clone())
-        .map_err(|e| anyhow!("Failed to set path: {e}"))?;
-
-    // Create headers table
-    let headers_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create headers table: {e}"))?;
-    for (k, v) in &request.headers {
-        headers_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set header: {e}"))?;
-    }
-    request_table
-        .set("headers", headers_table)
-        .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
-
-    // Convert body JSON to Lua value
-    let body_value =
-        json_to_lua(lua, &request.body).map_err(|e| anyhow!("Failed to convert body: {e}"))?;
-    request_table
-        .set("body", body_value)
-        .map_err(|e| anyhow!("Failed to set body: {e}"))?;
-
-    // Create query parameters table
-    let query_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create query table: {e}"))?;
-    for (k, v) in &request.query {
-        query_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set query param: {e}"))?;
-    }
-    request_table
-        .set("query", query_table)
-        .map_err(|e| anyhow!("Failed to set query: {e}"))?;
-
-    // Create path parameters table
-    let path_params_table = lua
-        .create_table()
-        .map_err(|e| anyhow!("Failed to create path_params table: {e}"))?;
-    for (k, v) in &request.path_params {
-        path_params_table
-            .set(k.as_str(), v.as_str())
-            .map_err(|e| anyhow!("Failed to set path param: {e}"))?;
-    }
-    request_table
-        .set("pathParams", path_params_table)
-        .map_err(|e| anyhow!("Failed to set pathParams: {e}"))?;
-
-    // Create flow_store userdata
-    let flow_store_ud = lua
-        .create_userdata(LuaFlowStore::new(flow_store))
-        .map_err(|e| anyhow!("Failed to create flow_store userdata: {e}"))?;
-
-    // Set global variables
-    let globals = lua.globals();
-    globals
-        .set("request", request_table)
-        .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
-    globals
-        .set("flow_store", flow_store_ud)
-        .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
-
-    // Load and execute script (from string for now, bytecode could be added later)
-    lua.load(script)
-        .exec()
-        .map_err(|e| anyhow!("Failed to execute script: {e}"))?;
-
-    // Call should_inject function
-    let should_inject: LuaFunction = globals
-        .get("should_inject")
-        .map_err(|e| anyhow!("Failed to get should_inject function: {e}"))?;
-    let request_arg: LuaTable = globals
-        .get("request")
-        .map_err(|e| anyhow!("Failed to get request: {e}"))?;
-    let flow_store_arg: LuaAnyUserData = globals
-        .get("flow_store")
-        .map_err(|e| anyhow!("Failed to get flow_store: {e}"))?;
-    let result: LuaTable = should_inject
-        .call((request_arg, flow_store_arg))
-        .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
-
-    // Parse result table with rule_id parameter
-    parse_fault_decision_lua(lua, result, rule_id)
+    let chunk_fn = lua
+        .load(script)
+        .into_function()
+        .map_err(|e| anyhow!("Failed to compile script: {e}"))?;
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(request);
+    call_respond_lua(lua, &chunk_fn, request, &ctx_input, flow_store, rule_id)
 }
 
 /// Helper to parse Lua fault decision with given rule_id
@@ -595,6 +290,477 @@ fn parse_fault_decision_lua(_lua: &Lua, result: LuaTable, rule_id: &str) -> Resu
             })
         }
         _ => Ok(FaultDecision::None),
+    }
+}
+
+// =============================================================================
+// v2 `ctx` API (issue #357 Items 1-4)
+// =============================================================================
+
+/// What a script entrypoint call returned, tagged with which contract (v1 vs v2) produced it.
+enum LuaEntrypointOutcome {
+    V1(LuaValue),
+    V2(LuaValue),
+}
+
+fn build_v1_request_table(lua: &Lua, request: &ScriptRequest) -> LuaResult<LuaTable> {
+    let request_table = lua.create_table()?;
+    request_table.set("method", request.method.clone())?;
+    request_table.set("path", request.path.clone())?;
+
+    let headers_table = lua.create_table()?;
+    for (k, v) in &request.headers {
+        headers_table.set(k.as_str(), v.as_str())?;
+    }
+    request_table.set("headers", headers_table)?;
+
+    let body_value = json_to_lua(lua, &request.body)?;
+    request_table.set("body", body_value)?;
+
+    let query_table = lua.create_table()?;
+    for (k, v) in &request.query {
+        query_table.set(k.as_str(), v.as_str())?;
+    }
+    request_table.set("query", query_table)?;
+
+    let path_params_table = lua.create_table()?;
+    for (k, v) in &request.path_params {
+        path_params_table.set(k.as_str(), v.as_str())?;
+    }
+    request_table.set("pathParams", path_params_table)?;
+
+    Ok(request_table)
+}
+
+fn parse_json_or_nil(lua: &Lua, raw: &str) -> LuaResult<LuaValue> {
+    match serde_json::from_str::<Value>(raw) {
+        Ok(v) => json_to_lua(lua, &v),
+        Err(_) => Ok(LuaValue::Nil),
+    }
+}
+
+/// Case-insensitive `header(name)` getter closure shared by `ctx.request`/`ctx.response`. Accepts
+/// both `t:header("X")` (colon self-call — the idiomatic Lua form) and `t.header("X")`.
+fn make_header_getter(
+    lua: &Lua,
+    headers: &std::collections::HashMap<String, String>,
+) -> LuaResult<LuaFunction> {
+    let owned: Vec<(String, String)> = headers
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    lua.create_function(move |lua, args: LuaMultiValue| -> LuaResult<LuaValue> {
+        let name = args
+            .iter()
+            .rev()
+            .find_map(|v| v.as_str().map(|s| s.to_string()));
+        match name.and_then(|n| {
+            owned
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(&n))
+                .map(|(_, v)| v.clone())
+        }) {
+            Some(v) => Ok(LuaValue::String(lua.create_string(&v)?)),
+            None => Ok(LuaValue::Nil),
+        }
+    })
+}
+
+fn build_request_ctx_table(lua: &Lua, request: &ScriptRequest) -> LuaResult<LuaTable> {
+    let t = lua.create_table()?;
+    t.set("method", request.method.clone())?;
+    t.set("path", request.path.clone())?;
+
+    let path_params = lua.create_table()?;
+    for (k, v) in &request.path_params {
+        path_params.set(k.as_str(), v.as_str())?;
+    }
+    t.set("pathParams", path_params)?;
+
+    let query = lua.create_table()?;
+    for (k, v) in &request.query {
+        query.set(k.as_str(), v.as_str())?;
+    }
+    t.set("query", query)?;
+
+    let mut lowercased = std::collections::HashMap::new();
+    for (k, v) in &request.headers {
+        lowercased.insert(k.to_ascii_lowercase(), v.clone());
+    }
+    let headers_table = lua.create_table()?;
+    for (k, v) in &lowercased {
+        headers_table.set(k.as_str(), v.as_str())?;
+    }
+    t.set("headers", headers_table)?;
+    t.set("header", make_header_getter(lua, &request.headers)?)?;
+
+    // ctx.request.body is always the raw string (issue #357 Item 1); fall back to
+    // re-serializing the parsed `body` for callers that only populated that field.
+    let raw = request.raw_body.clone().unwrap_or_else(|| {
+        if request.body.is_null() {
+            String::new()
+        } else {
+            serde_json::to_string(&request.body).unwrap_or_default()
+        }
+    });
+    t.set("json", parse_json_or_nil(lua, &raw)?)?;
+    t.set("body", raw)?;
+
+    Ok(t)
+}
+
+fn build_response_ctx_table(lua: &Lua, response: &ScriptResponseContext) -> LuaResult<LuaTable> {
+    let t = lua.create_table()?;
+    t.set("status", response.status)?;
+    let headers_table = lua.create_table()?;
+    for (k, v) in &response.headers {
+        headers_table.set(k.to_ascii_lowercase(), v.as_str())?;
+    }
+    t.set("headers", headers_table)?;
+    t.set("header", make_header_getter(lua, &response.headers)?)?;
+    t.set("json", parse_json_or_nil(lua, &response.body)?)?;
+    t.set("body", response.body.clone())?;
+    Ok(t)
+}
+
+fn build_stub_ctx_table(lua: &Lua, stub: &ScriptStubContext) -> LuaResult<LuaTable> {
+    let t = lua.create_table()?;
+    t.set("scenarioName", stub.scenario_name.clone())?;
+    t.set("scenarioState", stub.scenario_state.clone())?;
+    t.set("id", stub.stub_id.clone())?;
+    Ok(t)
+}
+
+/// Flow-state handle bound to one flow id — `ctx.state` and the value returned by
+/// `ctx.store:flow(id)` (issue #357 Item 1).
+struct LuaStateHandle {
+    inner: LuaFlowStore,
+    flow_id: String,
+}
+
+impl LuaStateHandle {
+    fn new(store: Arc<dyn FlowStore>, flow_id: String) -> Self {
+        Self {
+            inner: LuaFlowStore::new(store),
+            flow_id,
+        }
+    }
+}
+
+impl LuaUserData for LuaStateHandle {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("get", |lua, this, key: String| {
+            this.inner.get(lua, this.flow_id.clone(), key)
+        });
+        methods.add_method("set", |lua, this, (key, value): (String, LuaValue)| {
+            this.inner.set(lua, this.flow_id.clone(), key, value)
+        });
+        methods.add_method("incr", |_lua, this, key: String| {
+            this.inner.increment(this.flow_id.clone(), key)
+        });
+        methods.add_method("exists", |_lua, this, key: String| {
+            this.inner.exists(this.flow_id.clone(), key)
+        });
+        methods.add_method("delete", |_lua, this, key: String| {
+            this.inner.delete(this.flow_id.clone(), key)
+        });
+    }
+}
+
+/// `ctx.store`: the flow-store escape hatch (issue #357 Item 1) — `:flow(id)` returns a handle
+/// scoped to an arbitrary flow id.
+struct LuaStoreHandle {
+    store: Arc<dyn FlowStore>,
+}
+
+impl LuaUserData for LuaStoreHandle {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("flow", |_lua, this, flow_id: String| {
+            Ok(LuaStateHandle::new(Arc::clone(&this.store), flow_id))
+        });
+    }
+}
+
+/// `ctx.logger`: real `debug`/`info`/`warn`/`error`, routed to `tracing` at target
+/// `"rift::script"` (issue #357 Item 1, reusing P1's logging target — issue #355).
+struct LuaLoggerHandle {
+    port: u16,
+    stub_id: Option<String>,
+}
+
+impl LuaLoggerHandle {
+    fn log(&self, level: tracing::Level, message: &str) {
+        let port = self.port;
+        let stub_id = self.stub_id.as_deref().unwrap_or("");
+        match level {
+            tracing::Level::DEBUG => {
+                tracing::debug!(target: "rift::script", port, stub_id, "{message}")
+            }
+            tracing::Level::INFO => {
+                tracing::info!(target: "rift::script", port, stub_id, "{message}")
+            }
+            tracing::Level::WARN => {
+                tracing::warn!(target: "rift::script", port, stub_id, "{message}")
+            }
+            _ => tracing::error!(target: "rift::script", port, stub_id, "{message}"),
+        }
+    }
+}
+
+impl LuaUserData for LuaLoggerHandle {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("debug", |_lua, this, message: String| {
+            this.log(tracing::Level::DEBUG, &message);
+            Ok(())
+        });
+        methods.add_method("info", |_lua, this, message: String| {
+            this.log(tracing::Level::INFO, &message);
+            Ok(())
+        });
+        methods.add_method("warn", |_lua, this, message: String| {
+            this.log(tracing::Level::WARN, &message);
+            Ok(())
+        });
+        methods.add_method("error", |_lua, this, message: String| {
+            this.log(tracing::Level::ERROR, &message);
+            Ok(())
+        });
+    }
+}
+
+/// The v2 result-constructor builder (issue #357 Item 3): `http()`/`delay()`/`reset()`/`pass()`
+/// all produce one of these; `:header(k, v)` mutates and returns a clone for chaining.
+#[derive(Clone)]
+struct LuaScriptResultHandle(ScriptResult);
+
+impl LuaUserData for LuaScriptResultHandle {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method_mut("header", |_lua, this, (k, v): (String, String)| {
+            this.0.add_header(k, v);
+            Ok(this.clone())
+        });
+    }
+}
+
+fn clamp_u16(n: i64) -> u16 {
+    n.clamp(0, i64::from(u16::MAX)) as u16
+}
+
+fn lua_value_to_script_result_body(lua: &Lua, value: LuaValue) -> LuaResult<ScriptResultBody> {
+    match &value {
+        LuaValue::String(s) => Ok(ScriptResultBody::Str(s.to_str()?.to_string())),
+        _ => Ok(ScriptResultBody::Json(lua_to_json(lua, value)?)),
+    }
+}
+
+/// Register the v2 result constructors (issue #357 Item 3) as globals on `lua`. Cheap and
+/// idempotent, so it's called on every entrypoint run rather than requiring every `Lua::new()`
+/// call site in this module to remember to register them once.
+fn register_result_constructors(lua: &Lua) -> LuaResult<()> {
+    let globals = lua.globals();
+
+    let http_fn = lua.create_function(
+        |lua, args: LuaMultiValue| -> LuaResult<LuaScriptResultHandle> {
+            let mut it = args.into_iter();
+            let status = it.next().and_then(|v| v.as_i64()).unwrap_or(200);
+            let body = match it.next() {
+                None | Some(LuaValue::Nil) => None,
+                Some(v) => Some(lua_value_to_script_result_body(lua, v)?),
+            };
+            Ok(LuaScriptResultHandle(ScriptResult::http(
+                clamp_u16(status),
+                body,
+            )))
+        },
+    )?;
+    globals.set("http", http_fn)?;
+
+    let delay_fn = lua.create_function(|_lua, ms: i64| {
+        Ok(LuaScriptResultHandle(ScriptResult::Delay(ms.max(0) as u64)))
+    })?;
+    globals.set("delay", delay_fn)?;
+
+    let reset_fn =
+        lua.create_function(|_lua, ()| Ok(LuaScriptResultHandle(ScriptResult::Reset)))?;
+    globals.set("reset", reset_fn)?;
+
+    let pass_fn = lua.create_function(|_lua, ()| Ok(LuaScriptResultHandle(ScriptResult::Pass)))?;
+    globals.set("pass", pass_fn)?;
+
+    Ok(())
+}
+
+fn lua_value_to_fault_decision(value: LuaValue, rule_id: &str) -> Result<FaultDecision> {
+    match value {
+        LuaValue::Nil => Ok(FaultDecision::None),
+        LuaValue::UserData(ud) => {
+            let handle = ud
+                .borrow::<LuaScriptResultHandle>()
+                .map_err(|e| anyhow!("respond(ctx) result error: {e}"))?;
+            Ok(handle.0.clone().into_fault_decision(rule_id))
+        }
+        _ => Err(anyhow!(
+            "respond(ctx) must return http(...)/delay(...)/reset()/pass() or nothing"
+        )),
+    }
+}
+
+/// Build the v2 `ctx` table (issue #357 Item 1): identical field names/semantics across engines —
+/// see the doc comment on [`ScriptCtxInput`].
+fn build_ctx_table(
+    lua: &Lua,
+    input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> LuaResult<LuaTable> {
+    let ctx = lua.create_table()?;
+    ctx.set("request", build_request_ctx_table(lua, input.request)?)?;
+    if let Some(resp) = &input.response {
+        ctx.set("response", build_response_ctx_table(lua, resp)?)?;
+    }
+    ctx.set("flowId", input.flow_id.clone())?;
+    ctx.set("stub", build_stub_ctx_table(lua, &input.stub)?)?;
+    ctx.set(
+        "state",
+        LuaStateHandle::new(Arc::clone(&flow_store), input.flow_id.clone()),
+    )?;
+    ctx.set(
+        "store",
+        LuaStoreHandle {
+            store: Arc::clone(&flow_store),
+        },
+    )?;
+    ctx.set(
+        "logger",
+        LuaLoggerHandle {
+            port: input.port,
+            stub_id: input.stub.stub_id.clone(),
+        },
+    )?;
+    Ok(ctx)
+}
+
+/// Run one v2-placement entrypoint or its v1 `should_inject` fallback (issue #357 Items 2/4).
+/// Detection: the loaded chunk is called once (globals `request`/`flow_store`/`ctx` already set,
+/// so both forms have what they need); its return value is the bare-expression result. Then: a
+/// global `should_inject` AND `entrypoint == "respond"` → v1 (call it with the v1 args). Else a
+/// global function named `entrypoint` → v2 named (call it with `ctx`). Else → v2 bare (the
+/// chunk's own return value from the single call above).
+fn run_entrypoint_lua(
+    lua: &Lua,
+    chunk_fn: &LuaFunction,
+    entrypoint: &str,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> Result<LuaEntrypointOutcome> {
+    let request_table = build_v1_request_table(lua, request)
+        .map_err(|e| anyhow!("Failed to build request: {e}"))?;
+    let flow_store_ud = lua
+        .create_userdata(LuaFlowStore::new(Arc::clone(&flow_store)))
+        .map_err(|e| anyhow!("Failed to create flow_store userdata: {e}"))?;
+    let ctx_table = build_ctx_table(lua, ctx_input, flow_store)
+        .map_err(|e| anyhow!("Failed to build ctx: {e}"))?;
+    register_result_constructors(lua).map_err(|e| anyhow!("Failed to register result API: {e}"))?;
+
+    let globals = lua.globals();
+    globals
+        .set("request", request_table.clone())
+        .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
+    globals
+        .set("flow_store", flow_store_ud.clone())
+        .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
+    globals
+        .set("ctx", ctx_table.clone())
+        .map_err(|e| anyhow!("Failed to set ctx global: {e}"))?;
+
+    // Snapshot the global names present BEFORE running the chunk, so afterwards we can tell which
+    // function globals the SCRIPT itself declared (B1): Lua builtins plus the request/flow_store/
+    // ctx/http/delay/reset/pass globals we set above are all already present here.
+    let pre_existing: std::collections::HashSet<String> = globals
+        .pairs::<LuaValue, LuaValue>()
+        .filter_map(|pair| pair.ok())
+        .filter_map(|(k, _)| lua_string_key(&k))
+        .collect();
+
+    let bare_result: LuaValue = chunk_fn
+        .call(())
+        .map_err(|e| anyhow!("Script execution error: {e}"))?;
+
+    if entrypoint == entrypoints::RESPOND
+        && let Ok(f) = globals.get::<LuaFunction>(entrypoints::SHOULD_INJECT)
+    {
+        let result: LuaValue = f
+            .call((request_table, flow_store_ud))
+            .map_err(|e| anyhow!("Failed to call should_inject: {e}"))?;
+        return Ok(LuaEntrypointOutcome::V1(result));
+    }
+
+    if let Ok(f) = globals.get::<LuaFunction>(entrypoint) {
+        let result: LuaValue = f
+            .call(ctx_table)
+            .map_err(|e| anyhow!("Failed to call {entrypoint}(ctx): {e}"))?;
+        return Ok(LuaEntrypointOutcome::V2(result));
+    }
+
+    // B1 (issue #357, "nothing fails silently"): if the script DECLARED a function global that
+    // isn't the requested entrypoint (nor `should_inject`) and produced no bare-expression value
+    // (nil), it almost certainly has a MISNAMED entrypoint (e.g. `function respnod(ctx)`).
+    // Falling through to `bare_result` (nil → `None`) would silently serve a normal response with
+    // no sign the script never ran. Surface it as an explicit error instead. A genuine bare
+    // expression is still fine: it either declared no new functions, or produced a non-nil value.
+    if matches!(bare_result, LuaValue::Nil) {
+        let declared_a_function = globals
+            .pairs::<LuaValue, LuaValue>()
+            .filter_map(|pair| pair.ok())
+            .any(|(k, v)| {
+                matches!(v, LuaValue::Function(_))
+                    && lua_string_key(&k).is_some_and(|name| !pre_existing.contains(&name))
+            });
+        if declared_a_function {
+            return Err(anyhow!(
+                "script defines function(s) but none is the `{entrypoint}` entrypoint \
+                 (and there is no bare expression to evaluate); did you mean `{entrypoint}`?"
+            ));
+        }
+    }
+
+    Ok(LuaEntrypointOutcome::V2(bare_result))
+}
+
+/// A Lua value's string key as an owned `String`, or `None` for non-string keys.
+fn lua_string_key(k: &LuaValue) -> Option<String> {
+    match k {
+        LuaValue::String(s) => s.to_str().ok().map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
+/// `respond(ctx)` (issue #357 Item 2): the response-script entrypoint. Auto-detects the v1
+/// `should_inject` wrapper (issue #357 Item 4).
+fn call_respond_lua(
+    lua: &Lua,
+    chunk_fn: &LuaFunction,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+    rule_id: &str,
+) -> Result<FaultDecision> {
+    match run_entrypoint_lua(
+        lua,
+        chunk_fn,
+        entrypoints::RESPOND,
+        request,
+        ctx_input,
+        flow_store,
+    )? {
+        LuaEntrypointOutcome::V1(v) => {
+            let t: LuaTable = match v {
+                LuaValue::Table(t) => t,
+                _ => return Err(anyhow!("should_inject must return a table")),
+            };
+            parse_fault_decision_lua(lua, t, rule_id)
+        }
+        LuaEntrypointOutcome::V2(v) => lua_value_to_fault_decision(v, rule_id),
     }
 }
 
@@ -806,6 +972,7 @@ pub fn run_should_inject_with_abort_lua(
     request: &ScriptRequest,
     flow_store: Arc<dyn FlowStore>,
     abort: &Arc<AtomicBool>,
+    ctx_extra: &ScriptCtxExtras,
 ) -> Result<FaultDecision> {
     let lua = Lua::new();
     // Disable JIT: LuaJIT trace-compiles hot loops (e.g. `while true do end`) into machine
@@ -830,7 +997,12 @@ pub fn run_should_inject_with_abort_lua(
         },
     );
     let bytecode = compile_to_bytecode(code)?;
-    execute_lua_bytecode(&lua, &bytecode, request, flow_store, rule_id)
+    let chunk_fn = lua
+        .load(&bytecode)
+        .into_function()
+        .map_err(|e| anyhow!("Failed to load bytecode: {e}"))?;
+    let ctx_input = ctx_extra.build_ctx_input(request);
+    call_respond_lua(&lua, &chunk_fn, request, &ctx_input, flow_store, rule_id)
 }
 
 #[cfg(test)]
@@ -853,7 +1025,10 @@ end
     }
 
     #[tokio::test]
-    async fn test_lua_engine_missing_function() {
+    async fn test_lua_engine_without_should_inject_still_constructs() {
+        // Issue #357 Item 4: a script defining neither `should_inject` (v1) nor a v2 named
+        // entrypoint is now legal — it's a v2 bare-expression script (Item 2). Construction only
+        // validates that the script compiles.
         let script = r#"
 function some_other_function()
     return true
@@ -861,8 +1036,21 @@ end
 "#;
 
         let engine = LuaEngine::new(script, "test-rule");
-        assert!(engine.is_err());
-        assert!(engine.unwrap_err().to_string().contains("should_inject"));
+        assert!(
+            engine.is_ok(),
+            "bare/helper-only scripts must construct: {:?}",
+            engine.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lua_engine_syntax_error_fails_construction() {
+        let script = "function should_inject(request, flow_store {  -- missing paren";
+        let engine = LuaEngine::new(script, "test-rule");
+        assert!(
+            engine.is_err(),
+            "a genuine syntax error must still fail construction"
+        );
     }
 
     #[tokio::test]
@@ -888,6 +1076,7 @@ end
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -923,6 +1112,7 @@ end
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -972,6 +1162,7 @@ end
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -1040,6 +1231,7 @@ end
         let store: Arc<dyn FlowStore> = Arc::new(FailingGetFlowStore);
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
             headers: HashMap::new(),
@@ -1094,6 +1286,7 @@ end
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -1137,6 +1330,7 @@ end
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -1171,6 +1365,7 @@ end
 
         // Verify that we can execute a different request with the same state
         let request2 = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/other".to_string(),
             headers: HashMap::new(),
@@ -1215,6 +1410,7 @@ end
             headers.insert("x-flow-id".to_string(), "flow-A".to_string());
 
             let request = ScriptRequest {
+                raw_body: None,
                 method: "GET".to_string(),
                 path: "/api/test".to_string(),
                 headers,
@@ -1241,6 +1437,7 @@ end
         headers_b.insert("x-flow-id".to_string(), "flow-B".to_string());
 
         let request_b = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: headers_b,
@@ -1266,6 +1463,7 @@ end
         headers_a2.insert("x-flow-id".to_string(), "flow-A".to_string());
 
         let request_a2 = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: headers_a2,
@@ -1303,6 +1501,7 @@ end
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -1358,6 +1557,7 @@ end
 
         // Test with high value
         let request1 = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -1385,6 +1585,7 @@ end
 
         // Test with low value
         let request2 = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -1462,6 +1663,7 @@ end
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/bytecode".to_string(),
             headers,
@@ -1519,6 +1721,7 @@ end
         headers.insert("x-flow-id".to_string(), "flow-456".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers,
@@ -1568,6 +1771,7 @@ end
         query.insert("page".to_string(), "42".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -1614,6 +1818,7 @@ end
         path_params.insert("action".to_string(), "update".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/users/123/update".to_string(),
             headers: HashMap::new(),
@@ -1630,6 +1835,262 @@ end
                 assert_eq!(body, "User 123 action: update");
             }
             _ => panic!("Expected error fault decision with path params"),
+        }
+    }
+
+    // ============================================
+    // Issue #357: unified ctx, v2 respond entrypoint, result constructors (Lua)
+    // ============================================
+    mod v2 {
+        use super::*;
+
+        fn req(headers: HashMap<String, String>, raw_body: Option<&str>) -> ScriptRequest {
+            ScriptRequest {
+                method: "POST".to_string(),
+                path: "/api/orders".to_string(),
+                headers,
+                body: json!(null),
+                query: HashMap::new(),
+                path_params: HashMap::new(),
+                raw_body: raw_body.map(|s| s.to_string()),
+            }
+        }
+
+        fn store() -> Arc<dyn FlowStore> {
+            Arc::new(InMemoryFlowStore::new(300))
+        }
+
+        fn run_respond(script: &str, request: &ScriptRequest) -> Result<FaultDecision> {
+            let engine = LuaEngine::new(script, "v2-rule").unwrap();
+            engine.should_inject(request, store())
+        }
+
+        #[tokio::test]
+        async fn respond_named_wrapper() {
+            let script = r#"
+                function respond(ctx)
+                    return http(503, { error = "unavailable" })
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error {
+                    status,
+                    body,
+                    headers,
+                    ..
+                } => {
+                    assert_eq!(status, 503);
+                    assert!(body.contains("unavailable"));
+                    assert_eq!(
+                        headers.get("Content-Type").map(String::as_str),
+                        Some("application/json")
+                    );
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn respond_bare_expression() {
+            let script = r#"
+                if ctx.request.method == "POST" then
+                    return http(503, { error = "unavailable" })
+                else
+                    return pass()
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        #[tokio::test]
+        async fn ctx_request_header_case_insensitive() {
+            let headers = HashMap::from([("X-Flow-Id".to_string(), "flow-9".to_string())]);
+            let script = r#"
+                function respond(ctx)
+                    local v = ctx.request:header("x-flow-id")
+                    return http(200, { seen = v })
+                end
+            "#;
+            let decision = run_respond(script, &req(headers, None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("flow-9"));
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn ctx_request_json_lazy_parse() {
+            let script = r#"
+                function respond(ctx)
+                    if ctx.request.json == nil then
+                        return http(500)
+                    end
+                    return http(200, { n = ctx.request.json.n })
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), Some(r#"{"n": 7}"#))).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains('7'));
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+
+            let decision2 = run_respond(script, &req(HashMap::new(), Some("not json"))).unwrap();
+            assert!(matches!(
+                decision2,
+                FaultDecision::Error { status: 500, .. }
+            ));
+        }
+
+        #[tokio::test]
+        async fn result_constructors_delay_reset_pass() {
+            let delay = run_respond(
+                "function respond(ctx) return delay(42) end",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            match delay {
+                FaultDecision::Latency { duration_ms, .. } => assert_eq!(duration_ms, 42),
+                other => panic!("expected Latency, got {other:?}"),
+            }
+
+            let reset = run_respond(
+                "function respond(ctx) return reset() end",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            assert!(matches!(reset, FaultDecision::Reset { .. }));
+
+            let pass = run_respond(
+                "function respond(ctx) return pass() end",
+                &req(HashMap::new(), None),
+            )
+            .unwrap();
+            assert!(matches!(pass, FaultDecision::None));
+
+            let nothing =
+                run_respond("function respond(ctx) end", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(nothing, FaultDecision::None));
+        }
+
+        #[tokio::test]
+        async fn http_string_body_passes_through_verbatim() {
+            let script = r#"function respond(ctx) return http(200, "hello world") end"#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, headers, .. } => {
+                    assert_eq!(body, "hello world");
+                    assert!(!headers.contains_key("Content-Type"));
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        // v1 back-compat: `should_inject` still wins (issue #357 Item 4).
+        #[tokio::test]
+        async fn v1_should_inject_still_works_unchanged() {
+            let script = r#"
+                function should_inject(request, flow_store)
+                    return { inject = true, fault = "error", status = 418, body = "teapot" }
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 418);
+                    assert_eq!(body, "teapot");
+                }
+                other => panic!("expected v1 Error decision, got {other:?}"),
+            }
+        }
+
+        // Retry example from the issue: ctx.state:incr + http() executes end-to-end.
+        #[tokio::test]
+        async fn retry_example_end_to_end_with_ctx_state_incr() {
+            let script = r#"
+                function respond(ctx)
+                    local n = ctx.state:incr("attempts")
+                    if n <= 2 then
+                        return http(503, { error = "unavailable", attempt = n }):header("Retry-After", "1")
+                    end
+                    return http(200, { ok = true, succeededOnAttempt = n })
+                end
+            "#;
+            let engine = LuaEngine::new(script, "retry-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d1, FaultDecision::Error { status: 503, .. }));
+
+            let d2 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d2, FaultDecision::Error { status: 503, .. }));
+
+            let d3 = engine.should_inject(&request, shared_store).unwrap();
+            match d3 {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("succeededOnAttempt"));
+                }
+                other => panic!("expected 200 on third attempt, got {other:?}"),
+            }
+        }
+
+        // B1 (issue #357): a script defining ONLY a misnamed entrypoint must Err, not None.
+        #[tokio::test]
+        async fn misnamed_entrypoint_errors_not_none() {
+            let script = r#"
+                function respnod(ctx)
+                    return http(500)
+                end
+            "#;
+            let result = LuaEngine::new(script, "v2-rule")
+                .unwrap()
+                .should_inject(&req(HashMap::new(), None), store());
+            assert!(
+                result.is_err(),
+                "a misnamed entrypoint must surface an error, got {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn genuine_bare_expression_still_ok_after_b1() {
+            let decision = run_respond("return http(503)", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        // ctx.request.pathParams and ctx.request.query round-trip (mirrors the Rhai test).
+        #[tokio::test]
+        async fn ctx_request_path_params_and_query() {
+            let mut request = req(HashMap::new(), None);
+            request
+                .path_params
+                .insert("id".to_string(), "42".to_string());
+            request.query.insert("page".to_string(), "2".to_string());
+            let script = r#"
+                function respond(ctx)
+                    return http(200, { id = ctx.request.pathParams.id, page = ctx.request.query.page })
+                end
+            "#;
+            let decision = run_respond(script, &request).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("42"), "pathParams.id missing: {body}");
+                    assert!(body.contains('2'), "query.page missing: {body}");
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
         }
     }
 }

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 mod bounded;
 mod compiled_cache;
 mod rhai_engine;
-pub use bounded::{DEFAULT_SCRIPT_TIMEOUT_MS, resolve_script_timeout_ms, should_inject_bounded};
+pub use bounded::{
+    DEFAULT_SCRIPT_TIMEOUT_MS, resolve_script_timeout_ms, should_inject_bounded,
+    should_inject_bounded_with_ctx,
+};
 
 pub use rhai_engine::RhaiEngine;
 
@@ -90,6 +93,208 @@ pub enum FaultDecision {
         rule_id: String,
         headers: std::collections::HashMap<String, String>,
     },
+    /// Connection reset, requested via the v2 `reset()` result constructor (issue #357 Item 3) —
+    /// the scripting analogue of the Mountebank-compatible `_rift.fault.tcp` / top-level `fault`
+    /// carrier (see `imposter::fault_io::TcpFaultKind`). Callers apply it the same way: attach
+    /// `TcpFaultKind::Reset` to a carrier response's extensions so the serve loop's `FaultIo`
+    /// aborts the connection instead of framing a clean HTTP response.
+    Reset {
+        rule_id: String,
+    },
+}
+
+/// Everything about the calling stub thread into `ctx.stub` (issue #357 Item 1). Fields are
+/// `None` where unavailable, mirroring P1's `stub_id` contract (issue #355).
+#[derive(Debug, Clone, Default)]
+pub struct ScriptStubContext {
+    pub scenario_name: Option<String>,
+    pub scenario_state: Option<String>,
+    pub stub_id: Option<String>,
+}
+
+/// The in-flight response, exposed as `ctx.response` on transform/decorate hooks only (issue
+/// #357 Item 1). Absent (`None` on `ScriptCtxInput`) for every other hook point.
+#[derive(Debug, Clone)]
+pub struct ScriptResponseContext {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+}
+
+/// Everything the shared `ctx` builder (issue #357 Item 1) needs, engine-agnostic. Each engine
+/// (`rhai_engine`, `lua_engine`, `js_engine`) turns this into its own native `ctx` value; the
+/// field names/semantics are identical across engines by contract — keep them that way.
+#[derive(Debug, Clone)]
+pub struct ScriptCtxInput<'a> {
+    pub request: &'a ScriptRequest,
+    pub response: Option<ScriptResponseContext>,
+    pub flow_id: String,
+    pub stub: ScriptStubContext,
+    /// Imposter port, used only to tag `ctx.logger` output; 0 when not running under an imposter
+    /// (e.g. the proxy path, or a bare `ScriptEngine::should_inject_fault` call in tests).
+    pub port: u16,
+}
+
+impl<'a> ScriptCtxInput<'a> {
+    pub fn new(request: &'a ScriptRequest, flow_id: impl Into<String>) -> Self {
+        Self {
+            request,
+            response: None,
+            flow_id: flow_id.into(),
+            stub: ScriptStubContext::default(),
+            port: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn with_response(mut self, response: ScriptResponseContext) -> Self {
+        self.response = Some(response);
+        self
+    }
+
+    #[must_use]
+    pub fn with_stub(mut self, stub: ScriptStubContext) -> Self {
+        self.stub = stub;
+        self
+    }
+
+    #[must_use]
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+}
+
+/// Extra, optional context a caller can thread into `ctx` beyond the bare `(request, flow_store)`
+/// pair (issue #357 Item 1). Callers with no imposter context (the proxy path, direct engine unit
+/// tests) use `Default`, which falls back to `request.headers["x-flow-id"]` (or `""`) for
+/// `ctx.flowId` and leaves `ctx.stub` fields `None` — the real HTTP path
+/// (`imposter::handler`) supplies the resolved flow id and stub metadata for full fidelity.
+#[derive(Debug, Clone, Default)]
+pub struct ScriptCtxExtras {
+    pub flow_id: Option<String>,
+    pub stub: ScriptStubContext,
+    pub port: u16,
+}
+
+impl ScriptCtxExtras {
+    pub fn build_ctx_input<'a>(&self, request: &'a ScriptRequest) -> ScriptCtxInput<'a> {
+        let flow_id = self.flow_id.clone().unwrap_or_else(|| {
+            request
+                .headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case("x-flow-id"))
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default()
+        });
+        ScriptCtxInput::new(request, flow_id)
+            .with_stub(self.stub.clone())
+            .with_port(self.port)
+    }
+}
+
+/// A `respond`/bare-expression return value that isn't a string or a JSON-shaped value (issue
+/// #357 Item 3 — body values). `http(status, body)` decides which of these to serialize based on
+/// the script value's own type: a string passes through verbatim; a map/array is JSON-serialized.
+#[derive(Debug, Clone)]
+pub enum ScriptResultBody {
+    Json(Value),
+    Str(String),
+}
+
+/// The v2 result constructors (issue #357 Item 3), engine-agnostic: `http()`/`delay()`/`reset()`/
+/// `pass()` all build one of these, which `into_fault_decision` then turns into the
+/// [`FaultDecision`] the caller applies. Each engine wraps this in its own native "builder" value
+/// so `.header(k, v)` can chain.
+#[derive(Debug, Clone)]
+pub enum ScriptResult {
+    /// `pass()` or a script returning nothing: respond normally, no injection.
+    Pass,
+    /// `delay(ms)`.
+    Delay(u64),
+    /// `reset()`: connection reset (the old `fault: "tcp"` shape).
+    Reset,
+    /// `http(status, body?)`, with zero or more `.header(k, v)` calls applied.
+    Http {
+        status: u16,
+        body: Option<ScriptResultBody>,
+        headers: Vec<(String, String)>,
+    },
+}
+
+impl ScriptResult {
+    pub fn http(status: u16, body: Option<ScriptResultBody>) -> Self {
+        ScriptResult::Http {
+            status,
+            body,
+            headers: Vec::new(),
+        }
+    }
+
+    /// Apply a `.header(k, v)` builder call. A no-op on `Delay`/`Reset`/`Pass` — only `http()`
+    /// results carry headers.
+    pub fn add_header(&mut self, key: String, value: String) {
+        if let ScriptResult::Http { headers, .. } = self {
+            headers.push((key, value));
+        }
+    }
+
+    /// Convert a result constructor (issue #357 Item 3) into the [`FaultDecision`] the caller
+    /// applies. A JSON `body` gets `Content-Type: application/json` UNLESS the script already set
+    /// a `content-type` header itself (case-insensitive match; an explicit header always wins).
+    pub fn into_fault_decision(self, rule_id: &str) -> FaultDecision {
+        match self {
+            ScriptResult::Pass => FaultDecision::None,
+            ScriptResult::Delay(duration_ms) => FaultDecision::Latency {
+                duration_ms,
+                rule_id: rule_id.to_string(),
+            },
+            ScriptResult::Reset => FaultDecision::Reset {
+                rule_id: rule_id.to_string(),
+            },
+            ScriptResult::Http {
+                status,
+                body,
+                headers,
+            } => {
+                let mut header_map: HashMap<String, String> = HashMap::new();
+                let mut has_content_type = false;
+                for (k, v) in headers {
+                    if k.eq_ignore_ascii_case("content-type") {
+                        has_content_type = true;
+                    }
+                    header_map.insert(k, v);
+                }
+                let body_str = match body {
+                    None => String::new(),
+                    Some(ScriptResultBody::Str(s)) => s,
+                    Some(ScriptResultBody::Json(v)) => {
+                        if !has_content_type {
+                            header_map
+                                .insert("Content-Type".to_string(), "application/json".to_string());
+                        }
+                        serde_json::to_string(&v).unwrap_or_default()
+                    }
+                };
+                FaultDecision::Error {
+                    status,
+                    body: body_str,
+                    rule_id: rule_id.to_string(),
+                    headers: header_map,
+                }
+            }
+        }
+    }
+}
+
+/// Names of the v2 named entrypoints and the v1 back-compat wrapper (issue #357 Items 2/4).
+/// Placement determines which v2 name a hook looks for; `should_inject` always means v1.
+pub mod entrypoints {
+    pub const RESPOND: &str = "respond";
+    pub const MATCHES: &str = "matches";
+    pub const TRANSFORM: &str = "transform";
+    pub const DELAY: &str = "delay";
+    pub const SHOULD_INJECT: &str = "should_inject";
 }
 
 /// Unified script engine that supports Rhai, Lua, and JavaScript
@@ -124,18 +329,37 @@ impl ScriptEngine {
         }
     }
 
-    /// Execute the script and determine if a fault should be injected
+    /// Execute the script and determine if a fault should be injected. Auto-detects v1
+    /// (`should_inject(request, flow_store)`) vs v2 (`respond(ctx)` or bare) scripts (issue #357
+    /// Item 4). `ctx` gets best-effort defaults ([`ScriptCtxExtras::default`]) — callers with real
+    /// flow-id/stub context should use [`Self::should_inject_fault_with_ctx`] instead.
     pub fn should_inject_fault(
         &self,
         request: &ScriptRequest,
         flow_store: Arc<dyn FlowStore>,
     ) -> Result<FaultDecision> {
+        self.should_inject_fault_with_ctx(request, flow_store, &ScriptCtxExtras::default())
+    }
+
+    /// As [`Self::should_inject_fault`], but with real `ctx.flowId`/`ctx.stub` context (issue
+    /// #357 Item 1) — used by the imposter `_rift.script` hook, which knows the resolved flow id
+    /// and matched stub.
+    pub fn should_inject_fault_with_ctx(
+        &self,
+        request: &ScriptRequest,
+        flow_store: Arc<dyn FlowStore>,
+        extra: &ScriptCtxExtras,
+    ) -> Result<FaultDecision> {
         match self {
-            ScriptEngine::Rhai(engine) => engine.should_inject_fault(request, flow_store),
+            ScriptEngine::Rhai(engine) => {
+                engine.should_inject_fault_with_ctx(request, flow_store, extra)
+            }
             #[cfg(feature = "lua")]
-            ScriptEngine::Lua(engine) => engine.should_inject(request, flow_store),
+            ScriptEngine::Lua(engine) => engine.should_inject_with_ctx(request, flow_store, extra),
             #[cfg(feature = "javascript")]
-            ScriptEngine::JavaScript(engine) => engine.should_inject(request, flow_store),
+            ScriptEngine::JavaScript(engine) => {
+                engine.should_inject_with_ctx(request, flow_store, extra)
+            }
         }
     }
 }
@@ -152,6 +376,12 @@ pub struct ScriptRequest {
     pub query: HashMap<String, String>,
     /// Path parameters extracted from route patterns (e.g., /users/:id)
     pub path_params: HashMap<String, String>,
+    /// The raw request body text, exactly as received (issue #357 Item 1: `ctx.request.body` is
+    /// always the raw string, unifying the old split where the Mountebank path kept a raw string
+    /// and the `_rift.script` path kept parsed JSON). `None` when the caller only has/derives a
+    /// parsed `body`; ctx-building then falls back to re-serializing `body` (loses exact
+    /// whitespace but not shape) so callers migrated ad hoc from `body` alone still work.
+    pub raw_body: Option<String>,
 }
 
 /// Wrapper for FlowStore that can be used in scripts (both Rhai and Lua)
@@ -269,6 +499,7 @@ impl ScriptFlowStore {
 mod tests {
     use super::*;
     use crate::extensions::flow_state::NoOpFlowStore;
+    use serde_json::json;
     use std::collections::HashMap;
 
     /// A flow store whose every op fails — for exercising the error branches of the wrappers.
@@ -462,6 +693,84 @@ mod tests {
         assert!(debug_str.contains("None"));
     }
 
+    // Issue #357 Item 3: `reset()` maps to FaultDecision::Reset.
+    #[test]
+    fn test_fault_decision_reset() {
+        let decision = FaultDecision::Reset {
+            rule_id: "reset-rule".to_string(),
+        };
+        match decision {
+            FaultDecision::Reset { rule_id } => assert_eq!(rule_id, "reset-rule"),
+            _ => panic!("Expected FaultDecision::Reset"),
+        }
+    }
+
+    // Issue #357 Item 3: the ScriptResult -> FaultDecision conversions used by every engine.
+    #[test]
+    fn test_script_result_into_fault_decision() {
+        assert!(matches!(
+            ScriptResult::Pass.into_fault_decision("r"),
+            FaultDecision::None
+        ));
+        assert!(matches!(
+            ScriptResult::Delay(42).into_fault_decision("r"),
+            FaultDecision::Latency {
+                duration_ms: 42,
+                ..
+            }
+        ));
+        assert!(matches!(
+            ScriptResult::Reset.into_fault_decision("r"),
+            FaultDecision::Reset { .. }
+        ));
+
+        let mut json_result =
+            ScriptResult::http(503, Some(ScriptResultBody::Json(json!({"e": 1}))));
+        json_result.add_header("Retry-After".to_string(), "1".to_string());
+        match json_result.into_fault_decision("r") {
+            FaultDecision::Error {
+                status,
+                body,
+                headers,
+                ..
+            } => {
+                assert_eq!(status, 503);
+                assert_eq!(body, r#"{"e":1}"#);
+                assert_eq!(headers.get("Retry-After").map(String::as_str), Some("1"));
+                assert_eq!(
+                    headers.get("Content-Type").map(String::as_str),
+                    Some("application/json")
+                );
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // An explicit content-type header always wins over the JSON-body default.
+        let mut custom_ct = ScriptResult::http(200, Some(ScriptResultBody::Json(json!({}))));
+        custom_ct.add_header("content-type".to_string(), "application/custom".to_string());
+        match custom_ct.into_fault_decision("r") {
+            FaultDecision::Error { headers, .. } => {
+                assert_eq!(
+                    headers.get("content-type").map(String::as_str),
+                    Some("application/custom")
+                );
+                assert!(!headers.contains_key("Content-Type"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // A string body passes through verbatim with no Content-Type added.
+        match ScriptResult::http(200, Some(ScriptResultBody::Str("hi".to_string())))
+            .into_fault_decision("r")
+        {
+            FaultDecision::Error { body, headers, .. } => {
+                assert_eq!(body, "hi");
+                assert!(!headers.contains_key("Content-Type"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
     // ============================================
     // Tests for ScriptRequest
     // ============================================
@@ -469,6 +778,7 @@ mod tests {
     #[test]
     fn test_script_request_creation() {
         let request = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/api/users".to_string(),
             headers: HashMap::new(),
@@ -487,6 +797,7 @@ mod tests {
         headers.insert("Authorization".to_string(), "Bearer token".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/data".to_string(),
             headers,
@@ -508,6 +819,7 @@ mod tests {
         query.insert("limit".to_string(), "10".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/items".to_string(),
             headers: HashMap::new(),
@@ -526,6 +838,7 @@ mod tests {
         path_params.insert("action".to_string(), "edit".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "PUT".to_string(),
             path: "/api/users/123/edit".to_string(),
             headers: HashMap::new(),
@@ -539,6 +852,7 @@ mod tests {
     #[test]
     fn test_script_request_clone() {
         let request = ScriptRequest {
+            raw_body: None,
             method: "DELETE".to_string(),
             path: "/api/items/456".to_string(),
             headers: HashMap::new(),
@@ -554,6 +868,7 @@ mod tests {
     #[test]
     fn test_script_request_debug() {
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: HashMap::new(),
@@ -686,6 +1001,7 @@ mod tests {
         let engine = ScriptEngine::new("rhai", script, "test-rule").unwrap();
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: HashMap::new(),

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -5,7 +5,10 @@ use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use super::{FaultDecision, ScriptFlowStore, ScriptRequest};
+use super::{
+    FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptFlowStore, ScriptRequest,
+    ScriptResponseContext, ScriptResult, ScriptResultBody, entrypoints,
+};
 
 /// Helper function to check if a year is a leap year
 fn is_leap_year(year: u64) -> bool {
@@ -234,135 +237,568 @@ impl RhaiEngine {
             )
         });
 
+        register_v2_api(&mut engine);
+
         engine
     }
 
+    /// Execute the script and determine if a fault should be injected. Auto-detects v1
+    /// (`should_inject(request, flow_store)`) vs v2 (`respond(ctx)` or bare) — see
+    /// [`ScriptEngine::should_inject_fault`] for the full contract.
     pub fn should_inject_fault(
         &self,
         request: &ScriptRequest,
         flow_store: Arc<dyn FlowStore>,
     ) -> Result<FaultDecision> {
-        let engine = Self::create_engine();
-        let mut scope = Scope::new();
-
-        // Create request map
-        let request_map = create_request_map(request);
-
-        // Create flow_store wrapper
-        let flow_store_wrapper = ScriptFlowStore::new(flow_store);
-
-        // First, evaluate the AST to define the should_inject function
-        engine
-            .run_ast_with_scope(&mut scope, self.ast.as_ref())
-            .map_err(|e| anyhow!("Script execution error: {e}"))?;
-
-        // Now call the should_inject function with request and flow_store arguments
-        let result: Dynamic = engine
-            .call_fn(
-                &mut scope,
-                self.ast.as_ref(),
-                "should_inject",
-                (request_map, flow_store_wrapper),
-            )
-            .map_err(|e| anyhow!("Failed to call should_inject function: {e}"))?;
-
-        // Parse result
-        self.parse_fault_decision(result)
+        self.should_inject_fault_with_ctx(request, flow_store, &ScriptCtxExtras::default())
     }
 
-    fn parse_fault_decision(&self, result: Dynamic) -> Result<FaultDecision> {
-        if result.is_unit() {
-            return Ok(FaultDecision::None);
-        }
-
-        let map = result
-            .try_cast::<Map>()
-            .ok_or_else(|| anyhow!("Script must return a map"))?;
-
-        // Check inject flag
-        let inject = map
-            .get("inject")
-            .and_then(|v| v.as_bool().ok())
-            .unwrap_or(false);
-
-        if !inject {
-            return Ok(FaultDecision::None);
-        }
-
-        // Get fault type
-        let fault_type = map
-            .get("fault")
-            .and_then(|v| v.clone().try_cast::<String>())
-            .ok_or_else(|| anyhow!("Missing 'fault' field"))?;
-
-        match fault_type.as_str() {
-            "latency" => {
-                let duration_ms = map
-                    .get("duration_ms")
-                    .and_then(|v| v.as_int().ok())
-                    .ok_or_else(|| anyhow!("Missing 'duration_ms' for latency fault"))?;
-
-                Ok(FaultDecision::Latency {
-                    duration_ms: duration_ms as u64,
-                    rule_id: self.rule_id.clone(),
-                })
-            }
-            "error" => {
-                let status = map
-                    .get("status")
-                    .and_then(|v| v.as_int().ok())
-                    .ok_or_else(|| anyhow!("Missing 'status' for error fault"))?;
-
-                let body = map
-                    .get("body")
-                    .map(|v| {
-                        if let Some(s) = v.clone().try_cast::<String>() {
-                            s
-                        } else {
-                            match v.clone().try_cast::<Map>() {
-                                Some(m) => {
-                                    // Convert map to JSON string
-                                    serde_json::to_string(&dynamic_to_json(Dynamic::from(m)))
-                                        .unwrap_or_else(|_| "{}".to_string())
-                                }
-                                _ => {
-                                    format!("{v}")
-                                }
-                            }
-                        }
-                    })
-                    .unwrap_or_else(|| "{}".to_string());
-
-                // Extract optional headers map
-                let mut headers = std::collections::HashMap::new();
-                if let Some(headers_value) = map.get("headers")
-                    && let Some(headers_map) = headers_value.clone().try_cast::<Map>()
-                {
-                    for (key, value) in headers_map {
-                        // Try to convert value to string
-                        let value_str = if let Some(s) = value.clone().try_cast::<String>() {
-                            s
-                        } else {
-                            format!("{value}")
-                        };
-                        headers.insert(key.to_string(), value_str);
-                    }
-                }
-
-                Ok(FaultDecision::Error {
-                    status: status as u16,
-                    body,
-                    rule_id: self.rule_id.clone(),
-                    headers,
-                })
-            }
-            _ => Err(anyhow!("Unknown fault type: {fault_type}")),
-        }
+    /// As [`Self::should_inject_fault`], but with real `ctx.flowId`/`ctx.stub` context (issue
+    /// #357 Item 1).
+    pub fn should_inject_fault_with_ctx(
+        &self,
+        request: &ScriptRequest,
+        flow_store: Arc<dyn FlowStore>,
+        extra: &ScriptCtxExtras,
+    ) -> Result<FaultDecision> {
+        let engine = Self::create_engine();
+        let ctx_input = extra.build_ctx_input(request);
+        call_respond(
+            &engine,
+            self.ast.as_ref(),
+            request,
+            &ctx_input,
+            flow_store,
+            &self.rule_id,
+        )
     }
 }
 
-/// Public function to execute Rhai script with a reusable engine (for script pool)
-/// This is used by the script_pool module to execute scripts efficiently
+/// Register the v2 `ctx` API (issue #357 Items 1/3) on an [`Engine`]: `ctx.state`/`ctx.store`
+/// (flow-store handles), `ctx.logger`, the `http`/`delay`/`reset`/`pass` result constructors, and
+/// a case-insensitive `.header(name)` getter usable on `ctx.request`/`ctx.response`. Shared by
+/// `RhaiEngine::create_engine` so every caller (pooled, bounded, direct) gets the same API.
+fn register_v2_api(engine: &mut Engine) {
+    engine
+        .register_type::<RhaiStateHandle>()
+        .register_fn("get", RhaiStateHandle::get)
+        .register_fn("set", RhaiStateHandle::set)
+        .register_fn("incr", RhaiStateHandle::incr)
+        .register_fn("exists", RhaiStateHandle::exists)
+        .register_fn("delete", RhaiStateHandle::delete);
+
+    engine
+        .register_type::<RhaiStoreHandle>()
+        .register_fn("flow", RhaiStoreHandle::flow);
+
+    engine
+        .register_type::<RhaiLogger>()
+        .register_fn("debug", RhaiLogger::debug)
+        .register_fn("info", RhaiLogger::info)
+        .register_fn("warn", RhaiLogger::warn)
+        .register_fn("error", RhaiLogger::error);
+
+    engine
+        .register_type::<RhaiScriptResult>()
+        .register_fn("header", RhaiScriptResult::header);
+
+    engine.register_fn("http", |status: i64| {
+        RhaiScriptResult(ScriptResult::http(clamp_u16(status), None))
+    });
+    engine.register_fn("http", |status: i64, body: Dynamic| {
+        RhaiScriptResult(ScriptResult::http(
+            clamp_u16(status),
+            Some(dynamic_to_script_result_body(body)),
+        ))
+    });
+    engine.register_fn("delay", |ms: i64| {
+        RhaiScriptResult(ScriptResult::Delay(ms.max(0) as u64))
+    });
+    engine.register_fn("reset", || RhaiScriptResult(ScriptResult::Reset));
+    engine.register_fn("pass", || RhaiScriptResult(ScriptResult::Pass));
+
+    // `ctx.request.header("X-Flow-Id")` / `ctx.response.header(...)`: case-insensitive lookup
+    // into the receiver map's own `headers` field. Registered generically on `Map` (Rhai method
+    // calls dispatch on the receiver's runtime type), so it's a harmless no-op on any other map
+    // that doesn't happen to carry a `headers` key.
+    engine.register_fn("header", |m: &mut Map, name: &str| -> Dynamic {
+        let Some(headers_val) = m.get("headers") else {
+            return Dynamic::UNIT;
+        };
+        let Some(headers_map) = headers_val.clone().try_cast::<Map>() else {
+            return Dynamic::UNIT;
+        };
+        headers_map
+            .iter()
+            .find(|(k, _)| k.as_str().eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+            .unwrap_or(Dynamic::UNIT)
+    });
+}
+
+fn clamp_u16(n: i64) -> u16 {
+    n.clamp(0, i64::from(u16::MAX)) as u16
+}
+
+fn dynamic_to_script_result_body(value: Dynamic) -> ScriptResultBody {
+    if let Some(s) = value.clone().try_cast::<String>() {
+        ScriptResultBody::Str(s)
+    } else {
+        ScriptResultBody::Json(dynamic_to_json(value))
+    }
+}
+
+/// Flow-state handle bound to one flow id — `ctx.state` and the value returned by
+/// `ctx.store.flow(id)` (issue #357 Item 1). Exposes the subset of `ScriptFlowStore` that doesn't
+/// need a `flow_id` argument per call (full get_or/incr-with-args/cas is P3b, issue #358).
+#[derive(Clone)]
+pub struct RhaiStateHandle {
+    inner: ScriptFlowStore,
+    flow_id: String,
+}
+
+impl RhaiStateHandle {
+    fn new(store: Arc<dyn FlowStore>, flow_id: String) -> Self {
+        Self {
+            inner: ScriptFlowStore::new(store),
+            flow_id,
+        }
+    }
+
+    pub fn get(&mut self, key: String) -> std::result::Result<Dynamic, Box<rhai::EvalAltResult>> {
+        self.inner.get(self.flow_id.clone(), key)
+    }
+
+    pub fn set(
+        &mut self,
+        key: String,
+        value: Dynamic,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.set(self.flow_id.clone(), key, value)
+    }
+
+    pub fn incr(&mut self, key: String) -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
+        self.inner.increment(self.flow_id.clone(), key)
+    }
+
+    pub fn exists(&mut self, key: String) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.exists(self.flow_id.clone(), key)
+    }
+
+    pub fn delete(&mut self, key: String) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.delete(self.flow_id.clone(), key)
+    }
+}
+
+/// `ctx.store`: the flow-store escape hatch (issue #357 Item 1) — `.flow(id)` returns a handle
+/// scoped to an arbitrary (not necessarily the request's own) flow id.
+#[derive(Clone)]
+pub struct RhaiStoreHandle {
+    store: Arc<dyn FlowStore>,
+}
+
+impl RhaiStoreHandle {
+    fn new(store: Arc<dyn FlowStore>) -> Self {
+        Self { store }
+    }
+
+    pub fn flow(&mut self, flow_id: String) -> RhaiStateHandle {
+        RhaiStateHandle::new(Arc::clone(&self.store), flow_id)
+    }
+}
+
+/// `ctx.logger`: real `debug`/`info`/`warn`/`error`, routed to `tracing` at target
+/// `"rift::script"` (issue #357 Item 1, reusing P1's logging target — issue #355).
+#[derive(Clone)]
+pub struct RhaiLogger {
+    port: u16,
+    stub_id: Option<String>,
+}
+
+impl RhaiLogger {
+    fn log(&self, level: tracing::Level, message: &str) {
+        let port = self.port;
+        let stub_id = self.stub_id.as_deref().unwrap_or("");
+        match level {
+            tracing::Level::DEBUG => {
+                tracing::debug!(target: "rift::script", port, stub_id, "{message}")
+            }
+            tracing::Level::INFO => {
+                tracing::info!(target: "rift::script", port, stub_id, "{message}")
+            }
+            tracing::Level::WARN => {
+                tracing::warn!(target: "rift::script", port, stub_id, "{message}")
+            }
+            _ => tracing::error!(target: "rift::script", port, stub_id, "{message}"),
+        }
+    }
+
+    pub fn debug(&mut self, message: String) {
+        self.log(tracing::Level::DEBUG, &message);
+    }
+    pub fn info(&mut self, message: String) {
+        self.log(tracing::Level::INFO, &message);
+    }
+    pub fn warn(&mut self, message: String) {
+        self.log(tracing::Level::WARN, &message);
+    }
+    pub fn error(&mut self, message: String) {
+        self.log(tracing::Level::ERROR, &message);
+    }
+}
+
+/// The v2 result-constructor builder (issue #357 Item 3): `http()`/`delay()`/`reset()`/`pass()`
+/// all produce one of these; `.header(k, v)` mutates and returns a clone for chaining (Rhai's
+/// builder idiom — a `()`-returning method can't be chained).
+#[derive(Clone)]
+pub struct RhaiScriptResult(pub ScriptResult);
+
+impl RhaiScriptResult {
+    pub fn header(&mut self, key: String, value: String) -> Self {
+        self.0.add_header(key, value);
+        self.clone()
+    }
+}
+
+/// What a script entrypoint call returned, tagged with which contract (v1 vs v2) produced it —
+/// each has its own result parser (issue #357 Item 4).
+enum EntrypointOutcome {
+    V1(Dynamic),
+    V2(Dynamic),
+}
+
+/// Run one v2-placement entrypoint (`respond`/`matches`/`transform`/`delay`) or its v1
+/// `should_inject` fallback (issue #357 Items 2/4). Detection: `should_inject` defined AND
+/// `entrypoint == "respond"` → v1. Else a function named `entrypoint` → call it with `ctx`. Else
+/// (bare-expression form) → evaluate the whole script with `ctx` in scope and use the tail
+/// expression's value.
+fn run_entrypoint(
+    engine: &Engine,
+    ast: &AST,
+    entrypoint: &str,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> Result<EntrypointOutcome> {
+    let mut scope = Scope::new();
+    let request_map = create_request_map(request);
+    let flow_store_wrapper = ScriptFlowStore::new(Arc::clone(&flow_store));
+    let ctx_map = build_ctx_map(ctx_input, flow_store);
+
+    let has_should_inject = entrypoint == entrypoints::RESPOND
+        && ast
+            .iter_functions()
+            .any(|f| f.name == entrypoints::SHOULD_INJECT);
+
+    if has_should_inject {
+        engine
+            .run_ast_with_scope(&mut scope, ast)
+            .map_err(|e| anyhow!("Script execution error: {e}"))?;
+        let result: Dynamic = engine
+            .call_fn(
+                &mut scope,
+                ast,
+                entrypoints::SHOULD_INJECT,
+                (request_map, flow_store_wrapper),
+            )
+            .map_err(|e| anyhow!("Failed to call should_inject function: {e}"))?;
+        return Ok(EntrypointOutcome::V1(result));
+    }
+
+    let has_named = ast.iter_functions().any(|f| f.name == entrypoint);
+    if has_named {
+        engine
+            .run_ast_with_scope(&mut scope, ast)
+            .map_err(|e| anyhow!("Script execution error: {e}"))?;
+        let result: Dynamic = engine
+            .call_fn(&mut scope, ast, entrypoint, (ctx_map,))
+            .map_err(|e| anyhow!("Failed to call {entrypoint}(ctx): {e}"))?;
+        Ok(EntrypointOutcome::V2(result))
+    } else {
+        // Bare-expression script (issue #357 Item 2): the whole body IS the function, with `ctx`
+        // in scope; its tail expression is the return value (Rhai's normal "eval" semantics).
+        let has_any_function = ast.iter_functions().next().is_some();
+        scope.push("ctx", ctx_map);
+        let result: Dynamic = engine
+            .eval_ast_with_scope(&mut scope, ast)
+            .map_err(|e| anyhow!("Script execution error: {e}"))?;
+        // B1 (issue #357, "nothing fails silently"): a script that declares function(s) but none
+        // is the requested entrypoint (nor `should_inject`) and whose top-level completion value
+        // is unit almost certainly has a MISNAMED entrypoint (e.g. `fn respnod(ctx)`). Falling
+        // back to the bare-expression path would silently yield `None` — a normal response served
+        // with no sign the script never ran. Surface it as an explicit error instead. A genuine
+        // bare expression is still fine: it either has no function declarations, or produces a
+        // non-unit value.
+        if result.is_unit() && has_any_function {
+            return Err(anyhow!(
+                "script defines function(s) but none is the `{entrypoint}` entrypoint \
+                 (and there is no bare expression to evaluate); did you mean `{entrypoint}`?"
+            ));
+        }
+        Ok(EntrypointOutcome::V2(result))
+    }
+}
+
+fn dynamic_to_fault_decision(result: Dynamic, rule_id: &str) -> Result<FaultDecision> {
+    if result.is_unit() {
+        return Ok(FaultDecision::None);
+    }
+    let script_result = result.try_cast::<RhaiScriptResult>().ok_or_else(|| {
+        anyhow!("respond(ctx) must return http(...)/delay(...)/reset()/pass() or nothing")
+    })?;
+    Ok(script_result.0.into_fault_decision(rule_id))
+}
+
+fn dynamic_to_matches_bool(result: Dynamic) -> bool {
+    result.as_bool().unwrap_or(false)
+}
+
+fn dynamic_to_delay_ms(result: Dynamic) -> Result<u64> {
+    if let Ok(n) = result.as_int() {
+        Ok(n.max(0) as u64)
+    } else if let Ok(f) = result.as_float() {
+        Ok(f.max(0.0) as u64)
+    } else {
+        Err(anyhow!("delay(ctx) must return a number of milliseconds"))
+    }
+}
+
+fn dynamic_to_transform_result(result: Dynamic) -> Result<Option<ScriptResult>> {
+    if result.is_unit() {
+        return Ok(None);
+    }
+    let script_result = result
+        .try_cast::<RhaiScriptResult>()
+        .ok_or_else(|| anyhow!("transform(ctx) must return http(...)/pass() or nothing"))?;
+    Ok(Some(script_result.0))
+}
+
+/// `respond(ctx)` (issue #357 Item 2): the response-script entrypoint. Auto-detects the v1
+/// `should_inject` wrapper (issue #357 Item 4).
+pub fn call_respond(
+    engine: &Engine,
+    ast: &AST,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+    rule_id: &str,
+) -> Result<FaultDecision> {
+    match run_entrypoint(
+        engine,
+        ast,
+        entrypoints::RESPOND,
+        request,
+        ctx_input,
+        flow_store,
+    )? {
+        EntrypointOutcome::V1(d) => parse_fault_decision_with_rule_id(d, rule_id),
+        EntrypointOutcome::V2(d) => dynamic_to_fault_decision(d, rule_id),
+    }
+}
+
+/// `matches(ctx)` (issue #357 Item 2): the predicate-script entrypoint, returns a bool.
+pub fn call_matches(
+    engine: &Engine,
+    ast: &AST,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> Result<bool> {
+    match run_entrypoint(
+        engine,
+        ast,
+        entrypoints::MATCHES,
+        request,
+        ctx_input,
+        flow_store,
+    )? {
+        EntrypointOutcome::V1(_) => Err(anyhow!(
+            "matches(ctx) does not support the v1 should_inject wrapper"
+        )),
+        EntrypointOutcome::V2(d) => Ok(dynamic_to_matches_bool(d)),
+    }
+}
+
+/// `transform(ctx)` (issue #357 Item 2): the decorate-behavior entrypoint. Returns `None` when
+/// the script returns nothing (no change to the response); `Some(result)` when it returns an
+/// `http(...)`/`pass()` result constructor describing the new response. NOTE: unlike a true
+/// in-place `ctx.response` mutation, this iteration requires the new response to be *returned* —
+/// see the module-level doc for why in-place sharing isn't guaranteed across engines yet.
+pub fn call_transform(
+    engine: &Engine,
+    ast: &AST,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> Result<Option<ScriptResult>> {
+    match run_entrypoint(
+        engine,
+        ast,
+        entrypoints::TRANSFORM,
+        request,
+        ctx_input,
+        flow_store,
+    )? {
+        EntrypointOutcome::V1(_) => Err(anyhow!(
+            "transform(ctx) does not support the v1 should_inject wrapper"
+        )),
+        EntrypointOutcome::V2(d) => dynamic_to_transform_result(d),
+    }
+}
+
+/// `delay(ctx)` (issue #357 Item 2): the wait-behavior entrypoint, returns a millisecond count.
+pub fn call_delay(
+    engine: &Engine,
+    ast: &AST,
+    request: &ScriptRequest,
+    ctx_input: &ScriptCtxInput,
+    flow_store: Arc<dyn FlowStore>,
+) -> Result<u64> {
+    match run_entrypoint(
+        engine,
+        ast,
+        entrypoints::DELAY,
+        request,
+        ctx_input,
+        flow_store,
+    )? {
+        EntrypointOutcome::V1(_) => Err(anyhow!(
+            "delay(ctx) does not support the v1 should_inject wrapper"
+        )),
+        EntrypointOutcome::V2(d) => dynamic_to_delay_ms(d),
+    }
+}
+
+fn header_map_lowercased(headers: &std::collections::HashMap<String, String>) -> Map {
+    let mut m = Map::new();
+    for (k, v) in headers {
+        m.insert(k.to_ascii_lowercase().into(), Dynamic::from(v.clone()));
+    }
+    m
+}
+
+/// Parse `raw` as JSON for `ctx.request.json`/`ctx.response.json` (issue #357 Item 1): valid JSON
+/// (including the literal `null`) or a parse failure both yield `Dynamic::UNIT` — Rhai's "nothing"
+/// — since a `null` body and a non-JSON body are indistinguishable at this field's use sites.
+fn parse_json_or_unit(raw: &str) -> Dynamic {
+    serde_json::from_str::<Value>(raw)
+        .map(json_to_dynamic)
+        .unwrap_or(Dynamic::UNIT)
+}
+
+fn build_request_ctx_map(request: &ScriptRequest) -> Map {
+    let mut m = Map::new();
+    m.insert("method".into(), Dynamic::from(request.method.clone()));
+    m.insert("path".into(), Dynamic::from(request.path.clone()));
+
+    let mut path_params = Map::new();
+    for (k, v) in &request.path_params {
+        path_params.insert(k.clone().into(), Dynamic::from(v.clone()));
+    }
+    m.insert("pathParams".into(), Dynamic::from(path_params));
+
+    let mut query = Map::new();
+    for (k, v) in &request.query {
+        query.insert(k.clone().into(), Dynamic::from(v.clone()));
+    }
+    m.insert("query".into(), Dynamic::from(query));
+
+    m.insert(
+        "headers".into(),
+        Dynamic::from(header_map_lowercased(&request.headers)),
+    );
+
+    // ctx.request.body is always the raw string (issue #357 Item 1); fall back to
+    // re-serializing the parsed `body` for callers that only populated that field.
+    let raw = request.raw_body.clone().unwrap_or_else(|| {
+        if request.body.is_null() {
+            String::new()
+        } else {
+            serde_json::to_string(&request.body).unwrap_or_default()
+        }
+    });
+    m.insert("json".into(), parse_json_or_unit(&raw));
+    m.insert("body".into(), Dynamic::from(raw));
+
+    m
+}
+
+fn build_response_ctx_map(response: &ScriptResponseContext) -> Map {
+    let mut m = Map::new();
+    m.insert("status".into(), Dynamic::from(response.status as i64));
+    m.insert(
+        "headers".into(),
+        Dynamic::from(header_map_lowercased(&response.headers)),
+    );
+    m.insert("json".into(), parse_json_or_unit(&response.body));
+    m.insert("body".into(), Dynamic::from(response.body.clone()));
+    m
+}
+
+fn build_stub_ctx_map(stub: &super::ScriptStubContext) -> Map {
+    let mut m = Map::new();
+    m.insert(
+        "scenarioName".into(),
+        stub.scenario_name
+            .clone()
+            .map_or(Dynamic::UNIT, Dynamic::from),
+    );
+    m.insert(
+        "scenarioState".into(),
+        stub.scenario_state
+            .clone()
+            .map_or(Dynamic::UNIT, Dynamic::from),
+    );
+    m.insert(
+        "id".into(),
+        stub.stub_id.clone().map_or(Dynamic::UNIT, Dynamic::from),
+    );
+    m
+}
+
+/// Build the v2 `ctx` map (issue #357 Item 1): identical field names/semantics across engines —
+/// see the doc comment on [`ScriptCtxInput`].
+fn build_ctx_map(input: &ScriptCtxInput, flow_store: Arc<dyn FlowStore>) -> Map {
+    let mut ctx = Map::new();
+    ctx.insert(
+        "request".into(),
+        Dynamic::from(build_request_ctx_map(input.request)),
+    );
+    if let Some(resp) = &input.response {
+        ctx.insert(
+            "response".into(),
+            Dynamic::from(build_response_ctx_map(resp)),
+        );
+    }
+    ctx.insert("flowId".into(), Dynamic::from(input.flow_id.clone()));
+    ctx.insert(
+        "stub".into(),
+        Dynamic::from(build_stub_ctx_map(&input.stub)),
+    );
+    ctx.insert(
+        "state".into(),
+        Dynamic::from(RhaiStateHandle::new(
+            Arc::clone(&flow_store),
+            input.flow_id.clone(),
+        )),
+    );
+    ctx.insert(
+        "store".into(),
+        Dynamic::from(RhaiStoreHandle::new(Arc::clone(&flow_store))),
+    );
+    ctx.insert(
+        "logger".into(),
+        Dynamic::from(RhaiLogger {
+            port: input.port,
+            stub_id: input.stub.stub_id.clone(),
+        }),
+    );
+    ctx
+}
+
+/// Public function to execute Rhai script with a reusable engine (for script pool). Auto-detects
+/// v1/v2 the same way [`RhaiEngine::should_inject_fault`] does (issue #357 Item 4); `ctx` gets
+/// best-effort defaults since the pool has no imposter context here.
 pub fn execute_rhai_with_engine(
     engine: &Engine,
     ast: &Arc<AST>,
@@ -370,31 +806,8 @@ pub fn execute_rhai_with_engine(
     flow_store: Arc<dyn FlowStore>,
     rule_id: &str,
 ) -> Result<FaultDecision> {
-    let mut scope = Scope::new();
-
-    // Create request map
-    let request_map = create_request_map(request);
-
-    // Create flow_store wrapper
-    let flow_store_wrapper = ScriptFlowStore::new(flow_store);
-
-    // First, evaluate the AST to define the should_inject function
-    engine
-        .run_ast_with_scope(&mut scope, ast)
-        .map_err(|e| anyhow!("Script execution error: {e}"))?;
-
-    // Now call the should_inject function with request and flow_store arguments
-    let result: Dynamic = engine
-        .call_fn(
-            &mut scope,
-            ast,
-            "should_inject",
-            (request_map, flow_store_wrapper),
-        )
-        .map_err(|e| anyhow!("Failed to call should_inject function: {e}"))?;
-
-    // Parse result
-    parse_fault_decision_with_rule_id(result, rule_id)
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(request);
+    call_respond(engine, ast, request, &ctx_input, flow_store, rule_id)
 }
 
 /// Helper to parse fault decision with a given rule_id
@@ -560,6 +973,7 @@ pub fn run_should_inject_with_abort_rhai(
     request: &ScriptRequest,
     flow_store: Arc<dyn FlowStore>,
     abort: &Arc<AtomicBool>,
+    ctx_extra: &ScriptCtxExtras,
 ) -> Result<FaultDecision> {
     let ast = super::compiled_cache::cached_rhai_ast(code)?;
     let mut engine = RhaiEngine::create_engine();
@@ -571,7 +985,8 @@ pub fn run_should_inject_with_abort_rhai(
             None
         }
     });
-    execute_rhai_with_engine(&engine, &ast, request, flow_store, rule_id)
+    let ctx_input = ctx_extra.build_ctx_input(request);
+    call_respond(&engine, &ast, request, &ctx_input, flow_store, rule_id)
 }
 
 #[cfg(test)]
@@ -602,6 +1017,7 @@ mod tests {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "POST".to_string(),
             path: "/test".to_string(),
             headers: HashMap::new(),
@@ -644,6 +1060,7 @@ mod tests {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
             headers: HashMap::new(),
@@ -693,6 +1110,7 @@ mod tests {
         headers.insert("x-flow-id".to_string(), "flow123".to_string());
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: headers.clone(),
@@ -744,6 +1162,7 @@ mod tests {
         headers1.insert("x-user-id".to_string(), "beta-user-123".to_string());
 
         let request1 = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: headers1,
@@ -762,6 +1181,7 @@ mod tests {
         headers2.insert("x-user-id".to_string(), "regular-user-456".to_string());
 
         let request2 = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: headers2,
@@ -804,6 +1224,7 @@ mod tests {
         // Execute same AST multiple times with reusable engine
         for i in 0..10 {
             let request = ScriptRequest {
+                raw_body: None,
                 method: "GET".to_string(),
                 path: "/cache-test".to_string(),
                 headers: HashMap::new(),
@@ -835,5 +1256,490 @@ mod tests {
             Arc::ptr_eq(ast, &ast_clone),
             "AST should be same Arc instance"
         );
+    }
+
+    // ============================================
+    // Issue #357: unified ctx, v2 entrypoints, result constructors
+    // ============================================
+    mod v2 {
+        use super::*;
+        use crate::backends::InMemoryFlowStore;
+
+        fn req(headers: HashMap<String, String>, raw_body: Option<&str>) -> ScriptRequest {
+            ScriptRequest {
+                method: "POST".to_string(),
+                path: "/api/orders".to_string(),
+                headers,
+                body: serde_json::Value::Null,
+                query: HashMap::from([("page".to_string(), "2".to_string())]),
+                path_params: HashMap::from([("id".to_string(), "42".to_string())]),
+                raw_body: raw_body.map(|s| s.to_string()),
+            }
+        }
+
+        fn store() -> Arc<dyn FlowStore> {
+            Arc::new(InMemoryFlowStore::new(300))
+        }
+
+        fn run_respond(script: &str, request: &ScriptRequest) -> Result<FaultDecision> {
+            let engine = RhaiEngine::new(script, "v2-rule").unwrap();
+            engine.should_inject_fault(request, store())
+        }
+
+        // --- ctx.request ---
+
+        #[test]
+        fn ctx_request_header_is_case_insensitive() {
+            let headers = HashMap::from([("X-Flow-Id".to_string(), "flow-9".to_string())]);
+            let script = r#"
+                fn respond(ctx) {
+                    let v = ctx.request.header("x-flow-id");
+                    http(200, #{ seen: v })
+                }
+            "#;
+            let decision = run_respond(script, &req(headers, None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => assert!(body.contains("flow-9")),
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_headers_map_is_lowercased() {
+            let headers = HashMap::from([("X-Flow-Id".to_string(), "flow-9".to_string())]);
+            let script = r#"
+                fn respond(ctx) {
+                    if ctx.request.headers.contains("x-flow-id") {
+                        http(200)
+                    } else {
+                        http(500)
+                    }
+                }
+            "#;
+            let decision = run_respond(script, &req(headers, None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, .. } => assert_eq!(status, 200),
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_json_lazy_parse_valid() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(200, #{ n: ctx.request.json.n })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), Some(r#"{"n": 7}"#))).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => assert!(body.contains('7')),
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_json_is_unit_for_non_json_body() {
+            let script = r#"
+                fn respond(ctx) {
+                    if ctx.request.json == () {
+                        http(200)
+                    } else {
+                        http(500)
+                    }
+                }
+            "#;
+            let decision =
+                run_respond(script, &req(HashMap::new(), Some("not json at all"))).unwrap();
+            match decision {
+                FaultDecision::Error { status, .. } => assert_eq!(status, 200),
+                other => panic!("expected 200 (json is unit), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_path_params_and_query() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(200, #{ id: ctx.request.pathParams.id, page: ctx.request.query.page })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("42"));
+                    assert!(body.contains('2'));
+                }
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ctx_request_body_is_raw_string() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(200, ctx.request.body)
+                }
+            "#;
+            let decision =
+                run_respond(script, &req(HashMap::new(), Some("plain text, not json"))).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => assert_eq!(body, "plain text, not json"),
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        // --- entrypoints: named wrapper + bare, respond/matches/transform/delay ---
+
+        #[test]
+        fn respond_named_wrapper() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(503, #{ error: "unavailable" })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error {
+                    status,
+                    body,
+                    headers,
+                    ..
+                } => {
+                    assert_eq!(status, 503);
+                    assert!(body.contains("unavailable"));
+                    assert_eq!(
+                        headers.get("Content-Type").map(String::as_str),
+                        Some("application/json")
+                    );
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn respond_bare_expression() {
+            // No `fn respond` wrapper at all — the whole script body is the function.
+            let script = r#"
+                if ctx.request.method == "POST" {
+                    http(503, #{ error: "unavailable" })
+                } else {
+                    pass()
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        #[test]
+        fn matches_named_wrapper_true_and_false() {
+            let engine = RhaiEngine::create_engine();
+            let script = r#" fn matches(ctx) { ctx.request.method == "POST" } "#;
+            let ast = engine.compile(script).unwrap();
+
+            let post_req = req(HashMap::new(), None);
+            let ctx_input = ScriptCtxInput::new(&post_req, "flow-1");
+            let matched =
+                call_matches(&engine, &ast, ctx_input.request, &ctx_input, store()).unwrap();
+            assert!(matched);
+
+            let mut get_req = req(HashMap::new(), None);
+            get_req.method = "GET".to_string();
+            let ctx_input2 = ScriptCtxInput::new(&get_req, "flow-1");
+            let matched2 =
+                call_matches(&engine, &ast, ctx_input2.request, &ctx_input2, store()).unwrap();
+            assert!(!matched2);
+        }
+
+        #[test]
+        fn matches_bare_expression() {
+            let engine = RhaiEngine::create_engine();
+            let script = r#" ctx.request.path == "/api/orders" "#;
+            let ast = engine.compile(script).unwrap();
+            let request = req(HashMap::new(), None);
+            let ctx_input = ScriptCtxInput::new(&request, "flow-1");
+            let matched =
+                call_matches(&engine, &ast, ctx_input.request, &ctx_input, store()).unwrap();
+            assert!(matched);
+        }
+
+        #[test]
+        fn transform_named_wrapper_returns_new_response() {
+            let engine = RhaiEngine::create_engine();
+            let script = r#"
+                fn transform(ctx) {
+                    http(ctx.response.status, #{ wrapped: ctx.response.body })
+                }
+            "#;
+            let ast = engine.compile(script).unwrap();
+            let request = req(HashMap::new(), None);
+            let ctx_input =
+                ScriptCtxInput::new(&request, "flow-1").with_response(ScriptResponseContext {
+                    status: 201,
+                    headers: HashMap::new(),
+                    body: "original".to_string(),
+                });
+            let result = call_transform(&engine, &ast, ctx_input.request, &ctx_input, store())
+                .unwrap()
+                .expect("transform must return a result");
+            match result.into_fault_decision("rule") {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 201);
+                    assert!(body.contains("original"));
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn transform_bare_returns_nothing_means_no_change() {
+            let engine = RhaiEngine::create_engine();
+            let script = "()"; // explicit no-op bare expression
+            let ast = engine.compile(script).unwrap();
+            let request = req(HashMap::new(), None);
+            let ctx_input = ScriptCtxInput::new(&request, "flow-1");
+            let result =
+                call_transform(&engine, &ast, ctx_input.request, &ctx_input, store()).unwrap();
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn delay_named_wrapper_and_bare() {
+            let engine = RhaiEngine::create_engine();
+            let script = " fn delay(ctx) { 250 } ";
+            let ast = engine.compile(script).unwrap();
+            let request = req(HashMap::new(), None);
+            let ctx_input = ScriptCtxInput::new(&request, "flow-1");
+            let ms = call_delay(&engine, &ast, ctx_input.request, &ctx_input, store()).unwrap();
+            assert_eq!(ms, 250);
+
+            let bare_script = " 100 + 25 ";
+            let bare_ast = engine.compile(bare_script).unwrap();
+            let ms2 =
+                call_delay(&engine, &bare_ast, ctx_input.request, &ctx_input, store()).unwrap();
+            assert_eq!(ms2, 125);
+        }
+
+        // --- result constructors ---
+
+        #[test]
+        fn http_json_body_sets_content_type_unless_overridden() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(503, #{ error: "x" }).header("Retry-After", "1")
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error {
+                    status,
+                    body,
+                    headers,
+                    ..
+                } => {
+                    assert_eq!(status, 503);
+                    assert_eq!(body, r#"{"error":"x"}"#);
+                    assert_eq!(headers.get("Retry-After").map(String::as_str), Some("1"));
+                    assert_eq!(
+                        headers.get("Content-Type").map(String::as_str),
+                        Some("application/json")
+                    );
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn http_explicit_content_type_wins() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(200, #{ a: 1 }).header("Content-Type", "application/vnd.custom+json")
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { headers, .. } => {
+                    assert_eq!(
+                        headers.get("Content-Type").map(String::as_str),
+                        Some("application/vnd.custom+json")
+                    );
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn http_string_body_passes_through_verbatim() {
+            let script = r#"
+                fn respond(ctx) {
+                    http(200, "hello world")
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, headers, .. } => {
+                    assert_eq!(body, "hello world");
+                    assert!(!headers.contains_key("Content-Type"));
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn delay_constructor() {
+            let script = " fn respond(ctx) { delay(42) } ";
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Latency { duration_ms, .. } => assert_eq!(duration_ms, 42),
+                other => panic!("expected Latency, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn reset_constructor() {
+            let script = " fn respond(ctx) { reset() } ";
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Reset { .. }));
+        }
+
+        #[test]
+        fn pass_constructor_and_bare_nothing_both_mean_none() {
+            let decision =
+                run_respond(" fn respond(ctx) { pass() } ", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::None));
+
+            let decision2 =
+                run_respond(" fn respond(ctx) { () } ", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision2, FaultDecision::None));
+        }
+
+        // --- v1 back-compat ---
+
+        #[test]
+        fn v1_should_inject_still_wins_over_v2_detection() {
+            let script = r#"
+                fn should_inject(request, flow_store) {
+                    #{ inject: true, fault: "error", status: 418, body: "teapot" }
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 418);
+                    assert_eq!(body, "teapot");
+                }
+                other => panic!("expected v1 Error decision, got {other:?}"),
+            }
+        }
+
+        // --- retry example from the issue: ctx.state.incr + http() end-to-end ---
+
+        #[test]
+        fn retry_example_end_to_end_with_ctx_state_incr() {
+            let script = r#"
+                fn respond(ctx) {
+                    let n = ctx.state.incr("attempts");
+                    if n <= 2 {
+                        http(503, #{ error: "unavailable", attempt: n }).header("Retry-After", "1")
+                    } else {
+                        http(200, #{ ok: true, succeededOnAttempt: n })
+                    }
+                }
+            "#;
+            let engine = RhaiEngine::new(script, "retry-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject_fault(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d1, FaultDecision::Error { status: 503, .. }));
+
+            let d2 = engine
+                .should_inject_fault(&request, Arc::clone(&shared_store))
+                .unwrap();
+            assert!(matches!(d2, FaultDecision::Error { status: 503, .. }));
+
+            let d3 = engine.should_inject_fault(&request, shared_store).unwrap();
+            match d3 {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("succeededOnAttempt"));
+                }
+                other => panic!("expected 200 on third attempt, got {other:?}"),
+            }
+        }
+
+        // --- ctx.store escape hatch ---
+
+        #[test]
+        fn ctx_store_flow_scopes_to_another_flow_id() {
+            let script = r#"
+                fn respond(ctx) {
+                    ctx.store.flow("other-flow").set("shared", 99);
+                    let v = ctx.store.flow("other-flow").get("shared");
+                    http(200, #{ v: v })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { status, body, .. } => {
+                    assert_eq!(status, 200);
+                    assert!(body.contains("99"));
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        // --- ctx.stub ---
+
+        #[test]
+        fn ctx_stub_none_when_unavailable() {
+            let script = r#"
+                fn respond(ctx) {
+                    if ctx.stub.scenarioName == () && ctx.stub.id == () {
+                        http(200)
+                    } else {
+                        http(500)
+                    }
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 200, .. }));
+        }
+
+        // B1 (issue #357, "nothing fails silently"): a script that defines ONLY a misnamed
+        // entrypoint (`respnod` typo) must Err, not silently fall back to bare → None.
+        #[test]
+        fn misnamed_entrypoint_errors_not_none() {
+            let script = r#"
+                fn respnod(ctx) {
+                    http(500)
+                }
+            "#;
+            let result = run_respond(script, &req(HashMap::new(), None));
+            assert!(
+                result.is_err(),
+                "a misnamed entrypoint must surface an error, got {result:?}"
+            );
+        }
+
+        // A genuine bare expression (no function declarations, non-unit value) still works.
+        #[test]
+        fn genuine_bare_expression_still_ok_after_b1() {
+            let decision = run_respond("http(503)", &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
+
+        // A helper function plus a bare expression producing a value is still allowed (the bare
+        // value is non-unit, so B1's "declared-but-unmatched + unit" guard doesn't trip).
+        #[test]
+        fn helper_function_plus_bare_expression_ok() {
+            let script = r#"
+                fn helper() { 503 }
+                http(helper())
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            assert!(matches!(decision, FaultDecision::Error { status: 503, .. }));
+        }
     }
 }

--- a/crates/rift-core/src/scripting/script_pool.rs
+++ b/crates/rift-core/src/scripting/script_pool.rs
@@ -688,6 +688,7 @@ mod tests {
         let pool = ScriptPool::new(config).unwrap();
 
         let make_request = || ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: HashMap::new(),
@@ -796,6 +797,7 @@ mod tests {
         };
 
         let request = ScriptRequest {
+            raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
             headers: HashMap::new(),

--- a/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
+++ b/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
@@ -39,16 +39,18 @@ fn req(attempt_tag: &str) -> ScriptRequest {
         body: serde_json::Value::Null,
         query: Default::default(),
         path_params: Default::default(),
+        raw_body: None,
     }
 }
 
-/// (status, body) for an `Error` decision, or `None` for `FaultDecision::None`. `Latency` isn't
-/// produced by this script so it's left unmatched (a test failure if it ever were).
+/// (status, body) for an `Error` decision, or `None` for `FaultDecision::None`. `Latency`/`Reset`
+/// aren't produced by this script so they're left unmatched (a test failure if they ever were).
 fn decision_summary(decision: &FaultDecision) -> Option<(u16, String)> {
     match decision {
         FaultDecision::None => None,
         FaultDecision::Error { status, body, .. } => Some((*status, body.clone())),
         FaultDecision::Latency { .. } => panic!("script never injects latency"),
+        FaultDecision::Reset { .. } => panic!("script never resets the connection"),
     }
 }
 

--- a/crates/rift-http-proxy/tests/issue_357_script_reset.rs
+++ b/crates/rift-http-proxy/tests/issue_357_script_reset.rs
@@ -1,0 +1,34 @@
+//! Issue #357: a `_rift.script` whose `respond(ctx)` calls the v2 `reset()` result constructor
+//! resets the TCP connection (a real transport error) end-to-end through the imposter serve loop's
+//! FaultIo — the same behavior as a top-level `fault` / `_rift.fault.tcp`, not a framed HTTP 502.
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn script_reset_resets_the_connection() {
+    let manager = Arc::new(ImposterManager::new());
+    let cfg = serde_json::from_value(serde_json::json!({
+        "port": 19947, "protocol": "http",
+        "stubs": [{
+            "predicates": [{ "equals": { "path": "/boom" } }],
+            "responses": [{
+                "_rift": { "script": { "engine": "rhai", "code": "fn respond(ctx) { reset() }" } }
+            }]
+        }]
+    }))
+    .expect("valid imposter config");
+    manager.create_imposter(cfg).await.expect("create imposter");
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // A script reset() must tear down the socket, so the client sees a transport-level error
+    // (reqwest Err), not a normal HTTP response. If reset() were mis-wired to a plain 502 (or the
+    // H1-only gate were missing and HTTP/2 swallowed the abort), this would return Ok instead.
+    let result = reqwest::get("http://127.0.0.1:19947/boom").await;
+    assert!(
+        result.is_err(),
+        "script reset() must reset the connection (transport error), got: {result:?}"
+    );
+
+    manager.delete_all().await;
+}

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -106,7 +106,8 @@ fn read_script_file_relative(config_file: &Path, rel: &str) -> std::io::Result<S
 /// Syntax-check a resolved script's content at the same level inline `code:` would get for its
 /// engine. Only "javascript" has an embedded syntax checker in this crate (`js_validator`,
 /// gated behind the `javascript` feature) — rhai/lua scripts get the structural checks above
-/// (exactly-one-source, ref resolution, file existence) but no deep syntax check here.
+/// (exactly-one-source, ref resolution, file existence) but no deep syntax check here. Also flags
+/// the deprecated v1 `should_inject` wrapper (issue #357 Item 5), for every engine.
 fn check_script_syntax(
     file: &Path,
     code: &str,
@@ -124,6 +125,42 @@ fn check_script_syntax(
                 file.to_path_buf(),
             )
             .with_location(location),
+        );
+    }
+
+    check_script_v1_deprecation(file, code, location, result);
+}
+
+/// Matches a `should_inject` FUNCTION DECLARATION — the v1 wrapper across all three engines
+/// (`fn should_inject` in Rhai, `function should_inject` in Lua/JS). Anchoring on the declaration
+/// keyword (not a bare `should_inject` word) is what the runtime's own v1 detection keys on (a
+/// defined `should_inject` function), and keeps the lint from firing on the identifier appearing
+/// in a comment or string literal.
+static SHOULD_INJECT_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+
+/// Flag the deprecated v1 `should_inject(request, flow_store)` script wrapper (issue #357 Item 5,
+/// pairing with the runtime's own v1/v2 detection in `rift-core::scripting`, which treats a
+/// defined `should_inject` as the same unambiguous v1 signal). v2 scripts (`respond(ctx)`,
+/// `matches(ctx)`, `transform(ctx)`, `delay(ctx)`, or bare-expression) never match and so never
+/// trigger this lint.
+fn check_script_v1_deprecation(file: &Path, code: &str, location: &str, result: &mut LintResult) {
+    let re = SHOULD_INJECT_RE.get_or_init(|| {
+        Regex::new(r"\b(?:fn|function)\s+should_inject\b")
+            .expect("SHOULD_INJECT_RE is a fixed, valid pattern")
+    });
+    if re.is_match(code) {
+        result.add_issue(
+            LintIssue::warning(
+                "E041",
+                "Script uses the deprecated v1 `should_inject(request, flow_store)` wrapper",
+                file.to_path_buf(),
+            )
+            .with_location(location)
+            .with_suggestion(
+                "Rewrite as v2: define `respond(ctx)` (or a bare expression) and return \
+                 http(status, body)/delay(ms)/reset()/pass() instead of \
+                 #{ inject: true, fault: ... }",
+            ),
         );
     }
 }

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -1,7 +1,7 @@
 use rift_lint::{
-    LintOptions, LintResult, lint_directory, lint_file, lint_json, lint_value, validate_behavior,
-    validate_imposter, validate_is_response, validate_predicate, validate_proxy_response,
-    validate_response, validate_stub,
+    LintOptions, LintResult, Severity, lint_directory, lint_file, lint_json, lint_value,
+    validate_behavior, validate_imposter, validate_is_response, validate_predicate,
+    validate_proxy_response, validate_response, validate_stub,
 };
 use serde_json::{Value, json};
 use std::path::Path;
@@ -1127,4 +1127,89 @@ fn e040_invalid_javascript_file_syntax_is_an_error() {
 
     let r = lint_file(&config_path, &opts());
     assert!(has_code(&r, "E040"), "expected E040, got {:?}", codes(&r));
+}
+
+// ─── Issue #357 Item 5: E041 deprecation lint for the v1 `should_inject` wrapper ──────
+
+#[test]
+fn e041_fires_for_v1_should_inject_wrapper_rhai() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn should_inject(request, flow_store) { #{ inject: false } }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E041"), "expected E041, got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_fires_for_v1_should_inject_wrapper_lua() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "engine": "lua",
+        "code": "function should_inject(request, flow_store) return { inject = false } end"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E041"), "expected E041, got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_fires_for_v1_should_inject_wrapper_js() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "engine": "javascript",
+        "code": "function should_inject(request, flow_store) { return { inject: false }; }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E041"), "expected E041, got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_does_not_fire_for_v2_named_respond() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn respond(ctx) { http(200) }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E041"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_does_not_fire_for_v2_bare_expression() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "if ctx.request.method == \"POST\" { http(503) } else { pass() }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E041"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_does_not_fire_for_should_inject_only_in_a_comment() {
+    // The lint anchors on a function DECLARATION (`fn`/`function should_inject`), so a mere
+    // mention of the word in a comment/string is not a v1 wrapper and must not warn.
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "// migrated away from should_inject\nfn respond(ctx) { http(200) }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E041"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e041_is_a_warning_not_an_error() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn should_inject(request, flow_store) { #{ inject: false } }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    let issue = r
+        .issues
+        .iter()
+        .find(|i| i.code == "E041")
+        .expect("E041 must fire");
+    assert_eq!(
+        issue.severity,
+        Severity::Warning,
+        "E041 must be a deprecation warning, not a hard error"
+    );
 }

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -247,11 +247,18 @@ evaluated. If you want the top-level transport fault, the response must be a bar
 
 ## Scripted Faults
 
-For dynamic fault injection based on request data or state, use the scripting feature.
+For dynamic fault injection based on request data or state, use the scripting feature. Full
+reference (the unified `ctx` object, result constructors, entrypoint placement) lives on the
+[Scripting](./scripting.md#ctx-api-v2) page; this section just shows it applied to fault injection.
+`_rift.script` accepts both the v2 forms below and the deprecated v1 `should_inject(request,
+flow_store)` wrapper — a script needs neither an `inject`/`fault` map nor a `should_inject` wrapper
+to be valid; see [Scripting](./scripting.md) for the full v1/v2 contract.
 
 ### Rhai Script - Retry Simulation
 
-Fail the first 2 requests, pass through on the 3rd:
+Fail the first 2 requests, pass through on the 3rd. Bare-expression form (issue #357): the whole
+script body is the `respond(ctx)` function, with `ctx` already in scope, and `http(status, body)`
+replaces the hand-built `#{ inject:, fault: }` map:
 
 ```json
 {
@@ -265,7 +272,7 @@ Fail the first 2 requests, pass through on the 3rd:
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "let flow_id = request.headers[\"x-flow-id\"]; if flow_id == () { flow_id = \"default\"; }; let attempts = flow_store.get(flow_id, \"attempts\"); if attempts == () { attempts = 0; }; attempts += 1; flow_store.set(flow_id, \"attempts\", attempts); if attempts <= 2 { #{inject: true, fault: \"error\", status: 503, body: `{\"error\":\"Temporary failure\",\"attempt\":${attempts}}`, headers: #{\"Content-Type\": \"application/json\"}} } else { #{inject: false} }"
+          "code": "let n = ctx.state.incr(\"attempts\"); if n <= 2 { http(503, #{ error: \"Temporary failure\", attempt: n }) } else { pass() }"
         }
       }
     }]
@@ -293,7 +300,12 @@ Fail the first 2 requests, pass through on the 3rd:
 }
 ```
 
-### Script Return Values
+### Script Return Values (v1, deprecated)
+
+The Lua example above, and the shapes below, use the **v1** `should_inject(request, flow_store)`
+wrapper and its `inject`/`fault` return map — still supported, but superseded by the `respond(ctx)`
++ result-constructor contract shown in the Rhai example above and documented in full on the
+[Scripting](./scripting.md#ctx-api-v2) page. New scripts should prefer v2.
 
 Scripts must return a map/table with an `inject` flag:
 

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -11,6 +11,46 @@ Rift supports multiple scripting engines for dynamic behavior.
 
 ---
 
+## Script API v2: unified `ctx`, `respond(ctx)`, result constructors
+
+As of this release, `_rift.script` has a single contract that is **identical across Rhai, Lua, and
+JavaScript**: a `ctx` object passed into the script, and result constructors instead of a hand-built
+`#{ inject:, fault: }` map. This is the recommended way to write new scripts — see
+[`ctx` API v2](#ctx-api-v2) below for the full reference.
+
+The **v1 `should_inject(request, flow_store)` wrapper still works unchanged** and is not going
+away in this release; `rift-lint` flags it with a deprecation hint (`E041`) so you can migrate at
+your own pace. A script is v1 if (and only if) it defines a `should_inject` function — v2 scripts
+never need to.
+
+```rhai
+// v2: named entrypoint
+fn respond(ctx) {
+  let n = ctx.state.incr("attempts");
+  if n <= 2 {
+    http(503, #{ error: "unavailable", attempt: n }).header("Retry-After", "1")
+  } else {
+    http(200, #{ ok: true, succeededOnAttempt: n })
+  }
+}
+```
+
+```rhai
+// v2: bare-expression form — no `fn respond(ctx) { ... }` wrapper at all. The whole script body
+// IS the function, with `ctx` already in scope. Equivalent to the named form above.
+let n = ctx.state.incr("attempts");
+if n <= 2 {
+  http(503, #{ error: "unavailable", attempt: n }).header("Retry-After", "1")
+} else {
+  http(200, #{ ok: true, succeededOnAttempt: n })
+}
+```
+
+Both forms are legal for every hook placement; which named entrypoint applies depends on where the
+script is attached — see the table below.
+
+---
+
 ## Available Engines
 
 | Engine | Format | Use Case |
@@ -428,6 +468,123 @@ unknown `ref:` or a `file:` that can't be read is a config-time validation error
 
 ---
 
+## `ctx` API v2
+
+`ctx` is built the same way, with the same field names and semantics, in every engine and at every
+hook placement. Placement determines which entrypoint the engine looks for:
+
+| Placement | Entrypoint | Returns |
+|:----------|:-----------|:--------|
+| Response script (`_rift.script`) | `respond(ctx)` | a result constructor, or nothing (pass through) |
+| Predicate script | `matches(ctx)` | `true`/`false` |
+| Decorate behavior | `transform(ctx)` | a result constructor describing the new response, or nothing (no change) |
+| Wait behavior | `delay(ctx)` | a number of milliseconds |
+
+For each placement, the script may either define the named function explicitly, or omit the
+wrapper entirely and write the function body directly at the top level (bare-expression form) —
+both are shown above for `respond`.
+
+### `ctx.request`
+
+```
+ctx.request.method        // "GET", "POST", etc.
+ctx.request.path          // "/api/users/123"
+ctx.request.pathParams    // map: populated from the stub's routePattern
+ctx.request.query         // map of query-string parameters
+ctx.request.headers       // map with LOWERCASED keys — always, regardless of wire casing
+ctx.request.header(name)  // case-insensitive getter, e.g. ctx.request.header("X-Flow-Id")
+ctx.request.body          // the raw request body, as a string
+ctx.request.json          // the body lazily parsed as JSON; unit/nil/null if it isn't JSON
+```
+
+`ctx.request.header(name)` exists so `X-Flow-Id`, `x-flow-id`, and `X-FLOW-ID` all resolve the same
+value — a common source of bugs when reading `request.headers[...]` directly against on-the-wire
+casing.
+
+### `ctx.response`
+
+Available **only** on the decorate/`transform(ctx)` hook — `undefined`/`nil`/absent everywhere
+else. Same shape as `ctx.request`, describing the in-flight response instead:
+
+```
+ctx.response.status        // number
+ctx.response.headers       // map, lowercased keys
+ctx.response.header(name)  // case-insensitive getter
+ctx.response.body          // raw string
+ctx.response.json          // lazily parsed JSON, or unit/nil/null
+```
+
+### `ctx.state` and `ctx.store`
+
+`ctx.state` is a flow-scoped state handle, already bound to the request's resolved flow id (per
+`flowIdSource` — the same resolution the scenario-state gate uses):
+
+```rhai
+let n = ctx.state.get("key");     // unit if not set
+ctx.state.set("key", n + 1);
+let attempts = ctx.state.incr("attempts");
+ctx.state.exists("key");          // bool
+ctx.state.delete("key");
+```
+
+(Full `get_or`/parameterized `incr`/CAS support is a separate, upcoming addition — this covers the
+common get/set/incr/exists/delete case today.)
+
+`ctx.store` is the escape hatch for touching a *different* flow's state — `ctx.store.flow(id)`
+returns a handle just like `ctx.state`, but scoped to `id` instead of the request's own flow:
+
+```rhai
+ctx.store.flow("other-flow-id").set("shared", 99);
+```
+
+### `ctx.flowId` and `ctx.stub`
+
+```
+ctx.flowId              // the resolved flow id (string) — same value ctx.state is bound to
+ctx.stub.scenarioName    // string, or unit/nil/null if the stub isn't part of a scenario
+ctx.stub.scenarioState   // string, or unit/nil/null
+ctx.stub.id              // the stub's own id, or unit/nil/null if it has none
+```
+
+### `ctx.logger`
+
+Real logging (not a no-op): `debug`/`info`/`warn`/`error`, routed to the process's own tracing
+output at target `rift::script`, tagged with the imposter port and stub id where available.
+
+```rhai
+ctx.logger.info("handling request " + ctx.request.path);
+```
+
+### Result constructors
+
+Replace the v1 `#{ inject:, fault: }` map. Available in `respond(ctx)`/`transform(ctx)` (and as the
+return value of a bare-expression script for those placements):
+
+| Constructor | Meaning | Replaces (v1) |
+|:------------|:--------|:---------------|
+| `http(status)` / `http(status, body)` | respond with this status/body; chain `.header(k, v)` for extra headers | `#{inject:true, fault:"error", status, body, headers}` |
+| `delay(ms)` | inject latency, then respond normally | `#{inject:true, fault:"latency", duration_ms}` |
+| `reset()` | reset the connection (transport-level) | `fault: "tcp"` / a top-level `fault` string |
+| `pass()` | respond normally, no injection | `#{inject: false}` |
+| *(nothing)* | same as `pass()` | `#{inject: false}` |
+
+`http`'s body is a **value**, not a hand-assembled JSON string: pass a map/array and it is
+JSON-serialized with `Content-Type: application/json` set automatically (unless you set your own
+`Content-Type` via `.header(...)`, which always wins); pass a string and it's used verbatim.
+
+```rhai
+// Object body -> JSON + Content-Type: application/json
+http(503, #{ error: "unavailable", attempt: 2 })
+
+// String body -> passed through as-is, no Content-Type added
+http(200, "OK")
+
+// Chained headers
+http(429, #{ error: "rate limited" }).header("Retry-After", "60")
+```
+
+---
+
 ## Execution Limits
 
 `_rift.script` execution is bounded so a runaway script cannot wedge the engine.
@@ -493,7 +650,7 @@ The raised error propagates to the standard script-error path (`500` with `x-rif
 | Format | `inject` response | `_rift.script` | `_rift.script` |
 | State access | `state.key` | `flow_store.get(id, key)` | `flow_store:get(id, key)` |
 | Flow isolation | Per imposter | Per flow_id | Per flow_id |
-| Function wrapper | None needed | `should_inject(request, flow_store)` | `should_inject(request, flow_store)` |
+| Function wrapper | None needed | `respond(ctx)`/bare (v2, recommended) or `should_inject(request, flow_store)` (v1, deprecated) | same as Rhai |
 | Performance | Good | Excellent | Excellent |
 | Mountebank compatible | Yes | No | No |
 


### PR DESCRIPTION
Unified scripting context across all engines with named result constructors for v2 API.

Closes #357
Milestone: scripting DX (P3a)