### PR TITLE
feat(scripting): P3b flow-scoped ctx.state — get_or/incr/cas, auto-provisioned in-memory backend, fail-loud Redis

### DIFF
--- a/crates/rift-core/src/backends/inmemory.rs
+++ b/crates/rift-core/src/backends/inmemory.rs
@@ -96,6 +96,12 @@ impl FlowStore for InMemoryFlowStore {
     }
 
     fn increment(&self, flow_id: &str, key: &str) -> Result<i64> {
+        self.increment_by(flow_id, key, 1)
+    }
+
+    /// Atomic under the single write lock (issue #358), like `increment`: the read-modify-write
+    /// happens with the lock held, so no interleaving window with a concurrent increment/set.
+    fn increment_by(&self, flow_id: &str, key: &str, by: i64) -> Result<i64> {
         let key_str = self.make_key(flow_id, key);
         let expiry = SystemTime::now() + self.default_ttl;
         let mut data = self.data.write();
@@ -103,10 +109,15 @@ impl FlowStore for InMemoryFlowStore {
         // Opportunistically clean up this specific key if expired
         Self::cleanup_on_write(&mut data, &key_str, |exp| self.is_expired(exp));
 
-        let new_value = match data.get(&key_str) {
-            Some((Value::Number(n), _)) if n.is_i64() => n.as_i64().unwrap_or(0) + 1,
-            _ => 1,
+        let current = match data.get(&key_str) {
+            Some((Value::Number(n), _)) if n.is_i64() => n.as_i64().unwrap_or(0),
+            _ => 0,
         };
+        // `checked_add` so an overflow near i64::MAX errors (fail-loud) instead of panicking in
+        // debug / wrapping in release — matching Redis's INCRBY, which also errors on overflow.
+        let new_value = current.checked_add(by).ok_or_else(|| {
+            anyhow::anyhow!("increment_by overflow: {current} + {by} exceeds i64 range")
+        })?;
 
         data.insert(key_str, (Value::Number(new_value.into()), Some(expiry)));
         Ok(new_value)
@@ -312,6 +323,42 @@ mod tests {
             Some(json!(expected)),
             "Concurrent increments lost updates: expected {expected}, got {final_value:?}"
         );
+    }
+
+    // ===== increment_by (issue #358) =====
+
+    #[test]
+    fn increment_by_starts_at_zero_and_accumulates() {
+        let store = InMemoryFlowStore::new(300);
+        assert_eq!(store.increment_by("f", "k", 5).unwrap(), 5);
+        assert_eq!(store.increment_by("f", "k", 5).unwrap(), 10);
+    }
+
+    #[test]
+    fn increment_by_negative_decrements() {
+        let store = InMemoryFlowStore::new(300);
+        store.increment_by("f", "k", 10).unwrap();
+        assert_eq!(store.increment_by("f", "k", -3).unwrap(), 7);
+    }
+
+    #[test]
+    fn increment_delegates_to_increment_by_one() {
+        let store = InMemoryFlowStore::new(300);
+        assert_eq!(store.increment("f", "k").unwrap(), 1);
+        assert_eq!(store.increment_by("f", "k", 1).unwrap(), 2);
+    }
+
+    #[test]
+    fn increment_by_overflow_errors_not_panics() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f", "k", json!(i64::MAX)).unwrap();
+        let result = store.increment_by("f", "k", 1);
+        assert!(
+            result.is_err(),
+            "increment_by past i64::MAX must error, not panic/wrap"
+        );
+        // The stored value must be untouched by the failed op.
+        assert_eq!(store.get("f", "k").unwrap(), Some(json!(i64::MAX)));
     }
 
     // ===== compare_and_set (issue #311) =====

--- a/crates/rift-core/src/backends/redis.rs
+++ b/crates/rift-core/src/backends/redis.rs
@@ -188,6 +188,13 @@ impl FlowStore for RedisFlowStore {
     }
 
     fn increment(&self, flow_id: &str, key: &str) -> Result<i64> {
+        self.increment_by(flow_id, key, 1)
+    }
+
+    /// Atomic via Redis's own `INCRBY` (issue #358) — a single round trip, so there's no
+    /// interleaving window with a concurrent increment/set the way a get-then-set fallback would
+    /// have.
+    fn increment_by(&self, flow_id: &str, key: &str, by: i64) -> Result<i64> {
         let key_str = self.make_key(flow_id, key);
         let conn = self
             .pool
@@ -195,12 +202,12 @@ impl FlowStore for RedisFlowStore {
             .map_err(|e| backend_err("flowStore.pool", e))?;
         let mut conn_guard = conn.lock().unwrap();
 
-        // INCR returns the new value
+        // INCRBY returns the new value
         let new_value: i64 = conn_guard
-            .incr(&key_str, 1)
-            .map_err(|e| backend_err("flowStore.increment", e))?;
+            .incr(&key_str, by)
+            .map_err(|e| backend_err("flowStore.incrementBy", e))?;
 
-        // Set TTL on the key (INCR doesn't reset TTL)
+        // Set TTL on the key (INCRBY doesn't reset TTL)
         let _: () = redis::cmd("EXPIRE")
             .arg(&key_str)
             .arg(self.default_ttl_seconds)

--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -31,6 +31,27 @@ pub trait FlowStore: Send + Sync {
     /// Increment a numeric value (returns new value)
     fn increment(&self, flow_id: &str, key: &str) -> Result<i64>;
 
+    /// Atomically increment a numeric value by `by` (which may be negative), returning the new
+    /// value. Starts at 0 when the key is absent, so `increment_by(id, "k", 5)` on an absent key
+    /// yields 5 (issue #358).
+    ///
+    /// The provided default is a NON-ATOMIC get-then-set fallback kept so existing third-party
+    /// `FlowStore` impls keep compiling; real backends should override with a genuinely atomic
+    /// implementation (see `InMemoryFlowStore`/`RedisFlowStore`).
+    fn increment_by(&self, flow_id: &str, key: &str, by: i64) -> Result<i64> {
+        let current = match self.get(flow_id, key)? {
+            Some(Value::Number(n)) if n.is_i64() => n.as_i64().unwrap_or(0),
+            _ => 0,
+        };
+        // `checked_add` so an overflow near i64::MAX errors (fail-loud) instead of panicking in
+        // debug / wrapping in release — matching Redis's INCRBY, which also errors on overflow.
+        let new_value = current
+            .checked_add(by)
+            .ok_or_else(|| anyhow!("increment_by overflow: {current} + {by} exceeds i64 range"))?;
+        self.set(flow_id, key, Value::Number(new_value.into()))?;
+        Ok(new_value)
+    }
+
     /// Set TTL for all keys under a flow_id
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()>;
 
@@ -664,5 +685,24 @@ mod cas_tests {
             .compare_and_set("f", "k", None, json!("new"))
             .expect("cas");
         assert!(matches!(outcome, CasOutcome::Conflict(Some(_))));
+    }
+
+    // Issue #358 B4: the trait's default (non-atomic) increment_by must error on i64 overflow via
+    // checked_add, never panic (debug) or wrap (release).
+    #[test]
+    fn default_increment_by_overflow_errors() {
+        let store = MinimalStore::new();
+        store.set("f", "k", json!(i64::MAX)).expect("set");
+        assert!(
+            store.increment_by("f", "k", 1).is_err(),
+            "default increment_by past i64::MAX must error"
+        );
+    }
+
+    #[test]
+    fn default_increment_by_starts_at_zero_and_accumulates() {
+        let store = MinimalStore::new();
+        assert_eq!(store.increment_by("f", "k", 5).expect("incr"), 5);
+        assert_eq!(store.increment_by("f", "k", 5).expect("incr"), 10);
     }
 }

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -253,13 +253,15 @@ impl Imposter {
     }
 
     /// Create flow store based on _rift.flowState configuration.
-    /// Falls back to a default in-memory store (not NoOp) when stubs declare the scenario FSM,
-    /// so declarative scenarios work out of the box without explicit `_rift.flowState`.
+    /// Falls back to a default in-memory store (not NoOp) when stubs declare the scenario FSM or
+    /// carry a `_rift.script` that might call `ctx.state` (issue #358), so both work out of the
+    /// box without explicit `_rift.flowState`. Only an imposter with neither surface gets the
+    /// silent `NoOpFlowStore` — such an imposter never touches the store anyway.
     ///
-    /// Note: the store is chosen at construction. Scenario stubs added later via an in-place
-    /// `PUT /imposters/:port/stubs` to an imposter that started with no scenario stubs (and no
-    /// `_rift.flowState`) will hit the NoOp store and not advance — declare scenario stubs at
-    /// creation, configure `_rift.flowState`, use `PUT /imposters` (which recreates), or set a
+    /// Note: the store is chosen at construction. Scenario/script stubs added later via an
+    /// in-place `PUT /imposters/:port/stubs` to an imposter that started with neither (and no
+    /// `_rift.flowState`) will hit the NoOp store and not persist — declare them at creation,
+    /// configure `_rift.flowState`, use `PUT /imposters` (which recreates), or set a
     /// manager-scoped `FlowStoreProvider` returning a shared store (issue #312).
     fn create_flow_store(
         config: &ImposterConfig,
@@ -316,6 +318,23 @@ impl Imposter {
             )));
         }
 
+        if Self::uses_script(&config.stubs) {
+            // A script may call `ctx.state`/`flow_store` at runtime — not visible statically — so
+            // provision a real store rather than let it silently discard writes (issue #358). This
+            // is a convenience default, not a production recommendation: warn so an operator who
+            // didn't mean to rely on it notices in their logs.
+            tracing::warn!(
+                target: "rift::script",
+                ttl_seconds = DEFAULT_FLOW_STATE_TTL_SECS,
+                "imposter has a _rift.script stub but no _rift.flowState configured; \
+                 auto-provisioning an in-memory FlowStore. State will NOT persist across restarts \
+                 or be shared across a cluster — configure _rift.flowState for production."
+            );
+            return Ok(Arc::new(InMemoryFlowStore::new(
+                DEFAULT_FLOW_STATE_TTL_SECS,
+            )));
+        }
+
         Ok(Arc::new(NoOpFlowStore))
     }
 
@@ -324,6 +343,22 @@ impl Imposter {
         stubs
             .iter()
             .any(|s| s.required_scenario_state.is_some() || s.new_scenario_state.is_some())
+    }
+
+    /// Whether any stub can execute a Rift script (`_rift.script` on an `Is` response, or the
+    /// script-only `RiftScript` response) — such a stub might call `ctx.state`/`flow_store` at
+    /// runtime, so its imposter needs a real flow store even without `_rift.flowState`
+    /// configured (issue #358). Conservative like [`Self::uses_tcp_faults`]: a `RiftScript`
+    /// response always counts, since whether it actually touches the store isn't visible here.
+    fn uses_script(stubs: &[Stub]) -> bool {
+        stubs
+            .iter()
+            .flat_map(|s| &s.responses)
+            .any(|resp| match resp {
+                StubResponse::Is { rift: Some(r), .. } => r.script.is_some(),
+                StubResponse::RiftScript { .. } => true,
+                _ => false,
+            })
     }
 
     /// Whether any current stub can trigger a connection-level TCP fault (`_rift.fault.tcp`, or a
@@ -500,6 +535,79 @@ mod tests {
             result.is_err(),
             "redis backend without the redis-backend feature must fail construction, not NoOp"
         );
+    }
+
+    // Issue #325/#358: an unreachable redis URL must fail imposter creation loudly (via
+    // `RedisFlowStore::new`'s eager PING), not silently downgrade to NoOp/in-memory.
+    #[cfg(feature = "redis-backend")]
+    #[test]
+    fn redis_unreachable_url_fails_construction() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http", "stubs": [],
+            "_rift": { "flowState": { "backend": "redis", "redis": { "url": "redis://127.0.0.1:1" } } }
+        }))
+        .expect("valid imposter config");
+        let result = Imposter::new_with_hooks_and_journal(cfg, None, None, None);
+        assert!(
+            result.is_err(),
+            "an unreachable redis URL must fail imposter construction, not NoOp"
+        );
+    }
+
+    // Issue #358: a `_rift.script` stub might call `ctx.state`/`flow_store` at runtime — without
+    // `_rift.flowState` configured it must get a REAL in-memory store, not the silent NoOp (state
+    // must persist across calls; NoOp's `increment` always returns 1).
+    #[test]
+    fn script_stub_without_flow_state_auto_provisions_in_memory() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200 },
+                    "_rift": { "script": { "engine": "rhai", "code": "fn respond(ctx) { pass() }" } }
+                }]
+            }]
+        }))
+        .expect("valid imposter config");
+        let imp = Imposter::new(cfg).expect("test imposter");
+        assert_eq!(imp.flow_store.increment("f", "attempts").expect("incr"), 1);
+        assert_eq!(
+            imp.flow_store.increment("f", "attempts").expect("incr"),
+            2,
+            "NoOpFlowStore would return 1 both times; the auto-provisioned in-memory store must persist"
+        );
+    }
+
+    // Same guarantee for the script-only `RiftScript` response variant (no `is` wrapper).
+    #[test]
+    fn script_only_response_without_flow_state_auto_provisions_in_memory() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": { "script": { "engine": "rhai", "code": "fn respond(ctx) { http(200) }" } }
+                }]
+            }]
+        }))
+        .expect("valid imposter config");
+        let imp = Imposter::new(cfg).expect("test imposter");
+        assert_eq!(imp.flow_store.increment("f", "attempts").expect("incr"), 1);
+        assert_eq!(imp.flow_store.increment("f", "attempts").expect("incr"), 2);
+    }
+
+    // An imposter with neither a scenario stub nor a script stub keeps the silent NoOp — it never
+    // touches the store, so provisioning a real one would be pure waste.
+    #[test]
+    fn plain_stub_without_flow_state_stays_noop() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+        }))
+        .expect("valid imposter config");
+        let imp = Imposter::new(cfg).expect("test imposter");
+        // NoOpFlowStore.increment always returns 1 — it never persists.
+        assert_eq!(imp.flow_store.increment("f", "attempts").expect("incr"), 1);
+        assert_eq!(imp.flow_store.increment("f", "attempts").expect("incr"), 1);
     }
 
     #[test]

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
+use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result, strict_flow_store};
 use crate::scripting::{
     FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptRequest, ScriptResponseContext,
     ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
@@ -525,6 +525,21 @@ fn js_flow_outcome<T: Into<JsValue>>(
     }
 }
 
+/// Map a NEW (issue #358) atomic `ctx.state` op outcome to a JS value: unlike the #357 ops above,
+/// these ALWAYS raise a native error on a backend failure (fail-loud is the whole point of the new
+/// atomic ops) rather than the lenient `RIFT_STRICT_FLOW_STORE`-gated fallback.
+fn js_flow_outcome_strict<T: Into<JsValue>>(
+    outcome: Option<std::result::Result<T, String>>,
+) -> JsResult<JsValue> {
+    match outcome {
+        Some(Ok(v)) => Ok(v.into()),
+        Some(Err(msg)) => Err(JsNativeError::error().with_message(msg).into()),
+        None => Err(JsNativeError::error()
+            .with_message("no flow store bound on this thread")
+            .into()),
+    }
+}
+
 fn flow_store_get(_this: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
     let flow_id = args
         .first()
@@ -921,14 +936,16 @@ fn state_get(
         .and_then(|v| v.as_string())
         .map(|s| s.to_std_string_escaped())
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    // v2 `ctx.state` is ALWAYS fail-loud (issue #358): a backend failure raises regardless of the
+    // `RIFT_STRICT_FLOW_STORE` toggle (which only gates the legacy v1 `flow_store` global).
     let outcome = with_current_flow_store(|store| flow_result("get", store.get(flow_id, &key)));
     match outcome {
         Some(Ok(Some(value))) => json_to_js_result(ctx, &value),
         Some(Ok(None)) => Ok(JsValue::null()),
-        Some(Err(msg)) if strict_flow_store() => {
-            Err(JsNativeError::error().with_message(msg).into())
-        }
-        Some(Err(_)) | None => Ok(JsValue::null()),
+        Some(Err(msg)) => Err(JsNativeError::error().with_message(msg).into()),
+        None => Err(JsNativeError::error()
+            .with_message("no flow store bound on this thread")
+            .into()),
     }
 }
 
@@ -948,7 +965,7 @@ fn state_set(
     let outcome = with_current_flow_store(|store| {
         flow_result("set", store.set(flow_id, &key, json_value).map(|()| true))
     });
-    js_flow_outcome(outcome, false)
+    js_flow_outcome_strict(outcome)
 }
 
 fn state_incr(
@@ -964,7 +981,7 @@ fn state_incr(
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
     let outcome =
         with_current_flow_store(|store| flow_result("increment", store.increment(flow_id, &key)));
-    js_flow_outcome(outcome, 0i64)
+    js_flow_outcome_strict(outcome)
 }
 
 fn state_exists(
@@ -980,7 +997,7 @@ fn state_exists(
         .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
     let outcome =
         with_current_flow_store(|store| flow_result("exists", store.exists(flow_id, &key)));
-    js_flow_outcome(outcome, false)
+    js_flow_outcome_strict(outcome)
 }
 
 fn state_delete(
@@ -997,22 +1014,158 @@ fn state_delete(
     let outcome = with_current_flow_store(|store| {
         flow_result("delete", store.delete(flow_id, &key).map(|()| true))
     });
-    js_flow_outcome(outcome, false)
+    js_flow_outcome_strict(outcome)
 }
 
-/// `ctx.state` — a flow-state handle bound to one flow id (issue #357 Item 1). Exposes the subset
-/// of `flow_store` that doesn't need a `flow_id` argument per call (full get_or/incr-with-args/cas
-/// is P3b, issue #358).
+/// Get a value, or `default` if the key is absent (issue #358) — kills the
+/// `state.x = state.x || 0` idiom. A store failure ALWAYS raises (fail-loud), never conflated with
+/// "absent" the way `state_get`'s lenient fallback would.
+fn state_get_or(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let default = args.get(1).cloned().unwrap_or(JsValue::null());
+    let outcome = with_current_flow_store(|store| flow_result("getOr", store.get(flow_id, &key)));
+    match outcome {
+        Some(Ok(Some(value))) => json_to_js_result(ctx, &value),
+        Some(Ok(None)) => Ok(default),
+        Some(Err(msg)) => Err(JsNativeError::error().with_message(msg).into()),
+        None => Err(JsNativeError::error()
+            .with_message("no flow store bound on this thread")
+            .into()),
+    }
+}
+
+/// Atomic increment by `n`, starting at 0 when absent (issue #358). Always fail-loud.
+fn state_incr_by(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let by = args
+        .get(1)
+        .and_then(|v| v.as_number())
+        .map(|n| n as i64)
+        .ok_or_else(|| JsNativeError::typ().with_message("n must be a number"))?;
+    let outcome = with_current_flow_store(|store| {
+        flow_result("incrementBy", store.increment_by(flow_id, &key, by))
+    });
+    js_flow_outcome_strict(outcome)
+}
+
+/// Convert a [`CasOutcome`] to the JS return shape for `ctx.state.cas()` (issue #358): an object —
+/// `{ applied: true, current: null }` on success, or `{ applied: false, current: <value> }` on
+/// conflict — deliberately an object rather than a bare value so "conflict, current value happens
+/// to be `true`" can never be confused with "applied".
+fn cas_outcome_to_js(context: &mut Context, outcome: CasOutcome) -> JsResult<JsValue> {
+    let obj = create_js_object(context);
+    let (applied, current_js) = match outcome {
+        CasOutcome::Applied => (true, JsValue::null()),
+        CasOutcome::Conflict(current) => {
+            let current_js = match &current {
+                Some(v) => json_to_js_result(context, v)?,
+                None => JsValue::null(),
+            };
+            (false, current_js)
+        }
+    };
+    obj.set(
+        js_string!("applied"),
+        JsValue::from(applied),
+        false,
+        context,
+    )
+    .map_err(|e| JsNativeError::error().with_message(e.to_string()))?;
+    obj.set(js_string!("current"), current_js, false, context)
+        .map_err(|e| JsNativeError::error().with_message(e.to_string()))?;
+    Ok(obj.into())
+}
+
+/// Atomic compare-and-set (issue #358, #311): `key` is set to `new` iff its current value equals
+/// `expected` (`null`/`undefined` means "not present"). Always fail-loud.
+fn state_cas(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let key = args
+        .first()
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+        .ok_or_else(|| JsNativeError::typ().with_message("key must be a string"))?;
+    let expected_js = args.get(1).cloned().unwrap_or(JsValue::null());
+    let expected_json = js_to_json(ctx, &expected_js)?;
+    let expected = if expected_json.is_null() {
+        None
+    } else {
+        Some(expected_json)
+    };
+    let new_js = args.get(2).cloned().unwrap_or(JsValue::null());
+    let new_json = js_to_json(ctx, &new_js)?;
+
+    let outcome = with_current_flow_store(|store| {
+        flow_result(
+            "cas",
+            store.compare_and_set(flow_id, &key, expected.as_ref(), new_json),
+        )
+    });
+    match outcome {
+        Some(Ok(cas_outcome)) => cas_outcome_to_js(ctx, cas_outcome),
+        Some(Err(msg)) => Err(JsNativeError::error().with_message(msg).into()),
+        None => Err(JsNativeError::error()
+            .with_message("no flow store bound on this thread")
+            .into()),
+    }
+}
+
+/// Per-flow TTL override in seconds (issue #358). Always fail-loud.
+fn state_ttl(
+    _this: &JsValue,
+    args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
+    let ttl_seconds = args
+        .first()
+        .and_then(|v| v.as_number())
+        .map(|n| n as i64)
+        .ok_or_else(|| JsNativeError::typ().with_message("seconds must be a number"))?;
+    let outcome = with_current_flow_store(|store| {
+        flow_result("ttl", store.set_ttl(flow_id, ttl_seconds).map(|()| true))
+    });
+    js_flow_outcome_strict(outcome)
+}
+
+/// `ctx.state` — a flow-state handle bound to one flow id (issue #357 Item 1; atomic ops
+/// `getOr`/`incrBy`/`cas`/`ttl` added by issue #358).
 type StateMethodFn = fn(&JsValue, &[JsValue], &StateCaptures, &mut Context) -> JsResult<JsValue>;
 
 fn create_state_object(context: &mut Context, flow_id: String) -> Result<JsValue> {
     let obj = create_js_object(context);
-    let methods: [(&str, StateMethodFn); 5] = [
+    let methods: [(&str, StateMethodFn); 9] = [
         ("get", state_get),
         ("set", state_set),
         ("incr", state_incr),
         ("exists", state_exists),
         ("delete", state_delete),
+        ("getOr", state_get_or),
+        ("incrBy", state_incr_by),
+        ("cas", state_cas),
+        ("ttl", state_ttl),
     ];
     for (name, func) in methods {
         let native_fn = NativeFunction::from_copy_closure_with_captures(func, flow_id.clone())
@@ -1565,9 +1718,17 @@ fn js_to_json(context: &mut Context, value: &JsValue) -> JsResult<Value> {
     }
 
     if let Some(n) = value.as_number() {
-        return Ok(Value::Number(
-            serde_json::Number::from_f64(n).unwrap_or(serde_json::Number::from(0)),
-        ));
+        // JS has a single number type, so a whole number like `5` arrives as the f64 `5.0`.
+        // Encoding it via `from_f64` would store `5.0` (JSON `is_i64() == false`), which the
+        // integer-only `increment`/`increment_by` and Redis `INCRBY` can't accumulate — a later
+        // `incr` would silently start from 0 (issue #358 B2). So when the value is integral and in
+        // i64 range, emit an integer `Number` to keep counters usable across set→incr.
+        let number = if n.fract() == 0.0 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+            serde_json::Number::from(n as i64)
+        } else {
+            serde_json::Number::from_f64(n).unwrap_or(serde_json::Number::from(0))
+        };
+        return Ok(Value::Number(number));
     }
 
     if let Some(s) = value.as_string() {
@@ -4034,6 +4195,215 @@ function should_inject(request, flow_store) {
                 }
                 other => panic!("expected 200 on third attempt, got {other:?}"),
             }
+        }
+
+        // --- ctx.state atomic ops (issue #358) ---
+
+        #[test]
+        fn get_or_returns_default_when_absent_then_stored_value() {
+            let script = r#"
+                function respond(ctx) {
+                    var first = ctx.state.getOr("count", 0);
+                    ctx.state.set("count", 7);
+                    var second = ctx.state.getOr("count", 0);
+                    return http(200, { first: first, second: second });
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"first\":0"), "got {body}");
+                    assert!(body.contains("\"second\":7"), "got {body}");
+                }
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn incr_by_is_atomic_and_starts_at_zero() {
+            let script = r#"
+                function respond(ctx) {
+                    var n = ctx.state.incrBy("hits", 5);
+                    return http(200, { n: n });
+                }
+            "#;
+            let engine = JsEngine::new(script, "incr-by-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":5")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+
+            let d2 = engine.should_inject(&request, shared_store).unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":10")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn cas_distinguishes_applied_from_conflict() {
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            // First call: key "status" absent, expected null matches -> applied, sets "paid".
+            let applied_script = r#"
+                function respond(ctx) {
+                    var outcome = ctx.state.cas("status", null, "paid");
+                    return http(200, { applied: outcome.applied, current: outcome.current });
+                }
+            "#;
+            let applied_engine = JsEngine::new(applied_script, "cas-applied").unwrap();
+            let d1 = applied_engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+
+            // Second call: current is now "paid"; expecting "pending" must conflict and report the
+            // winning current value, distinguishing it from the Applied case above.
+            let conflict_script = r#"
+                function respond(ctx) {
+                    var outcome = ctx.state.cas("status", "pending", "shipped");
+                    return http(200, { applied: outcome.applied, current: outcome.current });
+                }
+            "#;
+            let conflict_engine = JsEngine::new(conflict_script, "cas-conflict").unwrap();
+            let d2 = conflict_engine
+                .should_inject(&request, shared_store)
+                .unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":false"), "got {body}");
+                    assert!(body.contains("\"current\":\"paid\""), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ttl_sets_per_flow_expiry() {
+            let script = r#"
+                function respond(ctx) {
+                    ctx.state.set("k", 1);
+                    var applied = ctx.state.ttl(3600);
+                    return http(200, { applied: applied });
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        // Issue #358 B2: JS has one number type, so `set("count", 5)` arrives as f64 5.0. The
+        // js_to_json integer fix stores it as an integer so a following incr_by/incr accumulates
+        // instead of silently restarting from 0.
+        #[test]
+        fn set_whole_number_then_incr_by_accumulates() {
+            let script = r#"
+                function respond(ctx) {
+                    ctx.state.set("count", 5);
+                    var a = ctx.state.incrBy("count", 1);
+                    var b = ctx.state.incr("count");
+                    return http(200, { a: a, b: b });
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(
+                        body.contains("\"a\":6"),
+                        "expected incr_by to yield 6, got {body}"
+                    );
+                    assert!(
+                        body.contains("\"b\":7"),
+                        "expected incr to yield 7, got {body}"
+                    );
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        // Issue #358 B3 (AC4): a backend failure on any atomic op must propagate as a script error.
+        #[cfg(feature = "test-backend")]
+        #[test]
+        fn atomic_ops_propagate_store_errors_fail_loud() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let request = req(HashMap::new(), None);
+
+            for (name, script) in [
+                (
+                    "get_or",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.getOr("k", 0) }); }"#,
+                ),
+                (
+                    "incr_by",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.incrBy("k", 1) }); }"#,
+                ),
+                (
+                    "cas",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.cas("k", null, "v").applied }); }"#,
+                ),
+                (
+                    "ttl",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.ttl(60) }); }"#,
+                ),
+            ] {
+                let result = JsEngine::new(script, "fail")
+                    .unwrap()
+                    .should_inject(&request, Arc::new(FailingFlowStore));
+                assert!(result.is_err(), "{name} must propagate a store failure");
+            }
+        }
+
+        // Issue #358 B1 / #322: pre-existing v2 ops (get/incr) fail loud even with the toggle
+        // unset, while the legacy v1 `flow_store` global stays lenient under the default toggle.
+        #[cfg(feature = "test-backend")]
+        #[test]
+        fn v2_state_ops_fail_loud_while_v1_flow_store_lenient() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let request = req(HashMap::new(), None);
+
+            let get_err = JsEngine::new(
+                r#"function respond(ctx) { return http(200, { v: ctx.state.get("k") }); }"#,
+                "v2-get",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(get_err.is_err(), "v2 ctx.state.get must fail loud");
+
+            let incr_err = JsEngine::new(
+                r#"function respond(ctx) { return http(200, { v: ctx.state.incr("k") }); }"#,
+                "v2-incr",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(incr_err.is_err(), "v2 ctx.state.incr must fail loud");
+
+            // v1 flow_store.get stays lenient under the default (unset) toggle — no raise.
+            let v1 = JsEngine::new(
+                r#"function should_inject(request, flow_store) { flow_store.get("f", "k"); return { inject: false }; }"#,
+                "v1-get",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(
+                matches!(v1, Ok(FaultDecision::None)),
+                "v1 flow_store.get must stay lenient under the default toggle, got {v1:?}"
+            );
         }
 
         // B1 (issue #357): a script defining ONLY a misnamed entrypoint must Err, not None.

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
+use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result, strict_flow_store};
 use crate::scripting::{
     FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptRequest, ScriptResponseContext,
     ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
@@ -432,7 +432,8 @@ fn build_stub_ctx_table(lua: &Lua, stub: &ScriptStubContext) -> LuaResult<LuaTab
 }
 
 /// Flow-state handle bound to one flow id — `ctx.state` and the value returned by
-/// `ctx.store:flow(id)` (issue #357 Item 1).
+/// `ctx.store:flow(id)` (issue #357 Item 1); atomic ops `get_or`/`incr_by`/`cas`/`ttl` added by
+/// issue #358.
 struct LuaStateHandle {
     inner: LuaFlowStore,
     flow_id: String,
@@ -441,7 +442,9 @@ struct LuaStateHandle {
 impl LuaStateHandle {
     fn new(store: Arc<dyn FlowStore>, flow_id: String) -> Self {
         Self {
-            inner: LuaFlowStore::new(store),
+            // v2 `ctx.state` is always fail-loud (issue #358), independent of the env toggle that
+            // gates the legacy v1 `flow_store` global.
+            inner: LuaFlowStore::new_strict(store),
             flow_id,
         }
     }
@@ -463,6 +466,23 @@ impl LuaUserData for LuaStateHandle {
         });
         methods.add_method("delete", |_lua, this, key: String| {
             this.inner.delete(this.flow_id.clone(), key)
+        });
+        // Atomic ops + ergonomic getters (issue #358).
+        methods.add_method("get_or", |lua, this, (key, default): (String, LuaValue)| {
+            this.inner.get_or(lua, this.flow_id.clone(), key, default)
+        });
+        methods.add_method("incr_by", |_lua, this, (key, by): (String, i64)| {
+            this.inner.increment_by(this.flow_id.clone(), key, by)
+        });
+        methods.add_method(
+            "cas",
+            |lua, this, (key, expected, new): (String, LuaValue, LuaValue)| {
+                this.inner
+                    .cas(lua, this.flow_id.clone(), key, expected, new)
+            },
+        );
+        methods.add_method("ttl", |_lua, this, seconds: i64| {
+            this.inner.ttl(this.flow_id.clone(), seconds)
         });
     }
 }
@@ -764,18 +784,36 @@ fn call_respond_lua(
     }
 }
 
-/// Wrapper for FlowStore that can be used in Lua scripts
+/// Wrapper for FlowStore that can be used in Lua scripts.
+///
+/// The `strict` flag decides how a backend failure surfaces (issues #322/#376/#358):
+/// - `strict == true` (the v2 `ctx.state` handle) — ALWAYS raise a Lua error on failure.
+/// - `strict == false` (the legacy v1 `flow_store` global) — honor the `RIFT_STRICT_FLOW_STORE`
+///   toggle (default lenient), preserving #322/#376 back-compat for v1 scripts.
 struct LuaFlowStore {
     store: Arc<dyn FlowStore>,
+    strict: bool,
 }
 
 impl LuaFlowStore {
+    /// Legacy v1 `flow_store` global: fail-loud gated by the `RIFT_STRICT_FLOW_STORE` toggle.
     fn new(store: Arc<dyn FlowStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            strict: strict_flow_store(),
+        }
     }
 
-    /// Get a value from flow state. Strict mode (issue #376) raises on a backend failure; otherwise
-    /// returns nil (the lenient #322 fallback) and records the error for `last_error()`.
+    /// v2 `ctx.state` handle: ALWAYS fail-loud regardless of the env toggle (issue #358).
+    fn new_strict(store: Arc<dyn FlowStore>) -> Self {
+        Self {
+            store,
+            strict: true,
+        }
+    }
+
+    /// Get a value from flow state. Fail-loud raises on a backend failure; otherwise returns nil
+    /// (the lenient #322 fallback) and records the error for `last_error()`.
     fn get(&self, lua: &Lua, flow_id: String, key: String) -> LuaResult<LuaValue> {
         let store = Arc::clone(&self.store);
 
@@ -783,12 +821,12 @@ impl LuaFlowStore {
         match flow_result("get", store.get(&flow_id, &key)) {
             Ok(Some(value)) => json_to_lua(lua, &value),
             Ok(None) => Ok(LuaValue::Nil),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(LuaValue::Nil),
         }
     }
 
-    /// Set a value in flow state. Strict mode raises on failure; else returns false (lenient #322).
+    /// Set a value in flow state. Fail-loud raises on failure; else returns false (lenient #322).
     fn set(&self, lua: &Lua, flow_id: String, key: String, value: LuaValue) -> LuaResult<bool> {
         // Convert Lua value to JSON
         let json_value = lua_to_json(lua, value)?;
@@ -797,45 +835,45 @@ impl LuaFlowStore {
 
         match flow_result("set", store.set(&flow_id, &key, json_value).map(|()| true)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(false),
         }
     }
 
-    /// Check if a key exists. Strict mode raises on failure; else returns false (lenient #322).
+    /// Check if a key exists. Fail-loud raises on failure; else returns false (lenient #322).
     fn exists(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
         match flow_result("exists", store.exists(&flow_id, &key)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(false),
         }
     }
 
-    /// Delete a key. Strict mode raises on failure; else returns false (lenient #322).
+    /// Delete a key. Fail-loud raises on failure; else returns false (lenient #322).
     fn delete(&self, flow_id: String, key: String) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
         match flow_result("delete", store.delete(&flow_id, &key).map(|()| true)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(false),
         }
     }
 
-    /// Increment a counter. Strict mode raises on failure; else returns 0 (lenient #322).
+    /// Increment a counter. Fail-loud raises on failure; else returns 0 (lenient #322).
     fn increment(&self, flow_id: String, key: String) -> LuaResult<i64> {
         let store = Arc::clone(&self.store);
 
         match flow_result("increment", store.increment(&flow_id, &key)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(0),
         }
     }
 
-    /// Set TTL for a flow. Strict mode raises on failure; else returns false (lenient #322).
+    /// Set TTL for a flow. Fail-loud raises on failure; else returns false (lenient #322).
     fn set_ttl(&self, flow_id: String, ttl_seconds: i64) -> LuaResult<bool> {
         let store = Arc::clone(&self.store);
 
@@ -844,7 +882,7 @@ impl LuaFlowStore {
             store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
         ) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(mlua::Error::runtime(msg)),
+            Err(msg) if self.strict => Err(mlua::Error::runtime(msg)),
             Err(_) => Ok(false),
         }
     }
@@ -854,6 +892,93 @@ impl LuaFlowStore {
     fn last_error(&self) -> LuaResult<Option<String>> {
         Ok(crate::extensions::flow_state::take_last_flow_error())
     }
+
+    // ============================================================
+    // Atomic ops + ergonomic getters (issue #358). Unlike the ops above, these ALWAYS raise a Lua
+    // error on a backend failure — fail-loud is the whole point of the new API, so a store outage
+    // must never be conflated with "key absent"/"conflict" the way the lenient #322 fallback would.
+    // ============================================================
+
+    /// Get a value, or `default` if the key is absent. A store failure always raises.
+    fn get_or(
+        &self,
+        lua: &Lua,
+        flow_id: String,
+        key: String,
+        default: LuaValue,
+    ) -> LuaResult<LuaValue> {
+        let store = Arc::clone(&self.store);
+        match flow_result("getOr", store.get(&flow_id, &key)) {
+            Ok(Some(value)) => json_to_lua(lua, &value),
+            Ok(None) => Ok(default),
+            Err(msg) => Err(mlua::Error::runtime(msg)),
+        }
+    }
+
+    /// Atomically increment by `by`, starting at 0 when absent. Always fail-loud.
+    fn increment_by(&self, flow_id: String, key: String, by: i64) -> LuaResult<i64> {
+        let store = Arc::clone(&self.store);
+        flow_result("incrementBy", store.increment_by(&flow_id, &key, by))
+            .map_err(mlua::Error::runtime)
+    }
+
+    /// Atomic compare-and-set (issue #358, #311). Returns a table `{ applied = true }` on success
+    /// or `{ applied = false, current = <value-or-nil> }` on conflict — deliberately a table
+    /// rather than a bare value so "conflict, current value happens to be `true`" can never be
+    /// confused with "applied". Always fail-loud.
+    fn cas(
+        &self,
+        lua: &Lua,
+        flow_id: String,
+        key: String,
+        expected: LuaValue,
+        new: LuaValue,
+    ) -> LuaResult<LuaTable> {
+        let expected_json = if matches!(expected, LuaValue::Nil) {
+            None
+        } else {
+            Some(lua_to_json(lua, expected)?)
+        };
+        let new_json = lua_to_json(lua, new)?;
+        let store = Arc::clone(&self.store);
+        match flow_result(
+            "cas",
+            store.compare_and_set(&flow_id, &key, expected_json.as_ref(), new_json),
+        ) {
+            Ok(outcome) => cas_outcome_to_lua(lua, outcome),
+            Err(msg) => Err(mlua::Error::runtime(msg)),
+        }
+    }
+
+    /// Set a per-flow TTL override in seconds. Always fail-loud.
+    fn ttl(&self, flow_id: String, ttl_seconds: i64) -> LuaResult<bool> {
+        let store = Arc::clone(&self.store);
+        flow_result("ttl", store.set_ttl(&flow_id, ttl_seconds).map(|()| true))
+            .map_err(mlua::Error::runtime)
+    }
+}
+
+/// Convert a [`CasOutcome`] to the Lua return shape for `ctx.state:cas()` (issue #358): a table
+/// with an `applied` flag and (on conflict) the winning `current` value, so success and conflict
+/// are always structurally distinguishable — never just a bare value that could coincidentally
+/// equal a "success" sentinel.
+fn cas_outcome_to_lua(lua: &Lua, outcome: CasOutcome) -> LuaResult<LuaTable> {
+    let t = lua.create_table()?;
+    match outcome {
+        CasOutcome::Applied => {
+            t.set("applied", true)?;
+            t.set("current", LuaValue::Nil)?;
+        }
+        CasOutcome::Conflict(current) => {
+            t.set("applied", false)?;
+            let current_lua = match &current {
+                Some(v) => json_to_lua(lua, v)?,
+                None => LuaValue::Nil,
+            };
+            t.set("current", current_lua)?;
+        }
+    }
+    Ok(t)
 }
 
 impl LuaUserData for LuaFlowStore {
@@ -2045,6 +2170,186 @@ end
                 }
                 other => panic!("expected 200 on third attempt, got {other:?}"),
             }
+        }
+
+        // --- ctx.state atomic ops (issue #358) ---
+
+        #[tokio::test]
+        async fn get_or_returns_default_when_absent_then_stored_value() {
+            let script = r#"
+                function respond(ctx)
+                    local first = ctx.state:get_or("count", 0)
+                    ctx.state:set("count", 7)
+                    local second = ctx.state:get_or("count", 0)
+                    return http(200, { first = first, second = second })
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"first\":0"), "got {body}");
+                    assert!(body.contains("\"second\":7"), "got {body}");
+                }
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn incr_by_is_atomic_and_starts_at_zero() {
+            let script = r#"
+                function respond(ctx)
+                    local n = ctx.state:incr_by("hits", 5)
+                    return http(200, { n = n })
+                end
+            "#;
+            let engine = LuaEngine::new(script, "incr-by-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":5")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+
+            let d2 = engine.should_inject(&request, shared_store).unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":10")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn cas_distinguishes_applied_from_conflict() {
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            // First call: key "status" absent, expected nil matches -> applied, sets "paid".
+            let applied_script = r#"
+                function respond(ctx)
+                    local outcome = ctx.state:cas("status", nil, "paid")
+                    return http(200, { applied = outcome.applied, current = outcome.current })
+                end
+            "#;
+            let applied_engine = LuaEngine::new(applied_script, "cas-applied").unwrap();
+            let d1 = applied_engine
+                .should_inject(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+
+            // Second call: current is now "paid"; expecting "pending" must conflict and report the
+            // winning current value, distinguishing it from the Applied case above.
+            let conflict_script = r#"
+                function respond(ctx)
+                    local outcome = ctx.state:cas("status", "pending", "shipped")
+                    return http(200, { applied = outcome.applied, current = outcome.current })
+                end
+            "#;
+            let conflict_engine = LuaEngine::new(conflict_script, "cas-conflict").unwrap();
+            let d2 = conflict_engine
+                .should_inject(&request, shared_store)
+                .unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":false"), "got {body}");
+                    assert!(body.contains("\"current\":\"paid\""), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn ttl_sets_per_flow_expiry() {
+            let script = r#"
+                function respond(ctx)
+                    ctx.state:set("k", 1)
+                    local applied = ctx.state:ttl(3600)
+                    return http(200, { applied = applied })
+                end
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        // Issue #358 B3 (AC4): a backend failure on any atomic op must propagate as a script error.
+        #[cfg(feature = "test-backend")]
+        #[tokio::test]
+        async fn atomic_ops_propagate_store_errors_fail_loud() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let request = req(HashMap::new(), None);
+
+            for (name, script) in [
+                (
+                    "get_or",
+                    r#"function respond(ctx) return http(200, { v = ctx.state:get_or("k", 0) }) end"#,
+                ),
+                (
+                    "incr_by",
+                    r#"function respond(ctx) return http(200, { v = ctx.state:incr_by("k", 1) }) end"#,
+                ),
+                (
+                    "cas",
+                    r#"function respond(ctx) return http(200, { v = ctx.state:cas("k", nil, "v").applied }) end"#,
+                ),
+                (
+                    "ttl",
+                    r#"function respond(ctx) return http(200, { v = ctx.state:ttl(60) }) end"#,
+                ),
+            ] {
+                let result = LuaEngine::new(script, "fail")
+                    .unwrap()
+                    .should_inject(&request, Arc::new(FailingFlowStore));
+                assert!(result.is_err(), "{name} must propagate a store failure");
+            }
+        }
+
+        // Issue #358 B1 / #322: pre-existing v2 ops (get/incr) fail loud even with the toggle
+        // unset, while the legacy v1 `flow_store` global stays lenient under the default toggle.
+        #[cfg(feature = "test-backend")]
+        #[tokio::test]
+        async fn v2_state_ops_fail_loud_while_v1_flow_store_lenient() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let request = req(HashMap::new(), None);
+
+            let get_err = LuaEngine::new(
+                r#"function respond(ctx) return http(200, { v = ctx.state:get("k") }) end"#,
+                "v2-get",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(get_err.is_err(), "v2 ctx.state:get must fail loud");
+
+            let incr_err = LuaEngine::new(
+                r#"function respond(ctx) return http(200, { v = ctx.state:incr("k") }) end"#,
+                "v2-incr",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(incr_err.is_err(), "v2 ctx.state:incr must fail loud");
+
+            // v1 flow_store:get stays lenient under the default (unset) toggle — no raise.
+            let v1 = LuaEngine::new(
+                r#"function should_inject(request, flow_store) flow_store:get("f", "k"); return { inject = false } end"#,
+                "v1-get",
+            )
+            .unwrap()
+            .should_inject(&request, Arc::new(FailingFlowStore));
+            assert!(
+                matches!(v1, Ok(FaultDecision::None)),
+                "v1 flow_store:get must stay lenient under the default toggle, got {v1:?}"
+            );
         }
 
         // B1 (issue #357): a script defining ONLY a misnamed entrypoint must Err, not None.

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::{FlowStore, flow_result, strict_flow_store};
+use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result, strict_flow_store};
 use anyhow::{Result, anyhow};
 use rhai::Dynamic;
 use serde_json::Value;
@@ -386,19 +386,40 @@ pub struct ScriptRequest {
 
 /// Wrapper for FlowStore that can be used in scripts (both Rhai and Lua)
 /// Uses direct synchronous calls since FlowStore is no longer async
+///
+/// The `strict` flag decides how a backend failure surfaces (issues #322/#376/#358):
+/// - `strict == true` (the v2 `ctx.state` handle) — ALWAYS raise a script error on failure, so the
+///   whole v2 surface uniformly fails loud and a store outage is never conflated with "absent".
+/// - `strict == false` (the legacy v1 `flow_store` global, `should_inject(request, flow_store)`) —
+///   honor the process-global `RIFT_STRICT_FLOW_STORE` toggle (default lenient: return a fallback
+///   and record `last_error()`), preserving #322/#376 back-compat for v1 scripts.
 #[derive(Clone)]
-
 pub struct ScriptFlowStore {
     store: Arc<dyn FlowStore>,
+    strict: bool,
 }
 
 impl ScriptFlowStore {
+    /// Legacy v1 `flow_store` global: fail-loud is gated by the `RIFT_STRICT_FLOW_STORE` toggle
+    /// (default lenient) — read once here at construction.
     pub fn new(store: Arc<dyn FlowStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            strict: strict_flow_store(),
+        }
     }
 
-    /// Get a value from flow state. In strict mode (issue #376) a backend failure raises; otherwise
-    /// it returns unit (the lenient #322 fallback) and records the error for `last_error()`.
+    /// v2 `ctx.state` handle: ALWAYS fail-loud, regardless of the env toggle (issue #358).
+    pub fn new_strict(store: Arc<dyn FlowStore>) -> Self {
+        Self {
+            store,
+            strict: true,
+        }
+    }
+
+    /// Get a value from flow state. Fail-loud (v2 handle, or v1 with the toggle on) raises on a
+    /// backend failure; otherwise returns unit (the lenient #322 fallback) and records the error
+    /// for `last_error()`.
     pub fn get(
         &mut self,
         flow_id: String,
@@ -407,12 +428,12 @@ impl ScriptFlowStore {
         match flow_result("get", self.store.get(&flow_id, &key)) {
             Ok(Some(val)) => Ok(rhai_engine::json_to_dynamic(val)),
             Ok(None) => Ok(Dynamic::UNIT),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(Dynamic::UNIT),
         }
     }
 
-    /// Set a value in flow state. Strict mode raises on failure; else returns false (lenient #322).
+    /// Set a value in flow state. Fail-loud raises on failure; else returns false (lenient #322).
     pub fn set(
         &mut self,
         flow_id: String,
@@ -425,12 +446,12 @@ impl ScriptFlowStore {
             self.store.set(&flow_id, &key, json_val).map(|()| true),
         ) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(false),
         }
     }
 
-    /// Check if a key exists. Strict mode raises on failure; else returns false (lenient #322).
+    /// Check if a key exists. Fail-loud raises on failure; else returns false (lenient #322).
     pub fn exists(
         &mut self,
         flow_id: String,
@@ -438,12 +459,12 @@ impl ScriptFlowStore {
     ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
         match flow_result("exists", self.store.exists(&flow_id, &key)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(false),
         }
     }
 
-    /// Delete a key. Strict mode raises on failure; else returns false (lenient #322).
+    /// Delete a key. Fail-loud raises on failure; else returns false (lenient #322).
     pub fn delete(
         &mut self,
         flow_id: String,
@@ -451,12 +472,12 @@ impl ScriptFlowStore {
     ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
         match flow_result("delete", self.store.delete(&flow_id, &key).map(|()| true)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(false),
         }
     }
 
-    /// Increment a counter. Strict mode raises on failure; else returns 0 (lenient #322).
+    /// Increment a counter. Fail-loud raises on failure; else returns 0 (lenient #322).
     pub fn increment(
         &mut self,
         flow_id: String,
@@ -464,12 +485,12 @@ impl ScriptFlowStore {
     ) -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
         match flow_result("increment", self.store.increment(&flow_id, &key)) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(0),
         }
     }
 
-    /// Set TTL for a flow. Strict mode raises on failure; else returns false (lenient #322).
+    /// Set TTL for a flow. Fail-loud raises on failure; else returns false (lenient #322).
     pub fn set_ttl(
         &mut self,
         flow_id: String,
@@ -480,7 +501,7 @@ impl ScriptFlowStore {
             self.store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
         ) {
             Ok(v) => Ok(v),
-            Err(msg) if strict_flow_store() => Err(msg.into()),
+            Err(msg) if self.strict => Err(msg.into()),
             Err(_) => Ok(false),
         }
     }
@@ -492,6 +513,75 @@ impl ScriptFlowStore {
             Some(msg) => Dynamic::from(msg),
             None => Dynamic::UNIT,
         }
+    }
+
+    // ============================================================
+    // Atomic ops + ergonomic getters (issue #358). Unlike the ops above, these ALWAYS raise a
+    // script error on a backend failure — fail-loud is the entire point of the new API, so a
+    // store outage must never be conflated with "key absent"/"conflict" the way the lenient #322
+    // fallback would.
+    // ============================================================
+
+    /// Get a value, or `default` if the key is absent. A store failure always raises.
+    pub fn get_or(
+        &mut self,
+        flow_id: String,
+        key: String,
+        default: Dynamic,
+    ) -> std::result::Result<Dynamic, Box<rhai::EvalAltResult>> {
+        match flow_result("getOr", self.store.get(&flow_id, &key)) {
+            Ok(Some(val)) => Ok(rhai_engine::json_to_dynamic(val)),
+            Ok(None) => Ok(default),
+            Err(msg) => Err(msg.into()),
+        }
+    }
+
+    /// Atomically increment by `by`, starting at 0 when absent. Always fail-loud.
+    pub fn increment_by(
+        &mut self,
+        flow_id: String,
+        key: String,
+        by: i64,
+    ) -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
+        flow_result("incrementBy", self.store.increment_by(&flow_id, &key, by)).map_err(Into::into)
+    }
+
+    /// Atomic compare-and-set (issues #358, #311): `key` is set to `new` iff its current value
+    /// equals `expected` (unit means "not present"). Returns the raw [`CasOutcome`]; the caller
+    /// (the Rhai-specific `RhaiStateHandle`) converts it to the engine's object-map return shape.
+    /// Always fail-loud.
+    pub fn cas(
+        &mut self,
+        flow_id: String,
+        key: String,
+        expected: Dynamic,
+        new: Dynamic,
+    ) -> std::result::Result<CasOutcome, Box<rhai::EvalAltResult>> {
+        let expected_json = if expected.is_unit() {
+            None
+        } else {
+            Some(rhai_engine::dynamic_to_json(expected))
+        };
+        let new_json = rhai_engine::dynamic_to_json(new);
+        flow_result(
+            "cas",
+            self.store
+                .compare_and_set(&flow_id, &key, expected_json.as_ref(), new_json),
+        )
+        .map_err(Into::into)
+    }
+
+    /// Set a per-flow TTL override. Always fail-loud.
+    pub fn ttl(
+        &mut self,
+        flow_id: String,
+        ttl_seconds: i64,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        flow_result(
+            "ttl",
+            self.store.set_ttl(&flow_id, ttl_seconds).map(|()| true),
+        )
+        .map_err(Into::into)
     }
 }
 

--- a/crates/rift-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-core/src/scripting/rhai_engine.rs
@@ -1,4 +1,4 @@
-use crate::extensions::flow_state::FlowStore;
+use crate::extensions::flow_state::{CasOutcome, FlowStore};
 use anyhow::{Result, anyhow};
 use rhai::{AST, Dynamic, Engine, Map, Scope};
 use serde_json::Value;
@@ -285,7 +285,11 @@ fn register_v2_api(engine: &mut Engine) {
         .register_fn("set", RhaiStateHandle::set)
         .register_fn("incr", RhaiStateHandle::incr)
         .register_fn("exists", RhaiStateHandle::exists)
-        .register_fn("delete", RhaiStateHandle::delete);
+        .register_fn("delete", RhaiStateHandle::delete)
+        .register_fn("get_or", RhaiStateHandle::get_or)
+        .register_fn("incr_by", RhaiStateHandle::incr_by)
+        .register_fn("cas", RhaiStateHandle::cas)
+        .register_fn("ttl", RhaiStateHandle::ttl);
 
     engine
         .register_type::<RhaiStoreHandle>()
@@ -349,8 +353,8 @@ fn dynamic_to_script_result_body(value: Dynamic) -> ScriptResultBody {
 }
 
 /// Flow-state handle bound to one flow id — `ctx.state` and the value returned by
-/// `ctx.store.flow(id)` (issue #357 Item 1). Exposes the subset of `ScriptFlowStore` that doesn't
-/// need a `flow_id` argument per call (full get_or/incr-with-args/cas is P3b, issue #358).
+/// `ctx.store.flow(id)` (issue #357 Item 1). Wraps `ScriptFlowStore` so every call omits the
+/// `flow_id` argument; also carries the atomic ops (`get_or`/`incr_by`/`cas`/`ttl`, issue #358).
 #[derive(Clone)]
 pub struct RhaiStateHandle {
     inner: ScriptFlowStore,
@@ -360,7 +364,9 @@ pub struct RhaiStateHandle {
 impl RhaiStateHandle {
     fn new(store: Arc<dyn FlowStore>, flow_id: String) -> Self {
         Self {
-            inner: ScriptFlowStore::new(store),
+            // v2 `ctx.state` is always fail-loud (issue #358), independent of the env toggle that
+            // gates the legacy v1 `flow_store` global.
+            inner: ScriptFlowStore::new_strict(store),
             flow_id,
         }
     }
@@ -388,6 +394,66 @@ impl RhaiStateHandle {
     pub fn delete(&mut self, key: String) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
         self.inner.delete(self.flow_id.clone(), key)
     }
+
+    /// Value or `default` if the key is absent (issue #358) — kills the
+    /// `if v == () { v = 0; }` idiom. A store failure always raises (fail-loud).
+    pub fn get_or(
+        &mut self,
+        key: String,
+        default: Dynamic,
+    ) -> std::result::Result<Dynamic, Box<rhai::EvalAltResult>> {
+        self.inner.get_or(self.flow_id.clone(), key, default)
+    }
+
+    /// Atomic increment by `by`, starting at 0 when absent (issue #358). Always fail-loud.
+    pub fn incr_by(
+        &mut self,
+        key: String,
+        by: i64,
+    ) -> std::result::Result<i64, Box<rhai::EvalAltResult>> {
+        self.inner.increment_by(self.flow_id.clone(), key, by)
+    }
+
+    /// Atomic compare-and-set (issue #358, #311). Returns an object map — `#{"applied": true}` on
+    /// success, or `#{"applied": false, "current": <value-or-unit>}` on conflict — deliberately an
+    /// object rather than a bare value so "conflict, current value happens to be `true`" can never
+    /// be confused with "applied". Always fail-loud.
+    pub fn cas(
+        &mut self,
+        key: String,
+        expected: Dynamic,
+        new: Dynamic,
+    ) -> std::result::Result<Dynamic, Box<rhai::EvalAltResult>> {
+        let outcome = self.inner.cas(self.flow_id.clone(), key, expected, new)?;
+        Ok(cas_outcome_to_dynamic(outcome))
+    }
+
+    /// Per-flow TTL override in seconds (issue #358). Always fail-loud.
+    pub fn ttl(&mut self, seconds: i64) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.ttl(self.flow_id.clone(), seconds)
+    }
+}
+
+/// Convert a [`CasOutcome`] to the Rhai return shape for `ctx.state.cas()` (issue #358): an object
+/// map with an `applied` flag and (on conflict) the winning `current` value, so success and
+/// conflict are always structurally distinguishable — never just a bare value that could
+/// coincidentally equal a "success" sentinel.
+fn cas_outcome_to_dynamic(outcome: CasOutcome) -> Dynamic {
+    let mut map = Map::new();
+    match outcome {
+        CasOutcome::Applied => {
+            map.insert("applied".into(), Dynamic::from(true));
+            map.insert("current".into(), Dynamic::UNIT);
+        }
+        CasOutcome::Conflict(current) => {
+            map.insert("applied".into(), Dynamic::from(false));
+            map.insert(
+                "current".into(),
+                current.map(json_to_dynamic).unwrap_or(Dynamic::UNIT),
+            );
+        }
+    }
+    Dynamic::from(map)
 }
 
 /// `ctx.store`: the flow-store escape hatch (issue #357 Item 1) — `.flow(id)` returns a handle
@@ -1688,6 +1754,196 @@ mod tests {
                 }
                 other => panic!("expected 200, got {other:?}"),
             }
+        }
+
+        // --- ctx.state atomic ops (issue #358) ---
+
+        #[test]
+        fn get_or_returns_default_when_absent_then_stored_value() {
+            let script = r#"
+                fn respond(ctx) {
+                    let n = ctx.state.get_or("count", 0);
+                    ctx.state.set("count", 7);
+                    let n2 = ctx.state.get_or("count", 0);
+                    http(200, #{ first: n, second: n2 })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"first\":0"), "got {body}");
+                    assert!(body.contains("\"second\":7"), "got {body}");
+                }
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn incr_by_is_atomic_and_starts_at_zero() {
+            let script = r#"
+                fn respond(ctx) {
+                    let n = ctx.state.incr_by("hits", 5);
+                    http(200, #{ n: n })
+                }
+            "#;
+            let engine = RhaiEngine::new(script, "incr-by-rule").unwrap();
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            let d1 = engine
+                .should_inject_fault(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":5")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+
+            let d2 = engine.should_inject_fault(&request, shared_store).unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => assert!(body.contains("\"n\":10")),
+                other => panic!("expected Error(200), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn cas_distinguishes_applied_from_conflict() {
+            let shared_store = store();
+            let request = req(HashMap::new(), None);
+
+            // First call: key "status" absent, expected () (unit) matches -> Applied, sets "paid".
+            let applied_script = r#"
+                fn respond(ctx) {
+                    let outcome = ctx.state.cas("status", (), "paid");
+                    http(200, #{ applied: outcome.applied, current: outcome.current })
+                }
+            "#;
+            let applied_engine = RhaiEngine::new(applied_script, "cas-applied").unwrap();
+            let d1 = applied_engine
+                .should_inject_fault(&request, Arc::clone(&shared_store))
+                .unwrap();
+            match d1 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+
+            // Second call: current is now "paid"; asking for expected "pending" must conflict and
+            // report the winning current value, distinguishing it from the Applied case above.
+            let conflict_script = r#"
+                fn respond(ctx) {
+                    let outcome = ctx.state.cas("status", "pending", "shipped");
+                    http(200, #{ applied: outcome.applied, current: outcome.current })
+                }
+            "#;
+            let conflict_engine = RhaiEngine::new(conflict_script, "cas-conflict").unwrap();
+            let d2 = conflict_engine
+                .should_inject_fault(&request, shared_store)
+                .unwrap();
+            match d2 {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":false"), "got {body}");
+                    assert!(body.contains("\"current\":\"paid\""), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn ttl_sets_per_flow_expiry() {
+            let script = r#"
+                fn respond(ctx) {
+                    ctx.state.set("k", 1);
+                    let applied = ctx.state.ttl(3600);
+                    http(200, #{ applied: applied })
+                }
+            "#;
+            let decision = run_respond(script, &req(HashMap::new(), None)).unwrap();
+            match decision {
+                FaultDecision::Error { body, .. } => {
+                    assert!(body.contains("\"applied\":true"), "got {body}");
+                }
+                other => panic!("expected 200, got {other:?}"),
+            }
+        }
+
+        // Issue #358 (fail-loud) / #322: a backend failure on any atomic op must propagate as a
+        // script error, never a silently-returned default — unlike the lenient #322 fallback the
+        // older get/set/incr/exists/delete ops use.
+        #[cfg(feature = "test-backend")]
+        #[test]
+        fn atomic_ops_propagate_store_errors_fail_loud() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let failing_store: Arc<dyn FlowStore> = Arc::new(FailingFlowStore);
+            let request = req(HashMap::new(), None);
+
+            let get_or_result = RhaiEngine::new(
+                r#"fn respond(ctx) { ctx.state.get_or("k", 0) }"#,
+                "fail-get-or",
+            )
+            .unwrap()
+            .should_inject_fault(&request, Arc::clone(&failing_store));
+            assert!(
+                get_or_result.is_err(),
+                "get_or must propagate a store failure, not a default"
+            );
+
+            let incr_by_result = RhaiEngine::new(
+                r#"fn respond(ctx) { ctx.state.incr_by("k", 1) }"#,
+                "fail-incr-by",
+            )
+            .unwrap()
+            .should_inject_fault(&request, Arc::clone(&failing_store));
+            assert!(
+                incr_by_result.is_err(),
+                "incr_by must propagate a store failure"
+            );
+
+            let cas_result = RhaiEngine::new(
+                r#"fn respond(ctx) { ctx.state.cas("k", (), "v") }"#,
+                "fail-cas",
+            )
+            .unwrap()
+            .should_inject_fault(&request, Arc::clone(&failing_store));
+            assert!(cas_result.is_err(), "cas must propagate a store failure");
+
+            let ttl_result =
+                RhaiEngine::new(r#"fn respond(ctx) { ctx.state.ttl(60) }"#, "fail-ttl")
+                    .unwrap()
+                    .should_inject_fault(&request, failing_store);
+            assert!(ttl_result.is_err(), "ttl must propagate a store failure");
+        }
+
+        // Issue #358 B1 / #322: the PRE-EXISTING v2 ops (get/incr) are also unconditionally
+        // fail-loud — they raise even with RIFT_STRICT_FLOW_STORE unset — while the legacy v1
+        // `flow_store` global stays lenient under the default toggle (returns a fallback, no raise).
+        #[cfg(feature = "test-backend")]
+        #[test]
+        fn v2_state_ops_fail_loud_while_v1_flow_store_lenient() {
+            use crate::extensions::flow_state::FailingFlowStore;
+            let request = req(HashMap::new(), None);
+
+            let get_err = RhaiEngine::new(r#"fn respond(ctx) { ctx.state.get("k") }"#, "v2-get")
+                .unwrap()
+                .should_inject_fault(&request, Arc::new(FailingFlowStore));
+            assert!(get_err.is_err(), "v2 ctx.state.get must fail loud");
+
+            let incr_err = RhaiEngine::new(r#"fn respond(ctx) { ctx.state.incr("k") }"#, "v2-incr")
+                .unwrap()
+                .should_inject_fault(&request, Arc::new(FailingFlowStore));
+            assert!(incr_err.is_err(), "v2 ctx.state.incr must fail loud");
+
+            // v1 flow_store.get stays lenient under the default (unset) toggle — no raise.
+            let v1 = RhaiEngine::new(
+                r#"fn should_inject(request, flow_store) { flow_store.get("f", "k"); #{ inject: false } }"#,
+                "v1-get",
+            )
+            .unwrap()
+            .should_inject_fault(&request, Arc::new(FailingFlowStore));
+            assert!(
+                matches!(v1, Ok(FaultDecision::None)),
+                "v1 flow_store.get must stay lenient under the default toggle, got {v1:?}"
+            );
         }
 
         // --- ctx.stub ---

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -60,6 +60,7 @@ pub fn validate_imposter(
     check_required_fields(file, imposter, result);
     check_protocol(file, imposter, result);
     check_port_range(file, imposter, result);
+    check_state_without_flow_state(file, imposter, result);
 
     // Named script registry (`_rift.scripts`, issue #356): validated once up front (each entry
     // must be a `code:`/`file:` leaf, not a `ref:`), then handed to every response so a
@@ -373,6 +374,76 @@ fn check_port_range(file: &Path, imposter: &Value, result: &mut LintResult) {
                 .with_location("port")
                 .with_suggestion("Consider using a port >= 1024"),
             );
+        }
+    }
+}
+
+/// Best-effort resolve of a `{ engine?, code?, file?, ref? }` script object's source text, for the
+/// E042 heuristic below. Unlike [`validate_script_source`] this doesn't itself report issues on a
+/// resolution failure (unreadable file, unknown ref) — those are already reported elsewhere by the
+/// real validation pass; here an unresolvable script is simply skipped.
+fn resolve_script_text(config_file: &Path, script: &Value, registry: &Value) -> Option<String> {
+    if let Some(code) = script.get("code").and_then(|v| v.as_str()) {
+        return Some(code.to_string());
+    }
+    if let Some(f) = script.get("file").and_then(|v| v.as_str()) {
+        return read_script_file_relative(config_file, f).ok();
+    }
+    if let Some(r) = script.get("ref").and_then(|v| v.as_str()) {
+        let target = registry.get(r)?;
+        return resolve_script_text(config_file, target, &Value::Null);
+    }
+    None
+}
+
+/// Issue #358: a script that calls `ctx.state` (or the v1 `flow_store`) needs a flow store to
+/// persist its writes. Without `_rift.flowState` configured, `Imposter::create_flow_store`
+/// auto-provisions an in-memory store instead of a silent no-op — state works, but only for this
+/// process's lifetime and isn't shared across a cluster. Warn so that's a deliberate choice, not a
+/// surprise at scale.
+fn check_state_without_flow_state(file: &Path, imposter: &Value, result: &mut LintResult) {
+    let has_flow_state = imposter
+        .get("_rift")
+        .and_then(|r| r.get("flowState"))
+        .is_some();
+    if has_flow_state {
+        return;
+    }
+
+    let registry = imposter
+        .get("_rift")
+        .and_then(|r| r.get("scripts"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let Some(stubs) = imposter.get("stubs").and_then(|v| v.as_array()) else {
+        return;
+    };
+    for (idx, stub) in stubs.iter().enumerate() {
+        let Some(responses) = stub.get("responses").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for (resp_idx, response) in responses.iter().enumerate() {
+            let Some(script) = response.get("_rift").and_then(|rift| rift.get("script")) else {
+                continue;
+            };
+            let Some(code) = resolve_script_text(file, script, &registry) else {
+                continue;
+            };
+            if code.contains("ctx.state") || code.contains("flow_store") {
+                result.add_issue(
+                    LintIssue::warning(
+                        "E042",
+                        "Script uses ctx.state (or flow_store) but no _rift.flowState is configured",
+                        file.to_path_buf(),
+                    )
+                    .with_location(format!("stubs[{idx}].responses[{resp_idx}]._rift.script"))
+                    .with_suggestion(
+                        "State will be auto-provisioned in-memory (won't persist across restarts \
+                         or be shared across a cluster) — configure _rift.flowState for production",
+                    ),
+                );
+            }
         }
     }
 }

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -1213,3 +1213,99 @@ fn e041_is_a_warning_not_an_error() {
         "E041 must be a deprecation warning, not a hard error"
     );
 }
+
+// ─── Issue #358: E042 — ctx.state used without _rift.flowState ──────────────
+
+#[test]
+fn e042_fires_for_ctx_state_without_flow_state() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn respond(ctx) { let n = ctx.state.incr(\"attempts\"); http(200) }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E042"), "expected E042, got {:?}", codes(&r));
+}
+
+#[test]
+fn e042_fires_for_v1_flow_store_without_flow_state() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn should_inject(request, flow_store) { flow_store.increment(\"f\", \"k\"); #{ inject: false } }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(has_code(&r, "E042"), "expected E042, got {:?}", codes(&r));
+}
+
+#[test]
+fn e042_does_not_fire_when_flow_state_is_configured() {
+    let mut v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn respond(ctx) { let n = ctx.state.incr(\"attempts\"); http(200) }"
+    }))]));
+    v["_rift"] = json!({ "flowState": { "backend": "inmemory" } });
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(
+        !has_code(&r, "E042"),
+        "flowState is configured, E042 must not fire, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn e042_does_not_fire_for_scripts_that_never_touch_state() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn respond(ctx) { http(200) }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(
+        !has_code(&r, "E042"),
+        "no ctx.state/flow_store usage, E042 must not fire, got {:?}",
+        codes(&r)
+    );
+}
+
+#[test]
+fn e042_does_not_fire_for_non_script_imposters() {
+    let v = make_imposter(json!([minimal_stub()]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    assert!(!has_code(&r, "E042"), "got {:?}", codes(&r));
+}
+
+#[test]
+fn e042_resolves_file_backed_scripts() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("stateful.rhai"),
+        "fn respond(ctx) { ctx.state.incr(\"n\"); http(200) }",
+    )
+    .unwrap();
+    let cfg = make_imposter(json!([rift_script_stub(
+        json!({ "file": "stateful.rhai" })
+    )]));
+    let config_path = dir.path().join("imposter.json");
+    std::fs::write(&config_path, serde_json::to_string(&cfg).unwrap()).unwrap();
+
+    let r = lint_file(&config_path, &opts());
+    assert!(has_code(&r, "E042"), "expected E042, got {:?}", codes(&r));
+}
+
+#[test]
+fn e042_is_a_warning_not_an_error() {
+    let v = make_imposter(json!([rift_script_stub(json!({
+        "code": "fn respond(ctx) { ctx.state.incr(\"n\"); http(200) }"
+    }))]));
+    let mut r = LintResult::new();
+    validate_imposter(path(), &v, &mut r, &opts());
+    let issue = r
+        .issues
+        .iter()
+        .find(|i| i.code == "E042")
+        .expect("E042 must fire");
+    assert_eq!(
+        issue.severity,
+        Severity::Warning,
+        "E042 must be a hint, not a hard error"
+    );
+}

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -46,15 +46,28 @@ An explicit `flowState` block that can't be honored now **fails imposter creatio
 - A **`redis` backend that can't be created** — no redis config block, a connection/pool failure, or
   a binary built without the `redis-backend` feature — fails creation too (issue #369).
 
-Only the *implicit* no-op case is silent: an imposter with **no** `flowState` block (and no scenario
-stubs) uses a no-op store where values never persist, exactly as before.
+Only imposters with genuinely **no state surface** stay on the silent no-op store: no `flowState`
+block, no scenario stubs, and no `_rift.script` stub (issue #358). Such an imposter never touches
+the store, so there is nothing to auto-provision.
+
+### No `flowState`, but a script or scenario stub — auto-provisioned in-memory
+
+An imposter with a `_rift.script` stub (which might call `ctx.state`/`flow_store` at runtime) or a
+scenario stub, but **no** `flowState` block, gets a real in-memory store auto-provisioned at the
+default TTL (300s) — a `tracing::warn!` (target `rift::script`) is logged so this doesn't go
+unnoticed, and `rift-lint` flags the same condition statically as `E042`. State works out of the
+box; it just doesn't persist across restarts or get shared across a cluster the way an explicit
+`flowState` (especially `backend: "redis"`) would.
 
 ---
 
 ## Script API
 
-The `flow_store` handle is passed to scripts (Rhai shown; Lua uses `flow_store:get(...)` method
-syntax). All operations take the flow id explicitly.
+`ctx.state` (the v2, recommended API — see [Scripting → `ctx.state` and `ctx.store`]({{ site.baseurl }}/features/scripting/#ctxstate-and-ctxstore))
+is pre-scoped to the request's resolved flow id and includes atomic ops (`get_or`/`incr_by`/`cas`/`ttl`,
+issue #358) beyond what's listed below. The `flow_store` handle shown here is the older v1 API,
+where every call takes the flow id explicitly (Rhai shown; Lua uses `flow_store:get(...)` method
+syntax) — it still works unchanged.
 
 | Call | Result |
 |:-----|:-------|
@@ -73,18 +86,23 @@ syntax). All operations take the flow id explicitly.
 Requires `--allow-injection`. The counter is keyed by the `X-Flow-Id` header so each caller retries
 independently.
 
+Using the v2 `ctx.state` API, `ctx.state.incr("attempts")` is already scoped to the caller's flow id
+(per `flowIdSource` below) — no flow-id prelude, no `if n == () { n = 0; }` default dance:
+
 ```json
 {
   "port": 4506,
   "protocol": "http",
-  "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 300 } },
+  "_rift": {
+    "flowState": { "backend": "inmemory", "ttlSeconds": 300, "flowIdSource": "header:X-Flow-Id" }
+  },
   "stubs": [{
     "predicates": [{ "equals": { "method": "GET", "path": "/api/resource" } }],
     "responses": [{
       "_rift": {
         "script": {
           "engine": "rhai",
-          "code": "fn should_inject(request, flow_store) { let id = request.headers[\"x-flow-id\"]; if id == () { id = \"default\"; } let n = flow_store.get(id, \"attempts\"); if n == () { n = 0; } n += 1; flow_store.set(id, \"attempts\", n); if n <= 2 { #{ inject: true, fault: \"error\", status: 503, body: `try ${n}` } } else { #{ inject: true, fault: \"error\", status: 200, body: `ok ${n}` } } }"
+          "code": "fn respond(ctx) { let n = ctx.state.incr(\"attempts\"); if n <= 2 { http(503, `try ${n}`) } else { http(200, `ok ${n}`) } }"
         }
       }
     }]
@@ -114,8 +132,9 @@ curl -X PUT http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts \
 curl -X DELETE http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts
 ```
 
-Note: an imposter gets a real store only when `_rift.flowState` is configured (or it declares
-scenario stubs); otherwise a no-op store is used and values never persist.
+Note: an imposter gets a real store when `_rift.flowState` is configured, or it declares scenario
+stubs, or it has a `_rift.script` stub (auto-provisioned in-memory, issue #358); only an imposter
+with none of those uses a no-op store where values never persist.
 
 > **Embedding over the C-ABI (non-Rust)**: a non-Rust host can read, write, and delete flow-state
 > keys with zero loopback HTTP via [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/#admin-long-tail-over-ffi-scenario-state--correlated-spaces) —

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -527,8 +527,33 @@ ctx.state.exists("key");          // bool
 ctx.state.delete("key");
 ```
 
-(Full `get_or`/parameterized `incr`/CAS support is a separate, upcoming addition — this covers the
-common get/set/incr/exists/delete case today.)
+Atomic ops and ergonomic getters (issue #358):
+
+```rhai
+let n = ctx.state.get_or("attempts", 0);   // value, or the default if absent — kills
+                                            // the `if v == () { v = 0; }` idiom
+let n = ctx.state.incr_by("attempts", 5);  // atomic +5, starts at 0 when absent
+ctx.state.ttl(60);                         // per-flow TTL override, in seconds
+
+let outcome = ctx.state.cas("status", "pending", "paid");
+if outcome.applied {
+  // this call won the race
+} else {
+  // outcome.current is who won instead (unit/nil/null if the key was absent)
+}
+```
+
+`cas(key, expected, new)` is Rift's atomic compare-and-set (issue #311). It always returns an
+**object** — `{ applied: true }` on success, or `{ applied: false, current: <value> }` on conflict —
+rather than a bare value, so a conflicting stored value that happens to equal `true` can never be
+mistaken for "applied". This shape is identical in all three engines; only the method spelling
+differs to match each engine's naming convention — Rhai/Lua use `get_or`/`incr_by` (snake_case), JS
+uses `getOr`/`incrBy` (camelCase); `cas` and `ttl` are spelled the same everywhere.
+
+Every `ctx.state` call is fail-loud: a store failure (a Redis connection dropping mid-request, for
+example) raises a script error and is logged — it is never silently swallowed into a default value.
+See [Flow State]({{ site.baseurl }}/features/flow-state/) for how the underlying store is selected,
+including the in-memory auto-provisioning that lets `ctx.state` work with zero configuration.
 
 `ctx.store` is the escape hatch for touching a *different* flow's state — `ctx.store.flow(id)`
 returns a handle just like `ctx.state`, but scoped to `id` instead of the request's own flow:
@@ -621,10 +646,16 @@ always takes precedence over `defaultEngine`.
 
 ## Flow-Store Error Semantics
 
-By **default** a flow-store backend failure (e.g. a Redis outage mid-request) is **lenient**: the
-failing op returns its empty fallback (`()` / `nil` / `null`, `false`, or `0`) and the script keeps
-running. So a script can't tell "key genuinely absent" from "backend down" by the return value
-alone — use `last_error()` for that:
+The v2 `ctx.state` API and the legacy v1 `flow_store` global (the `should_inject(request,
+flow_store)` path) differ in how a backend failure (e.g. a Redis outage mid-request) surfaces:
+
+- **`ctx.state` (v2) is always fail-loud.** Every op — `get`/`set`/`incr`/`exists`/`delete` and the
+  atomic `get_or`/`incr_by`/`cas`/`ttl` — **raises** a script error on a backend failure and logs
+  it, so a store outage is never silently returned as an empty/absent value. This is unconditional
+  and not affected by `RIFT_STRICT_FLOW_STORE`.
+- **`flow_store` (legacy v1 global) is lenient by default.** A failing op returns its empty fallback
+  (`()` / `nil` / `null`, `false`, or `0`) and the script keeps running, so a v1 script can't tell
+  "key genuinely absent" from "backend down" by the return value alone — use `last_error()`:
 
 ```rhai
 let v = flow_store.get("flow-1", "attempts");
@@ -637,9 +668,10 @@ if flow_store.last_error() != () {
 succeeded) and is reset at the start of every script execution. The call syntax follows each engine:
 `flow_store.last_error()` (Rhai), `flow_store:last_error()` (Lua), `flow_store.last_error()` (JS).
 
-Set the **`RIFT_STRICT_FLOW_STORE`** environment variable (truthy: `1`/`true`/`yes`/`on`) to make a
-flow-store op failure **raise** a script error in all three engines instead of returning a fallback.
-The raised error propagates to the standard script-error path (`500` with `x-rift-script-error`).
+Set the **`RIFT_STRICT_FLOW_STORE`** environment variable (truthy: `1`/`true`/`yes`/`on`) to make the
+legacy `flow_store` global **raise** on failure too (matching the v2 default) instead of returning a
+fallback. The raised error propagates to the standard script-error path (`500` with
+`x-rift-script-error`). This toggle does not change `ctx.state`, which is always fail-loud.
 
 ---
 


### PR DESCRIPTION
Unified ctx.state API scoped to resolved flow ID with atomic get_or, increment_by, compare-and-swap, and TTL operations across all 3 engines. Auto-provisions in-memory backend for script-bearing imposters lacking _rift.flowState instead of silently NoOping. Redis misconfiguration fails imposter creation with 400.

Closes #358
Milestone: scripting DX (P3b)