### PR TITLE
feat(cli): P5 script tooling — rift script check / rift script run + debug-mode script trace

### DIFF
--- a/crates/rift-core/src/backends/inmemory.rs
+++ b/crates/rift-core/src/backends/inmemory.rs
@@ -28,6 +28,19 @@ impl InMemoryFlowStore {
         format!("flow:{flow_id}:{key}")
     }
 
+    /// List every non-expired key currently stored under `flow_id`, for `rift script run`'s
+    /// post-execution state dump (issue #360 Item 2) — the [`FlowStore`] trait itself has no
+    /// enumeration method (a real backend like Redis may not make that cheap), but the CLI works
+    /// with a concrete `InMemoryFlowStore` fixture, so an inherent method here is enough.
+    pub fn keys_for_flow(&self, flow_id: &str) -> Vec<String> {
+        let prefix = format!("flow:{flow_id}:");
+        let data = self.data.read();
+        data.iter()
+            .filter(|(_, (_, expiry))| !self.is_expired(expiry))
+            .filter_map(|(key, _)| key.strip_prefix(&prefix).map(str::to_string))
+            .collect()
+    }
+
     fn is_expired(&self, expiry: &Option<SystemTime>) -> bool {
         if let Some(exp) = expiry {
             SystemTime::now() > *exp
@@ -166,6 +179,33 @@ impl FlowStore for InMemoryFlowStore {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Issue #360 Item 2: `rift script run` dumps the flow's keys after execution.
+    #[test]
+    fn keys_for_flow_lists_only_that_flows_non_expired_keys() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("flow1", "attempts", json!(2)).unwrap();
+        store.set("flow1", "last_status", json!("ok")).unwrap();
+        store.set("other-flow", "unrelated", json!(true)).unwrap();
+
+        let mut keys = store.keys_for_flow("flow1");
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["attempts".to_string(), "last_status".to_string()]
+        );
+
+        assert!(store.keys_for_flow("no-such-flow").is_empty());
+    }
+
+    #[test]
+    fn keys_for_flow_excludes_expired_keys() {
+        let store = InMemoryFlowStore::new(1);
+        store.set("flow1", "key1", json!("value1")).unwrap();
+        assert_eq!(store.keys_for_flow("flow1"), vec!["key1".to_string()]);
+        std::thread::sleep(Duration::from_secs(2));
+        assert!(store.keys_for_flow("flow1").is_empty());
+    }
 
     #[test]
     fn test_inmemory_get_set() {

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -19,7 +19,7 @@ use crate::extensions::decorate::{
 use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::scripting::{
     FaultDecision, ScriptCtxExtras, ScriptRequest, ScriptStubContext, resolve_script_timeout_ms,
-    should_inject_bounded_with_ctx,
+    should_inject_bounded_with_ctx, should_inject_bounded_with_ctx_traced,
 };
 #[cfg(feature = "javascript")]
 use crate::scripting::{MountebankRequest, execute_mountebank_inject};
@@ -499,17 +499,49 @@ async fn handle_request_inner(
                 port: imposter.config.port.unwrap_or(0),
             };
 
-            match should_inject_bounded_with_ctx(
-                engine.clone(),
-                code,
-                format!("rift_script_{stub_index}"),
-                script_request,
-                flow_store,
-                Duration::from_millis(timeout_ms),
-                ctx_extra,
-            )
-            .await
-            {
+            // Debug-mode script trace (issue #360 Item 3): which hook ran, its decision,
+            // duration, and ctx.logger lines, so "why didn't my script run the way I expected"
+            // is answerable from the response alone. Zero-cost when debug mode is off — the
+            // capturing-subscriber/Instant path in the `_traced` variant is only ever built when
+            // this flag is set, so the hot (non-debug) path calls the original, unchanged
+            // `should_inject_bounded_with_ctx`.
+            let (script_result, trace_header): (Result<FaultDecision, anyhow::Error>, _) =
+                if crate::util::rift_debug_env() {
+                    let (result, mut entry) = should_inject_bounded_with_ctx_traced(
+                        engine.clone(),
+                        code,
+                        format!("rift_script_{stub_index}"),
+                        script_request,
+                        flow_store,
+                        Duration::from_millis(timeout_ms),
+                        ctx_extra,
+                    )
+                    .await;
+                    // Cap a chatty script's logger output: the trace ships on a response header,
+                    // which must stay bounded (issue #360).
+                    entry.logs = crate::scripting::cap_trace_logs(entry.logs);
+                    // `ScriptTraceEntry` is plain strings/numbers, so this can't realistically
+                    // fail — but on the off chance it does, trace the failure instead of
+                    // silently dropping the header.
+                    let header = serde_json::to_string(&[entry])
+                        .inspect_err(|e| warn!("failed to serialize x-rift-script-trace: {}", e))
+                        .ok();
+                    (result, header)
+                } else {
+                    let result = should_inject_bounded_with_ctx(
+                        engine.clone(),
+                        code,
+                        format!("rift_script_{stub_index}"),
+                        script_request,
+                        flow_store,
+                        Duration::from_millis(timeout_ms),
+                        ctx_extra,
+                    )
+                    .await;
+                    (result, None)
+                };
+
+            match script_result {
                 Ok(FaultDecision::Error {
                     status,
                     body,
@@ -526,6 +558,9 @@ async fn handle_request_inner(
                     }
                     response = response.header("x-rift-imposter", "true");
                     response = response.header("x-rift-script", &engine);
+                    if let Some(trace) = &trace_header {
+                        response = response.header("x-rift-script-trace", trace.as_str());
+                    }
 
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
@@ -543,13 +578,17 @@ async fn handle_request_inner(
                         return Ok(backend_error_response(&e));
                     }
 
+                    let mut headers = vec![
+                        ("x-rift-imposter".to_string(), "true".to_string()),
+                        ("x-rift-script".to_string(), engine.clone()),
+                        ("x-rift-latency-ms".to_string(), duration_ms.to_string()),
+                    ];
+                    if let Some(trace) = trace_header {
+                        headers.push(("x-rift-script-trace".to_string(), trace));
+                    }
                     return Ok(build_response_with_headers(
                         StatusCode::OK,
-                        [
-                            ("x-rift-imposter", "true"),
-                            ("x-rift-script", &engine),
-                            ("x-rift-latency-ms", &duration_ms.to_string()),
-                        ],
+                        headers,
                         Bytes::new(),
                     ));
                 }
@@ -559,12 +598,16 @@ async fn handle_request_inner(
                         return Ok(backend_error_response(&e));
                     }
 
+                    let mut headers = vec![
+                        ("x-rift-imposter".to_string(), "true".to_string()),
+                        ("x-rift-script".to_string(), engine.clone()),
+                    ];
+                    if let Some(trace) = trace_header {
+                        headers.push(("x-rift-script-trace".to_string(), trace));
+                    }
                     return Ok(build_response_with_headers(
                         StatusCode::OK,
-                        [
-                            ("x-rift-imposter", "true"),
-                            ("x-rift-script", engine.as_str()),
-                        ],
+                        headers,
                         Bytes::new(),
                     ));
                 }
@@ -578,14 +621,15 @@ async fn handle_request_inner(
                         return Ok(backend_error_response(&e));
                     }
 
-                    let mut response = build_response_with_headers(
-                        StatusCode::BAD_GATEWAY,
-                        [
-                            ("x-rift-imposter", "true"),
-                            ("x-rift-script", engine.as_str()),
-                        ],
-                        Bytes::new(),
-                    );
+                    let mut headers = vec![
+                        ("x-rift-imposter".to_string(), "true".to_string()),
+                        ("x-rift-script".to_string(), engine.clone()),
+                    ];
+                    if let Some(trace) = trace_header {
+                        headers.push(("x-rift-script-trace".to_string(), trace));
+                    }
+                    let mut response =
+                        build_response_with_headers(StatusCode::BAD_GATEWAY, headers, Bytes::new());
                     response
                         .extensions_mut()
                         .insert(super::fault_io::TcpFaultKind::Reset);
@@ -593,9 +637,16 @@ async fn handle_request_inner(
                 }
                 Err(e) => {
                     warn!("Rift script execution failed: {}", e);
+                    let mut headers = vec![
+                        ("x-rift-imposter".to_string(), "true".to_string()),
+                        ("x-rift-script-error".to_string(), "true".to_string()),
+                    ];
+                    if let Some(trace) = trace_header {
+                        headers.push(("x-rift-script-trace".to_string(), trace));
+                    }
                     return Ok(build_response_with_headers(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
+                        headers,
                         format!(r#"{{"error": "Script error: {e}"}}"#),
                     ));
                 }

--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -6,13 +6,16 @@
 //! at a wall-clock deadline using the same abort-flag mechanism as the pooled path (#172):
 //! Rhai's `on_progress` callback, and a Lua instruction hook.
 
-use super::{FaultDecision, ScriptCtxExtras, ScriptEngine, ScriptRequest};
+use super::{
+    FaultDecision, ScriptCtxExtras, ScriptEngine, ScriptRequest, ScriptTraceEntry,
+    capture_script_logs, render_decision,
+};
 use crate::extensions::flow_state::FlowStore;
 use crate::imposter::ImposterConfig;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::warn;
 
 /// Default script timeout when `_rift.scriptEngine.timeoutMs` is not configured.
@@ -100,6 +103,76 @@ pub async fn should_inject_bounded_with_ctx(
             ))
         }
     }
+}
+
+/// As [`should_inject_bounded_with_ctx`], but also builds a debug-mode script trace (issue #360
+/// Item 3): the rendered decision, wall-clock duration, and any `ctx.logger` lines this run
+/// emitted. Only called when debug mode is on — [`should_inject_bounded_with_ctx`] above is
+/// unchanged and stays the zero-cost default the rest of the time (no capturing subscriber, no
+/// extra `Instant`/allocation).
+pub async fn should_inject_bounded_with_ctx_traced(
+    engine_type: String,
+    code: String,
+    rule_id: String,
+    request: ScriptRequest,
+    flow_store: Arc<dyn FlowStore>,
+    timeout: Duration,
+    ctx_extra: ScriptCtxExtras,
+) -> (Result<FaultDecision>, ScriptTraceEntry) {
+    let abort = Arc::new(AtomicBool::new(false));
+    let run_abort = Arc::clone(&abort);
+    let start = Instant::now();
+    let handle = tokio::task::spawn_blocking(move || {
+        capture_script_logs(|| {
+            run_should_inject_with_abort(
+                &engine_type,
+                &code,
+                &rule_id,
+                &request,
+                flow_store,
+                &run_abort,
+                &ctx_extra,
+            )
+        })
+    });
+
+    let (result, logs) = match tokio::time::timeout(timeout, handle).await {
+        Ok(Ok((result, logs))) => (result, logs),
+        Ok(Err(join_err)) => (
+            Err(anyhow::anyhow!("script task panicked: {join_err}")),
+            Vec::new(),
+        ),
+        Err(_elapsed) => {
+            abort.store(true, Ordering::Relaxed);
+            warn!(
+                "_rift.script execution timed out after {}ms",
+                timeout.as_millis()
+            );
+            (
+                Err(anyhow::anyhow!(
+                    "script execution timed out after {}ms",
+                    timeout.as_millis()
+                )),
+                Vec::new(),
+            )
+        }
+    };
+    let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let decision = match &result {
+        Ok(d) => render_decision(d),
+        Err(e) => format!("error: {e}"),
+    };
+    // Raw (uncapped) logs here: `rift script run` prints them all to the terminal. The
+    // header-bound debug trace caps them at its own serialization site (issue #360) — a
+    // response header, unlike a terminal dump, must stay bounded.
+    let entry = ScriptTraceEntry {
+        hook: "respond".to_string(),
+        decision,
+        duration_ms,
+        logs,
+        cache: None,
+    };
+    (result, entry)
 }
 
 /// Execute `should_inject` synchronously with the abort flag wired into the interpreter, so
@@ -365,5 +438,57 @@ mod tests {
             FaultDecision::Error { status, .. } => assert_eq!(status, 503),
             other => panic!("expected Error decision, got {other:?}"),
         }
+    }
+
+    // Issue #360 Item 3: the traced variant captures the decision, duration, and ctx.logger
+    // lines from a single run, without changing the decision itself.
+    #[tokio::test]
+    async fn traced_variant_captures_decision_duration_and_logs() {
+        let code = r#"
+            fn respond(ctx) {
+                ctx.logger.info("about to respond");
+                http(503, "boom")
+            }
+        "#;
+        let (result, entry) = should_inject_bounded_with_ctx_traced(
+            "rhai".into(),
+            code.into(),
+            "t".into(),
+            req(),
+            store(),
+            Duration::from_millis(2000),
+            ScriptCtxExtras::default(),
+        )
+        .await;
+        match result {
+            Ok(FaultDecision::Error { status, .. }) => assert_eq!(status, 503),
+            other => panic!("expected Error decision, got {other:?}"),
+        }
+        assert_eq!(entry.hook, "respond");
+        assert_eq!(entry.decision, "http(503) body=\"boom\"");
+        assert_eq!(entry.logs, vec!["about to respond".to_string()]);
+        assert!(entry.cache.is_none());
+    }
+
+    // A timeout still produces a trace entry (best-effort: no logs, an error decision string),
+    // instead of panicking or losing the timeout error.
+    #[tokio::test]
+    async fn traced_variant_reports_timeout() {
+        let (result, entry) = should_inject_bounded_with_ctx_traced(
+            "rhai".into(),
+            RUNAWAY_RHAI.into(),
+            "t".into(),
+            req(),
+            store(),
+            Duration::from_millis(150),
+            ScriptCtxExtras::default(),
+        )
+        .await;
+        assert!(result.is_err(), "runaway must time out, not hang");
+        assert!(
+            entry.decision.starts_with("error:"),
+            "got {}",
+            entry.decision
+        );
     }
 }

--- a/crates/rift-core/src/scripting/entrypoint_check.rs
+++ b/crates/rift-core/src/scripting/entrypoint_check.rs
@@ -1,0 +1,367 @@
+//! Static entrypoint/arity checking for `rift script check` (issue #360 Item 1).
+//!
+//! Complements the per-response syntax-only checks in `stub_validator.rs`/`rift-lint`: this
+//! module answers "does the script actually define the entrypoint the given hook will call at
+//! request time?" — issue #357 already added detection for exactly this ("script defines
+//! function(s) but none is the `respond` entrypoint...") inside each engine's runtime dispatch
+//! (`run_entrypoint` in `rhai_engine.rs`, and its JS/Lua equivalents in `js_engine.rs`/
+//! `lua_engine.rs`), but only as a request-time error. This module exposes the same
+//! function-name-based detection statically, so `rift script check` can catch a misnamed
+//! entrypoint (e.g. `fn respnod(ctx)`) before any request ever exercises it.
+//!
+//! "Static" here means never calling the entrypoint function itself. Rhai needs no evaluation at
+//! all — `rhai::AST::iter_functions()` lists declared functions straight from the parsed AST.
+//! JS/Lua have no cheap public AST walk, so they compile the script (syntax check, WITHOUT
+//! running), then evaluate its top level ONCE to discover which functions it declared, by diffing
+//! the global object/table before and after — the same technique the runtime path uses to spot a
+//! misnamed entrypoint. Crucially that top-level eval binds the SAME host globals the real
+//! execution path binds (`ctx`/`http`/`pass`/`delay`/`reset`/`request`/`flow_store`) under the
+//! engine's runtime limits (a JS loop-iteration cap; a Lua instruction budget) — so a legitimate
+//! #357 bare-expression response script (`http(503, "boom")`) is neither mis-flagged as an
+//! unbound-global error nor able to hang the check with a top-level `while(true){}`. That
+//! binding-and-budgeting lives in the engines themselves (`js_engine::declared_functions_js`,
+//! `lua_engine::declared_functions_lua`), reusing their real ctx/result-constructor setup.
+
+use super::entrypoints;
+
+/// Which entrypoint contract a script satisfies for the checked hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntrypointMatch {
+    /// The legacy v1 `should_inject(request, flow_store)` wrapper (only possible when the
+    /// checked hook is `respond`).
+    V1ShouldInject,
+    /// A v2 function declared with exactly the hook's name (e.g. `respond`, `matches`).
+    Named,
+    /// No functions declared at all — a legal v2 bare-expression script.
+    Bare,
+}
+
+/// Why a script failed the entrypoint/arity check.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EntrypointCheckError {
+    #[error("Unknown script engine type: '{0}'")]
+    UnknownEngine(String),
+    #[error("{engine} engine is not enabled (requires the '{feature}' feature)")]
+    EngineDisabled { engine: String, feature: String },
+    #[error("Syntax error: {0}")]
+    Syntax(String),
+    #[error(
+        "script defines function(s) ({declared}) but none is the `{hook}` entrypoint (and \
+         there is no bare expression to evaluate); did you mean `{hook}`?"
+    )]
+    Mismatch { hook: String, declared: String },
+}
+
+/// Statically check whether `script` (for `engine_type`) defines a valid entrypoint for `hook`
+/// (`"respond"`, `"matches"`, `"transform"`, or `"delay"`). `Err` covers both a compile/syntax
+/// error and an entrypoint mismatch — see [`EntrypointCheckError`]'s variants.
+pub fn check_entrypoint(
+    engine_type: &str,
+    script: &str,
+    hook: &str,
+) -> Result<EntrypointMatch, EntrypointCheckError> {
+    let declared = declared_functions(engine_type, script)?;
+    decide(&declared, hook)
+}
+
+/// Apply the same has-should-inject/has-named/has-any-function decision `run_entrypoint` (issue
+/// #357) makes at request time, given the set of top-level function names a script declares.
+fn decide(declared: &[String], hook: &str) -> Result<EntrypointMatch, EntrypointCheckError> {
+    if hook == entrypoints::RESPOND && declared.iter().any(|n| n == entrypoints::SHOULD_INJECT) {
+        return Ok(EntrypointMatch::V1ShouldInject);
+    }
+    if declared.iter().any(|n| n == hook) {
+        return Ok(EntrypointMatch::Named);
+    }
+    if declared.is_empty() {
+        return Ok(EntrypointMatch::Bare);
+    }
+    Err(EntrypointCheckError::Mismatch {
+        hook: hook.to_string(),
+        declared: declared.join(", "),
+    })
+}
+
+/// The top-level function names `script` declares, for `engine_type`. Empty means the script has
+/// no function declarations at all (a bare expression).
+fn declared_functions(
+    engine_type: &str,
+    script: &str,
+) -> Result<Vec<String>, EntrypointCheckError> {
+    match engine_type {
+        "rhai" => rhai_declared_functions(script),
+        #[cfg(feature = "lua")]
+        // The engine owns the compile-only syntax check + bounded, host-globals-bound top-level
+        // exec — its only `Err` is a compile/syntax failure, mapped to `Syntax` here.
+        "lua" => super::lua_engine::declared_functions_lua(script)
+            .map_err(|e| EntrypointCheckError::Syntax(e.to_string())),
+        #[cfg(not(feature = "lua"))]
+        "lua" => Err(EntrypointCheckError::EngineDisabled {
+            engine: "lua".to_string(),
+            feature: "lua".to_string(),
+        }),
+        #[cfg(feature = "javascript")]
+        "javascript" | "js" => super::js_engine::declared_functions_js(script)
+            .map_err(|e| EntrypointCheckError::Syntax(e.to_string())),
+        #[cfg(not(feature = "javascript"))]
+        "javascript" | "js" => Err(EntrypointCheckError::EngineDisabled {
+            engine: "javascript".to_string(),
+            feature: "javascript".to_string(),
+        }),
+        other => Err(EntrypointCheckError::UnknownEngine(other.to_string())),
+    }
+}
+
+/// Pure AST introspection — `compile` only parses, it never runs top-level statements, so this
+/// has zero execution side effects (unlike the JS/Lua paths, which have no public AST walk).
+fn rhai_declared_functions(script: &str) -> Result<Vec<String>, EntrypointCheckError> {
+    let engine = rhai::Engine::new();
+    let ast = engine
+        .compile(script)
+        .map_err(|e| EntrypointCheckError::Syntax(e.to_string()))?;
+    Ok(ast.iter_functions().map(|f| f.name.to_string()).collect())
+}
+
+/// True when `code` declares the deprecated v1 `should_inject` wrapper (`fn should_inject` in
+/// Rhai, `function should_inject` in Lua/JS) — the same signal rift-lint's E041 lint keys on
+/// (`crate::validator::check_script_v1_deprecation` there), exposed here so `rift script check`
+/// can flag a raw script file too (no imposter config for rift-lint's own config-shaped pass to
+/// run over).
+pub fn is_v1_should_inject(code: &str) -> bool {
+    // The pattern is a fixed literal (never fails to compile in practice), but `OnceLock` can
+    // only cache a value, not un-panic a `.expect()` — cache the fallible `Option` instead so a
+    // hypothetical compile failure degrades to "not detected" rather than a panic.
+    static SHOULD_INJECT_RE: std::sync::OnceLock<Option<regex::Regex>> = std::sync::OnceLock::new();
+    SHOULD_INJECT_RE
+        .get_or_init(|| regex::Regex::new(r"\b(?:fn|function)\s+should_inject\b").ok())
+        .as_ref()
+        .is_some_and(|re| re.is_match(code))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rhai_respond_named_matches() {
+        let script = "fn respond(ctx) { pass() }";
+        assert_eq!(
+            check_entrypoint("rhai", script, "respond"),
+            Ok(EntrypointMatch::Named)
+        );
+    }
+
+    #[test]
+    fn rhai_should_inject_is_v1() {
+        let script = "fn should_inject(request, flow_store) { #{ inject: false } }";
+        assert_eq!(
+            check_entrypoint("rhai", script, "respond"),
+            Ok(EntrypointMatch::V1ShouldInject)
+        );
+    }
+
+    #[test]
+    fn rhai_bare_expression_is_ok() {
+        assert_eq!(
+            check_entrypoint("rhai", "pass()", "respond"),
+            Ok(EntrypointMatch::Bare)
+        );
+    }
+
+    // AC (issue #360): a syntax-valid script whose only function is misnamed fails naming the
+    // expected entrypoint.
+    #[test]
+    fn rhai_misnamed_entrypoint_fails_naming_respond() {
+        let script = "fn respnod(ctx) { pass() }";
+        let err = check_entrypoint("rhai", script, "respond").unwrap_err();
+        match err {
+            EntrypointCheckError::Mismatch { hook, declared } => {
+                assert_eq!(hook, "respond");
+                assert_eq!(declared, "respnod");
+            }
+            other => panic!("expected Mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rhai_syntax_error_is_syntax_variant() {
+        let script = "fn respond(ctx { pass() }";
+        let err = check_entrypoint("rhai", script, "respond").unwrap_err();
+        assert!(matches!(err, EntrypointCheckError::Syntax(_)));
+    }
+
+    #[test]
+    fn rhai_matches_hook_checks_matches_name() {
+        assert_eq!(
+            check_entrypoint("rhai", "fn matches(ctx) { true }", "matches"),
+            Ok(EntrypointMatch::Named)
+        );
+        let err = check_entrypoint("rhai", "fn respond(ctx) { pass() }", "matches").unwrap_err();
+        assert!(matches!(err, EntrypointCheckError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn unknown_engine_errors() {
+        let err = check_entrypoint("cobol", "whatever", "respond").unwrap_err();
+        assert!(matches!(err, EntrypointCheckError::UnknownEngine(e) if e == "cobol"));
+    }
+
+    #[test]
+    fn v1_deprecation_detects_declaration_not_substring() {
+        assert!(is_v1_should_inject(
+            "fn should_inject(request, flow_store) { #{ inject: false } }"
+        ));
+        assert!(!is_v1_should_inject("fn respond(ctx) { pass() }"));
+        // A comment mentioning should_inject without declaring it must not false-positive.
+        assert!(!is_v1_should_inject(
+            "// migrated off should_inject\nfn respond(ctx) { pass() }"
+        ));
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_respond_named_matches() {
+        let script = "function respond(ctx) { return pass(); }";
+        assert_eq!(
+            check_entrypoint("javascript", script, "respond"),
+            Ok(EntrypointMatch::Named)
+        );
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_should_inject_is_v1() {
+        let script = "function should_inject(request, flow_store) { return {inject: false}; }";
+        assert_eq!(
+            check_entrypoint("javascript", script, "respond"),
+            Ok(EntrypointMatch::V1ShouldInject)
+        );
+    }
+
+    // AC (issue #360), JS variant: misnamed entrypoint fails naming `respond`.
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_misnamed_entrypoint_fails_naming_respond() {
+        let script = "function respnod(ctx) { return pass(); }";
+        let err = check_entrypoint("javascript", script, "respond").unwrap_err();
+        match err {
+            EntrypointCheckError::Mismatch { hook, declared } => {
+                assert_eq!(hook, "respond");
+                assert_eq!(declared, "respnod");
+            }
+            other => panic!("expected Mismatch, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_syntax_error_is_syntax_variant() {
+        let err = check_entrypoint("javascript", "function respond(ctx {", "respond").unwrap_err();
+        assert!(matches!(err, EntrypointCheckError::Syntax(_)));
+    }
+
+    // B1 regression (issue #360): a legitimate #357 bare-expression JS response script must NOT
+    // false-fail — the top-level `http(...)`/`ctx.*` references resolve against the bound host
+    // globals, exactly as at request time.
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_bare_expression_calling_http_is_ok() {
+        assert_eq!(
+            check_entrypoint("javascript", r#"http(503, "boom")"#, "respond"),
+            Ok(EntrypointMatch::Bare)
+        );
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_bare_expression_reading_ctx_request_is_ok() {
+        let script = r#"(ctx.request.method === "POST") ? http(503, {error:"x"}) : pass()"#;
+        assert_eq!(
+            check_entrypoint("javascript", script, "respond"),
+            Ok(EntrypointMatch::Bare)
+        );
+    }
+
+    // B1 regression: a top-level `while(true){}` must TERMINATE the check (via the loop-iteration
+    // cap), not hang. It surfaces as OK/Bare here (no functions declared) — the point is it
+    // returns at all.
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn js_top_level_infinite_loop_terminates() {
+        let script = "while (true) {}";
+        // Returns (bounded) rather than hanging; the exact classification is immaterial.
+        let _ = check_entrypoint("javascript", script, "respond");
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_respond_named_matches() {
+        let script = "function respond(ctx) return pass() end";
+        assert_eq!(
+            check_entrypoint("lua", script, "respond"),
+            Ok(EntrypointMatch::Named)
+        );
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_should_inject_is_v1() {
+        let script = "function should_inject(request, flow_store) return { inject = false } end";
+        assert_eq!(
+            check_entrypoint("lua", script, "respond"),
+            Ok(EntrypointMatch::V1ShouldInject)
+        );
+    }
+
+    // AC (issue #360), Lua variant: misnamed entrypoint fails naming `respond`.
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_misnamed_entrypoint_fails_naming_respond() {
+        let script = "function respnod(ctx) return pass() end";
+        let err = check_entrypoint("lua", script, "respond").unwrap_err();
+        match err {
+            EntrypointCheckError::Mismatch { hook, declared } => {
+                assert_eq!(hook, "respond");
+                assert_eq!(declared, "respnod");
+            }
+            other => panic!("expected Mismatch, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_syntax_error_is_syntax_variant() {
+        let err = check_entrypoint("lua", "function respond(ctx", "respond").unwrap_err();
+        assert!(matches!(err, EntrypointCheckError::Syntax(_)));
+    }
+
+    // B1 regression (issue #360): a bare-expression Lua response script must NOT false-fail — the
+    // top-level `http(...)` resolves against the bound host global.
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_bare_expression_calling_http_is_ok() {
+        assert_eq!(
+            check_entrypoint("lua", r#"return http(503, "x")"#, "respond"),
+            Ok(EntrypointMatch::Bare)
+        );
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_bare_expression_reading_ctx_request_is_ok() {
+        let script =
+            r#"if ctx.request.method == "POST" then return http(503) else return pass() end"#;
+        assert_eq!(
+            check_entrypoint("lua", script, "respond"),
+            Ok(EntrypointMatch::Bare)
+        );
+    }
+
+    // B1 regression: a top-level `while true do end` must TERMINATE the check (via the
+    // instruction budget), not hang.
+    #[cfg(feature = "lua")]
+    #[test]
+    fn lua_top_level_infinite_loop_terminates() {
+        let _ = check_entrypoint("lua", "while true do end", "respond");
+    }
+}

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -278,6 +278,118 @@ pub(crate) fn bounded_js_context() -> Context {
     context
 }
 
+/// The top-level function names a JS script declares, for the static entrypoint check (issue
+/// #360 Item 1). Two-phase, deliberately NOT a blind `context.eval` of the raw source:
+///
+///  1. **Syntax** — `Script::parse` catches genuine syntax errors WITHOUT executing anything
+///     (exactly what [`JsEngine::new`] does). `Err` here is a real syntax error.
+///  2. **Detection** — evaluate once with the SAME host globals the real execution path binds
+///     (`request`/`flow_store`/`ctx`/`http`/`delay`/`reset`/`pass`), under the SAME
+///     loop-iteration limit ([`JS_SCRIPT_LOOP_ITERATION_LIMIT`]) that stops a top-level
+///     `while(true){}` from hanging. Binding the globals is what keeps a legitimate #357
+///     bare-expression response script (e.g. `http(503, "boom")`, or
+///     `(ctx.request.method === "POST") ? http(503) : pass()`) from spuriously throwing
+///     "http/ctx is not defined" — the very false-fail a blind unbound eval caused. The eval's
+///     own Result is intentionally ignored: JS hoists every top-level `function` declaration onto
+///     the global object BEFORE running statements, so the declared-function set is complete even
+///     if a bare expression later throws at runtime — a runtime throw is not this check's concern
+///     (matching Rhai, which never executes at all).
+///
+/// Returns the names of functions the SCRIPT itself declared (via a before/after global-key
+/// diff), never the host builtins/globals bound above.
+pub(crate) fn declared_functions_js(script: &str) -> Result<Vec<String>> {
+    // Phase 1: syntax only.
+    {
+        let mut parse_ctx = Context::default();
+        boa_engine::Script::parse(Source::from_bytes(script.as_bytes()), None, &mut parse_ctx)
+            .map_err(|e| anyhow!("Syntax error: {e}"))?;
+    }
+
+    // Phase 2: bounded eval with real globals, then diff for declared functions.
+    SCRIPT_RESULT_REGISTRY.with(|r| r.borrow_mut().clear());
+
+    let dummy_request = ScriptRequest {
+        method: "GET".to_string(),
+        path: "/".to_string(),
+        headers: std::collections::HashMap::new(),
+        body: Value::Null,
+        query: std::collections::HashMap::new(),
+        path_params: std::collections::HashMap::new(),
+        raw_body: None,
+    };
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(&dummy_request);
+    // A top-level `ctx.state.*` call needs a flow store bound; a no-op one is enough — the check
+    // never inspects state, only which functions the script declared.
+    set_current_flow_store(Arc::new(crate::extensions::flow_state::NoOpFlowStore));
+
+    let mut context = Context::default();
+    context
+        .runtime_limits_mut()
+        .set_loop_iteration_limit(JS_SCRIPT_LOOP_ITERATION_LIMIT);
+    context
+        .runtime_limits_mut()
+        .set_recursion_limit(JS_SCRIPT_RECURSION_LIMIT);
+    context
+        .runtime_limits_mut()
+        .set_stack_size_limit(JS_SCRIPT_STACK_SIZE_LIMIT);
+
+    let request_obj = create_request_object(&mut context, &dummy_request)?;
+    let flow_store_obj = create_flow_store_object(&mut context)?;
+    let ctx_obj = create_ctx_object(&mut context, &ctx_input)?;
+    register_result_constructors(&mut context)?;
+
+    let global = context.global_object();
+    global
+        .set(js_string!("request"), request_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set request global: {e}"))?;
+    global
+        .set(
+            js_string!("flow_store"),
+            flow_store_obj,
+            false,
+            &mut context,
+        )
+        .map_err(|e| anyhow!("Failed to set flow_store global: {e}"))?;
+    global
+        .set(js_string!("ctx"), ctx_obj, false, &mut context)
+        .map_err(|e| anyhow!("Failed to set ctx global: {e}"))?;
+
+    let pre_existing: std::collections::HashSet<String> = global
+        .own_property_keys(&mut context)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|k| match k {
+            PropertyKey::String(s) => Some(s.to_std_string_escaped()),
+            _ => None,
+        })
+        .collect();
+
+    // Ignore the eval Result: a bare-expression script may throw at runtime (that's not this
+    // check's job), while hoisted function declarations are already on the global regardless.
+    let _ = context.eval(Source::from_bytes(script.as_bytes()));
+
+    let mut names = Vec::new();
+    for key in global.own_property_keys(&mut context).unwrap_or_default() {
+        let name = match &key {
+            PropertyKey::String(s) => s.to_std_string_escaped(),
+            _ => continue,
+        };
+        if pre_existing.contains(&name) {
+            continue;
+        }
+        if global
+            .get(key, &mut context)
+            .ok()
+            .filter(JsValue::is_callable)
+            .is_some()
+        {
+            names.push(name);
+        }
+    }
+    SCRIPT_RESULT_REGISTRY.with(|r| r.borrow_mut().clear());
+    Ok(names)
+}
+
 /// Inner function that does the actual JavaScript execution
 fn execute_js_script_inner(
     script: &str,

--- a/crates/rift-core/src/scripting/lua_engine.rs
+++ b/crates/rift-core/src/scripting/lua_engine.rs
@@ -1130,6 +1130,117 @@ pub fn run_should_inject_with_abort_lua(
     call_respond_lua(&lua, &chunk_fn, request, &ctx_input, flow_store, rule_id)
 }
 
+/// The top-level function names a Lua script declares, for the static entrypoint check (issue
+/// #360 Item 1). Like the JS twin, deliberately NOT a blind `.exec()` of the raw source:
+///
+///  1. **Syntax** — `.into_function()` COMPILES without running (exactly what [`LuaEngine::new`]
+///     does). The chunk is given an explicit name so a syntax error's text reads `[string
+///     "<script>"]` rather than leaking the internal on-disk source path. `Err` here is a real
+///     syntax error.
+///  2. **Detection** — Lua has no cheap AST walk and (unlike JS) does not hoist function
+///     declarations, so the top level MUST run for `function respnod(ctx) ... end` to assign its
+///     global. It's executed with the SAME host globals the real path binds
+///     (`request`/`flow_store`/`ctx`/`http`/`delay`/`reset`/`pass`) — so a bare-expression script
+///     (`return http(503, "x")`) doesn't error on an unbound global — AND under a self-tripping
+///     instruction-count budget (LuaJIT disabled so the count hook can't be trace-compiled away,
+///     mirroring [`run_should_inject_with_abort_lua`]) so a top-level `while true do end` can't
+///     hang the check. The chunk's own run Result is ignored; we then diff the globals for any
+///     function the script assigned.
+#[cfg(feature = "lua")]
+pub(crate) fn declared_functions_lua(script: &str) -> Result<Vec<String>> {
+    // Phase 1: compile only (syntax). Named so error text doesn't leak the source path.
+    {
+        let lua = Lua::new();
+        lua.load(script)
+            .set_name("<script>")
+            .into_function()
+            .map_err(|e| anyhow!("Syntax error: {e}"))?;
+    }
+
+    // Phase 2: bounded exec with real globals, then diff for assigned functions.
+    let lua = Lua::new();
+    if let Err(e) = lua.load("if jit then jit.off() end").exec() {
+        tracing::warn!("failed to disable LuaJIT for script check budget: {e}");
+    }
+    // Self-tripping instruction budget: the hook fires every 2048 instructions; erroring after
+    // MAX_HOOK_FIRES fires caps total work at ~MAX_HOOK_FIRES * 2048 instructions (sub-second),
+    // so a runaway top-level loop terminates the check instead of hanging it.
+    const MAX_HOOK_FIRES: u64 = 5000;
+    let fires = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let budget = Arc::clone(&fires);
+    lua.set_hook(
+        mlua::HookTriggers::new().every_nth_instruction(2048),
+        move |_lua, _debug| {
+            if budget.fetch_add(1, Ordering::Relaxed) >= MAX_HOOK_FIRES {
+                Err(mlua::Error::runtime(
+                    "script exceeded instruction budget during check",
+                ))
+            } else {
+                Ok(mlua::VmState::Continue)
+            }
+        },
+    );
+
+    let chunk_fn = lua
+        .load(script)
+        .set_name("<script>")
+        .into_function()
+        .map_err(|e| anyhow!("Syntax error: {e}"))?;
+
+    let dummy_request = ScriptRequest {
+        method: "GET".to_string(),
+        path: "/".to_string(),
+        headers: std::collections::HashMap::new(),
+        body: Value::Null,
+        query: std::collections::HashMap::new(),
+        path_params: std::collections::HashMap::new(),
+        raw_body: None,
+    };
+    let ctx_input = ScriptCtxExtras::default().build_ctx_input(&dummy_request);
+    let flow_store: Arc<dyn FlowStore> = Arc::new(crate::extensions::flow_state::NoOpFlowStore);
+
+    let globals = lua.globals();
+    let request_table =
+        build_v1_request_table(&lua, &dummy_request).map_err(|e| anyhow!("build request: {e}"))?;
+    let flow_store_ud = lua
+        .create_userdata(LuaFlowStore::new(Arc::clone(&flow_store)))
+        .map_err(|e| anyhow!("build flow_store: {e}"))?;
+    let ctx_table = build_ctx_table(&lua, &ctx_input, Arc::clone(&flow_store))
+        .map_err(|e| anyhow!("build ctx: {e}"))?;
+    register_result_constructors(&lua).map_err(|e| anyhow!("register result API: {e}"))?;
+    globals
+        .set("request", request_table)
+        .map_err(|e| anyhow!("set request: {e}"))?;
+    globals
+        .set("flow_store", flow_store_ud)
+        .map_err(|e| anyhow!("set flow_store: {e}"))?;
+    globals
+        .set("ctx", ctx_table)
+        .map_err(|e| anyhow!("set ctx: {e}"))?;
+
+    let pre_existing: std::collections::HashSet<String> = globals
+        .pairs::<LuaValue, LuaValue>()
+        .filter_map(std::result::Result::ok)
+        .filter_map(|(k, _)| lua_string_key(&k))
+        .collect();
+
+    // Ignore the run Result: a bare expression may raise, and the budget hook may trip — a
+    // function assigned before either point is still visible in the global diff below.
+    let _ = chunk_fn.call::<LuaMultiValue>(());
+
+    let names = globals
+        .pairs::<LuaValue, LuaValue>()
+        .filter_map(std::result::Result::ok)
+        .filter_map(|(k, v)| {
+            if !matches!(v, LuaValue::Function(_)) {
+                return None;
+            }
+            lua_string_key(&k).filter(|name| !pre_existing.contains(name))
+        })
+        .collect();
+    Ok(names)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -11,7 +11,7 @@ mod compiled_cache;
 mod rhai_engine;
 pub use bounded::{
     DEFAULT_SCRIPT_TIMEOUT_MS, resolve_script_timeout_ms, should_inject_bounded,
-    should_inject_bounded_with_ctx,
+    should_inject_bounded_with_ctx, should_inject_bounded_with_ctx_traced,
 };
 
 pub use rhai_engine::RhaiEngine;
@@ -77,6 +77,17 @@ pub use js_validator::JsValidator;
 // Stub script validation for Admin API
 mod stub_validator;
 pub use stub_validator::{validate_stub, validate_stubs};
+
+// Static entrypoint/arity checking, for `rift script check` (issue #360)
+mod entrypoint_check;
+pub use entrypoint_check::{
+    EntrypointCheckError, EntrypointMatch, check_entrypoint, is_v1_should_inject,
+};
+
+// Script decision/log tracing, for `rift script run` and the debug-mode per-request trace
+// (issue #360)
+mod trace;
+pub use trace::{ScriptTraceEntry, cap_trace_logs, capture_script_logs, render_decision};
 
 /// Script execution result for fault injection decisions
 #[derive(Debug, Clone)]

--- a/crates/rift-core/src/scripting/trace.rs
+++ b/crates/rift-core/src/scripting/trace.rs
@@ -1,0 +1,259 @@
+//! Script decision/log tracing (issue #360 Items 2/3): capturing `ctx.logger` output for `rift
+//! script run`, and the debug-mode per-request script trace surfaced on `x-rift-script-trace`.
+//!
+//! `ctx.logger` (issue #355 P1) routes to `tracing` at a fixed target, `"rift::script"`. Outside
+//! a running server there is no global `tracing` subscriber installed (`rift script run`/`check`
+//! are one-shot CLI invocations), and even inside a running server the debug-mode trace needs to
+//! capture only ONE request's log lines, not everything any subscriber sees process-wide. Both
+//! are solved the same way: [`capture_script_logs`] installs a subscriber scoped to a single
+//! closure call via `tracing::subscriber::with_default` (a thread-local override, not a global
+//! one), so it composes with whatever subscriber (if any) is already installed.
+//!
+//! This is a hand-written [`tracing::Subscriber`] rather than a `tracing-subscriber` `Layer` —
+//! `rift-core` doesn't otherwise depend on `tracing-subscriber`, and capturing one field from one
+//! target is a handful of trait methods, not worth a new dependency.
+
+use super::FaultDecision;
+use std::sync::{Arc, Mutex};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Metadata, Subscriber, span};
+
+/// The `tracing` target every `ctx.logger` call is routed to (issue #355 P1).
+const SCRIPT_LOG_TARGET: &str = "rift::script";
+
+/// Max `ctx.logger` lines kept in a debug-mode [`ScriptTraceEntry`] (issue #360): the trace ships
+/// on the `x-rift-script-trace` response header, so a chatty script must not blow the header up
+/// unbounded. `rift script run` output is uncapped (it's a terminal dump, not a header) — only
+/// the header-bound trace applies this via [`cap_trace_logs`].
+const MAX_TRACE_LOG_LINES: usize = 50;
+
+/// Max characters per retained trace log line (each is also body-capped like the decision), so one
+/// enormous `ctx.logger` line can't dominate the header either.
+const MAX_TRACE_LOG_LINE_CHARS: usize = 500;
+
+/// Cap `logs` for a header-bound trace entry: at most [`MAX_TRACE_LOG_LINES`] lines (with an
+/// elision marker naming how many were dropped), each truncated to [`MAX_TRACE_LOG_LINE_CHARS`].
+pub fn cap_trace_logs(mut logs: Vec<String>) -> Vec<String> {
+    let dropped = logs.len().saturating_sub(MAX_TRACE_LOG_LINES);
+    logs.truncate(MAX_TRACE_LOG_LINES);
+    for line in &mut logs {
+        if line.chars().count() > MAX_TRACE_LOG_LINE_CHARS {
+            let truncated: String = line.chars().take(MAX_TRACE_LOG_LINE_CHARS).collect();
+            *line = format!("{truncated}…");
+        }
+    }
+    if dropped > 0 {
+        logs.push(format!("… ({dropped} more log line(s) elided)"));
+    }
+    logs
+}
+
+/// One script hook invocation's trace record: which hook ran, its rendered decision, how long it
+/// took, and any `ctx.logger` lines it emitted. `cache` is `Some("hit"|"miss")` only on the
+/// proxy path's `DecisionCache`-backed hook; `None` elsewhere (e.g. every imposter-stub hook,
+/// which has no decision cache).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ScriptTraceEntry {
+    pub hook: String,
+    pub decision: String,
+    #[serde(rename = "durationMs")]
+    pub duration_ms: u64,
+    pub logs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<String>,
+}
+
+/// Render a [`FaultDecision`] the way `rift script run`/the debug trace print it: `pass()` /
+/// `delay(<ms>ms)` / `reset()` / `http(<status>) { headers } body=<preview>`.
+pub fn render_decision(decision: &FaultDecision) -> String {
+    match decision {
+        FaultDecision::None => "pass()".to_string(),
+        FaultDecision::Latency { duration_ms, .. } => format!("delay({duration_ms}ms)"),
+        FaultDecision::Reset { .. } => "reset()".to_string(),
+        FaultDecision::Error {
+            status,
+            body,
+            headers,
+            ..
+        } => {
+            let mut rendered = format!("http({status})");
+            if !headers.is_empty() {
+                let mut pairs: Vec<String> = headers
+                    .iter()
+                    .map(|(k, v)| format!("{k:?}: {v:?}"))
+                    .collect();
+                pairs.sort();
+                rendered.push_str(&format!(" {{ {} }}", pairs.join(", ")));
+            }
+            if !body.is_empty() {
+                // Cap the preview so a large response body doesn't blow up a header/CLI line.
+                let preview: String = body.chars().take(200).collect();
+                let truncated = preview.len() < body.len();
+                rendered.push_str(&format!(
+                    " body={preview:?}{}",
+                    if truncated { "…" } else { "" }
+                ));
+            }
+            rendered
+        }
+    }
+}
+
+/// Run `f` with a subscriber that captures every `"rift::script"` event into an in-memory
+/// buffer, returning `f`'s result alongside the captured log lines in call order.
+/// Thread-scoped: doesn't touch or require any process-wide default subscriber.
+pub fn capture_script_logs<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let capture = ScriptLogCapture {
+        logs: Arc::clone(&logs),
+    };
+    let result = tracing::subscriber::with_default(capture, f);
+    let collected = logs
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    (result, collected)
+}
+
+/// A minimal [`Subscriber`] that only records events at [`SCRIPT_LOG_TARGET`]'s "message" field.
+/// Spans are accepted but not tracked (`ctx.logger` never opens one) — `new_span` always returns
+/// the same id, matching the trivial no-op span handling this capture needs.
+struct ScriptLogCapture {
+    logs: Arc<Mutex<Vec<String>>>,
+}
+
+impl Subscriber for ScriptLogCapture {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == SCRIPT_LOG_TARGET
+    }
+
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        if let Some(message) = visitor.message {
+            self.logs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(message);
+        }
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+/// Extracts the `message` field's text from a `tracing` event.
+#[derive(Default)]
+struct MessageVisitor {
+    message: Option<String>,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn render_decision_variants() {
+        assert_eq!(render_decision(&FaultDecision::None), "pass()");
+        assert_eq!(
+            render_decision(&FaultDecision::Latency {
+                duration_ms: 42,
+                rule_id: "r".into(),
+            }),
+            "delay(42ms)"
+        );
+        assert_eq!(
+            render_decision(&FaultDecision::Reset {
+                rule_id: "r".into()
+            }),
+            "reset()"
+        );
+        let mut headers = HashMap::new();
+        headers.insert("Retry-After".to_string(), "1".to_string());
+        let rendered = render_decision(&FaultDecision::Error {
+            status: 503,
+            body: "boom".to_string(),
+            rule_id: "r".into(),
+            headers,
+        });
+        assert!(rendered.starts_with("http(503)"), "got {rendered}");
+        assert!(
+            rendered.contains("\"Retry-After\": \"1\""),
+            "got {rendered}"
+        );
+        assert!(rendered.contains("body=\"boom\""), "got {rendered}");
+    }
+
+    // Issue #360 Item 2: `ctx.logger` lines emitted during `f` are captured, in order, and
+    // events at other targets are ignored.
+    #[test]
+    fn capture_script_logs_collects_only_the_script_target() {
+        let (value, logs) = capture_script_logs(|| {
+            tracing::info!(target: "rift::script", "first");
+            tracing::warn!(target: "other::target", "ignored");
+            tracing::error!(target: "rift::script", "second");
+            42
+        });
+        assert_eq!(value, 42);
+        assert_eq!(logs, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn capture_script_logs_empty_when_nothing_logged() {
+        let (_, logs) = capture_script_logs(|| ());
+        assert!(logs.is_empty());
+    }
+
+    // Issue #360: the header-bound trace caps a chatty script's logs (line count + per-line
+    // length) so the `x-rift-script-trace` header can't grow unbounded.
+    #[test]
+    fn cap_trace_logs_bounds_line_count_and_length() {
+        let logs: Vec<String> = (0..MAX_TRACE_LOG_LINES + 20)
+            .map(|i| format!("line {i}"))
+            .collect();
+        let capped = cap_trace_logs(logs);
+        assert_eq!(capped.len(), MAX_TRACE_LOG_LINES + 1); // +1 for the elision marker
+        assert!(
+            capped
+                .last()
+                .unwrap()
+                .contains("20 more log line(s) elided")
+        );
+
+        let long = vec!["x".repeat(MAX_TRACE_LOG_LINE_CHARS + 100)];
+        let capped = cap_trace_logs(long);
+        assert_eq!(capped.len(), 1);
+        assert!(capped[0].ends_with('…'));
+        assert_eq!(capped[0].chars().count(), MAX_TRACE_LOG_LINE_CHARS + 1);
+    }
+
+    #[test]
+    fn cap_trace_logs_leaves_small_logs_untouched() {
+        let logs = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(cap_trace_logs(logs.clone()), logs);
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -31,6 +31,9 @@ pub mod intercept_rules;
 // Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
 pub mod config_loader;
 
+// `rift script check` / `rift script run` (issue #360): scripting DX outside a running server
+pub mod script_cli;
+
 // ===== Embeddable server composition (issue #317) =====
 // Gateway dispatch (issue #212) callable from any listener
 pub mod gateway;

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -27,6 +27,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::Parser;
 use rift_http_proxy::admin_api::DEFAULT_ADMIN_PORT;
+use rift_http_proxy::script_cli;
 use rift_http_proxy::server::{Cli, Commands, ServerBuilder};
 use std::path::PathBuf;
 use tracing::{info, warn};
@@ -34,6 +35,21 @@ use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
 
 fn main() -> Result<(), anyhow::Error> {
     let mut cli = Cli::parse();
+
+    // Handle the `script` subcommand up front: no server bootstrap (tracing/rustls/rcfile),
+    // just the CLI's own exit code (issue #360). Cloned rather than matched by value so `cli`
+    // (and `cli.command`) stay intact for the Stop/Restart/Save/Replay dispatch below.
+    if let Some(Commands::Script { action }) = cli.command.clone() {
+        return script_cli::dispatch(action);
+    }
+
+    // `--debug` is the server-flag spelling of debug mode (issue #360 Item 3); `RIFT_DEBUG` is
+    // the env-var spelling `rift_core::util::rift_debug_env()` reads everywhere else (issue
+    // #359). Setting it here (before anything calls `rift_debug_env()`, which caches its read)
+    // makes both spellings equivalent. Safe: single-threaded, before the tokio runtime starts.
+    if cli.debug {
+        unsafe { std::env::set_var("RIFT_DEBUG", "1") };
+    }
 
     // Apply rcfile defaults before using CLI values (only for fields at their clap defaults)
     if let Some(ref rcfile) = cli.rcfile.clone() {
@@ -108,6 +124,11 @@ fn main() -> Result<(), anyhow::Error> {
                 configfile: Some(configfile.clone()),
                 ..cli
             });
+        }
+        // Already handled (and returned) above, before the server bootstrap; kept here so the
+        // match stays exhaustive and correct if that ever changes.
+        Some(Commands::Script { action }) => {
+            return script_cli::dispatch(action.clone());
         }
         Some(Commands::Start) | None => {
             // Default behavior - start in Mountebank mode

--- a/crates/rift-http-proxy/src/script_cli.rs
+++ b/crates/rift-http-proxy/src/script_cli.rs
@@ -1,0 +1,854 @@
+//! `rift script check` / `rift script run` (issue #360): scripting DX tools that validate or
+//! execute a script without a running server. Kept as plain, testable library functions —
+//! `main.rs`/[`dispatch`] are thin CLI wrappers (arg parsing, printing, exit codes) around
+//! [`run_check`] and [`run_run`], which tests call directly.
+
+use crate::config_loader::{self, ConfigSource};
+use crate::flow_state::FlowStore;
+use crate::imposter::{RiftScriptConfig, StubResponse};
+use crate::server::ScriptAction;
+use anyhow::{Context, Result, anyhow, bail};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+// ===========================================================================
+// `rift script check`
+// ===========================================================================
+
+/// The result of `rift script check <target>`: zero or more errors/warnings, each already
+/// formatted with its location (file, or `imposter[i].stubs[j].responses[k]` for a config).
+#[derive(Debug, Default)]
+pub struct CheckReport {
+    pub target: String,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl CheckReport {
+    fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+/// Statically validate `target` — a raw script file (`.rhai`/`.lua`/`.js`) or a rift config file
+/// (`.json`/`.yaml`/`.yml`) — with no server running. `hook` is only used for a raw script file
+/// (a config's `_rift.script` entries are always response-position, i.e. `respond`).
+pub fn run_check(target: &Path, hook: &str) -> Result<CheckReport> {
+    if !target.exists() {
+        bail!("file not found: {}", target.display());
+    }
+    match target_kind(target)? {
+        TargetKind::Script(engine) => check_raw_script(target, &engine, hook),
+        TargetKind::Config => check_config(target),
+    }
+}
+
+enum TargetKind {
+    Script(String),
+    Config,
+}
+
+fn target_kind(path: &Path) -> Result<TargetKind> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rhai") => Ok(TargetKind::Script("rhai".to_string())),
+        Some("lua") => Ok(TargetKind::Script("lua".to_string())),
+        Some("js") => Ok(TargetKind::Script("javascript".to_string())),
+        Some("json") | Some("yaml") | Some("yml") => Ok(TargetKind::Config),
+        other => Err(anyhow!(
+            "cannot determine target kind from extension {:?} of {}; expected .rhai/.lua/.js \
+             (script) or .json/.yaml/.yml (config)",
+            other,
+            path.display()
+        )),
+    }
+}
+
+fn check_raw_script(path: &Path, engine: &str, hook: &str) -> Result<CheckReport> {
+    let code = std::fs::read_to_string(path)
+        .with_context(|| format!("reading script file {}", path.display()))?;
+    let mut report = CheckReport::new(path.display().to_string());
+    check_one_script(&code, engine, hook, path.display().to_string(), &mut report);
+    Ok(report)
+}
+
+/// Run every static check this module knows over one script, appending findings to `report`
+/// (each message already prefixed with `location`).
+fn check_one_script(
+    code: &str,
+    engine: &str,
+    hook: &str,
+    location: String,
+    report: &mut CheckReport,
+) {
+    // The key new check (issue #360): entrypoint presence/arity for the intended hook. Reuses
+    // the same declared-function detection issue #357 added to each engine's runtime dispatch
+    // (`run_entrypoint`/`should_inject_with_ctx`) — see `scripting::entrypoint_check` — so a
+    // script that only compiles/parses but calls the wrong function name is caught here instead
+    // of at request time.
+    if let Err(e) = crate::scripting::check_entrypoint(engine, code, hook) {
+        report.errors.push(format!("{location}: {e}"));
+    }
+
+    // v1-shape deprecation lint (issue #357 Item 5 / rift-lint E041), with a v2 rewrite hint.
+    if crate::scripting::is_v1_should_inject(code) {
+        report.warnings.push(format!(
+            "{location}: uses the deprecated v1 `should_inject(request, flow_store)` wrapper; \
+             rewrite as v2: define `{hook}(ctx)` (or a bare expression) and return \
+             http(status, body)/delay(ms)/reset()/pass() instead of \
+             #{{ inject: true, fault: ... }}"
+        ));
+    }
+}
+
+fn check_config(path: &Path) -> Result<CheckReport> {
+    let mut report = CheckReport::new(path.display().to_string());
+
+    // Reuses the exact `--configfile` load path (issue #356 `file:`/`ref:` resolution, EJS
+    // preprocessing, single/array/`{"imposters":[...]}` shape handling) — a config `script
+    // check` sees precisely what a real `rift --configfile` startup would.
+    let configs = config_loader::load_configs(&ConfigSource::File {
+        path: path.to_path_buf(),
+        no_parse: false,
+    })
+    .with_context(|| format!("loading config {}", path.display()))?;
+
+    for (cfg_idx, config) in configs.iter().enumerate() {
+        let has_flow_state = config
+            .rift
+            .as_ref()
+            .and_then(|r| r.flow_state.as_ref())
+            .is_some();
+
+        for (stub_idx, stub) in config.stubs.iter().enumerate() {
+            for (resp_idx, response) in stub.responses.iter().enumerate() {
+                let Some(script_cfg) = response_script(response) else {
+                    continue;
+                };
+                let location = if configs.len() == 1 {
+                    format!("stubs[{stub_idx}].responses[{resp_idx}]")
+                } else {
+                    format!("imposter[{cfg_idx}].stubs[{stub_idx}].responses[{resp_idx}]")
+                };
+                check_config_script(script_cfg, has_flow_state, location, &mut report);
+            }
+        }
+    }
+    Ok(report)
+}
+
+/// One resolved `_rift.script` config: syntax + entrypoint (always `respond` — every
+/// `_rift.script` here is response-position), v1 deprecation, and state-without-flowState
+/// (rift-lint E042's check, re-implemented here against the typed config rather than the raw
+/// JSON `Value` rift-lint walks — see the module docs on why this crate doesn't pull in
+/// rift-lint itself).
+fn check_config_script(
+    script_cfg: &RiftScriptConfig,
+    has_flow_state: bool,
+    location: String,
+    report: &mut CheckReport,
+) {
+    let Some(code) = script_cfg.code.as_deref() else {
+        // `config_loader::load_configs` always resolves file:/ref: into `code` before returning
+        // — a `None` here would mean that pass was skipped, which would already have errored.
+        report.errors.push(format!(
+            "{location}: script has no resolved source (internal error)"
+        ));
+        return;
+    };
+    let engine = script_cfg.engine.as_deref().unwrap_or("rhai");
+    check_one_script(code, engine, "respond", location.clone(), report);
+
+    if !has_flow_state && (code.contains("ctx.state") || code.contains("flow_store")) {
+        report.warnings.push(format!(
+            "{location}: uses ctx.state (or flow_store) but no _rift.flowState is configured; \
+             state will be auto-provisioned in-memory (won't persist across restarts or be \
+             shared across a cluster) — configure _rift.flowState for production"
+        ));
+    }
+}
+
+/// Borrow the `_rift.script` config out of a stub response, if it has one — covers both the
+/// `is` response's optional `_rift` extension and the script-only `RiftScript` response (mirrors
+/// `imposter::script_resolve`'s private `response_script_mut`, read-only).
+fn response_script(response: &StubResponse) -> Option<&RiftScriptConfig> {
+    match response {
+        StubResponse::Is {
+            rift: Some(rift), ..
+        } => rift.script.as_ref(),
+        StubResponse::RiftScript { rift } => rift.script.as_ref(),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// `rift script run`
+// ===========================================================================
+
+/// The result of `rift script run <target>`.
+#[derive(Debug)]
+pub struct RunReport {
+    /// The rendered decision (`pass()` / `http(503) ...` / `delay(42ms)` / `reset()`), or
+    /// `"error"` when the script itself failed — see `error` for the message in that case.
+    pub decision: String,
+    pub duration_ms: u64,
+    pub logs: Vec<String>,
+    /// The flow's state after the run, sorted by key.
+    pub state: Vec<(String, serde_json::Value)>,
+    pub error: Option<String>,
+}
+
+/// The request-object shape scripts see (issue #360 Item 2's `--request` fixture): the same
+/// fields `ScriptRequest` carries, all optional so a minimal fixture (or none at all) is valid.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RequestFixture {
+    method: Option<String>,
+    path: Option<String>,
+    headers: HashMap<String, String>,
+    query: HashMap<String, String>,
+    path_params: HashMap<String, String>,
+    body: serde_json::Value,
+}
+
+fn fixture_to_script_request(fixture: RequestFixture) -> crate::scripting::ScriptRequest {
+    let raw_body = if fixture.body.is_null() {
+        None
+    } else {
+        Some(fixture.body.to_string())
+    };
+    crate::scripting::ScriptRequest {
+        method: fixture.method.unwrap_or_else(|| "GET".to_string()),
+        path: fixture.path.unwrap_or_else(|| "/".to_string()),
+        headers: fixture.headers,
+        query: fixture.query,
+        path_params: fixture.path_params,
+        body: fixture.body,
+        raw_body,
+    }
+}
+
+/// Infer the script engine from `path`'s extension (`.rhai`/`.lua`/`.js`); `None` when it isn't
+/// one of the three recognized extensions.
+fn infer_engine_from_extension(path: &Path) -> Option<String> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rhai") => Some("rhai".to_string()),
+        Some("lua") => Some("lua".to_string()),
+        Some("js") => Some("javascript".to_string()),
+        _ => None,
+    }
+}
+
+/// Parse a `--state key=value` entry: the value is JSON if it parses, else a plain string (issue
+/// #360 Item 2).
+fn parse_state_entry(entry: &str) -> Result<(String, serde_json::Value)> {
+    let (key, raw_value) = entry
+        .split_once('=')
+        .ok_or_else(|| anyhow!("--state must be `key=value`, got '{entry}'"))?;
+    let value = serde_json::from_str(raw_value)
+        .unwrap_or_else(|_| serde_json::Value::String(raw_value.to_string()));
+    Ok((key.to_string(), value))
+}
+
+/// Execute `target` against a fixture request and seeded flow state, with no server running
+/// (issue #360 Item 2). Only `hook == "respond"` is supported today — `matches`/`transform`/
+/// `delay` are Rhai-only and not wired end-to-end outside the engine's own unit tests (see
+/// `ScriptEngine::should_inject_fault_with_ctx`, the only engine-agnostic entrypoint that
+/// exists); asking for another hook is a clean error, not a silent no-op.
+#[allow(clippy::too_many_arguments)]
+pub fn run_run(
+    target: &Path,
+    request_path: Option<&Path>,
+    state_entries: &[String],
+    flow_id: &str,
+    engine_override: Option<&str>,
+    hook: &str,
+) -> Result<RunReport> {
+    if hook != "respond" {
+        bail!(
+            "`rift script run --hook {hook}` is not supported: only `respond` is wired \
+             end-to-end across all three engines today"
+        );
+    }
+
+    let code = std::fs::read_to_string(target)
+        .with_context(|| format!("reading script file {}", target.display()))?;
+    let engine_type = match engine_override {
+        Some(e) => e.to_string(),
+        None => infer_engine_from_extension(target).ok_or_else(|| {
+            anyhow!(
+                "cannot infer script engine from extension of {}; pass --engine rhai|lua|js",
+                target.display()
+            )
+        })?,
+    };
+
+    let fixture: RequestFixture = match request_path {
+        Some(p) => {
+            let raw = std::fs::read_to_string(p)
+                .with_context(|| format!("reading request fixture {}", p.display()))?;
+            serde_json::from_str(&raw)
+                .with_context(|| format!("parsing request fixture {}", p.display()))?
+        }
+        None => RequestFixture::default(),
+    };
+    let script_request = fixture_to_script_request(fixture);
+
+    // A fresh, disposable in-memory store per run — never persisted, exactly like a real
+    // request's auto-provisioned flow store when no `_rift.flowState` backend is configured. A
+    // generous TTL keeps this run's seeded state alive for the run itself; nothing outlives the
+    // process either way.
+    let store = Arc::new(crate::backends::InMemoryFlowStore::new(3600));
+    for entry in state_entries {
+        let (key, value) = parse_state_entry(entry)?;
+        store
+            .set(flow_id, &key, value)
+            .map_err(|e| anyhow!("seeding --state {entry}: {e}"))?;
+    }
+    let store_dyn: Arc<dyn FlowStore> = store.clone();
+
+    // Surface a genuine compile/syntax error as a clean CLI error up front (rather than an
+    // "error:" decision in the report).
+    crate::scripting::ScriptEngine::new(&engine_type, &code, "cli-run")
+        .with_context(|| format!("compiling {}", target.display()))?;
+    let extras = crate::scripting::ScriptCtxExtras {
+        flow_id: Some(flow_id.to_string()),
+        ..Default::default()
+    };
+
+    // Run through the SAME bounded path the real proxy uses (issue #360): `spawn_blocking` +
+    // wall-clock timeout with the Rhai/Lua abort flag wired in, so an infinite-loop script (a
+    // Lua `while true do end` in particular, whose direct engine path has no instruction hook)
+    // TERMINATES the CLI at the deadline instead of hanging it. This also captures `ctx.logger`
+    // output and the duration for free. A fresh current-thread runtime is built here because the
+    // `script` subcommand runs before/without the server's tokio runtime.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building CLI tokio runtime")?;
+    let timeout = std::time::Duration::from_millis(crate::scripting::DEFAULT_SCRIPT_TIMEOUT_MS);
+    let (result, entry) =
+        runtime.block_on(crate::scripting::should_inject_bounded_with_ctx_traced(
+            engine_type,
+            code,
+            "cli-run".to_string(),
+            script_request,
+            store_dyn,
+            timeout,
+            extras,
+        ));
+
+    let mut keys = store.keys_for_flow(flow_id);
+    keys.sort();
+    let state = keys
+        .into_iter()
+        .map(|k| {
+            let v = store
+                .get(flow_id, &k)
+                .ok()
+                .flatten()
+                .unwrap_or(serde_json::Value::Null);
+            (k, v)
+        })
+        .collect();
+
+    // `entry` carries the rendered decision, duration, and (uncapped) logger lines; `result`
+    // distinguishes a script error from a real decision for the exit code.
+    match result {
+        Ok(_) => Ok(RunReport {
+            decision: entry.decision,
+            duration_ms: entry.duration_ms,
+            logs: entry.logs,
+            state,
+            error: None,
+        }),
+        Err(e) => Ok(RunReport {
+            decision: "error".to_string(),
+            duration_ms: entry.duration_ms,
+            logs: entry.logs,
+            state,
+            error: Some(e.to_string()),
+        }),
+    }
+}
+
+// ===========================================================================
+// CLI dispatch (printing + exit codes) — `main.rs` calls only this.
+// ===========================================================================
+
+/// Handle `rift script <check|run>`: run the library function, print a human-readable report,
+/// and exit non-zero on failure. Returned `Err` is reserved for a usage/IO error (e.g. the
+/// target file doesn't exist) that never got as far as producing a report.
+pub fn dispatch(action: ScriptAction) -> Result<()> {
+    match action {
+        ScriptAction::Check { target, hook } => {
+            let report = run_check(&target, &hook)?;
+            print_check_report(&report);
+            if report.is_ok() {
+                Ok(())
+            } else {
+                std::process::exit(1);
+            }
+        }
+        ScriptAction::Run {
+            target,
+            request,
+            state,
+            flow_id,
+            engine,
+            hook,
+        } => {
+            let report = run_run(
+                &target,
+                request.as_deref(),
+                &state,
+                &flow_id,
+                engine.as_deref(),
+                &hook,
+            )?;
+            print_run_report(&report);
+            if report.error.is_some() {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_check_report(report: &CheckReport) {
+    println!("Checking {}", report.target);
+    for e in &report.errors {
+        println!("  error: {e}");
+    }
+    for w in &report.warnings {
+        println!("  warning: {w}");
+    }
+    if report.is_ok() {
+        println!("OK");
+    } else {
+        println!(
+            "FAILED ({} error(s), {} warning(s))",
+            report.errors.len(),
+            report.warnings.len()
+        );
+    }
+}
+
+fn print_run_report(report: &RunReport) {
+    println!("decision: {}", report.decision);
+    if let Some(err) = &report.error {
+        println!("error: {err}");
+    }
+    println!("duration: {}ms", report.duration_ms);
+    println!("state:");
+    if report.state.is_empty() {
+        println!("  (empty)");
+    } else {
+        for (k, v) in &report.state {
+            println!("  {k} = {v}");
+        }
+    }
+    println!("logs:");
+    if report.logs.is_empty() {
+        println!("  (none)");
+    } else {
+        for line in &report.logs {
+            println!("  {line}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(dir: &tempfile::TempDir, name: &str, contents: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).expect("create temp file");
+        f.write_all(contents.as_bytes()).expect("write temp file");
+        path
+    }
+
+    // ----- check: raw script -----
+
+    // AC (issue #360): a valid v2 `respond` script passes.
+    #[test]
+    fn check_raw_v2_respond_script_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", "fn respond(ctx) { pass() }");
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(report.is_ok(), "expected OK, got {:?}", report.errors);
+    }
+
+    // AC: a valid v1 `should_inject` script passes (with a deprecation warning).
+    #[test]
+    fn check_raw_v1_should_inject_script_ok_with_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "s.rhai",
+            "fn should_inject(request, flow_store) { #{ inject: false } }",
+        );
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(report.is_ok(), "expected OK, got {:?}", report.errors);
+        assert_eq!(report.warnings.len(), 1);
+        assert!(report.warnings[0].contains("deprecated v1"));
+    }
+
+    // AC (the issue's headline case): a syntax-valid script whose only function is misnamed
+    // fails, naming the expected entrypoint.
+    #[test]
+    fn check_raw_misnamed_entrypoint_fails_naming_respond() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", "fn respnod(ctx) { pass() }");
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(!report.is_ok(), "misnamed entrypoint must fail");
+        assert!(
+            report.errors[0].contains('`') && report.errors[0].contains("respond"),
+            "error must name the expected entrypoint, got {:?}",
+            report.errors
+        );
+    }
+
+    // AC: a syntax error fails.
+    #[test]
+    fn check_raw_syntax_error_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", "fn respond(ctx { pass() }");
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(!report.is_ok());
+        assert!(report.errors[0].contains("Syntax error"));
+    }
+
+    #[test]
+    fn check_unknown_extension_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.txt", "whatever");
+        let err = run_check(&path, "respond").unwrap_err();
+        assert!(err.to_string().contains("extension"));
+    }
+
+    #[test]
+    fn check_missing_file_errors() {
+        let err = run_check(Path::new("/no/such/file.rhai"), "respond").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn check_raw_js_misnamed_entrypoint_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.js", "function respnod(ctx) { return pass(); }");
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(!report.is_ok());
+        assert!(report.errors[0].contains("respond"));
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn check_raw_lua_misnamed_entrypoint_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.lua", "function respnod(ctx) return pass() end");
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(!report.is_ok());
+        assert!(report.errors[0].contains("respond"));
+    }
+
+    // ----- check: config -----
+
+    #[test]
+    fn check_config_reports_entrypoint_mismatch_with_location() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = serde_json::json!({
+            "port": 4545,
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": { "script": { "engine": "rhai", "code": "fn respnod(ctx) { pass() }" } }
+                }]
+            }]
+        });
+        let path = write_temp(&dir, "imposter.json", &config.to_string());
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(!report.is_ok());
+        assert!(report.errors[0].contains("stubs[0].responses[0]"));
+        assert!(report.errors[0].contains("respond"));
+    }
+
+    // Issue #360: state-used-without-flowState warning (rift-lint E042's check), reused here.
+    #[test]
+    fn check_config_warns_state_without_flow_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = serde_json::json!({
+            "port": 4545,
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": {
+                        "script": {
+                            "engine": "rhai",
+                            "code": "fn respond(ctx) { ctx.state.incr(\"n\"); pass() }"
+                        }
+                    }
+                }]
+            }]
+        });
+        let path = write_temp(&dir, "imposter.json", &config.to_string());
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(report.is_ok(), "state usage alone isn't an error");
+        assert!(
+            report.warnings.iter().any(|w| w.contains("flowState")),
+            "expected a flowState warning, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn check_config_no_warning_when_flow_state_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = serde_json::json!({
+            "port": 4545,
+            "protocol": "http",
+            "_rift": { "flowState": { "ttlSeconds": 300 } },
+            "stubs": [{
+                "responses": [{
+                    "_rift": {
+                        "script": {
+                            "engine": "rhai",
+                            "code": "fn respond(ctx) { ctx.state.incr(\"n\"); pass() }"
+                        }
+                    }
+                }]
+            }]
+        });
+        let path = write_temp(&dir, "imposter.json", &config.to_string());
+        let report = run_check(&path, "respond").expect("check runs");
+        assert!(report.is_ok());
+        assert!(report.warnings.is_empty(), "got {:?}", report.warnings);
+    }
+
+    // ----- run -----
+
+    // AC (issue #360): the fail-twice fixture with --state attempts=2 prints the 200 (pass)
+    // branch; attempts=1 prints the 503 branch.
+    #[test]
+    fn run_fail_twice_fixture_attempts_2_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "fail-twice.rhai",
+            r#"
+                fn respond(ctx) {
+                    let attempts = ctx.state.get_or("attempts", 0);
+                    if attempts < 2 {
+                        http(503, `attempt ${attempts}`)
+                    } else {
+                        pass()
+                    }
+                }
+            "#,
+        );
+        let report = run_run(
+            &path,
+            None,
+            &["attempts=2".to_string()],
+            "cli",
+            None,
+            "respond",
+        )
+        .expect("run succeeds");
+        assert_eq!(report.decision, "pass()");
+        assert!(report.error.is_none());
+    }
+
+    #[test]
+    fn run_fail_twice_fixture_attempts_1_fails_with_503() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "fail-twice.rhai",
+            r#"
+                fn respond(ctx) {
+                    let attempts = ctx.state.get_or("attempts", 0);
+                    if attempts < 2 {
+                        http(503, `attempt ${attempts}`)
+                    } else {
+                        pass()
+                    }
+                }
+            "#,
+        );
+        let report = run_run(
+            &path,
+            None,
+            &["attempts=1".to_string()],
+            "cli",
+            None,
+            "respond",
+        )
+        .expect("run succeeds");
+        assert!(
+            report.decision.starts_with("http(503)"),
+            "got {}",
+            report.decision
+        );
+    }
+
+    // Issue #360 Item 2: mutated state and duration are reported.
+    #[test]
+    fn run_reports_mutated_state_and_duration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "s.rhai",
+            r#"fn respond(ctx) { ctx.state.set("seen", true); ctx.state.incr("hits"); pass() }"#,
+        );
+        let report = run_run(&path, None, &[], "cli", None, "respond").expect("run succeeds");
+        assert_eq!(report.decision, "pass()");
+        let state: HashMap<_, _> = report.state.into_iter().collect();
+        assert_eq!(state.get("seen"), Some(&serde_json::json!(true)));
+        assert_eq!(state.get("hits"), Some(&serde_json::json!(1)));
+    }
+
+    // Issue #360 Item 2: ctx.logger output is captured in the report.
+    #[test]
+    fn run_captures_logger_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "s.rhai",
+            r#"fn respond(ctx) { ctx.logger.info("hello from script"); pass() }"#,
+        );
+        let report = run_run(&path, None, &[], "cli", None, "respond").expect("run succeeds");
+        assert_eq!(report.logs, vec!["hello from script".to_string()]);
+    }
+
+    // v1 shape: `should_inject` scripts also work under `script run`.
+    #[test]
+    fn run_supports_v1_should_inject_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "s.rhai",
+            r#"fn should_inject(request, flow_store) { #{ inject: true, fault: "error", status: 429, body: "slow down" } }"#,
+        );
+        let report = run_run(&path, None, &[], "cli", None, "respond").expect("run succeeds");
+        assert!(
+            report.decision.starts_with("http(429)"),
+            "got {}",
+            report.decision
+        );
+    }
+
+    #[test]
+    fn run_uses_request_fixture() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_temp(
+            &dir,
+            "s.rhai",
+            r#"fn respond(ctx) { if ctx.request.path == "/widgets" { http(201) } else { pass() } }"#,
+        );
+        let request = write_temp(&dir, "req.json", r#"{"method":"GET","path":"/widgets"}"#);
+        let report =
+            run_run(&script, Some(&request), &[], "cli", None, "respond").expect("run succeeds");
+        assert!(
+            report.decision.starts_with("http(201)"),
+            "got {}",
+            report.decision
+        );
+    }
+
+    #[test]
+    fn run_unsupported_hook_is_a_clean_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", "fn matches(ctx) { true }");
+        let err = run_run(&path, None, &[], "cli", None, "matches").unwrap_err();
+        assert!(err.to_string().contains("matches"));
+    }
+
+    #[test]
+    fn run_infers_engine_from_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", "fn respond(ctx) { pass() }");
+        let report = run_run(&path, None, &[], "cli", None, "respond").expect("run succeeds");
+        assert_eq!(report.decision, "pass()");
+    }
+
+    // A script that raises is reported, not propagated as a hard CLI error — duration/logs are
+    // still meaningful for a failed run.
+    #[test]
+    fn run_script_error_is_reported_not_propagated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(&dir, "s.rhai", r#"fn respond(ctx) { throw "boom" }"#);
+        let report = run_run(&path, None, &[], "cli", None, "respond").expect("run succeeds");
+        assert!(report.error.is_some());
+        assert!(report.error.unwrap().contains("boom"));
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn run_js_fail_twice_fixture() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "fail-twice.js",
+            r#"
+                function respond(ctx) {
+                    var attempts = ctx.state.getOr("attempts", 0);
+                    if (attempts < 2) {
+                        return http(503, "attempt " + attempts);
+                    }
+                    return pass();
+                }
+            "#,
+        );
+        let report = run_run(
+            &path,
+            None,
+            &["attempts=2".to_string()],
+            "cli",
+            None,
+            "respond",
+        )
+        .expect("run succeeds");
+        assert_eq!(report.decision, "pass()");
+    }
+
+    #[cfg(feature = "lua")]
+    #[test]
+    fn run_lua_fail_twice_fixture() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp(
+            &dir,
+            "fail-twice.lua",
+            r#"
+                function respond(ctx)
+                    local attempts = ctx.state:get_or("attempts", 0)
+                    if attempts < 2 then
+                        return http(503, "attempt " .. attempts)
+                    end
+                    return pass()
+                end
+            "#,
+        );
+        let report = run_run(
+            &path,
+            None,
+            &["attempts=2".to_string()],
+            "cli",
+            None,
+            "respond",
+        )
+        .expect("run succeeds");
+        assert_eq!(report.decision, "pass()");
+    }
+}

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -156,7 +156,7 @@ pub struct Cli {
     pub intercept_ca_key: Option<PathBuf>,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     /// Start the Rift server (default command)
     Start,
@@ -191,6 +191,66 @@ pub enum Commands {
         /// Input file path
         #[arg(long, required = true)]
         configfile: PathBuf,
+    },
+
+    /// Validate or run a script outside a running server (issue #360)
+    Script {
+        #[command(subcommand)]
+        action: ScriptAction,
+    },
+}
+
+/// `rift script <check|run>` (issue #360): scripting DX tools that need neither an admin API nor
+/// a running imposter — everything runs synchronously, in-process, against a fixture.
+#[derive(Subcommand, Debug, Clone)]
+pub enum ScriptAction {
+    /// Statically validate a script or config file: engine syntax, entrypoint presence/arity for
+    /// the intended hook, v1-shape deprecation, and (for a config) state-used-without-flowState.
+    /// No server is started. Exits non-zero on any error.
+    Check {
+        /// A raw script file (`.rhai`/`.lua`/`.js`) or a rift config file (JSON/YAML)
+        /// containing `_rift.script` entries.
+        target: PathBuf,
+
+        /// Which entrypoint hook to check a raw script file against
+        /// (`respond`/`matches`/`transform`/`delay`). Ignored for a config file target — every
+        /// `_rift.script` there is a response-position script, i.e. always `respond`.
+        #[arg(long, default_value = "respond")]
+        hook: String,
+    },
+
+    /// Execute a script against a fixture request and seeded flow state — no server running.
+    /// Prints the decision, the mutated flow state, captured `ctx.logger` output, and the
+    /// execution duration.
+    Run {
+        /// Script file (`.rhai`/`.lua`/`.js`).
+        target: PathBuf,
+
+        /// JSON file with the request-object shape scripts see:
+        /// `{method, path, headers, query, pathParams, body}`. All fields are optional; an
+        /// empty `GET /` with no headers/body is used when this flag is omitted entirely.
+        #[arg(long)]
+        request: Option<PathBuf>,
+
+        /// Seed flow state before running: `key=value`, repeatable. The value is parsed as JSON
+        /// when it parses (numbers/bools/objects/arrays/quoted strings); otherwise it's stored
+        /// as a plain string.
+        #[arg(long = "state", value_name = "KEY=VALUE")]
+        state: Vec<String>,
+
+        /// Flow id the seeded state and the script's `ctx.state`/`flow_store` calls use.
+        #[arg(long, default_value = "cli")]
+        flow_id: String,
+
+        /// Script engine (`rhai`/`lua`/`js`). Inferred from the file extension when omitted.
+        #[arg(long)]
+        engine: Option<String>,
+
+        /// Entrypoint hook to run. Only `respond` is wired end-to-end for all three engines
+        /// today (`matches`/`transform`/`delay` are Rhai-only and not yet reachable outside the
+        /// engine's own unit tests) — any other value is a clean error, not a panic.
+        #[arg(long, default_value = "respond")]
+        hook: String,
     },
 }
 

--- a/crates/rift-http-proxy/tests/fixtures/fail-twice.rhai
+++ b/crates/rift-http-proxy/tests/fixtures/fail-twice.rhai
@@ -1,0 +1,20 @@
+// Fixture for `rift script run` / `rift script check` (issue #360).
+//
+// Fails the first two attempts (503) then passes — a common chaos-testing shape. `attempts` is
+// read from flow state (`ctx.state`), seeded here by `--state attempts=<n>` rather than
+// incremented by the script itself, so a single `script run` invocation is deterministic:
+//
+//   rift script run crates/rift-http-proxy/tests/fixtures/fail-twice.rhai --state attempts=2
+//   -> pass()            (>= 2 prior attempts already recorded: let the request through)
+//
+//   rift script run crates/rift-http-proxy/tests/fixtures/fail-twice.rhai --state attempts=1
+//   -> http(503) ...     (< 2 prior attempts: still failing)
+fn respond(ctx) {
+    let attempts = ctx.state.get_or("attempts", 0);
+    ctx.logger.info(`attempts so far: ${attempts}`);
+    if attempts < 2 {
+        http(503, `Service unavailable (attempt ${attempts})`).header("Retry-After", "1")
+    } else {
+        pass()
+    }
+}

--- a/crates/rift-http-proxy/tests/fixtures/get-resource.json
+++ b/crates/rift-http-proxy/tests/fixtures/get-resource.json
@@ -1,0 +1,10 @@
+{
+  "method": "GET",
+  "path": "/api/resource",
+  "headers": {
+    "accept": "application/json"
+  },
+  "query": {},
+  "pathParams": {},
+  "body": null
+}

--- a/crates/rift-http-proxy/tests/issue_360_debug_script_trace.rs
+++ b/crates/rift-http-proxy/tests/issue_360_debug_script_trace.rs
@@ -1,0 +1,70 @@
+//! Issue #360 Item 3 (debug ON): a matched request whose stub ran a `_rift.script` carries an
+//! `x-rift-script-trace` response header showing the script's decision chain — which hook ran,
+//! its rendered decision, duration, and captured `ctx.logger` lines.
+//!
+//! This needs its own process: `RIFT_DEBUG` is read once into a `OnceLock`
+//! (`rift_core::util::rift_debug_env`), so it must be set before the very first script run in
+//! this binary — same pattern as `issue_359_response_templating_debug.rs`. The "trace absent
+//! when debug is off" half of the AC lives in `issue_360_debug_script_trace_off.rs`, a separate
+//! binary that never sets `RIFT_DEBUG`, since within one process the flag can only go one way.
+
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::time::Duration;
+
+fn enable_debug() {
+    // SAFETY (env mutation, not memory): set before any request is served, matching the
+    // established RIFT_DEBUG/RIFT_STRICT_FLOW_STORE test pattern in this crate.
+    unsafe { std::env::set_var("RIFT_DEBUG", "1") };
+}
+
+#[tokio::test]
+async fn matched_script_response_carries_trace_header_in_debug_mode() {
+    enable_debug();
+    let manager = ImposterManager::new();
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 20090, "protocol": "http",
+        "stubs": [{
+            "responses": [{
+                "_rift": {
+                    "script": {
+                        "engine": "rhai",
+                        "code": r#"fn respond(ctx) { ctx.logger.info("debug trace test"); http(200, "hi") }"#
+                    }
+                }
+            }]
+        }]
+    }))
+    .expect("valid imposter config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::get("http://127.0.0.1:20090/x")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 200);
+    let trace_header = resp
+        .headers()
+        .get("x-rift-script-trace")
+        .expect("x-rift-script-trace header must be present in debug mode")
+        .to_str()
+        .expect("header is valid utf8")
+        .to_string();
+
+    let trace: serde_json::Value =
+        serde_json::from_str(&trace_header).expect("trace header is valid JSON");
+    let entries = trace.as_array().expect("trace is a JSON array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["hook"], "respond");
+    assert!(
+        entries[0]["decision"]
+            .as_str()
+            .unwrap()
+            .starts_with("http(200)"),
+        "got {:?}",
+        entries[0]["decision"]
+    );
+    assert!(entries[0]["durationMs"].is_number());
+    assert_eq!(entries[0]["logs"][0], "debug trace test");
+
+    let _ = manager.delete_imposter(20090).await;
+}

--- a/crates/rift-http-proxy/tests/issue_360_debug_script_trace_off.rs
+++ b/crates/rift-http-proxy/tests/issue_360_debug_script_trace_off.rs
@@ -1,0 +1,40 @@
+//! Issue #360 Item 3 (debug OFF, the default): the `x-rift-script-trace` header must be absent —
+//! and, more importantly, must never be BUILT — when debug mode is off. This file deliberately
+//! never sets `RIFT_DEBUG` (a separate binary/process from `issue_360_debug_script_trace.rs`,
+//! whose whole point is the opposite): `rift_core::util::rift_debug_env()` caches its first read
+//! in a `OnceLock`, so debug-on in one binary can't leak into this one.
+
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use std::time::Duration;
+
+#[tokio::test]
+async fn matched_script_response_has_no_trace_header_when_debug_is_off() {
+    let manager = ImposterManager::new();
+    let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "port": 20091, "protocol": "http",
+        "stubs": [{
+            "responses": [{
+                "_rift": {
+                    "script": {
+                        "engine": "rhai",
+                        "code": r#"fn respond(ctx) { http(200, "hi") }"#
+                    }
+                }
+            }]
+        }]
+    }))
+    .expect("valid imposter config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::get("http://127.0.0.1:20091/x")
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 200);
+    assert!(
+        !resp.headers().contains_key("x-rift-script-trace"),
+        "trace header must be absent when debug mode is off"
+    );
+
+    let _ = manager.delete_imposter(20091).await;
+}

--- a/crates/rift-http-proxy/tests/issue_360_script_cli.rs
+++ b/crates/rift-http-proxy/tests/issue_360_script_cli.rs
@@ -1,0 +1,99 @@
+//! Integration test for issue #360: `rift script check` / `rift script run` invoked as the real
+//! built binary (a bonus over the library-level tests in `src/script_cli.rs`, which cover the
+//! check/run LOGIC directly). One happy path each, via `std::process::Command` against the
+//! checked-in fixtures.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn rift_bin() -> PathBuf {
+    // The binary target is named `rift-http-proxy` (no `[[bin]] name = "rift"` override in
+    // Cargo.toml — the CLI itself is invoked as `rift` only once packaged/aliased downstream).
+    PathBuf::from(env!("CARGO_BIN_EXE_rift-http-proxy"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+// AC (issue #360): `rift script check` on a valid script exits 0 and prints OK.
+#[test]
+fn script_check_valid_fixture_exits_zero() {
+    let output = Command::new(rift_bin())
+        .args(["script", "check"])
+        .arg(fixture("fail-twice.rhai"))
+        .output()
+        .expect("run rift script check");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stdout: {stdout}, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("OK"), "stdout: {stdout}");
+}
+
+// AC (issue #360): a syntax-valid script whose only function is misnamed fails `script check`,
+// naming the expected entrypoint, and exits non-zero.
+#[test]
+fn script_check_misnamed_entrypoint_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("bad.rhai");
+    std::fs::write(&path, "fn respnod(ctx) { pass() }").expect("write fixture");
+
+    let output = Command::new(rift_bin())
+        .args(["script", "check"])
+        .arg(&path)
+        .output()
+        .expect("run rift script check");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("respond"),
+        "error must name the expected entrypoint: {stdout}"
+    );
+}
+
+// AC (issue #360): `rift script run` on the fail-twice fixture with `--state attempts=2` prints
+// the 200 (pass) branch, with no server running.
+#[test]
+fn script_run_fail_twice_attempts_2_passes() {
+    let output = Command::new(rift_bin())
+        .args(["script", "run"])
+        .arg(fixture("fail-twice.rhai"))
+        .args(["--request"])
+        .arg(fixture("get-resource.json"))
+        .args(["--state", "attempts=2"])
+        .output()
+        .expect("run rift script run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stdout: {stdout}, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("pass()"), "stdout: {stdout}");
+}
+
+#[test]
+fn script_run_fail_twice_attempts_1_fails_with_503() {
+    let output = Command::new(rift_bin())
+        .args(["script", "run"])
+        .arg(fixture("fail-twice.rhai"))
+        .args(["--state", "attempts=1"])
+        .output()
+        .expect("run rift script run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stdout: {stdout}, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("http(503)"), "stdout: {stdout}");
+    assert!(stdout.contains("attempts"), "state dump missing: {stdout}");
+}


### PR DESCRIPTION
Implements rift script check for static validation of scripts/configs including engine syntax and entrypoint/arity checks. Implements rift script run for local script execution against fixtures with state seeding and detailed output. Adds --debug mode attaching x-rift-script-trace response header with per-request hook/decision/duration/log chain.

Check/run use parse-only + bounded evaluation so bare-expression scripts don't false-fail and can't hang.

Closes #360
Part of epic #354
Milestone: scripting DX (P5)