### PR TITLE
fix(scripting): predicate-inject errors fail loud with a Mountebank-shaped 400

### DIFF
--- a/crates/rift-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-core/benches/imposter_matcher_bench.rs
@@ -38,6 +38,7 @@ fn bench_stub_matches(c: &mut Criterion) {
                 None,
                 0,
             )
+            .unwrap()
         })
     });
 
@@ -59,6 +60,7 @@ fn bench_stub_matches(c: &mut Criterion) {
                 None,
                 0,
             )
+            .unwrap()
         })
     });
 
@@ -82,6 +84,7 @@ fn bench_stub_matches(c: &mut Criterion) {
                 None,
                 0,
             )
+            .unwrap()
         })
     });
 

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -85,7 +85,7 @@ impl Imposter {
                 form.as_ref(),
                 imposter_port,
                 body_json.as_ref(),
-            ) {
+            )? {
                 // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
                 // The caller (`handler.rs`) holds the returned `Arc<StubState>` across `.await`
                 // points, so the arc-swap load guard must be released before returning (issue #291);
@@ -144,7 +144,7 @@ impl Imposter {
                 form.as_ref(),
                 imposter_port,
                 body_json.as_ref(),
-            ) {
+            )? {
                 return Ok(Some((Arc::clone(stub_state), index)));
             }
         }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -48,6 +48,35 @@ fn csv_cache() -> &'static CsvCache {
     CSV_CACHE.get_or_init(CsvCache::new)
 }
 
+/// Map a matcher error (`find_matching_stub_with_client`) to its response.
+///
+/// A predicate-`inject` failure (issue #440 — an object-build failure or the script itself
+/// throwing) is Mountebank-shaped error parity with the response-inject case just below: a 400
+/// with `{"errors":[{"code":"invalid predicate injection","message":"..."}]}`, not a bare 500 —
+/// the script failed to produce a valid match decision, a client (config) problem, not a server
+/// fault. Every other matcher error (e.g. a scenario-state backend failure, issue #318) keeps
+/// the existing [`backend_error_response`] 5xx mapping.
+fn matcher_error_response(e: &anyhow::Error) -> Response<Full<Bytes>> {
+    #[cfg(feature = "javascript")]
+    {
+        if let Some(pred_err) = e.downcast_ref::<crate::scripting::PredicateInjectionError>() {
+            let body = serde_json::json!({
+                "errors": [{
+                    "code": "invalid predicate injection",
+                    "message": pred_err.to_string(),
+                }]
+            })
+            .to_string();
+            return build_response_with_headers(
+                StatusCode::BAD_REQUEST,
+                [("x-rift-imposter", "true"), ("x-rift-inject-error", "true")],
+                body,
+            );
+        }
+    }
+    backend_error_response(e)
+}
+
 /// [`handle_imposter_request`] inside a per-request annotation scope, with the configured
 /// [`ResponseDecorator`](crate::extensions::decorate::ResponseDecorator) applied (phase
 /// `DataPlane`, the imposter's `port`) before the response is written (issue #318). This
@@ -281,9 +310,10 @@ async fn handle_request_inner(
         Some(&client_ip),
     ) {
         Ok(matched) => matched,
-        // A backend consulted during matching failed (issue #318): surface it, never
-        // fall through to "no match" (which would serve the wrong response).
-        Err(e) => return Ok(backend_error_response(&e)),
+        // A backend consulted during matching failed (issue #318), or a predicate-`inject`
+        // errored (issue #440): surface it, never fall through to "no match" (which would
+        // serve the wrong response).
+        Err(e) => return Ok(matcher_error_response(&e)),
     };
     if let Some((stub_state, stub_index)) = matched {
         // Scenario FSM: apply the matched stub's newScenarioState transition (no-op unless set).
@@ -1143,7 +1173,7 @@ fn handle_debug_request(
         Some(&client_ip),
     ) {
         Ok(matched) => matched,
-        Err(e) => return Ok(backend_error_response(&e)),
+        Err(e) => return Ok(matcher_error_response(&e)),
     };
     let match_result = if let Some((stub_state, stub_index)) = matched {
         // Match found

--- a/crates/rift-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-core/src/imposter/predicates/mod.rs
@@ -7,7 +7,12 @@ use crate::behaviors::{extract_jsonpath, extract_xpath_with_ns};
 use crate::imposter::types::{Predicate, PredicateOperation, PredicateSelector};
 use std::collections::HashMap;
 
-/// Check if a stub matches a request based on its predicates
+/// Check if a stub matches a request based on its predicates.
+///
+/// `Err` propagates a predicate-`inject` failure (issue #440: object-build failure or the
+/// script itself throwing) — Mountebank fails the request loud on this rather than treating the
+/// predicate as non-matching, so callers must surface the error rather than swallow it into
+/// `false`. Every other predicate op is infallible.
 #[allow(clippy::too_many_arguments)]
 pub fn stub_matches(
     predicates: &[Predicate],
@@ -20,7 +25,7 @@ pub fn stub_matches(
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
-) -> bool {
+) -> anyhow::Result<bool> {
     // Parse the body once for standalone callers; the request hot path parses once per request
     // (before the stub scan) and calls `stub_matches_inner` directly (issue #290).
     let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
@@ -41,6 +46,8 @@ pub fn stub_matches(
 
 /// Body of [`stub_matches`] taking the once-parsed request body so every predicate reuses one
 /// parse rather than re-parsing the body per predicate and per stub (issue #290).
+///
+/// See [`stub_matches`] for the `Err` contract (issue #440).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn stub_matches_inner(
     predicates: &[Predicate],
@@ -54,10 +61,10 @@ pub(crate) fn stub_matches_inner(
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
-) -> bool {
+) -> anyhow::Result<bool> {
     // If no predicates, match everything
     if predicates.is_empty() {
-        return true;
+        return Ok(true);
     }
 
     // All predicates must match (implicit AND)
@@ -74,11 +81,11 @@ pub(crate) fn stub_matches_inner(
             form,
             imposter_port,
             body_json,
-        ) {
-            return false;
+        )? {
+            return Ok(false);
         }
     }
-    true
+    Ok(true)
 }
 
 /// Parse query string for predicate matching, URL-decoding both keys and values
@@ -89,6 +96,9 @@ pub fn parse_query(query: Option<&str>) -> HashMap<String, String> {
 /// Check if a single predicate matches (Mountebank-compatible)
 /// Supports: equals, deepEquals, contains, startsWith, endsWith, matches, exists, not, or, and
 /// Also supports requestFrom, ip, and form fields
+///
+/// `Err` propagates a predicate-`inject` failure (issue #440) — see [`stub_matches`] for the
+/// full contract. Every other predicate op is infallible.
 #[allow(clippy::too_many_arguments)]
 pub fn predicate_matches(
     predicate: &Predicate,
@@ -101,7 +111,7 @@ pub fn predicate_matches(
     client_ip: Option<&str>,
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
-) -> bool {
+) -> anyhow::Result<bool> {
     // Standalone callers parse the body here; the request hot path parses once per request and
     // calls `predicate_matches_inner` directly with the shared parse (issue #290).
     let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
@@ -123,6 +133,8 @@ pub fn predicate_matches(
 /// Body of [`predicate_matches`] taking the once-parsed request body (`body_json`) so it is not
 /// re-parsed per predicate/stub. `body_json` is the parse of the raw request body; it is only
 /// used for a no-selector predicate's `body` field (a selector makes the effective body differ).
+///
+/// See [`stub_matches`] for the `Err` contract (issue #440).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn predicate_matches_inner(
     predicate: &Predicate,
@@ -136,7 +148,7 @@ pub(crate) fn predicate_matches_inner(
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
-) -> bool {
+) -> anyhow::Result<bool> {
     // Get predicate options
     let case_sensitive = predicate.parameters.case_sensitive.unwrap_or(false);
 
@@ -229,43 +241,39 @@ pub(crate) fn predicate_matches_inner(
     };
 
     match &predicate.operation {
-        PredicateOperation::Equals(fields) => {
-            check_predicate_fields(
-                fields,
-                method,
-                path,
-                &query_map,
-                headers,
-                effective_body,
-                &apply_except,
-                str_equals,
-                false, // not deep equals
-                request_from,
-                client_ip,
-                form,
-                key_case_sensitive,
-                field_body_json,
-            )
-        }
-        PredicateOperation::DeepEquals(fields) => {
-            check_predicate_fields(
-                fields,
-                method,
-                path,
-                &query_map,
-                headers,
-                effective_body,
-                &apply_except,
-                str_equals,
-                true, // deep equals
-                request_from,
-                client_ip,
-                form,
-                key_case_sensitive,
-                field_body_json,
-            )
-        }
-        PredicateOperation::Contains(fields) => check_predicate_fields(
+        PredicateOperation::Equals(fields) => Ok(check_predicate_fields(
+            fields,
+            method,
+            path,
+            &query_map,
+            headers,
+            effective_body,
+            &apply_except,
+            str_equals,
+            false, // not deep equals
+            request_from,
+            client_ip,
+            form,
+            key_case_sensitive,
+            field_body_json,
+        )),
+        PredicateOperation::DeepEquals(fields) => Ok(check_predicate_fields(
+            fields,
+            method,
+            path,
+            &query_map,
+            headers,
+            effective_body,
+            &apply_except,
+            str_equals,
+            true, // deep equals
+            request_from,
+            client_ip,
+            form,
+            key_case_sensitive,
+            field_body_json,
+        )),
+        PredicateOperation::Contains(fields) => Ok(check_predicate_fields(
             fields,
             method,
             path,
@@ -280,8 +288,8 @@ pub(crate) fn predicate_matches_inner(
             form,
             key_case_sensitive,
             field_body_json,
-        ),
-        PredicateOperation::StartsWith(fields) => check_predicate_fields(
+        )),
+        PredicateOperation::StartsWith(fields) => Ok(check_predicate_fields(
             fields,
             method,
             path,
@@ -296,8 +304,8 @@ pub(crate) fn predicate_matches_inner(
             form,
             key_case_sensitive,
             field_body_json,
-        ),
-        PredicateOperation::EndsWith(fields) => check_predicate_fields(
+        )),
+        PredicateOperation::EndsWith(fields) => Ok(check_predicate_fields(
             fields,
             method,
             path,
@@ -312,8 +320,8 @@ pub(crate) fn predicate_matches_inner(
             form,
             key_case_sensitive,
             field_body_json,
-        ),
-        PredicateOperation::Matches(fields) => check_predicate_fields_regex(
+        )),
+        PredicateOperation::Matches(fields) => Ok(check_predicate_fields_regex(
             fields,
             method,
             path,
@@ -327,8 +335,8 @@ pub(crate) fn predicate_matches_inner(
             form,
             key_case_sensitive,
             field_body_json,
-        ),
-        PredicateOperation::Exists(fields) => check_exists_predicate(
+        )),
+        PredicateOperation::Exists(fields) => Ok(check_exists_predicate(
             fields,
             method,
             path,
@@ -339,8 +347,8 @@ pub(crate) fn predicate_matches_inner(
             client_ip,
             form,
             key_case_sensitive,
-        ),
-        PredicateOperation::Not(inner) => !predicate_matches_inner(
+        )),
+        PredicateOperation::Not(inner) => Ok(!predicate_matches_inner(
             inner,
             method,
             path,
@@ -352,37 +360,52 @@ pub(crate) fn predicate_matches_inner(
             form,
             imposter_port,
             body_json,
-        ),
-        PredicateOperation::Or(children) => children.iter().any(|p| {
-            predicate_matches_inner(
-                p,
-                method,
-                path,
-                query,
-                headers,
-                body,
-                request_from,
-                client_ip,
-                form,
-                imposter_port,
-                body_json,
-            )
-        }),
-        PredicateOperation::And(children) => children.iter().all(|p| {
-            predicate_matches_inner(
-                p,
-                method,
-                path,
-                query,
-                headers,
-                body,
-                request_from,
-                client_ip,
-                form,
-                imposter_port,
-                body_json,
-            )
-        }),
+        )?),
+        PredicateOperation::Or(children) => {
+            // Short-circuits on the first match, like the old `.any()`; a predicate-inject error
+            // (issue #440) encountered along the way propagates immediately rather than being
+            // treated as "this branch didn't match".
+            for p in children {
+                if predicate_matches_inner(
+                    p,
+                    method,
+                    path,
+                    query,
+                    headers,
+                    body,
+                    request_from,
+                    client_ip,
+                    form,
+                    imposter_port,
+                    body_json,
+                )? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        PredicateOperation::And(children) => {
+            // Short-circuits on the first non-match, like the old `.all()`; an inject error
+            // propagates immediately (issue #440).
+            for p in children {
+                if !predicate_matches_inner(
+                    p,
+                    method,
+                    path,
+                    query,
+                    headers,
+                    body,
+                    request_from,
+                    client_ip,
+                    form,
+                    imposter_port,
+                    body_json,
+                )? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
         PredicateOperation::Inject(inject_fn) => {
             #[cfg(feature = "javascript")]
             {
@@ -403,7 +426,7 @@ pub(crate) fn predicate_matches_inner(
                     "inject predicate requires the 'javascript' feature; predicate will not match"
                 );
                 let _ = inject_fn;
-                false
+                Ok(false)
             }
         }
     }
@@ -506,7 +529,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -562,7 +586,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -597,7 +622,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -623,44 +649,53 @@ mod tests {
         ];
 
         // Matching body satisfies both predicates.
-        assert!(stub_matches(
-            &predicates,
-            "POST",
-            "/x",
-            None,
-            &empty_headers(),
-            Some(r#"{"b":2,"a":1}"#),
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            stub_matches(
+                &predicates,
+                "POST",
+                "/x",
+                None,
+                &empty_headers(),
+                Some(r#"{"b":2,"a":1}"#),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // A body that breaks deepEquals (extra key) must fail the AND.
-        assert!(!stub_matches(
-            &predicates,
-            "POST",
-            "/x",
-            None,
-            &empty_headers(),
-            Some(r#"{"a":1,"b":2,"c":3}"#),
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !stub_matches(
+                &predicates,
+                "POST",
+                "/x",
+                None,
+                &empty_headers(),
+                Some(r#"{"a":1,"b":2,"c":3}"#),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // Non-JSON body must not match a JSON-object predicate.
-        assert!(!stub_matches(
-            &predicates,
-            "POST",
-            "/x",
-            None,
-            &empty_headers(),
-            Some("not json"),
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !stub_matches(
+                &predicates,
+                "POST",
+                "/x",
+                None,
+                &empty_headers(),
+                Some("not json"),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -693,7 +728,8 @@ mod tests {
                 None,
                 None,
                 0,
-            ),
+            )
+            .unwrap(),
             "deepEquals over the jsonpath-extracted object must match; reusing the raw-body parse \
              (which also has `other`) would wrongly fail"
         );
@@ -720,7 +756,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(result, "deepEquals should match identical string bodies");
     }
@@ -751,7 +788,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -780,7 +818,8 @@ mod tests {
 
         let result = predicate_matches(
             &pred, "GET", "/test", None, &headers, None, None, None, None, 0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -813,7 +852,8 @@ mod tests {
             None,
             Some(&form),
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -851,7 +891,8 @@ mod tests {
 
         let result = predicate_matches(
             &pred, "GET", "/test", None, &headers, None, None, None, None, 0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -886,7 +927,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -906,43 +948,52 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::Equals(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "POST",
-            "/test",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/test",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // Default is case-insensitive
-        assert!(predicate_matches(
-            &pred,
-            "post",
-            "/test",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/test",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "post",
+                "/test",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/test",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -954,30 +1005,36 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::Equals(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/api/users",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/api/other",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/api/other",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -987,30 +1044,36 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::Contains(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            Some("say hello world"),
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            Some("goodbye"),
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                Some("say hello world"),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                Some("goodbye"),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1020,30 +1083,36 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::StartsWith(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/api/users",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/web/page",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/web/page",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1053,30 +1122,36 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::EndsWith(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/data/file.json",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/data/file.xml",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/data/file.json",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/data/file.xml",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1088,30 +1163,36 @@ mod tests {
 
         let pred = make_predicate(PredicateOperation::Matches(fields));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/api/users/123",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/api/users/abc",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/api/users/123",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/api/users/abc",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1123,18 +1204,21 @@ mod tests {
         // Default (caseSensitive unset → false): the cached regex is case-insensitive, so an
         // uppercase pattern matches a lowercase path.
         let insensitive = make_predicate(PredicateOperation::Matches(fields.clone()));
-        assert!(predicate_matches(
-            &insensitive,
-            "GET",
-            "/api/users",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &insensitive,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
 
         // caseSensitive: true → the cached regex is case-sensitive and must NOT match.
         let sensitive = make_predicate_with_params(
@@ -1144,18 +1228,21 @@ mod tests {
                 ..PredicateParameters::default()
             },
         );
-        assert!(!predicate_matches(
-            &sensitive,
-            "GET",
-            "/api/users",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &sensitive,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1166,30 +1253,36 @@ mod tests {
         let inner = make_predicate(PredicateOperation::Equals(inner_fields));
         let pred = make_predicate(PredicateOperation::Not(Box::new(inner)));
 
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(predicate_matches(
-            &pred,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1205,42 +1298,51 @@ mod tests {
             make_predicate(PredicateOperation::Equals(eq_post)),
         ]));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(predicate_matches(
-            &pred,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "DELETE",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "DELETE",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1255,42 +1357,51 @@ mod tests {
             make_predicate(PredicateOperation::Equals(eq_path)),
         ]));
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/api",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "POST",
-            "/api",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/other",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/api",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "POST",
+                "/api",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/other",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1306,31 +1417,37 @@ mod tests {
 
         let pred = make_predicate_with_params(PredicateOperation::Equals(fields), params);
 
-        assert!(predicate_matches(
-            &pred,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // With caseSensitive: true, "post" should NOT match "POST"
-        assert!(!predicate_matches(
-            &pred,
-            "post",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &pred,
+                "post",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1349,18 +1466,21 @@ mod tests {
 
         // except removes "/api" from actual path, so "/api/users" becomes "/users"
         // which doesn't match "/api/users"
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/api/users",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1375,44 +1495,53 @@ mod tests {
         let pred_false = make_predicate(PredicateOperation::Exists(fields_false));
 
         // Body exists
-        assert!(predicate_matches(
-            &pred_true,
-            "POST",
-            "/",
-            None,
-            &empty_headers(),
-            Some("content"),
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred_true,
+                "POST",
+                "/",
+                None,
+                &empty_headers(),
+                Some("content"),
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // Body does not exist
-        assert!(!predicate_matches(
-            &pred_true,
-            "GET",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &pred_true,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // Body should NOT exist (false) - empty body
-        assert!(predicate_matches(
-            &pred_false,
-            "GET",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred_false,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1427,21 +1556,25 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
 
-        assert!(predicate_matches(
-            &pred, "GET", "/", None, &headers, None, None, None, None, 0
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(&pred, "GET", "/", None, &headers, None, None, None, None, 0)
+                .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1454,31 +1587,37 @@ mod tests {
         let pred = make_predicate(PredicateOperation::DeepEquals(fields));
 
         // Exact match - should pass
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            Some("a=1"),
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                Some("a=1"),
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
         // Extra param - should fail for deepEquals
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            Some("a=1&b=2"),
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                Some("a=1&b=2"),
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1498,47 +1637,56 @@ mod tests {
         extra_headers.insert("x-custom".to_string(), "value".to_string());
         extra_headers.insert("x-other".to_string(), "other".to_string());
 
-        assert!(predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            None,
-            &exact_headers,
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
-        assert!(!predicate_matches(
-            &pred,
-            "GET",
-            "/",
-            None,
-            &extra_headers,
-            None,
-            None,
-            None,
-            None,
-            0,
-        ));
+        assert!(
+            predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                None,
+                &exact_headers,
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
+        assert!(
+            !predicate_matches(
+                &pred,
+                "GET",
+                "/",
+                None,
+                &extra_headers,
+                None,
+                None,
+                None,
+                None,
+                0,
+            )
+            .unwrap()
+        );
     }
 
     #[test]
     fn test_stub_matches_empty_predicates() {
         // Empty predicates should match everything
-        assert!(stub_matches(
-            &[],
-            "GET",
-            "/anything",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0
-        ));
+        assert!(
+            stub_matches(
+                &[],
+                "GET",
+                "/anything",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1553,30 +1701,36 @@ mod tests {
             )),
         ];
 
-        assert!(stub_matches(
-            &predicates,
-            "GET",
-            "/api",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0
-        ));
-        assert!(!stub_matches(
-            &predicates,
-            "POST",
-            "/api",
-            None,
-            &empty_headers(),
-            None,
-            None,
-            None,
-            None,
-            0
-        ));
+        assert!(
+            stub_matches(
+                &predicates,
+                "GET",
+                "/api",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0
+            )
+            .unwrap()
+        );
+        assert!(
+            !stub_matches(
+                &predicates,
+                "POST",
+                "/api",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0
+            )
+            .unwrap()
+        );
     }
 
     #[test]
@@ -1616,7 +1770,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -1654,7 +1809,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -1682,7 +1838,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             !result,
@@ -1717,7 +1874,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -1744,7 +1902,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             !result,
@@ -1771,7 +1930,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             !result,
@@ -1798,7 +1958,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             !result,
@@ -1824,7 +1985,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             !result,
@@ -1857,7 +2019,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
 
         assert!(
             result,
@@ -1886,7 +2049,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
         assert!(result, "inject predicate returning true should match");
     }
 
@@ -1907,7 +2071,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
         assert!(!result, "inject predicate returning false should not match");
     }
 
@@ -1920,9 +2085,11 @@ mod tests {
         let headers = HashMap::new();
         let post_result = predicate_matches(
             &pred, "POST", "/", None, &headers, None, None, None, None, 0,
-        );
+        )
+        .unwrap();
         let get_result =
-            predicate_matches(&pred, "GET", "/", None, &headers, None, None, None, None, 0);
+            predicate_matches(&pred, "GET", "/", None, &headers, None, None, None, None, 0)
+                .unwrap();
         assert!(post_result, "inject predicate should match POST");
         assert!(!get_result, "inject predicate should not match GET");
     }
@@ -1945,7 +2112,8 @@ mod tests {
             None,
             None,
             0,
-        );
+        )
+        .unwrap();
         assert!(result, "inject predicate should access request body");
     }
 
@@ -1954,5 +2122,160 @@ mod tests {
         let json = r#"{"inject": "function(request) { return true; }"}"#;
         let op: PredicateOperation = serde_json::from_str(json).expect("should deserialize inject");
         assert!(matches!(op, PredicateOperation::Inject(_)));
+    }
+
+    // =========================================================================
+    // Issue #440: a predicate `inject` that throws/errors must fail loud (Err), not silently
+    // collapse to "didn't match" (Ok(false)) — matching Mountebank's `InjectionError` behavior.
+    // =========================================================================
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_throwing_script_fails_loud() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            "function(request) { throw new Error('boom'); }".to_string(),
+        ));
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "a throwing inject predicate must return Err, not Ok(false)"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid predicate injection"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_undefined_reference_fails_loud() {
+        let pred = make_predicate(PredicateOperation::Inject(
+            "function(request) { return someUndefinedVariable.path === request.path; }".to_string(),
+        ));
+        let result = predicate_matches(
+            &pred,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "a reference-error inject predicate must return Err, not Ok(false)"
+        );
+    }
+
+    // Not/Or/And must propagate an inject error from a nested predicate rather than swallow it
+    // into the boolean combinator result.
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_inject_predicate_error_propagates_through_or_and_not() {
+        let throwing = || {
+            make_predicate(PredicateOperation::Inject(
+                "function(request) { throw new Error('boom'); }".to_string(),
+            ))
+        };
+        let always_true = || make_predicate(PredicateOperation::Exists(HashMap::new()));
+
+        let or_pred = make_predicate(PredicateOperation::Or(vec![throwing(), always_true()]));
+        assert!(
+            predicate_matches_inner(
+                &or_pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+            )
+            .is_err(),
+            "an `or` must propagate a nested inject error rather than short-circuit past it"
+        );
+
+        let and_pred = make_predicate(PredicateOperation::And(vec![always_true(), throwing()]));
+        assert!(
+            predicate_matches_inner(
+                &and_pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+            )
+            .is_err(),
+            "an `and` must propagate a nested inject error"
+        );
+
+        let not_pred = make_predicate(PredicateOperation::Not(Box::new(throwing())));
+        assert!(
+            predicate_matches_inner(
+                &not_pred,
+                "GET",
+                "/",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+            )
+            .is_err(),
+            "a `not` must propagate a nested inject error rather than negate it into a match"
+        );
+    }
+
+    // stub_matches (used by the request hot path via stub_matches_inner) must not swallow a
+    // predicate-inject error into "stub didn't match" — it must propagate so the caller can fail
+    // the request loud (issue #440).
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn test_stub_matches_propagates_predicate_inject_error() {
+        let predicates = vec![make_predicate(PredicateOperation::Inject(
+            "function(request) { throw new Error('boom'); }".to_string(),
+        ))];
+        let result = stub_matches(
+            &predicates,
+            "GET",
+            "/api",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "stub_matches must propagate a predicate-inject error, not collapse it to false"
+        );
     }
 }

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -68,56 +68,68 @@ fn test_predicate_matching() {
     let empty_headers = HashMap::new();
 
     // Should match
-    assert!(stub_matches(
-        &stub.predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &stub.predicates,
-        "get",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    )); // case-insensitive method
+    assert!(
+        stub_matches(
+            &stub.predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &stub.predicates,
+            "get",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    ); // case-insensitive method
 
     // Should not match
-    assert!(!stub_matches(
-        &stub.predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &stub.predicates,
-        "GET",
-        "/other",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &stub.predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &stub.predicates,
+            "GET",
+            "/other",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -492,56 +504,68 @@ fn test_predicate_ends_with() {
     let empty_headers = HashMap::new();
 
     // Should match
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/api/lender-details",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/user-details",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/api/lender-details",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/user-details",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Should not match
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/details/other",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/api/details/v1",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/details/other",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/api/details/v1",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -553,42 +577,51 @@ fn test_predicate_deep_equals_method() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "get",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    )); // case-insensitive
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "get",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    ); // case-insensitive
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -601,44 +634,53 @@ fn test_predicate_deep_equals_body() {
     let empty_headers = HashMap::new();
 
     // Empty body should match
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        Some(""),
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            Some(""),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Non-empty body should not match
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        Some("content"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            Some("content"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -651,68 +693,83 @@ fn test_predicate_contains_query() {
     let empty_headers = HashMap::new();
 
     // Should match - query contains "CofTest"
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("lenderIds=CofTestWL"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("lenderIds=CofTest"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("lenderIds=123CofTest456"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("lenderIds=CofTestWL"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("lenderIds=CofTest"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("lenderIds=123CofTest456"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Should not match
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("lenderIds=Other"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("lenderIds=Other"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -725,65 +782,77 @@ fn test_predicate_equals_headers() {
     let mut headers = HashMap::new();
     headers.insert("Content-Type".to_string(), "application/json".to_string());
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Header key lookup is case-insensitive
     let mut headers_lower = HashMap::new();
     headers_lower.insert("content-type".to_string(), "application/json".to_string());
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers_lower,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers_lower,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Wrong value
     let mut wrong_headers = HashMap::new();
     wrong_headers.insert("Content-Type".to_string(), "text/html".to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &wrong_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &wrong_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Missing header
     let empty_headers = HashMap::new();
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -801,61 +870,73 @@ fn test_predicate_exists() {
     headers.insert("Authorization".to_string(), "Bearer xyz".to_string());
 
     // All exist
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        Some("token=abc"),
-        &headers,
-        Some("body content"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            Some("token=abc"),
+            &headers,
+            Some("body content"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Missing query param
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &headers,
-        Some("body content"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &headers,
+            Some("body content"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Missing header
     let empty_headers = HashMap::new();
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        Some("token=abc"),
-        &empty_headers,
-        Some("body content"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            Some("token=abc"),
+            &empty_headers,
+            Some("body content"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Missing body
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        Some("token=abc"),
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            Some("token=abc"),
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -868,42 +949,51 @@ fn test_predicate_logical_not() {
     let empty_headers = HashMap::new();
 
     // Should match anything except DELETE
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "DELETE",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "DELETE",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -918,42 +1008,51 @@ fn test_predicate_logical_or() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "HEAD",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "HEAD",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -968,42 +1067,51 @@ fn test_predicate_logical_and() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/api/users",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/api/users",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/other",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/api/users",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/api/users",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/other",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1018,54 +1126,66 @@ fn test_predicate_matches_regex_all_fields() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/api/v1/users",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/api/v2/items",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "DELETE",
-        "/api/v1/users",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/other/path",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/api/v1/users",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/api/v2/items",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "DELETE",
+            "/api/v1/users",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/other/path",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1077,30 +1197,36 @@ fn test_predicate_matches_body_regex() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"userId": "abc-123-def"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"userId": "invalid!"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"userId": "abc-123-def"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"userId": "invalid!"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -1121,32 +1247,38 @@ fn test_exists_predicate_body_object_field_present() {
     let empty_headers = HashMap::new();
 
     // Body has "blah" field → should match
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"blah": "hello", "other": "stuff"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"blah": "hello", "other": "stuff"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Body does NOT have "blah" field → should not match
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"other": "stuff"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"other": "stuff"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1163,32 +1295,38 @@ fn test_exists_predicate_body_object_field_absent() {
     let empty_headers = HashMap::new();
 
     // Body has "blah" field → should NOT match (we want it absent)
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"blah": "hello"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"blah": "hello"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Body does NOT have "blah" field → should match
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"other": "stuff"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"other": "stuff"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1204,18 +1342,21 @@ fn test_exists_predicate_body_object_non_json_body() {
 
     let empty_headers = HashMap::new();
 
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some("not json at all"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some("not json at all"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1229,31 +1370,37 @@ fn test_exists_predicate_body_boolean_still_works() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some("any body content"),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some("any body content"),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -1272,18 +1419,21 @@ fn test_ends_with_object_value_does_not_always_match() {
     let empty_headers = HashMap::new();
 
     // Path is a plain string, not JSON → should NOT match (was incorrectly always matching)
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/blah",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/blah",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1298,32 +1448,38 @@ fn test_ends_with_path_as_json_object() {
     let empty_headers = HashMap::new();
 
     // Path is a JSON string with a field whose value ends with "123"
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        r#"{"abc": "other123", "other": "ignored"}"#,
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            r#"{"abc": "other123", "other": "ignored"}"#,
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Path is a JSON string but field doesn't end with "123"
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        r#"{"abc": "other456"}"#,
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            r#"{"abc": "other456"}"#,
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1337,18 +1493,21 @@ fn test_starts_with_object_value_does_not_always_match() {
 
     let empty_headers = HashMap::new();
 
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/something",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/something",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1365,46 +1524,55 @@ fn test_equals_body_as_json_object() {
     let empty_headers = HashMap::new();
 
     // Body with matching field (extra fields ignored for equals)
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"blah": "123", "other": "ignored"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"blah": "123", "other": "ignored"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Body with wrong value
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"blah": "456"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"blah": "456"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Body missing the field
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"other": "123"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"other": "123"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1418,31 +1586,37 @@ fn test_ends_with_body_object_with_numeric_value() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"abc": "other123"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"abc": "other123"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"abc": "other456"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"abc": "other456"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // Issue #77 (reopened): Object predicates in query, headers, and form
@@ -1474,7 +1648,8 @@ fn test_ends_with_query_object_value_does_not_always_match() {
             None,
             None,
             0
-        ),
+        )
+        .unwrap(),
         "Object expected value in query should not match a plain string"
     );
 }
@@ -1491,32 +1666,38 @@ fn test_ends_with_query_object_value_recursive_match() {
     let empty_headers = HashMap::new();
 
     // query param 'data' is a JSON string with a field ending in "123"
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"key": "other123", "extra": "ignored"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"key": "other123", "extra": "ignored"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // query param 'data' has a field NOT ending in "123"
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"key": "other456"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"key": "other456"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1544,7 +1725,8 @@ fn test_ends_with_header_object_value_does_not_always_match() {
             None,
             None,
             0
-        ),
+        )
+        .unwrap(),
         "Object expected value in headers should not match a plain string"
     );
 }
@@ -1564,33 +1746,39 @@ fn test_ends_with_header_object_value_recursive_match() {
         r#"{"abc": "other123", "extra": "ignored"}"#.to_string(),
     );
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Header value with field NOT ending in "123"
     headers.insert("X-Data".to_string(), r#"{"abc": "other456"}"#.to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1619,7 +1807,8 @@ fn test_ends_with_form_object_value_does_not_always_match() {
             None,
             Some(&form),
             0
-        ),
+        )
+        .unwrap(),
         "Object expected value in form should not match a plain string"
     );
 }
@@ -1640,33 +1829,39 @@ fn test_ends_with_form_object_value_recursive_match() {
         r#"{"key": "other123", "extra": "ignored"}"#.to_string(),
     );
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/submit",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        Some(&form),
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/submit",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form),
+            0
+        )
+        .unwrap()
+    );
 
     // Form field with value NOT ending in "123"
     form.insert("payload".to_string(), r#"{"key": "other456"}"#.to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/submit",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        Some(&form),
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/submit",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form),
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1681,32 +1876,38 @@ fn test_contains_query_object_value() {
     let empty_headers = HashMap::new();
 
     // query param 'data' is a JSON string with a field containing "ohn"
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"name": "John", "age": "30"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"name": "John", "age": "30"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // query param 'data' does NOT contain "ohn"
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"name": "Jane"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"name": "Jane"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1725,33 +1926,39 @@ fn test_equals_header_object_value() {
     );
 
     // equals with object does recursive field match (extra fields OK)
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Mismatched value
     headers.insert("X-Config".to_string(), r#"{"mode": "prod"}"#.to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // Issue #77: matches predicate with object expected values in query/headers/form
@@ -1781,7 +1988,8 @@ fn test_matches_query_object_value_does_not_always_match() {
             None,
             None,
             0
-        ),
+        )
+        .unwrap(),
         "Object expected value in matches/query should not match a plain string"
     );
 }
@@ -1798,32 +2006,38 @@ fn test_matches_query_object_value_recursive_regex() {
     let empty_headers = HashMap::new();
 
     // query param 'data' is JSON with a "name" field matching regex ^J.*n$
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"name": "John", "age": "30"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"name": "John", "age": "30"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // "Jane" does NOT match ^J.*n$ (ends with 'e')
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some(r#"data={"name": "Jane"}"#),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some(r#"data={"name": "Jane"}"#),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1841,33 +2055,39 @@ fn test_matches_header_object_value_recursive_regex() {
     );
 
     // "12345" matches ^\d+$
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // "abc" does NOT match ^\d+$
     headers.insert("X-Data".to_string(), r#"{"id": "abc"}"#.to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1886,33 +2106,39 @@ fn test_matches_form_object_value_recursive_regex() {
     );
 
     // "ABC" matches ^[A-Z]{3}$
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/submit",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        Some(&form),
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/submit",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form),
+            0
+        )
+        .unwrap()
+    );
 
     // "abcd" does NOT match ^[A-Z]{3}$
     form.insert("payload".to_string(), r#"{"code": "abcd"}"#.to_string());
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/submit",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        Some(&form),
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/submit",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form),
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -1930,32 +2156,38 @@ fn test_deep_equals_body_extra_keys_rejected() {
     let empty_headers = HashMap::new();
 
     // Exact match should pass
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"a": "1"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"a": "1"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Extra key should be rejected by deepEquals
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"a": "1", "b": "2"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"a": "1", "b": "2"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1969,18 +2201,21 @@ fn test_equals_body_extra_keys_allowed() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"a": "1", "b": "2"}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"a": "1", "b": "2"}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -1994,32 +2229,38 @@ fn test_deep_equals_body_nested_extra_keys_rejected() {
     let empty_headers = HashMap::new();
 
     // Exact nested match
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"outer": {"inner": "val"}}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"outer": {"inner": "val"}}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Extra key in nested object
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"outer": {"inner": "val", "extra": "x"}}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"outer": {"inner": "val", "extra": "x"}}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2033,46 +2274,55 @@ fn test_deep_equals_body_array_comparison() {
     let empty_headers = HashMap::new();
 
     // Exact array match
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"items": [1, 2, 3]}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"items": [1, 2, 3]}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Different length array
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"items": [1, 2, 3, 4]}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"items": [1, 2, 3, 4]}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     // Different values
-    assert!(!stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        Some(r#"{"items": [1, 2, 99]}"#),
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            Some(r#"{"items": [1, 2, 99]}"#),
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -2089,18 +2339,21 @@ fn test_exists_predicate_query_key_case_insensitive() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("token=abc"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("token=abc"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2114,31 +2367,37 @@ fn test_exists_predicate_query_key_case_sensitive() {
 
     let empty_headers = HashMap::new();
 
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("token=abc"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("token=abc"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("Token=abc"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("Token=abc"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2153,18 +2412,21 @@ fn test_exists_predicate_form_key_case_insensitive() {
     let mut form = HashMap::new();
     form.insert("username".to_string(), "alice".to_string());
 
-    assert!(stub_matches(
-        &predicates,
-        "POST",
-        "/test",
-        None,
-        &empty_headers,
-        None,
-        None,
-        None,
-        Some(&form),
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "POST",
+            "/test",
+            None,
+            &empty_headers,
+            None,
+            None,
+            None,
+            Some(&form),
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2179,34 +2441,40 @@ fn test_exists_predicate_headers_key_case_sensitive() {
     let mut headers = HashMap::new();
     headers.insert("x-custom".to_string(), "value".to_string());
 
-    assert!(!stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        !stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 
     let mut headers_exact = HashMap::new();
     headers_exact.insert("X-Custom".to_string(), "value".to_string());
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers_exact,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers_exact,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -2240,18 +2508,21 @@ fn test_header_predicate_matches_title_case() {
     let mut headers = HashMap::new();
     headers.insert("Content-Type".to_string(), "application/json".to_string());
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        None,
-        &headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            None,
+            &headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -2281,18 +2552,21 @@ fn test_bare_query_param_exists_predicate() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("flag"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("flag"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2305,18 +2579,21 @@ fn test_bare_query_param_equals_empty_string() {
 
     let empty_headers = HashMap::new();
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("flag"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("flag"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================
@@ -2344,18 +2621,21 @@ fn test_multi_valued_query_param_equals() {
         }
     })]);
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("key=a&key=b"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("key=a&key=b"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 #[test]
@@ -2367,18 +2647,21 @@ fn test_multi_valued_query_param_contains() {
         }
     })]);
 
-    assert!(stub_matches(
-        &predicates,
-        "GET",
-        "/test",
-        Some("key=a&key=b&other=x"),
-        &empty_headers,
-        None,
-        None,
-        None,
-        None,
-        0
-    ));
+    assert!(
+        stub_matches(
+            &predicates,
+            "GET",
+            "/test",
+            Some("key=a&key=b&other=x"),
+            &empty_headers,
+            None,
+            None,
+            None,
+            None,
+            0
+        )
+        .unwrap()
+    );
 }
 
 // =============================================================================

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1627,25 +1627,40 @@ pub fn execute_mountebank_inject(
     parse_mountebank_response(&mut context, result)
 }
 
+/// A Mountebank predicate `inject` function failed — an object-build failure or the script
+/// itself throwing/erroring. Mountebank's own `InjectionError` fails the request loud rather
+/// than silently treating the predicate as non-matching (issue #440); this type lets the HTTP
+/// handler tell this class of error apart, via `anyhow::Error::downcast_ref`, from other matcher
+/// errors (e.g. a scenario-state backend failure, issue #318) that must keep their existing 5xx
+/// mapping instead of becoming a 400.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid predicate injection: {0}")]
+pub struct PredicateInjectionError(pub String);
+
 /// Execute a Mountebank-style predicate inject function.
 ///
 /// v2 `config`-first calling convention (issue #355 Item 0): full signature
 /// `fn(config, logger, imposterState) { return bool; }`, where `config` also stands in for the
 /// legacy `request` positional argument (request fields are flattened onto `config`), and
 /// `imposterState` aliases `config.state` — the same per-port state shared with response injects
-/// and decorate for the same imposter. Returns `true` if the predicate matches, `false` otherwise.
+/// and decorate for the same imposter. Returns `Ok(true)`/`Ok(false)` for a legitimate
+/// match/non-match. Any failure to build the script's inputs, or the inject function itself
+/// throwing/erroring, returns `Err(PredicateInjectionError)` (issue #440) — mirroring Mountebank,
+/// which fails the request rather than treating an injection error as "did not match".
 pub fn execute_predicate_inject(
     inject_fn: &str,
     request: &MountebankRequest,
     imposter_port: u16,
-) -> bool {
+) -> anyhow::Result<bool> {
     let mut context = bounded_js_context();
 
     let request_obj = match create_mountebank_request_object(&mut context, request) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build request object: {e}");
-            return false;
+            return Err(
+                PredicateInjectionError(format!("failed to build request object: {e}")).into(),
+            );
         }
     };
 
@@ -1654,7 +1669,9 @@ pub fn execute_predicate_inject(
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build state object: {e}");
-            return false;
+            return Err(
+                PredicateInjectionError(format!("failed to build state object: {e}")).into(),
+            );
         }
     };
 
@@ -1665,7 +1682,9 @@ pub fn execute_predicate_inject(
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build logger object: {e}");
-            return false;
+            return Err(
+                PredicateInjectionError(format!("failed to build logger object: {e}")).into(),
+            );
         }
     };
 
@@ -1692,7 +1711,7 @@ pub fn execute_predicate_inject(
         || flatten_request_onto(&config_obj, &request_obj, &mut context).is_err()
     {
         tracing::warn!("inject predicate: failed to build config object");
-        return false;
+        return Err(PredicateInjectionError("failed to build config object".to_string()).into());
     }
 
     let global = context.global_object();
@@ -1717,7 +1736,7 @@ pub fn execute_predicate_inject(
         Ok(v) => v,
         Err(e) => {
             tracing::warn!("inject predicate: script execution error: {e}");
-            return false;
+            return Err(PredicateInjectionError(format!("script execution error: {e}")).into());
         }
     };
 
@@ -1728,7 +1747,7 @@ pub fn execute_predicate_inject(
         save_imposter_state(imposter_port, map);
     }
 
-    result.to_boolean()
+    Ok(result.to_boolean())
 }
 
 /// Execute a `predicateGenerators.inject` function during proxy recording.
@@ -3307,31 +3326,19 @@ function respond(ctx) {
     #[test]
     fn predicate_v2_config_request_path() {
         let script = r#"function(config) { return config.request.path === "/match"; }"#;
-        assert!(execute_predicate_inject(
-            script,
-            &mb_req("GET", "/match"),
-            test_port()
-        ));
+        assert!(execute_predicate_inject(script, &mb_req("GET", "/match"), test_port()).unwrap());
     }
 
     #[test]
     fn predicate_legacy_positional() {
         let script = r#"function(request, logger, state) { return request.path === "/match"; }"#;
-        assert!(execute_predicate_inject(
-            script,
-            &mb_req("GET", "/match"),
-            test_port()
-        ));
+        assert!(execute_predicate_inject(script, &mb_req("GET", "/match"), test_port()).unwrap());
     }
 
     #[test]
     fn predicate_flattened_config_path() {
         let script = r#"function(config) { return config.path === "/match"; }"#;
-        assert!(execute_predicate_inject(
-            script,
-            &mb_req("GET", "/match"),
-            test_port()
-        ));
+        assert!(execute_predicate_inject(script, &mb_req("GET", "/match"), test_port()).unwrap());
     }
 
     #[test]
@@ -3340,11 +3347,7 @@ function respond(ctx) {
             var req = config.request || config;
             return req.path === "/match";
         }"#;
-        assert!(execute_predicate_inject(
-            script,
-            &mb_req("GET", "/match"),
-            test_port()
-        ));
+        assert!(execute_predicate_inject(script, &mb_req("GET", "/match"), test_port()).unwrap());
     }
 
     #[test]
@@ -3353,11 +3356,7 @@ function respond(ctx) {
             state.checked = true;
             return config.method === "GET";
         }"#;
-        assert!(execute_predicate_inject(
-            script,
-            &mb_req("GET", "/match"),
-            test_port()
-        ));
+        assert!(execute_predicate_inject(script, &mb_req("GET", "/match"), test_port()).unwrap());
     }
 
     // Decorate: same five conventions.
@@ -3454,11 +3453,9 @@ function respond(ctx) {
         let port = test_port();
         let predicate_script =
             r#"function(config) { config.state.seen = "from-predicate"; return true; }"#;
-        assert!(execute_predicate_inject(
-            predicate_script,
-            &mb_req("GET", "/shared"),
-            port
-        ));
+        assert!(
+            execute_predicate_inject(predicate_script, &mb_req("GET", "/shared"), port).unwrap()
+        );
 
         let inject_script = r#"function(config) { return { statusCode: 200, body: config.state.seen || "missing" }; }"#;
         let resp = execute_mountebank_inject(inject_script, &mb_req("GET", "/shared"), port, None)

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -33,9 +33,9 @@ mod js_engine;
 pub(crate) use js_engine::bounded_js_context;
 #[cfg(feature = "javascript")]
 pub use js_engine::{
-    JsEngine, MountebankRequest, clear_imposter_state, compile_js_to_bytecode,
-    execute_mountebank_config_decorate, execute_mountebank_decorate, execute_mountebank_inject,
-    execute_predicate_generator_inject, execute_predicate_inject,
+    JsEngine, MountebankRequest, PredicateInjectionError, clear_imposter_state,
+    compile_js_to_bytecode, execute_mountebank_config_decorate, execute_mountebank_decorate,
+    execute_mountebank_inject, execute_predicate_generator_inject, execute_predicate_inject,
 };
 #[cfg(feature = "javascript")]
 #[allow(unused_imports)]

--- a/crates/rift-http-proxy/src/intercept_rules.rs
+++ b/crates/rift-http-proxy/src/intercept_rules.rs
@@ -125,7 +125,15 @@ impl InterceptRules {
                             None,
                             None,
                             0,
-                        ))
+                        )
+                        // A predicate `inject` error (e.g. a throwing script) is out of scope for
+                        // intercept-rule fail-loud handling (issue #440 only covers imposter stub
+                        // matching) — log and treat the rule as non-matching rather than panic the
+                        // intercept listener on a bad script.
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "intercept rule predicate match failed");
+                            false
+                        }))
             })
             .map(|rule| rule.action.clone())
     }

--- a/crates/rift-http-proxy/tests/issue_440_predicate_inject_error_parity.rs
+++ b/crates/rift-http-proxy/tests/issue_440_predicate_inject_error_parity.rs
@@ -1,0 +1,123 @@
+//! Issue #440: a Mountebank predicate `inject` function that THROWS must FAIL LOUD — a
+//! Mountebank-shaped 400 error (`{"errors":[{"code":"invalid predicate injection", ...}]}`), not
+//! a silent fall-through to "didn't match" (which would let a later stub, or the imposter's
+//! default response, wrongly serve the request). Mountebank's own `InjectionError` fails the
+//! request on this rather than treating the predicate as non-matching — mirrors the
+//! response-inject error parity added for issue #355 Item 5
+//! (`issue_355_inject_error_parity.rs`).
+
+use rift_http_proxy::imposter::ImposterManager;
+use std::time::Duration;
+
+// A throwing predicate inject returns HTTP 400 with the Mountebank error body shape, and never
+// falls through to a later stub — proven here by a catch-all fallback stub that must NOT be
+// reached.
+#[tokio::test]
+async fn throwing_predicate_inject_returns_mountebank_400_not_fallthrough() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19898, "protocol": "http", "stubs": [
+            {
+                "predicates": [
+                    { "inject": "function (config) { throw new Error('boom-predicate'); }" }
+                ],
+                "responses": [{ "is": { "statusCode": 200, "body": "should never be served" } }]
+            },
+            {
+                // Catch-all fallback: if the throwing predicate silently fell through to "no
+                // match" (the pre-#440 bug), the request would land here and return 201 — the
+                // fix requires this stub to NEVER be reached.
+                "responses": [
+                    { "is": { "statusCode": 201, "body": "fallback - must not be served either" } }
+                ]
+            }
+        ]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let resp = reqwest::Client::new()
+        .get("http://127.0.0.1:19898/x")
+        .send()
+        .await
+        .expect("send");
+
+    assert_eq!(
+        resp.status(),
+        400,
+        "a throwing predicate inject must fail the request with 400 (Mountebank error parity), \
+         not fall through to another stub or a bare 500"
+    );
+    assert!(
+        resp.headers().contains_key("x-rift-imposter"),
+        "the imposter marker header must be preserved"
+    );
+    assert!(
+        resp.headers().contains_key("x-rift-inject-error"),
+        "the inject-error marker header must be present"
+    );
+
+    let body: serde_json::Value = resp.json().await.expect("json body");
+    assert_eq!(
+        body["errors"][0]["code"], "invalid predicate injection",
+        "error code must be 'invalid predicate injection', got: {body}"
+    );
+    assert!(
+        body["errors"][0]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("boom-predicate")),
+        "the error message must surface the script failure, got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19898).await;
+}
+
+// Happy-path parity check (no behavior change): a predicate inject that does NOT throw still
+// matches / doesn't-match correctly, and a non-match falls through to the next stub as before.
+#[tokio::test]
+async fn non_erroring_predicate_inject_still_matches_correctly() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19899, "protocol": "http", "stubs": [
+            {
+                "predicates": [
+                    { "inject": "function (config) { return config.path === '/match'; }" }
+                ],
+                "responses": [{ "is": { "statusCode": 200, "body": "matched" } }]
+            },
+            {
+                "responses": [{ "is": { "statusCode": 201, "body": "fallback" } }]
+            }
+        ]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let client = reqwest::Client::new();
+
+    let matched = client
+        .get("http://127.0.0.1:19899/match")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        matched.status(),
+        200,
+        "a matching (Ok(true)) predicate inject must still match"
+    );
+
+    let not_matched = client
+        .get("http://127.0.0.1:19899/other")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        not_matched.status(),
+        201,
+        "a non-matching (Ok(false)) predicate inject must still fall through to the next stub"
+    );
+
+    let _ = manager.delete_imposter(19899).await;
+}

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -532,14 +532,19 @@ value. The raised error propagates to the standard script-error path (`500` with
 
 ## Engine Comparison
 
+Both engines share the same unified `ctx` API for `_rift.script` — `respond(ctx)`, `ctx.state`,
+and the `http()`/`delay()`/`reset()`/`pass()` result constructors all work identically on either
+engine. The two real differentiators are Mountebank-native `inject`/`decorate` compat (JavaScript
+only) and raw throughput (Rhai, compiled and cached).
+
 | Feature | JavaScript | Rhai |
 |:--------|:-----------|:-----|
-| Format | `inject` response | `_rift.script` |
-| State access | `state.key` | `ctx.state.get(key)` |
-| Flow isolation | Per imposter | Per flow_id |
-| Function wrapper | None needed | `respond(ctx)`/bare |
+| Format | `_rift.script` (unified `ctx`), or Mountebank `inject`/`decorate` | `_rift.script` (unified `ctx`) |
+| State access | `ctx.state.get(key)` (Mountebank `inject` path: `config.state`) | `ctx.state.get(key)` |
+| Flow isolation | Per flow_id | Per flow_id |
+| Function wrapper | `respond(ctx)` or bare expression | `respond(ctx)` or bare expression |
 | Performance | Good | Excellent |
-| Mountebank compatible | Yes | No |
+| Mountebank compatible | Yes (via `inject`/`decorate`) | No |
 
 ---
 


### PR DESCRIPTION
Closes #440

Part of epic #354 (folds into #448)