### PR TITLE
fix: port-0 collision for imposters without explicit port — use assigned port as state key

### DIFF
--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -48,7 +48,7 @@ impl Imposter {
         // Parse form data if Content-Type is application/x-www-form-urlencoded
         let form = Self::parse_form_data(headers_map, body);
 
-        let imposter_port = self.config.port.unwrap_or(0);
+        let imposter_port = self.script_state_key();
         let flow_id = self.resolve_flow_id(headers_map);
         // Parse the request body as JSON once per request and reuse it across every stub's
         // predicates, instead of re-parsing per predicate per stub (issue #290).
@@ -116,7 +116,7 @@ impl Imposter {
     ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
         let stubs = self.stubs.load();
         let form = Self::parse_form_data(headers_map, body);
-        let imposter_port = self.config.port.unwrap_or(0);
+        let imposter_port = self.script_state_key();
         let flow_id = self.resolve_flow_id(headers_map);
         let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
         for (index, stub_state) in stubs.iter().enumerate() {

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -390,6 +390,21 @@ impl Imposter {
             })
     }
 
+    /// The key under which this imposter's Mountebank inject/decorate script state is stored in
+    /// the process-global `IMPOSTER_STATE` map — the imposter's bound listener port.
+    ///
+    /// `config.port` is `Some(bound_port)` for the entire life of a live imposter: the manager
+    /// assigns and records the real, distinct bound port in `create_imposter_inner` *before* the
+    /// imposter is constructed or serves a request, so distinct imposters (including auto-bind
+    /// ones) always get distinct keys and never clobber each other's script state (issue #439).
+    /// The `unwrap_or(0)` fallback is therefore unreachable for a live imposter — `0` is the
+    /// documented "no live imposter" sentinel (see `rift-ffi`); it exists only to keep this
+    /// total. Centralised here so the invariant has one greppable home rather than a scattered
+    /// magic `config.port.unwrap_or(0)` at every script call site.
+    pub(crate) fn script_state_key(&self) -> u16 {
+        self.config.port.unwrap_or(0)
+    }
+
     /// Create Redis flow store if configured and available.
     ///
     /// An explicitly-requested `"redis"` backend that cannot be built must fail imposter

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -404,7 +404,7 @@ async fn handle_request_inner(
             match execute_mountebank_inject(
                 &inject_fn,
                 &mb_request,
-                imposter.config.port.unwrap_or(0),
+                imposter.script_state_key(),
                 stub_state.stub.id.as_deref(),
             ) {
                 Ok(inject_response) => {
@@ -893,7 +893,7 @@ async fn handle_request_inner(
                             &body,
                             status,
                             &mut single,
-                            imposter.config.port.unwrap_or(0),
+                            imposter.script_state_key(),
                             stub_state.stub.id.as_deref(),
                         ) {
                             Ok((new_body, new_status)) => {

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -3467,6 +3467,40 @@ function respond(ctx) {
         );
     }
 
+    // Complement of the sharing contract: two DISTINCT imposters (distinct state keys) must NOT
+    // share Mountebank inject state (issue #439). State written under one imposter's key is
+    // invisible to a response inject running under another's — auto-bind imposters, which the
+    // manager gives distinct bound ports, therefore never clobber each other's script state.
+    #[test]
+    fn mountebank_inject_state_isolated_between_distinct_imposters() {
+        let port_a = test_port();
+        let port_b = test_port();
+        assert_ne!(
+            port_a, port_b,
+            "distinct imposters must have distinct state keys"
+        );
+
+        // Imposter A writes state via a predicate inject.
+        let writer = r#"function(config) { config.state.marker = "from-A"; return true; }"#;
+        assert!(execute_predicate_inject(writer, &mb_req("GET", "/iso"), port_a).unwrap());
+
+        // Imposter B reads state via a response inject: it must see its own (empty) state, not A's.
+        let reader = r#"function(config) { return { statusCode: 200, body: config.state.marker || "isolated" }; }"#;
+        let resp_b = execute_mountebank_inject(reader, &mb_req("GET", "/iso"), port_b, None)
+            .expect("response inject should run");
+        assert_eq!(
+            resp_b.body, "isolated",
+            "state written under imposter A's key must be invisible to imposter B (issue #439)"
+        );
+
+        // Sanity: A still sees its own state — isolation didn't wipe it.
+        let resp_a = execute_mountebank_inject(reader, &mb_req("GET", "/iso"), port_a, None)
+            .expect("response inject should run");
+        assert_eq!(resp_a.body, "from-A");
+        // (Decorate keys the SAME `IMPOSTER_STATE` map via the identical `imposter_port`, so its
+        // isolation follows from the same mechanism proven here.)
+    }
+
     // =========================================================================================
     // Issue #355 Item 1: native logger routes to `tracing`.
     // =========================================================================================


### PR DESCRIPTION
## Summary

Centralizes Mountebank script state keying on the bound port via a new `Imposter::script_state_key()` accessor. The process-global IMPOSTER_STATE map previously used `config.port.unwrap_or(0)` scattered across call sites; this invariant-encoding change consolidates that derivation and adds a regression test pinning cross-imposter state isolation.

Note: The literal collision is unreachable because the manager always assigns a distinct bound port to each live imposter. No user-facing behavior change.

Closes #439