### PR TITLE
build(release): x86_64-unknown-linux-musl cdylib lane (Alpine CI hosts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,42 @@ jobs:
       - name: Verify ffi-manifest generator
         run: ./scripts/gen-ffi-manifest.sh --self-test
 
+  musl-cdylib:
+    name: musl cdylib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+
+      # Issue #463: the release workflow's musl matrix isn't exercised by PR CI, so this job is the
+      # gate that keeps the musl librift_ffi cdylib from silently breaking. It reproduces the
+      # release build path (cross + crt-static OFF + the same feature set) and asserts a
+      # dynamically linked shared object that exports the C-ABI — what Alpine embedded SDK tests
+      # load. crt-static is scoped to this cdylib build; the release binaries stay static.
+      - name: Build librift_ffi cdylib for musl
+        run: |
+          RUSTFLAGS="-C target-feature=-crt-static" \
+            cross build --release --package rift-ffi --target x86_64-unknown-linux-musl \
+            --no-default-features --features javascript,redis-backend
+
+      - name: Assert a shared object exporting the C-ABI
+        run: |
+          lib="target/x86_64-unknown-linux-musl/release/librift_ffi.so"
+          test -f "$lib" || { echo "[fail] musl cdylib not produced at $lib" >&2; exit 1; }
+          file "$lib"
+          file "$lib" | grep -q "shared object" || { echo "[fail] $lib is not a shared object" >&2; exit 1; }
+          for sym in rift_start rift_serve_admin rift_build_info; do
+            nm -D "$lib" | grep -qw "$sym" || { echo "[fail] missing exported C-ABI symbol: $sym" >&2; exit 1; }
+          done
+          echo "[pass] musl librift_ffi cdylib builds and exports the C-ABI"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,18 @@ jobs:
             cross build --release --package rift-http-proxy --target ${{ matrix.target }} $FEATURE_FLAGS
             cross build --release --package rift-lint --target ${{ matrix.target }}
             cross build --release --package rift-tui --target ${{ matrix.target }}
-            # No rift-ffi cdylib on musl: the static-only musl toolchain drops the `cdylib`
-            # crate type (issue #205), so a musl librift_ffi can't be produced. gnu Linux covers
-            # the JVM embedded-backend use case.
+            # librift_ffi cdylib for musl (issue #463): a cdylib is a dynamic `.so`, but musl
+            # defaults to `crt-static` (correct for the static binaries above), under which a
+            # cdylib can't be produced. Build rift-ffi in a SEPARATE invocation with crt-static
+            # OFF — scoped to this crate so the binaries stay static — yielding a `.so` that links
+            # against Alpine's musl libc. Enables embedded SDK tests on Alpine CI images.
+            # Scoped to x86_64: that's the lane the issue targets and the one the `musl cdylib`
+            # PR-CI job validates; an aarch64-musl cdylib has no PR-time gate, so it's not shipped
+            # (it would only surface a link failure at release time).
+            if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-musl" ]]; then
+              RUSTFLAGS="-C target-feature=-crt-static" \
+                cross build --release --package rift-ffi --target ${{ matrix.target }} $FEATURE_FLAGS
+            fi
           else
             cargo build --release --package rift-http-proxy --target ${{ matrix.target }} $FEATURE_FLAGS
             cargo build --release --package rift-lint --target ${{ matrix.target }}
@@ -220,8 +229,10 @@ jobs:
 
           # rift-ffi cdylib as a standalone, classifier-named release asset (issue #205): the JVM
           # embedded backend loads the raw library by os/arch, so it ships outside the binary tarball.
-          # Skipped on musl, which can't produce a cdylib (the build step builds no librift_ffi there).
-          if [[ "${{ matrix.target }}" != *"musl"* ]]; then
+          # x86_64 musl now builds a crt-static-off cdylib (issue #463); the classifier carries the
+          # `-musl` suffix, so it's distinct from the gnu asset. aarch64 musl has no cdylib lane
+          # (no PR-CI gate) — the build step produces no librift_ffi there, so skip packaging it.
+          if [[ "${{ matrix.target }}" != "aarch64-unknown-linux-musl" ]]; then
             if [[ "$OSTYPE" == "darwin"* ]]; then EXT="dylib"; else EXT="so"; fi
             FFI_NAME="librift_ffi-${{ matrix.classifier }}.$EXT"
             cp "librift_ffi.$EXT" "$FFI_NAME"

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,6 +5,10 @@
 passthrough = [
     "RUST_BACKTRACE",
     "CARGO_TERM_COLOR",
+    # So the release/CI musl librift_ffi cdylib build can disable crt-static
+    # (`-C target-feature=-crt-static`) inside the container — a cdylib is a dynamic .so and
+    # musl defaults to static linking (issue #463).
+    "RUSTFLAGS",
 ]
 
 # x86_64 musl target configuration

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -171,8 +171,9 @@ cargo build -p rift-ffi --release --no-default-features
 Every release ships the `librift_ffi` cdylib as a standalone, classifier-named asset per platform
 (`librift_ffi-<classifier>.{so,dylib,dll}`, e.g. `librift_ffi-linux-x86_64.so`,
 `librift_ffi-darwin-aarch64.dylib`, `librift_ffi-windows-x86_64.dll`) alongside a matching
-`.sha256`. Musl targets have no cdylib (the static-only musl toolchain drops the `cdylib` crate
-type), so they are not published.
+`.sha256`. The x86_64 musl target ships a cdylib too (`librift_ffi-linux-x86_64-musl.so`) — built
+with `crt-static` disabled so the `.so` links dynamically against Alpine's musl libc (the
+platform's static binaries stay statically linked), for embedded SDK tests on Alpine CI images.
 
 To let SDK consumers (rift-java's natives packaging, rift-go's fetcher/loader, spawn-transport
 binary downloads) resolve these assets without hardcoding release-URL patterns, each release also


### PR DESCRIPTION
## Summary
The release workflow skipped the rift-ffi cdylib on musl due to musl's default crt-static setting, which prevents building dynamic .so files. This adds a separate cross invocation with `-C target-feature=-crt-static` to build the cdylib while keeping binaries static, packages it as a release asset, and adds a new `musl cdylib` CI job that runs on every PR to prevent regression. Scoped to x86_64.

Closes #463
Milestone: SDK-M0 (epic #458, task 0.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)