### PR TITLE
PERF: stub-overlap analysis is O(n²), runs on the HTTP hot path, and is skipped entirely when embedded

### DIFF
--- a/crates/rift-core/src/extensions/stub_analysis.rs
+++ b/crates/rift-core/src/extensions/stub_analysis.rs
@@ -16,6 +16,16 @@ use crate::imposter::{Predicate, PredicateOperation};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
+/// Cap on the number of stub-analysis warnings retained in a single result (issue #423). Beyond
+/// this, a single [`WarningType::Truncated`] summary records how many were suppressed, so a
+/// pathological config (thousands of overlapping stubs) can't allocate unbounded memory.
+pub const MAX_STUB_WARNINGS: usize = 100;
+
+/// Above this stub count the O(n²) subset-shadowing heuristic is skipped (issue #423): it is
+/// advisory only, and quadratic pairwise comparison is not worth its cost on large imposters.
+/// Exact-duplicate detection stays O(n) (hash-based) at any size.
+const SHADOW_HEURISTIC_MAX_STUBS: usize = 200;
+
 /// Warning types for stub analysis (Rift extension)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -49,6 +59,9 @@ pub enum WarningType {
     CatchAll,
     /// Catch-all stub is not at the end of the list
     CatchAllNotLast,
+    /// Analysis produced more warnings than the retained cap; the summary records how many were
+    /// suppressed (issue #423).
+    Truncated,
 }
 
 /// Result of stub analysis
@@ -78,110 +91,183 @@ impl StubAnalysisResult {
 /// This is a Rift extension - Mountebank does not provide this functionality.
 pub fn analyze_stubs(stubs: &[Stub]) -> StubAnalysisResult {
     let mut result = StubAnalysisResult::new();
+    // Count of every warning the analysis *would* emit; `result.warnings` retains at most
+    // MAX_STUB_WARNINGS of them, and the gap becomes the Truncated summary (issue #423).
+    let mut total: usize = 0;
+    let mut push = |warnings: &mut Vec<StubWarning>, w: StubWarning| {
+        total += 1;
+        if warnings.len() < MAX_STUB_WARNINGS {
+            warnings.push(w);
+        }
+    };
 
-    // Track IDs for duplicate detection
     let mut seen_ids: HashMap<String, usize> = HashMap::new();
-
-    // Track catch-all stubs
-    let mut catch_all_indices: Vec<usize> = vec![];
+    // Canonical predicate-set key -> first stub index carrying it. Exact-duplicate detection is
+    // O(n) instead of the old O(n²) pairwise scan (issue #423): the key encodes exactly what
+    // `predicates_equal` compares — the predicate count plus the order-independent, de-duplicated
+    // set of canonicalized predicates — so a hash hit means the same match set.
+    let mut seen_predicates: HashMap<String, usize> = HashMap::new();
+    // Index of the first catch-all (empty-predicate) stub seen so far.
+    let mut first_catch_all: Option<usize> = None;
+    // The subset-shadowing heuristic is the only remaining quadratic scan; gate it by size.
+    let run_shadow_heuristic = stubs.len() <= SHADOW_HEURISTIC_MAX_STUBS;
 
     for (index, stub) in stubs.iter().enumerate() {
-        // Check for duplicate IDs
+        // Duplicate IDs.
         if let Some(id) = &stub.id {
             if let Some(&existing_index) = seen_ids.get(id) {
-                result.add_warning(StubWarning {
-                    warning_type: WarningType::DuplicateId,
-                    message: format!(
-                        "Stub at index {index} has duplicate ID '{id}' (same as stub at index {existing_index})"
-                    ),
-                    stub_index: Some(index),
-                    stub_id: Some(id.clone()),
-                    shadowed_by_index: Some(existing_index),
-                });
+                push(
+                    &mut result.warnings,
+                    StubWarning {
+                        warning_type: WarningType::DuplicateId,
+                        message: format!(
+                            "Stub at index {index} has duplicate ID '{id}' (same as stub at index {existing_index})"
+                        ),
+                        stub_index: Some(index),
+                        stub_id: Some(id.clone()),
+                        shadowed_by_index: Some(existing_index),
+                    },
+                );
             } else {
                 seen_ids.insert(id.clone(), index);
             }
         }
 
-        // Check for catch-all stubs (empty predicates)
+        // Catch-all (empty predicates).
         if stub.predicates.is_empty() {
-            catch_all_indices.push(index);
-            result.add_warning(StubWarning {
-                warning_type: WarningType::CatchAll,
-                message: format!(
-                    "Stub at index {index} has empty predicates and will match ALL requests"
-                ),
-                stub_index: Some(index),
-                stub_id: stub.id.clone(),
-                shadowed_by_index: None,
-            });
-        }
-
-        // Check for exact predicate duplicates
-        for (earlier_index, earlier_stub) in stubs[..index].iter().enumerate() {
-            if predicates_equal(&stub.predicates, &earlier_stub.predicates) {
-                result.add_warning(StubWarning {
-                    warning_type: WarningType::ExactDuplicate,
+            if first_catch_all.is_none() {
+                first_catch_all = Some(index);
+            }
+            push(
+                &mut result.warnings,
+                StubWarning {
+                    warning_type: WarningType::CatchAll,
                     message: format!(
-                        "Stub at index {index} has identical predicates to stub at index {earlier_index} and will never match"
+                        "Stub at index {index} has empty predicates and will match ALL requests"
                     ),
                     stub_index: Some(index),
                     stub_id: stub.id.clone(),
-                    shadowed_by_index: Some(earlier_index),
-                });
+                    shadowed_by_index: None,
+                },
+            );
+        }
+
+        // Exact predicate duplicates — O(1) hash lookup against the first stub with this key.
+        let key = predicate_key(&stub.predicates);
+        match seen_predicates.get(&key) {
+            Some(&first_index) => push(
+                &mut result.warnings,
+                StubWarning {
+                    warning_type: WarningType::ExactDuplicate,
+                    message: format!(
+                        "Stub at index {index} has identical predicates to stub at index {first_index} and will never match"
+                    ),
+                    stub_index: Some(index),
+                    stub_id: stub.id.clone(),
+                    shadowed_by_index: Some(first_index),
+                },
+            ),
+            None => {
+                seen_predicates.insert(key, index);
             }
         }
 
-        // Check for potential shadowing by earlier stubs
-        // This is a heuristic check for common shadowing scenarios
+        // Potential shadowing of a specific (non-empty) stub by an earlier one.
         if !stub.predicates.is_empty() {
-            for (earlier_index, earlier_stub) in stubs[..index].iter().enumerate() {
-                if earlier_stub.predicates.is_empty() {
-                    // Catch-all before this stub
-                    result.add_warning(StubWarning {
+            // Any earlier catch-all shadows this stub — O(1) via the first-catch-all index.
+            if let Some(catch_all_index) = first_catch_all {
+                push(
+                    &mut result.warnings,
+                    StubWarning {
                         warning_type: WarningType::PotentiallyShadowed,
                         message: format!(
-                            "Stub at index {index} may be shadowed by catch-all stub at index {earlier_index}"
+                            "Stub at index {index} may be shadowed by catch-all stub at index {catch_all_index}"
                         ),
                         stub_index: Some(index),
                         stub_id: stub.id.clone(),
-                        shadowed_by_index: Some(earlier_index),
-                    });
-                } else if is_subset_predicates(&stub.predicates, &earlier_stub.predicates) {
-                    // Earlier stub has more specific predicates that are a subset
-                    // This means the earlier stub will match first for overlapping requests
-                    result.add_warning(StubWarning {
-                        warning_type: WarningType::PotentiallyShadowed,
-                        message: format!(
-                            "Stub at index {index} may be partially shadowed by stub at index {earlier_index} which has overlapping predicates"
-                        ),
-                        stub_index: Some(index),
-                        stub_id: stub.id.clone(),
-                        shadowed_by_index: Some(earlier_index),
-                    });
+                        shadowed_by_index: Some(catch_all_index),
+                    },
+                );
+            }
+            // Subset-overlap heuristic — the remaining O(n²) scan, skipped on large imposters.
+            if run_shadow_heuristic {
+                for (earlier_index, earlier_stub) in stubs[..index].iter().enumerate() {
+                    if !earlier_stub.predicates.is_empty()
+                        && is_subset_predicates(&stub.predicates, &earlier_stub.predicates)
+                    {
+                        push(
+                            &mut result.warnings,
+                            StubWarning {
+                                warning_type: WarningType::PotentiallyShadowed,
+                                message: format!(
+                                    "Stub at index {index} may be partially shadowed by stub at index {earlier_index} which has overlapping predicates"
+                                ),
+                                stub_index: Some(index),
+                                stub_id: stub.id.clone(),
+                                shadowed_by_index: Some(earlier_index),
+                            },
+                        );
+                    }
                 }
             }
         }
     }
 
-    // Warn if catch-all is not at the end
-    if let Some(&catch_all_idx) = catch_all_indices.first()
+    // Warn if a catch-all is not at the end.
+    if let Some(catch_all_idx) = first_catch_all
         && catch_all_idx < stubs.len() - 1
     {
-        result.add_warning(StubWarning {
-            warning_type: WarningType::CatchAllNotLast,
+        push(
+            &mut result.warnings,
+            StubWarning {
+                warning_type: WarningType::CatchAllNotLast,
+                message: format!(
+                    "Catch-all stub at index {} will shadow {} stub(s) after it",
+                    catch_all_idx,
+                    stubs.len() - catch_all_idx - 1
+                ),
+                stub_index: Some(catch_all_idx),
+                stub_id: stubs[catch_all_idx].id.clone(),
+                shadowed_by_index: None,
+            },
+        );
+    }
+
+    // Record how many warnings were suppressed by the cap rather than silently dropping them.
+    let retained = result.warnings.len();
+    if total > retained {
+        result.warnings.push(StubWarning {
+            warning_type: WarningType::Truncated,
             message: format!(
-                "Catch-all stub at index {} will shadow {} stub(s) after it",
-                catch_all_idx,
-                stubs.len() - catch_all_idx - 1
+                "{} additional stub warning(s) suppressed (showing first {retained})",
+                total - retained
             ),
-            stub_index: Some(catch_all_idx),
-            stub_id: stubs[catch_all_idx].id.clone(),
+            stub_index: None,
+            stub_id: None,
             shadowed_by_index: None,
         });
     }
 
     result
+}
+
+/// Canonical key for a predicate list that matches [`predicates_equal`] semantics: two lists share
+/// a key iff they have the same length and the same order-independent set of canonicalized
+/// predicates. Used for O(n) exact-duplicate detection (issue #423).
+fn predicate_key(predicates: &[Predicate]) -> String {
+    let mut set: Vec<String> = predicates
+        .iter()
+        .map(|pred| {
+            let mut value =
+                serde_json::to_value(pred).expect("predicate can be serialized to json");
+            value.sort_all_objects();
+            value.to_string()
+        })
+        .collect();
+    set.sort();
+    set.dedup();
+    // Length prefix so `[P, P]` and `[P]` (equal sets, different lengths) stay distinct.
+    format!("{}\u{1e}{}", predicates.len(), set.join("\u{1e}"))
 }
 
 /// Analyzes adding a new stub to existing stubs.
@@ -510,6 +596,104 @@ mod tests {
                 .warnings
                 .iter()
                 .any(|w| w.warning_type == WarningType::ExactDuplicate)
+        );
+    }
+
+    // Issue #423: N identical-predicate stubs must be analyzed in O(N) with a bounded warning set
+    // (the old O(N²) exact-duplicate loop emitted ≈N²/2 warnings — hundreds of MB at N=1000).
+    #[test]
+    fn analyze_stubs_linear_capped_on_overlap() {
+        let stubs: Vec<Stub> = (0..500)
+            .map(|_| stub_with_predicates(vec![json!({"equals": {"path": "/data"}})]))
+            .collect();
+
+        let result = analyze_stubs(&stubs);
+
+        // Bounded: at most the cap plus the single Truncated summary — never O(N²).
+        assert!(
+            result.warnings.len() <= MAX_STUB_WARNINGS + 1,
+            "warnings must be bounded, got {}",
+            result.warnings.len()
+        );
+        // The overlap is still detected...
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate)
+        );
+        // ...and truncation is reported rather than silently dropped, with the exact count.
+        // 500 identical stubs => 499 ExactDuplicate warnings (stubs 1..=499); 100 retained,
+        // 399 suppressed (the shadow heuristic is gated off at N=500, so nothing else fires).
+        let summary = result
+            .warnings
+            .iter()
+            .find(|w| w.warning_type == WarningType::Truncated)
+            .expect("a Truncated summary must record the suppressed warnings");
+        assert!(
+            summary.message.contains("399 additional"),
+            "wrong suppressed count: {}",
+            summary.message
+        );
+    }
+
+    // Issue #423: exact-duplicate detection is now O(n) and points every duplicate at the FIRST
+    // occurrence — three identical stubs yield exactly two warnings (not one per earlier pair).
+    #[test]
+    fn exact_duplicate_points_at_first_occurrence() {
+        let stubs: Vec<Stub> = (0..3)
+            .map(|_| stub_with_predicates(vec![json!({"equals": {"path": "/same"}})]))
+            .collect();
+
+        let result = analyze_stubs(&stubs);
+        let dups: Vec<&StubWarning> = result
+            .warnings
+            .iter()
+            .filter(|w| w.warning_type == WarningType::ExactDuplicate)
+            .collect();
+        assert_eq!(
+            dups.len(),
+            2,
+            "one warning per later duplicate, not per pair"
+        );
+        assert!(
+            dups.iter().all(|w| w.shadowed_by_index == Some(0)),
+            "each duplicate must point at the first occurrence"
+        );
+    }
+
+    // Issue #423: the O(n²) subset-shadowing heuristic is gated off above the threshold, so a
+    // general stub followed by many specifics doesn't reintroduce quadratic work — while the same
+    // shape below the threshold still produces the advisory warning.
+    #[test]
+    fn subset_shadow_heuristic_gated_above_threshold() {
+        let mut stubs = vec![stub_with_predicates(vec![
+            json!({"startsWith": {"path": "/api"}}),
+        ])];
+        for i in 0..SHADOW_HEURISTIC_MAX_STUBS {
+            stubs.push(stub_with_predicates(vec![
+                json!({"equals": {"path": format!("/api/{i}")}}),
+            ]));
+        }
+        assert!(stubs.len() > SHADOW_HEURISTIC_MAX_STUBS);
+        assert!(
+            !analyze_stubs(&stubs)
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::PotentiallyShadowed),
+            "subset-shadowing heuristic must be skipped above the threshold"
+        );
+
+        let small = vec![
+            stub_with_predicates(vec![json!({"startsWith": {"path": "/api"}})]),
+            stub_with_predicates(vec![json!({"equals": {"path": "/api/users"}})]),
+        ];
+        assert!(
+            analyze_stubs(&small)
+                .warnings
+                .iter()
+                .any(|w| w.warning_type == WarningType::PotentiallyShadowed),
+            "below the threshold the heuristic still runs"
         );
     }
 

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -24,7 +24,7 @@ use crate::recording::{
     RequestSignature,
 };
 use anyhow::Context;
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -147,6 +147,10 @@ pub struct Imposter {
     pub flow_store: Arc<dyn FlowStore>,
     /// Pluggable response-cursor backend (issue #313); None = embedded per-stub cycler.
     pub(crate) sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
+    /// Cached stub-overlap analysis warnings (issue #423). `None` = dirty; recomputed lazily on the
+    /// next [`Self::stub_warnings`] read and reused until the next `mutate_stubs`. Keeps the O(n)
+    /// analysis off the per-`GET` hot path and gives HTTP and embedded/FFI one shared code path.
+    stub_warnings: ArcSwapOption<Vec<crate::extensions::stub_analysis::StubWarning>>,
 }
 
 impl Imposter {
@@ -219,6 +223,7 @@ impl Imposter {
             shutdown_tx: None,
             flow_store,
             sequencer,
+            stub_warnings: ArcSwapOption::empty(),
         })
     }
 
@@ -241,7 +246,35 @@ impl Imposter {
         let next_arc = Arc::new(next);
         self.stubs.store(Arc::clone(&next_arc));
         self.stub_index.store(Arc::new(StubIndex::build(next_arc)));
+        // Invalidate the cached stub-analysis warnings (issue #423). This is O(1) — the actual
+        // O(n) recompute is deferred to the next `stub_warnings()` read — so high-frequency
+        // mutations (e.g. proxy recording) don't pay analysis cost on every recorded stub.
+        self.stub_warnings.store(None);
         result
+    }
+
+    /// The imposter's stub-overlap analysis warnings (issue #423), computed once and cached until
+    /// the next stub mutation. The HTTP `GET /imposters/:port` handler and embedded/FFI consumers
+    /// both read this, so analysis runs off the per-read hot path and is identical for standalone
+    /// and embedded instances (which previously got no analysis at all).
+    pub fn stub_warnings(&self) -> Arc<Vec<crate::extensions::stub_analysis::StubWarning>> {
+        // Fast path: a warm cache is a wait-free load, so the request/read hot path never blocks.
+        if let Some(cached) = self.stub_warnings.load_full() {
+            return cached;
+        }
+        // Miss: compute-and-store under the same `stubs_write` lock `mutate_stubs` holds, so a
+        // mutation's invalidation can never be lost by a slow reader that computed over a stale
+        // snapshot (a store racing an invalidation would pin stale warnings). The lock is taken
+        // only on a miss — once per mutation — and the O(n) analysis is off the request hot path.
+        let _writer = self.stubs_write.lock();
+        // Re-check under the lock: another reader may have populated it while we waited.
+        if let Some(cached) = self.stub_warnings.load_full() {
+            return cached;
+        }
+        let warnings = crate::extensions::stub_analysis::analyze_stubs(&self.get_stubs()).warnings;
+        let arc = Arc::new(warnings);
+        self.stub_warnings.store(Some(Arc::clone(&arc)));
+        arc
     }
 
     /// Replace all stubs
@@ -491,6 +524,58 @@ mod tests {
             ..Default::default()
         };
         Imposter::new(config).expect("test imposter")
+    }
+
+    // Issue #423: stub-analysis warnings are computed once and cached — repeated reads return the
+    // SAME Arc (no per-read recompute) — and a stub mutation invalidates the cache so the next read
+    // reflects the new stubs.
+    #[test]
+    fn stub_warnings_cached_until_mutation() {
+        use crate::extensions::stub_analysis::WarningType;
+
+        let cfg = serde_json::from_value(json!({
+            "port": 0,
+            "protocol": "http",
+            "stubs": [
+                { "predicates": [{ "equals": { "path": "/dup" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "x" } }] },
+                { "predicates": [{ "equals": { "path": "/dup" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "x" } }] }
+            ]
+        }))
+        .unwrap();
+        let imp = Imposter::new(cfg).expect("test imposter");
+
+        let a = imp.stub_warnings();
+        assert!(
+            a.iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate),
+            "duplicate stubs must be flagged"
+        );
+        let b = imp.stub_warnings();
+        assert!(
+            std::sync::Arc::ptr_eq(&a, &b),
+            "repeated reads must return the cached Arc — no recompute on the hot path"
+        );
+
+        // Mutating the stubs invalidates the cache; the next read recomputes over the new stubs.
+        let distinct: Vec<Stub> = serde_json::from_value(json!([
+            { "predicates": [{ "equals": { "path": "/only" } }],
+              "responses": [{ "is": { "statusCode": 200, "body": "y" } }] }
+        ]))
+        .unwrap();
+        imp.replace_stubs(distinct);
+
+        let c = imp.stub_warnings();
+        assert!(
+            !std::sync::Arc::ptr_eq(&a, &c),
+            "a stub mutation must invalidate the cached warnings"
+        );
+        assert!(
+            !c.iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate),
+            "distinct stubs must have no exact-duplicate warning"
+        );
     }
 
     #[test]

--- a/crates/rift-core/src/imposter/manager.rs
+++ b/crates/rift-core/src/imposter/manager.rs
@@ -1245,6 +1245,35 @@ mod tests {
         serde_json::from_value(v).expect("test imposter config")
     }
 
+    // Issue #423: imposters created through the manager (the path embedded/FFI consumers use, which
+    // previously got NO stub analysis) now carry computed stub-overlap warnings.
+    #[tokio::test]
+    async fn create_imposter_computes_stub_warnings_for_embedded() {
+        use crate::extensions::stub_analysis::WarningType;
+        let manager = ImposterManager::new();
+        let port = manager
+            .create_imposter(imposter_cfg(json!({
+                "protocol": "http",
+                "port": 0,
+                "stubs": [
+                    {"predicates": [{"equals": {"path": "/dup"}}],
+                     "responses": [{"is": {"statusCode": 200, "body": "x"}}]},
+                    {"predicates": [{"equals": {"path": "/dup"}}],
+                     "responses": [{"is": {"statusCode": 200, "body": "x"}}]}
+                ]
+            })))
+            .await
+            .expect("create");
+        let imposter = manager.get_imposter(port).expect("imposter exists");
+        assert!(
+            imposter
+                .stub_warnings()
+                .iter()
+                .any(|w| w.warning_type == WarningType::ExactDuplicate),
+            "embedded/manager-created imposter must have computed stub-analysis warnings"
+        );
+    }
+
     fn stub_json(body: &str) -> serde_json::Value {
         json!({
             "predicates": [{"equals": {"path": format!("/{body}")}}],

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -71,6 +71,18 @@ int32_t rift_delete_imposter(RiftHandle *h, uint16_t port);
 char *rift_recorded(RiftHandle *h, uint16_t port);
 
 /**
+ * Return the stub-overlap analysis warnings for `port` as a JSON array string the caller must free
+ * with [`rift_free`] (issue #423). This gives embedded / direct C-ABI consumers the config-lint
+ * warnings (duplicate/shadowed/catch-all stubs) that previously only the HTTP admin layer
+ * surfaced. The warnings are computed once on stub mutation and cached, so this is a cheap read.
+ * Returns null on any error (null/unknown handle or port, or encode failure).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+char *rift_stub_warnings(RiftHandle *h, uint16_t port);
+
+/**
  * Get a scenario/flow-state value as a JSON envelope `{"found","flowId","key","value"}` the caller
  * frees with [`rift_free`]. `found` disambiguates an absent key from a failure: a missing key is a
  * non-error outcome (`{"found":false,"value":null}`), while a null pointer is returned **only** on a

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -320,6 +320,41 @@ pub unsafe extern "C" fn rift_recorded(h: *mut RiftHandle, port: u16) -> *mut c_
     }
 }
 
+/// Return the stub-overlap analysis warnings for `port` as a JSON array string the caller must free
+/// with [`rift_free`] (issue #423). This gives embedded / direct C-ABI consumers the config-lint
+/// warnings (duplicate/shadowed/catch-all stubs) that previously only the HTTP admin layer
+/// surfaced. The warnings are computed once on stub mutation and cached, so this is a cheap read.
+/// Returns null on any error (null/unknown handle or port, or encode failure).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_stub_warnings(h: *mut RiftHandle, port: u16) -> *mut c_char {
+    unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_stub_warnings: null handle");
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_stub_warnings: {e}"));
+                warn!(error = %e, port, "rift_stub_warnings: no such imposter");
+                return std::ptr::null_mut();
+            }
+        };
+        match serde_json::to_string(&*imposter.stub_warnings()) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_stub_warnings: encode failed: {e}"));
+                warn!(error = %e, port, "rift_stub_warnings: failed to encode warnings");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
 // ── Admin long tail over direct C-ABI: scenario state + correlated spaces (issue #411) ──────────
 // Each function calls the same `ImposterManager`/`Imposter` methods the admin-HTTP handlers call
 // and returns the same JSON, so an embedder can drive scenario state and correlated spaces with

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -7,7 +7,6 @@ use crate::admin_api::types::{
     error_response, json_response, make_imposter_links, make_stub_links,
 };
 use crate::extensions::decorate::backend_error_response;
-use crate::extensions::stub_analysis::analyze_stubs;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
     RecordedRequest, ScriptBaseDir, Stub, StubResponse, resolve_scripts,
@@ -372,9 +371,12 @@ pub async fn handle_get(
                 stubs = filter_proxy_stubs(stubs);
             }
 
-            let analysis = analyze_stubs(&stubs);
-            if analysis.has_warnings() {
-                for warning in &analysis.warnings {
+            // Cached stub-overlap analysis (issue #423): computed once in core on stub mutation,
+            // not recomputed here on every read. Reflects the imposter's real stubs regardless of
+            // the `removeProxies` view (the warnings are advisory).
+            let warnings = imposter.stub_warnings();
+            if !warnings.is_empty() {
+                for warning in warnings.iter() {
                     warn!(
                         port = port,
                         warning_type = ?warning.warning_type,
@@ -391,9 +393,9 @@ pub async fn handle_get(
                 .as_ref()
                 .and_then(|r| r.flow_state.as_ref())
                 .map(expose_flow_state);
-            let rift_extensions = if analysis.has_warnings() || flow_state.is_some() {
+            let rift_extensions = if !warnings.is_empty() || flow_state.is_some() {
                 Some(RiftImposterExtensions {
-                    warnings: analysis.warnings,
+                    warnings: (*warnings).clone(),
                     flow_state,
                 })
             } else {

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -8,7 +8,7 @@ use crate::admin_api::types::{
     AddStubRequest, ReplaceStubsRequest, StubWithLinks, collect_body, error_response,
     json_response, make_stub_links,
 };
-use crate::extensions::stub_analysis::{analyze_new_stub, analyze_stubs};
+use crate::extensions::stub_analysis::analyze_new_stub;
 use crate::imposter::{ImposterManager, Stub, resolve_stub_scripts};
 use crate::scripting::{validate_stub, validate_stubs};
 use bytes::Bytes;
@@ -180,17 +180,8 @@ pub async fn handle_replace_all(
         );
     }
 
-    // Analyze the new stubs (Rift extension)
-    let analysis = analyze_stubs(&replace_req.stubs);
-    for warning in &analysis.warnings {
-        warn!(
-            port = port,
-            warning_type = ?warning.warning_type,
-            "Stub replacement warning: {}",
-            warning.message
-        );
-    }
-
+    // Stub-overlap analysis is computed once in core on the replace (issue #423) and surfaced by
+    // the GET render below via the imposter's cached warnings — no redundant recompute here.
     if let Err(e) = manager.replace_stubs(port, replace_req.stubs).await {
         return e.into();
     }

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -43,6 +43,7 @@ rift_stop(h);                     // stop and free
 | `rift_delete_imposter` | `int rift_delete_imposter(RiftHandle* h, uint16_t port)` | `0` on success, `-1` on error. |
 | `rift_delete_all` | `int rift_delete_all(RiftHandle* h)` | `0` on success, `-1` on error. |
 | `rift_recorded` | `char* rift_recorded(RiftHandle* h, uint16_t port)` | Recorded requests as a JSON string (**caller frees** with `rift_free`), or `NULL` on error. |
+| `rift_stub_warnings` | `char* rift_stub_warnings(RiftHandle* h, uint16_t port)` | [Stub-analysis warnings](../features/stub-analysis.md) (duplicate/shadowed/catch-all) as a JSON array (**caller frees**), or `NULL` on error. |
 | `rift_apply_config` | `char* rift_apply_config(RiftHandle* h, const char* json)` | Reconcile the full imposter set (like `POST /admin/reload`); returns the apply report JSON (caller frees). |
 
 ## Admin long tail over FFI (scenario state + correlated spaces)

--- a/docs/features/stub-analysis.md
+++ b/docs/features/stub-analysis.md
@@ -174,6 +174,32 @@ A catch-all stub appears before other stubs, shadowing them:
 }
 ```
 
+### truncated
+
+Analysis retains at most 100 warnings per imposter. If more are produced (e.g. hundreds of
+overlapping stubs), a single `truncated` summary records how many were suppressed instead of
+returning an unbounded list:
+
+```json
+{
+  "warningType": "truncated",
+  "message": "412 additional stub warning(s) suppressed (showing first 100)"
+}
+```
+
+---
+
+## Performance & availability
+
+Analysis is computed **once when the stubs change** (on create and stub replace/add) and cached on
+the imposter; `GET /imposters/:port` returns the cached warnings without recomputing. Exact-duplicate
+detection is O(n) (hash-based), and warnings are capped (see `truncated`), so even a pathological
+config with thousands of overlapping stubs stays cheap and bounded.
+
+Because the analysis now lives in the engine, **embedded consumers get it too**: over the C-ABI,
+call `rift_stub_warnings(handle, port)` to retrieve the same warnings as a JSON array (see
+[Embedding — FFI](../embedding/ffi.md)).
+
 ---
 
 ## Stub ID Field

--- a/scripts/verify-ffi-cdylib.sh
+++ b/scripts/verify-ffi-cdylib.sh
@@ -20,6 +20,8 @@ SYMBOLS=(
   rift_delete_imposter
   rift_build_info
   rift_last_error
+  # issue #423: stub-analysis warnings over the C-ABI
+  rift_stub_warnings
 )
 
 # Issue #344: the checked-in C header is the ABI's source of truth — assert it matches a fresh


### PR DESCRIPTION
## Summary
- O(n²)→O(n) exact-dup detection via predicate hashing; cap subset-shadowing heuristic and warnings
- Move stub-overlap compute off HTTP hot path: lazily cached, computed once per read under stub-write lock
- New FFI accessor `rift_stub_warnings` closes embedded consumer gap; shared code path for standalone/embedded
- Docs updated (features/stub-analysis.md, embedding/ffi.md)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)