### PR TITLE
perf(response): _behaviors re-deserialized and JSON bodies re-serialized on every request — precompute per stub

### DIFF
--- a/crates/rift-core/src/imposter/core/responses.rs
+++ b/crates/rift-core/src/imposter/core/responses.rs
@@ -139,7 +139,7 @@ impl Imposter {
             u16,
             HashMap<String, Vec<String>>,
             String,
-            Option<serde_json::Value>,
+            Option<std::sync::Arc<crate::behaviors::ResponseBehaviors>>,
             Option<RiftResponseExtension>,
             ResponseMode,
             bool,

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -10,8 +10,8 @@ use super::types::{
     DebugMatchResult, DebugRequest, DebugResponse, ProxyResponse, RecordedRequest, ResponseMode,
 };
 use crate::behaviors::{
-    CsvCache, RequestContext, ResponseBehaviors, apply_copy_behaviors, apply_lookup_behaviors,
-    apply_shell_transform, header_to_title_case,
+    CsvCache, RequestContext, apply_copy_behaviors, apply_lookup_behaviors, apply_shell_transform,
+    header_to_title_case,
 };
 use crate::extensions::decorate::{
     ResponseDecorator, ResponsePhase, backend_error_response, with_annotation_scope,
@@ -821,150 +821,146 @@ async fn handle_request_inner(
                 }
             }
 
-            // Apply behaviors if present
-            if let Some(ref behaviors_json) = behaviors {
-                // Parse behaviors
-                if let Ok(parsed_behaviors) =
-                    serde_json::from_value::<ResponseBehaviors>(behaviors_json.clone())
-                {
-                    // Apply wait behavior
-                    if let Some(ref wait) = parsed_behaviors.wait {
-                        let wait_ms = wait.get_duration_ms();
-                        if wait_ms > 0 {
-                            tokio::time::sleep(Duration::from_millis(wait_ms)).await;
-                        }
+            // Apply behaviors if present. Issue #479: `behaviors` is now the precomputed
+            // `Option<Arc<ResponseBehaviors>>` (parsed once at stub construction, see
+            // `StubResponse::new_is`) — no more re-parsing `_behaviors` JSON on every request.
+            if let Some(ref parsed_behaviors) = behaviors {
+                // Apply wait behavior
+                if let Some(ref wait) = parsed_behaviors.wait {
+                    let wait_ms = wait.get_duration_ms();
+                    if wait_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(wait_ms)).await;
                     }
+                }
 
-                    // copy/lookup are pure token substitution — apply them across each value of
-                    // multi-value headers so multiplicity survives (e.g. multiple Set-Cookie;
-                    // RFC 7230 §3.2.2 forbids folding Set-Cookie). decorate uses a single-value
-                    // JS/Rhai object model, so only that path collapses — and even there Set-Cookie
-                    // is held aside, never comma-folded.
-                    if !parsed_behaviors.copy.is_empty() {
-                        body = apply_copy_behaviors(
-                            &body,
-                            &mut headers,
-                            &parsed_behaviors.copy,
-                            &request_context,
-                        );
-                    }
-                    if !parsed_behaviors.lookup.is_empty() {
-                        body = apply_lookup_behaviors(
-                            &body,
-                            &mut headers,
-                            &parsed_behaviors.lookup,
-                            &request_context,
-                            csv_cache(),
-                        );
-                    }
-                    if let Some(ref decorate_script) = parsed_behaviors.decorate {
-                        // decorate uses a single-value JS/Rhai object model. Set-Cookie is held
-                        // aside and never folded (RFC 7230 §3.2.2); other multi-value headers
-                        // degrade to single-value for the script (issue #238 boundary) — warn so
-                        // the collapse is not silent (e.g. WWW-Authenticate is also corrupted by
-                        // comma-folding).
-                        let is_set_cookie = |k: &str| k.eq_ignore_ascii_case("set-cookie");
-                        let folded: Vec<&String> = headers
-                            .iter()
-                            .filter(|(k, v)| v.len() > 1 && !is_set_cookie(k))
-                            .map(|(k, _)| k)
-                            .collect();
-                        if !folded.is_empty() {
-                            warn!(
-                                "decorate uses a single-value object model; multi-value headers \
+                // copy/lookup are pure token substitution — apply them across each value of
+                // multi-value headers so multiplicity survives (e.g. multiple Set-Cookie;
+                // RFC 7230 §3.2.2 forbids folding Set-Cookie). decorate uses a single-value
+                // JS/Rhai object model, so only that path collapses — and even there Set-Cookie
+                // is held aside, never comma-folded.
+                if !parsed_behaviors.copy.is_empty() {
+                    body = apply_copy_behaviors(
+                        &body,
+                        &mut headers,
+                        &parsed_behaviors.copy,
+                        &request_context,
+                    );
+                }
+                if !parsed_behaviors.lookup.is_empty() {
+                    body = apply_lookup_behaviors(
+                        &body,
+                        &mut headers,
+                        &parsed_behaviors.lookup,
+                        &request_context,
+                        csv_cache(),
+                    );
+                }
+                if let Some(ref decorate_script) = parsed_behaviors.decorate {
+                    // decorate uses a single-value JS/Rhai object model. Set-Cookie is held
+                    // aside and never folded (RFC 7230 §3.2.2); other multi-value headers
+                    // degrade to single-value for the script (issue #238 boundary) — warn so
+                    // the collapse is not silent (e.g. WWW-Authenticate is also corrupted by
+                    // comma-folding).
+                    let is_set_cookie = |k: &str| k.eq_ignore_ascii_case("set-cookie");
+                    let folded: Vec<&String> = headers
+                        .iter()
+                        .filter(|(k, v)| v.len() > 1 && !is_set_cookie(k))
+                        .map(|(k, _)| k)
+                        .collect();
+                    if !folded.is_empty() {
+                        warn!(
+                            "decorate uses a single-value object model; multi-value headers \
                                  {folded:?} are comma-folded (issue #238 boundary). Set-Cookie is \
                                  exempt; other headers that forbid list-folding will be corrupted."
-                            );
-                        }
-
-                        let set_cookie: Vec<(String, Vec<String>)> = headers
-                            .iter()
-                            .filter(|(k, _)| is_set_cookie(k))
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect();
-                        let mut single: HashMap<String, String> = headers
-                            .iter()
-                            .filter(|(k, _)| !is_set_cookie(k))
-                            .map(|(k, v)| (k.clone(), v.join(", ")))
-                            .collect();
-                        match apply_js_or_rhai_decorate(
-                            decorate_script,
-                            &request_context,
-                            &body,
-                            status,
-                            &mut single,
-                            imposter.script_state_key(),
-                            stub_state.stub.id.as_deref(),
-                        ) {
-                            Ok((new_body, new_status)) => {
-                                body = new_body;
-                                status = new_status;
-                                // Restore the held-aside Set-Cookie lines unless the script set its
-                                // own (case-insensitively) — a script override wins deterministically.
-                                let script_set_cookie = single.keys().any(|k| is_set_cookie(k));
-                                headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
-                                if !script_set_cookie {
-                                    headers.extend(set_cookie);
-                                }
-                            }
-                            // Behave as if decorate was absent: keep the original multi-value
-                            // `headers` and pre-decorate body/status rather than serving a folded,
-                            // undecorated response. Attach a visible signal so the skipped behavior
-                            // isn't a silent success (issue #323); the body is still served (#269).
-                            Err(e) => {
-                                warn!("Decorate script error: {e}");
-                                if strict_behaviors {
-                                    return Ok(build_response_with_headers(
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                        [
-                                            ("x-rift-imposter", "true"),
-                                            ("x-rift-decorate-error", "true"),
-                                        ],
-                                        format!(
-                                            r#"{{"error": "decorate failed (strictBehaviors): {e}"}}"#
-                                        ),
-                                    ));
-                                }
-                                headers.insert(
-                                    "x-rift-decorate-error".to_string(),
-                                    vec!["true".to_string()],
-                                );
-                            }
-                        }
+                        );
                     }
 
-                    // shellTransform (issue #269): pipe the body through external command(s);
-                    // stdout becomes the new body. Runs on the static `is` path too, not only the
-                    // proxy path, and independently of copy/lookup/decorate.
-                    for cmd in &parsed_behaviors.shell_transform {
-                        match apply_shell_transform(cmd, &request_context, &body, status) {
-                            Ok(transformed) => body = transformed,
-                            // Keep the body unchanged (issue #269) but signal the failure so it
-                            // isn't a silent success (issue #323).
-                            Err(e) => {
-                                warn!("shellTransform command {cmd:?} failed: {e}");
-                                if strict_behaviors {
-                                    return Ok(build_response_with_headers(
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                        [
-                                            ("x-rift-imposter", "true"),
-                                            ("x-rift-shelltransform-error", "true"),
-                                        ],
-                                        format!(
-                                            r#"{{"error": "shellTransform failed (strictBehaviors): {e}"}}"#
-                                        ),
-                                    ));
-                                }
-                                headers.insert(
-                                    "x-rift-shelltransform-error".to_string(),
-                                    vec!["true".to_string()],
-                                );
+                    let set_cookie: Vec<(String, Vec<String>)> = headers
+                        .iter()
+                        .filter(|(k, _)| is_set_cookie(k))
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    let mut single: HashMap<String, String> = headers
+                        .iter()
+                        .filter(|(k, _)| !is_set_cookie(k))
+                        .map(|(k, v)| (k.clone(), v.join(", ")))
+                        .collect();
+                    match apply_js_or_rhai_decorate(
+                        decorate_script,
+                        &request_context,
+                        &body,
+                        status,
+                        &mut single,
+                        imposter.script_state_key(),
+                        stub_state.stub.id.as_deref(),
+                    ) {
+                        Ok((new_body, new_status)) => {
+                            body = new_body;
+                            status = new_status;
+                            // Restore the held-aside Set-Cookie lines unless the script set its
+                            // own (case-insensitively) — a script override wins deterministically.
+                            let script_set_cookie = single.keys().any(|k| is_set_cookie(k));
+                            headers = single.into_iter().map(|(k, v)| (k, vec![v])).collect();
+                            if !script_set_cookie {
+                                headers.extend(set_cookie);
                             }
+                        }
+                        // Behave as if decorate was absent: keep the original multi-value
+                        // `headers` and pre-decorate body/status rather than serving a folded,
+                        // undecorated response. Attach a visible signal so the skipped behavior
+                        // isn't a silent success (issue #323); the body is still served (#269).
+                        Err(e) => {
+                            warn!("Decorate script error: {e}");
+                            if strict_behaviors {
+                                return Ok(build_response_with_headers(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    [
+                                        ("x-rift-imposter", "true"),
+                                        ("x-rift-decorate-error", "true"),
+                                    ],
+                                    format!(
+                                        r#"{{"error": "decorate failed (strictBehaviors): {e}"}}"#
+                                    ),
+                                ));
+                            }
+                            headers.insert(
+                                "x-rift-decorate-error".to_string(),
+                                vec!["true".to_string()],
+                            );
+                        }
+                    }
+                }
+
+                // shellTransform (issue #269): pipe the body through external command(s);
+                // stdout becomes the new body. Runs on the static `is` path too, not only the
+                // proxy path, and independently of copy/lookup/decorate.
+                for cmd in &parsed_behaviors.shell_transform {
+                    match apply_shell_transform(cmd, &request_context, &body, status) {
+                        Ok(transformed) => body = transformed,
+                        // Keep the body unchanged (issue #269) but signal the failure so it
+                        // isn't a silent success (issue #323).
+                        Err(e) => {
+                            warn!("shellTransform command {cmd:?} failed: {e}");
+                            if strict_behaviors {
+                                return Ok(build_response_with_headers(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    [
+                                        ("x-rift-imposter", "true"),
+                                        ("x-rift-shelltransform-error", "true"),
+                                    ],
+                                    format!(
+                                        r#"{{"error": "shellTransform failed (strictBehaviors): {e}"}}"#
+                                    ),
+                                ));
+                            }
+                            headers.insert(
+                                "x-rift-shelltransform-error".to_string(),
+                                vec!["true".to_string()],
+                            );
                         }
                     }
                 }
             }
-
             let mut response = Response::builder().status(status);
 
             // One header line per value (issue #238 multi-value headers, e.g. multiple Set-Cookie).

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -123,7 +123,7 @@ pub fn execute_stub_response_with_rift(
     u16,
     HashMap<String, Vec<String>>,
     String,
-    Option<serde_json::Value>,
+    Option<std::sync::Arc<crate::behaviors::ResponseBehaviors>>,
     Option<RiftResponseExtension>,
     ResponseMode,
     bool,
@@ -131,37 +131,41 @@ pub fn execute_stub_response_with_rift(
     match response {
         StubResponse::Is {
             is,
-            behaviors,
+            behaviors_parsed,
             rift,
+            rendered_body,
+            ..
         } => {
             let mut headers = is.headers.clone();
             let mode = is.mode.clone();
 
-            let body = is
-                .body
-                .as_ref()
-                .map(|b| {
-                    if b.is_string() {
-                        b.as_str().unwrap_or("").to_string()
-                    } else {
-                        if !headers.contains_key("content-type")
-                            && !headers.contains_key("Content-Type")
-                        {
-                            headers.insert(
-                                "Content-Type".to_string(),
-                                vec!["application/json".to_string()],
-                            );
-                        }
-                        serde_json::to_string(b).unwrap_or_default()
+            // Issue #479: `rendered_body` is precomputed once at construction (see
+            // `StubResponse::new_is`) for a non-string body — no more re-serializing on every
+            // request. A string body (or no body) has no `rendered_body` and is used as-is.
+            let body = match rendered_body {
+                Some(rb) => {
+                    if !headers.contains_key("content-type")
+                        && !headers.contains_key("Content-Type")
+                    {
+                        headers.insert(
+                            "Content-Type".to_string(),
+                            vec!["application/json".to_string()],
+                        );
                     }
-                })
-                .unwrap_or_default();
+                    rb.to_string()
+                }
+                None => is
+                    .body
+                    .as_ref()
+                    .map(|b| b.as_str().unwrap_or("").to_string())
+                    .unwrap_or_default(),
+            };
 
             Some((
                 is.status_code,
                 headers,
                 body,
-                behaviors.clone(),
+                behaviors_parsed.clone(),
                 rift.clone(),
                 mode,
                 false,
@@ -266,11 +270,7 @@ pub fn create_stub_from_proxy_response(
         id: None,
         route_pattern: None,
         predicates,
-        responses: vec![StubResponse::Is {
-            is: is_response,
-            behaviors,
-            rift: None,
-        }],
+        responses: vec![StubResponse::new_is(is_response, behaviors, None)],
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -47,16 +47,16 @@ fn test_predicate_matching() {
                 "path": "/test"
             }
         })]),
-        responses: vec![StubResponse::Is {
-            is: IsResponse {
+        responses: vec![StubResponse::new_is(
+            IsResponse {
                 status_code: 200,
                 headers: HashMap::new(),
                 body: Some(serde_json::json!({"message": "hello"})),
                 ..Default::default()
             },
-            behaviors: None,
-            rift: None,
-        }],
+            None,
+            None,
+        )],
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
@@ -153,16 +153,16 @@ fn test_execute_stub() {
         id: None,
         route_pattern: None,
         predicates: vec![],
-        responses: vec![StubResponse::Is {
-            is: IsResponse {
+        responses: vec![StubResponse::new_is(
+            IsResponse {
                 status_code: 201,
                 headers: HashMap::new(),
                 body: Some(serde_json::json!({"created": true})),
                 ..Default::default()
             },
-            behaviors: None,
-            rift: None,
-        }],
+            None,
+            None,
+        )],
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,
@@ -2716,16 +2716,16 @@ async fn test_cors_headers_on_stub_response() {
         predicates: predicates_from_jsons(vec![serde_json::json!({
             "equals": {"method": "GET", "path": "/test"}
         })]),
-        responses: vec![StubResponse::Is {
-            is: IsResponse {
+        responses: vec![StubResponse::new_is(
+            IsResponse {
                 status_code: 200,
                 headers: HashMap::new(),
                 body: Some(serde_json::json!("ok")),
                 ..Default::default()
             },
-            behaviors: None,
-            rift: None,
-        }],
+            None,
+            None,
+        )],
         scenario_name: None,
         required_scenario_state: None,
         new_scenario_state: None,

--- a/crates/rift-core/src/imposter/types.rs
+++ b/crates/rift-core/src/imposter/types.rs
@@ -317,6 +317,7 @@ fn inject_wait_behavior(response: StubResponse, wait_val: serde_json::Value) -> 
             is,
             behaviors,
             rift,
+            ..
         } => {
             let behaviors = Some(match behaviors {
                 Some(serde_json::Value::Object(mut obj)) => {
@@ -326,11 +327,9 @@ fn inject_wait_behavior(response: StubResponse, wait_val: serde_json::Value) -> 
                 Some(other) => other,
                 None => serde_json::json!({ "wait": wait_val }),
             });
-            StubResponse::Is {
-                is,
-                behaviors,
-                rift,
-            }
+            // Behaviors changed (the `wait` entry was injected) — recompute via `new_is` rather
+            // than reusing the stale `behaviors_parsed`/`rendered_body` that were dropped above.
+            StubResponse::new_is(is, behaviors, rift)
         }
         other => other,
     }
@@ -351,6 +350,16 @@ pub enum StubResponse {
         behaviors: Option<serde_json::Value>,
         #[serde(rename = "_rift", skip_serializing_if = "Option::is_none")]
         rift: Option<RiftResponseExtension>,
+        /// Issue #479: `_behaviors` parsed ONCE at construction so the request hot path never
+        /// re-deserializes it. Not serde-driven (see the `from`/`into` attributes on this enum) —
+        /// purely a precomputed cache alongside `behaviors`.
+        #[serde(skip)]
+        behaviors_parsed: Option<std::sync::Arc<crate::behaviors::ResponseBehaviors>>,
+        /// Issue #479: pre-rendered JSON string for a non-string `is.body`, computed ONCE at
+        /// construction so the request hot path never re-serializes it. `None` for a string body
+        /// (served as-is) or no body at all.
+        #[serde(skip)]
+        rendered_body: Option<std::sync::Arc<str>>,
     },
     Proxy {
         proxy: ProxyResponse,
@@ -365,6 +374,38 @@ pub enum StubResponse {
     RiftScript {
         rift: RiftResponseExtension,
     },
+}
+
+impl StubResponse {
+    /// Build an `Is` response, precomputing (issue #479) the parsed `_behaviors` and — for a
+    /// non-string body only — the rendered JSON string, so the request hot path never
+    /// re-deserializes/re-serializes them on every request. This is the ONLY place an `Is`
+    /// variant should be constructed; callers that need to rebuild one after mutating `behaviors`
+    /// (e.g. `inject_wait_behavior`) must go through here too, to keep the caches consistent.
+    pub(crate) fn new_is(
+        is: IsResponse,
+        behaviors: Option<serde_json::Value>,
+        rift: Option<RiftResponseExtension>,
+    ) -> StubResponse {
+        let behaviors_parsed = behaviors
+            .as_ref()
+            .and_then(|v| {
+                serde_json::from_value::<crate::behaviors::ResponseBehaviors>(v.clone()).ok()
+            })
+            .map(std::sync::Arc::new);
+        // Only a non-string body needs rendering; a string body is served as-is.
+        let rendered_body =
+            is.body.as_ref().filter(|b| !b.is_string()).map(|b| {
+                std::sync::Arc::from(serde_json::to_string(b).unwrap_or_default().as_str())
+            });
+        StubResponse::Is {
+            is,
+            behaviors,
+            rift,
+            behaviors_parsed,
+            rendered_body,
+        }
+    }
 }
 
 /// Raw deserialization type that handles multiple JSON formats for stub responses
@@ -523,16 +564,16 @@ impl From<StubResponseRaw> for StubResponse {
                 // Convert array format to object format if needed
                 raw.behaviors.and_then(normalize_behaviors)
             });
-            StubResponse::Is {
-                is: IsResponse {
+            StubResponse::new_is(
+                IsResponse {
                     status_code: is_raw.status_code,
                     headers: is_raw.headers,
                     body: is_raw.body,
                     mode: is_raw.mode,
                 },
                 behaviors,
-                rift: raw.rift,
-            }
+                raw.rift,
+            )
         } else if let Some(proxy) = raw.proxy {
             StubResponse::Proxy { proxy }
         } else if let Some(inject) = raw.inject {
@@ -548,28 +589,28 @@ impl From<StubResponseRaw> for StubResponse {
             let behaviors = raw
                 .underscore_behaviors
                 .or_else(|| raw.behaviors.and_then(normalize_behaviors));
-            StubResponse::Is {
-                is: IsResponse {
+            StubResponse::new_is(
+                IsResponse {
                     status_code: raw.status_code.unwrap_or_else(default_status_code),
                     headers: raw.headers,
                     body: raw.body,
                     mode: raw.mode,
                 },
                 behaviors,
-                rift: None,
-            }
+                None,
+            )
         } else {
             // Default to empty Is response
-            StubResponse::Is {
-                is: IsResponse {
+            StubResponse::new_is(
+                IsResponse {
                     status_code: 200,
                     headers: HashMap::new(),
                     body: None,
                     mode: ResponseMode::Text,
                 },
-                behaviors: None,
-                rift: None,
-            }
+                None,
+                None,
+            )
         }
     }
 }
@@ -581,6 +622,7 @@ impl From<StubResponse> for StubResponseOut {
                 is,
                 behaviors,
                 rift,
+                ..
             } => StubResponseOut {
                 is: Some(IsResponseOut {
                     status_code: is.status_code,
@@ -1145,6 +1187,51 @@ pub enum ImposterError {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Issue #479: `_behaviors` are parsed and a non-string body is rendered ONCE at construction,
+    // so the request hot path reads cached values instead of re-deserializing/re-serializing.
+    #[test]
+    fn is_response_precomputes_behaviors_and_rendered_body() {
+        let resp: StubResponse = serde_json::from_value(json!({
+            "is": { "statusCode": 200, "body": { "id": 1, "name": "x" } },
+            "_behaviors": { "wait": 25 }
+        }))
+        .unwrap();
+        match resp {
+            StubResponse::Is {
+                behaviors_parsed,
+                rendered_body,
+                ..
+            } => {
+                assert!(
+                    behaviors_parsed.is_some(),
+                    "_behaviors must be parsed once at construction"
+                );
+                assert_eq!(
+                    rendered_body.as_deref(),
+                    Some(r#"{"id":1,"name":"x"}"#),
+                    "a non-string body must be pre-rendered once at construction"
+                );
+            }
+            other => panic!("expected Is, got {other:?}"),
+        }
+
+        // A string body needs no rendering, and no _behaviors means no parsed behaviors.
+        let plain: StubResponse =
+            serde_json::from_value(json!({ "is": { "statusCode": 200, "body": "hello" } }))
+                .unwrap();
+        match plain {
+            StubResponse::Is {
+                behaviors_parsed,
+                rendered_body,
+                ..
+            } => {
+                assert!(behaviors_parsed.is_none());
+                assert!(rendered_body.is_none(), "a string body is not pre-rendered");
+            }
+            other => panic!("expected Is, got {other:?}"),
+        }
+    }
 
     // Issue #266: `flowIdSource` is flat under `flowState` and survives a serialize round-trip.
     #[test]


### PR DESCRIPTION
StubResponse::new_is precomputes parsed behaviors (Arc) + rendered body (Arc<str>) once; hot path no longer re-parses/re-serializes. Pure optimization, byte-identical behavior + GET round-trip fidelity preserved.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)