### PR TITLE
perf: bare Regex::new on request paths (template regex filter, proxy predicate generators, wait fallback) — route through regex_cache

### DIFF
--- a/crates/rift-core/src/behaviors/wait.rs
+++ b/crates/rift-core/src/behaviors/wait.rs
@@ -1,6 +1,28 @@
 //! Wait behavior - add latency before response.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+// Fixed patterns for the no-`javascript`-feature wait fallback (issue #481): compile once at
+// first use instead of on every request. These are compile-time-constant patterns, so a compile
+// failure is a programming error caught immediately by tests, not a data-dependent runtime error.
+static WAIT_FLOOR_OFFSET_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"Math\.floor\s*\(\s*Math\.random\s*\(\s*\)\s*\*\s*(\d+)\s*\)\s*\+\s*(\d+)")
+        .expect("wait floor+offset pattern is a valid constant regex")
+});
+static WAIT_RANDOM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"Math\.random\s*\(\s*\)\s*\*\s*(\d+)")
+        .expect("wait random pattern is a valid constant regex")
+});
+static WAIT_SOLO_MIN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"var\s+min\s*=\s*Math\.ceil\s*\(\s*(\d+)\s*\)")
+        .expect("wait solo-min pattern is a valid constant regex")
+});
+static WAIT_SOLO_MAX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"var\s+max\s*=\s*Math\.floor\s*\(\s*(\d+)\s*\)")
+        .expect("wait solo-max pattern is a valid constant regex")
+});
 
 /// Wait behavior - add latency before response
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -125,21 +147,15 @@ impl WaitBehavior {
             // Parse: Math.floor(Math.random() * N) + M
             if body.contains("Math.random()") {
                 use rand::Rng;
-                // Extract multiplier and offset using regex
-                let re = regex::Regex::new(
-                    r"Math\.floor\s*\(\s*Math\.random\s*\(\s*\)\s*\*\s*(\d+)\s*\)\s*\+\s*(\d+)",
-                )
-                .ok()?;
-
-                if let Some(caps) = re.captures(&body) {
+                // Extract multiplier and offset using the cached constant patterns.
+                if let Some(caps) = WAIT_FLOOR_OFFSET_RE.captures(&body) {
                     let range = caps.get(1)?.as_str().parse::<u64>().ok()?;
                     let offset = caps.get(2)?.as_str().parse::<u64>().ok()?;
                     return Some(rand::thread_rng().gen_range(offset..=offset + range));
                 }
 
                 // Simpler pattern: Math.random() * N
-                let re = regex::Regex::new(r"Math\.random\s*\(\s*\)\s*\*\s*(\d+)").ok()?;
-                if let Some(caps) = re.captures(&body) {
+                if let Some(caps) = WAIT_RANDOM_RE.captures(&body) {
                     let range = caps.get(1)?.as_str().parse::<u64>().ok()?;
                     return Some(rand::thread_rng().gen_range(0..=range));
                 }
@@ -158,16 +174,14 @@ impl WaitBehavior {
         use rand::Rng;
 
         // Extract min value: var min = Math.ceil(N)
-        let min_re = regex::Regex::new(r"var\s+min\s*=\s*Math\.ceil\s*\(\s*(\d+)\s*\)").ok()?;
-        let min_val = min_re
+        let min_val = WAIT_SOLO_MIN_RE
             .captures(body)
             .and_then(|c| c.get(1))
             .and_then(|m| m.as_str().parse::<u64>().ok())
             .unwrap_or(0);
 
         // Extract max value: var max = Math.floor(N)
-        let max_re = regex::Regex::new(r"var\s+max\s*=\s*Math\.floor\s*\(\s*(\d+)\s*\)").ok()?;
-        let max_val = max_re
+        let max_val = WAIT_SOLO_MAX_RE
             .captures(body)
             .and_then(|c| c.get(1))
             .and_then(|m| m.as_str().parse::<u64>().ok())
@@ -286,5 +300,30 @@ mod tests {
     fn wait_function_huge_value_is_capped() {
         let wait = WaitBehavior::Function("function() { return 999999999; }".to_string());
         assert_eq!(wait.get_duration_ms(), 60_000);
+    }
+
+    // Issue #481: the no-`javascript`-feature regex fallback now uses shared LazyLock statics.
+    // Exercise it directly (the default-feature tests above hit the Boa path instead) so every
+    // constant pattern is compiled and matched — this pins that the statics' `.expect` never
+    // fires and the patterns still recognize each shape.
+    #[test]
+    fn wait_regex_fallback_parses_all_patterns() {
+        // Math.floor(Math.random() * N) + M
+        let floor = WaitBehavior::execute_js_wait_function_regex(
+            "function() { return Math.floor(Math.random() * 100) + 50; }",
+        );
+        assert!(matches!(floor, Some(d) if (50..=150).contains(&d)));
+
+        // Math.random() * N (no offset)
+        let random = WaitBehavior::execute_js_wait_function_regex(
+            "function() { return Math.floor(Math.random() * 30); }",
+        );
+        assert!(matches!(random, Some(d) if d <= 30));
+
+        // Solo pattern (var min = Math.ceil(N); var max = Math.floor(M); ...)
+        let solo = WaitBehavior::execute_js_wait_function_regex(
+            "function() { var min = Math.ceil(50); var max = Math.floor(100); var num = Math.floor(Math.random() * (max - min + 1)); var wait = (num + min); return wait; }",
+        );
+        assert!(matches!(solo, Some(d) if (50..=100).contains(&d)));
     }
 }

--- a/crates/rift-core/src/extensions/template_fn.rs
+++ b/crates/rift-core/src/extensions/template_fn.rs
@@ -308,8 +308,17 @@ fn apply_filter(value: &str, name: &str, args: &[String]) -> Result<String, Stri
             let group: usize = group_str
                 .parse()
                 .map_err(|_| format!("regex filter: invalid group number '{group_str}'"))?;
-            let re = Regex::new(pattern)
-                .map_err(|e| format!("regex filter: invalid pattern '{pattern}': {e}"))?;
+            // Route through the shared regex cache (issue #481) so a templated response that
+            // uses this filter does not recompile the pattern on every render.
+            let Some(re) = crate::imposter::predicates::regex_cache::cached_regex(pattern, false)
+            else {
+                // Cold path: an invalid pattern errors anyway — recompile once to surface the
+                // concrete syntax error in the message.
+                return Err(match Regex::new(pattern) {
+                    Err(e) => format!("regex filter: invalid pattern '{pattern}': {e}"),
+                    Ok(_) => format!("regex filter: invalid pattern '{pattern}'"),
+                });
+            };
             let caps = re
                 .captures(value)
                 .ok_or_else(|| format!("regex filter: pattern '{pattern}' did not match"))?;
@@ -631,6 +640,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out, "11111111-1111-1111-1111-111111111111");
+    }
+
+    // Issue #481: the regex filter now resolves via the shared cache, which returns None on an
+    // invalid pattern. The error contract (a message naming the bad pattern) must be preserved.
+    #[test]
+    fn regex_filter_invalid_pattern_errors() {
+        let data = request_data();
+        let s = store();
+        let tctx = ctx(&data, "flow-1", &s);
+        // debug=true so a failing token aborts with its error instead of rendering empty.
+        let err = render_templated("{{request.path | regex '([' 1}}", &tctx, true).unwrap_err();
+        assert!(err.contains("invalid pattern"), "got: {err}");
     }
 
     #[test]

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -1120,6 +1120,63 @@ mod tests {
         );
     }
 
+    // Issue #481: the `except` regex for the path site now resolves via the shared cache;
+    // this pins that the strip still applies (the method site alone left path/body untested).
+    #[test]
+    fn test_generator_except_applied_to_path() {
+        let imposter = make_test_imposter();
+
+        let generators = vec![json!({
+            "matches": { "path": true },
+            "except": r"\d+$"
+        })];
+
+        let headers = HashMap::new();
+        let predicates = imposter.generate_predicates_from_request(
+            &generators,
+            "GET",
+            "/orders/123",
+            &headers,
+            None,
+            None,
+        );
+
+        assert_eq!(predicates.len(), 1);
+        let path_val = predicates[0]["equals"]["path"].as_str().unwrap();
+        assert_eq!(
+            path_val, "/orders/",
+            "except pattern should strip the trailing digits from the path"
+        );
+    }
+
+    // Issue #481: same for the body except site.
+    #[test]
+    fn test_generator_except_applied_to_body() {
+        let imposter = make_test_imposter();
+
+        let generators = vec![json!({
+            "matches": { "body": true },
+            "except": r"\d+"
+        })];
+
+        let headers = HashMap::new();
+        let predicates = imposter.generate_predicates_from_request(
+            &generators,
+            "POST",
+            "/test",
+            &headers,
+            Some("token=abc123"),
+            None,
+        );
+
+        assert_eq!(predicates.len(), 1);
+        let body_val = predicates[0]["equals"]["body"].as_str().unwrap();
+        assert_eq!(
+            body_val, "token=abc",
+            "except pattern should strip digits from the body"
+        );
+    }
+
     // Fix #109: generate_predicates_from_request now handles query parameters
     #[test]
     fn test_generator_includes_query_parameters() {

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -3,6 +3,7 @@
 //! Part of the `Imposter` implementation; see `core/mod.rs` for the struct definition.
 
 use super::*;
+use crate::imposter::predicates::regex_cache::cached_regex;
 
 /// Parts read from a successful upstream proxy response, before recording:
 /// `(status, headers, body, latency_ms)`.
@@ -84,7 +85,7 @@ impl Imposter {
                 let mut path_val = path.to_string();
                 // Apply except pattern if present
                 if let Some(pattern) = except_pattern
-                    && let Ok(re) = regex::Regex::new(pattern)
+                    && let Some(re) = cached_regex(pattern, false)
                 {
                     path_val = re.replace_all(&path_val, "").to_string();
                 }
@@ -99,7 +100,7 @@ impl Imposter {
             {
                 let mut method_val = method.to_string();
                 if let Some(pattern) = except_pattern
-                    && let Ok(re) = regex::Regex::new(pattern)
+                    && let Some(re) = cached_regex(pattern, false)
                 {
                     method_val = re.replace_all(&method_val, "").to_string();
                 }
@@ -154,7 +155,7 @@ impl Imposter {
                 let mut body_val = body_str.to_string();
                 // Apply except pattern if present
                 if let Some(pattern) = except_pattern
-                    && let Ok(re) = regex::Regex::new(pattern)
+                    && let Some(re) = cached_regex(pattern, false)
                 {
                     body_val = re.replace_all(&body_val, "").to_string();
                 }

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -20,7 +20,7 @@ mod core;
 mod fault_io;
 mod handler;
 mod manager;
-mod predicates;
+pub(crate) mod predicates;
 mod reconcile;
 mod response;
 mod script_resolve;

--- a/crates/rift-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-core/src/imposter/predicates/mod.rs
@@ -434,7 +434,7 @@ pub(crate) fn predicate_matches_inner(
 
 mod fields;
 mod json;
-mod regex_cache;
+pub(crate) mod regex_cache;
 use fields::{check_predicate_fields, check_predicate_fields_regex};
 use json::check_exists_predicate;
 use regex_cache::cached_regex;


### PR DESCRIPTION
Routes three per-request `Regex::new` sites through the existing shared regex cache (or LazyLock statics), eliminating per-call regex recompilation on the imposter hot path.

- Template `| regex 'pat' N` filter → `regex_cache::cached_regex`
- Proxy `predicateGenerators` `except` (path/method/body) → `cached_regex`
- No-`javascript` wait fallback's 4 constant patterns → `LazyLock<Regex>` statics

Byte-identical behavior. Adds regression tests for all three except sites, the wait fallback patterns, and the template invalid-pattern error contract.

Closes #481

Verification already done locally: `cargo fmt` clean, `cargo clippy -- -D warnings` zero warnings, `cargo test -p rift-core --lib` 978 passed / 0 failed.