### PR TITLE
perf(proxy): imposter proxy client disables connection pooling; gateway recording clones the full body needlessly

### DIFF
--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -50,7 +50,9 @@ fn get_http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .timeout(PROXY_HTTP_CLIENT_TIMEOUT)
-            .pool_max_idle_per_host(0) // Disable connection pooling to avoid stale connections
+            // Keep connection pooling on (issue #482): every proxied request otherwise paid a
+            // fresh TCP + TLS handshake. Staleness is bounded by reqwest's default
+            // `pool_idle_timeout` (90s) — the standard reqwest pooling tradeoff.
             .build()
             .expect("Failed to create HTTP client: check system TLS/DNS configuration")
     })
@@ -516,6 +518,13 @@ mod tests {
     use super::*;
     use crate::imposter::types::ImposterConfig;
     use serde_json::json;
+
+    // Issue #482: removing `pool_max_idle_per_host(0)` (re-enabling connection pooling) must keep
+    // the client builder valid — a bad builder config would panic in the `.expect` on first use.
+    #[test]
+    fn proxy_http_client_builds() {
+        let _client = get_http_client();
+    }
 
     fn make_test_imposter() -> Imposter {
         let config = ImposterConfig {

--- a/crates/rift-core/src/proxy/forwarding.rs
+++ b/crates/rift-core/src/proxy/forwarding.rs
@@ -238,7 +238,7 @@ pub async fn forward_with_recording(
         timestamp_secs: crate::util::unix_timestamp(),
     };
 
-    recording_store.record(signature, recorded_response.clone());
+    recording_store.record(signature, recorded_response);
     debug!(
         "Recorded response for {} {} (status: {}, latency: {}ms)",
         method,


### PR DESCRIPTION
Two proxy-path perf fixes (issue #482):

- **Connection pooling**: the process-wide imposter proxy `reqwest::Client` set `pool_max_idle_per_host(0)`, forcing a fresh TCP+TLS handshake on every proxied request. Removed it; reqwest's default `pool_idle_timeout` (90s) bounds staleness and hyper validates pooled connections on reuse. The client is stateless and pooled per-host, so there's no affinity/auth state to corrupt.
- **Wasted clone**: gateway recording passed `recorded_response.clone()` to `record(...)` though the value (holding the full body as `Vec<u8>`) was never used again — the response is rebuilt from a separately-held `Bytes`. Now moved.

Behavior-identical. Verification: `cargo fmt` clean, `cargo clippy -- -D warnings` zero, `cargo test -p rift-core --lib` 980 passed / 0 failed, `rift-http-proxy` 124 passed.

Closes #482