### PR TITLE
build(release): crates.io publishing is broken — only rift-lint is current; rift-core & rift-http-proxy stale, unversioned path deps, failures masked by || echo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,10 +324,29 @@ jobs:
 
       - name: Update Cargo.toml version
         run: |
-          # Update workspace version in root Cargo.toml
-          sed -i 's/^version = ".*"/version = "'"${{ steps.version.outputs.VERSION }}"'"/' Cargo.toml
-          # Verify the change
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          # Workspace package version (inherited by every member via `version.workspace = true`).
+          sed -i 's/^version = ".*"/version = "'"$VERSION"'"/' Cargo.toml
+          # Keep internal path-dependency version requirements in lockstep (issue #474): bump the
+          # `version = "..."` that follows each `path = "../rift-*"`, so `cargo publish` sees a
+          # matching, published version for every internal dependency instead of an unversioned
+          # (rejected) or stale-versioned (unresolvable) path dep.
+          find crates -name Cargo.toml -exec sed -i -E \
+            's|(path = "\.\./rift-[a-z-]+", version = ")[^"]*|\1'"$VERSION"'|g' {} +
+          echo "Set workspace + internal dep versions to $VERSION:"
           grep 'version = ' Cargo.toml | head -1
+          grep -R 'path = "\.\./rift-' crates/*/Cargo.toml || true
+          # Assert the lockstep bump actually covered every internal path dep (issue #474): sed
+          # exits 0 even when it matches nothing, so a reformatted dep line could silently keep a
+          # stale — but still crates.io-resolvable — version and publish a wrong artifact GREEN.
+          # Fail loudly instead if any internal path dep carries a version other than $VERSION.
+          STALE=$(grep -RE 'path = "\.\./rift-[a-z-]+"' crates/*/Cargo.toml \
+            | grep 'version = "' | grep -v "version = \"$VERSION\"" || true)
+          if [ -n "$STALE" ]; then
+            echo "::error::internal dependency version(s) not bumped to $VERSION:"
+            echo "$STALE"
+            exit 1
+          fi
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -338,19 +357,33 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Publish rift-lint
+      # Publish in dependency order: rift-types -> rift-core -> rift-http-proxy (rift-lint is a
+      # leaf and independent). Failures are LOUD (issue #474): the old `|| echo` masked a broken
+      # rift-http-proxy publish so releases went green while the crate stayed frozen at 0.4.0.
+      - name: Publish to crates.io (in dependency order)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          cargo publish -p rift-lint --allow-dirty || echo "rift-lint may already be published"
-
-      - name: Publish rift-http-proxy
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # Wait a bit for crates.io to index rift-lint if it was just published
-          sleep 30
-          cargo publish -p rift-http-proxy --allow-dirty || echo "rift-http-proxy may already be published"
+          set -euo pipefail
+          publish_crate() {
+            local crate="$1"
+            # Idempotent re-runs: skip ONLY if this exact version is already on crates.io. Any
+            # real failure (bad manifest, missing owner, unpublished/unresolvable dep) still fails
+            # the job loudly — it is not swallowed.
+            if curl -sf "https://crates.io/api/v1/crates/${crate}/${VERSION}" >/dev/null 2>&1; then
+              echo "${crate} ${VERSION} already on crates.io — skipping"
+              return 0
+            fi
+            echo "Publishing ${crate} ${VERSION}..."
+            cargo publish -p "${crate}" --allow-dirty
+            # Let crates.io index the new version before a dependent crate tries to resolve it.
+            sleep 30
+          }
+          publish_crate rift-lint
+          publish_crate rift-types
+          publish_crate rift-core
+          publish_crate rift-http-proxy
 
   # =============================================================================
   # Create GitHub Release

--- a/crates/rift-core/Cargo.toml
+++ b/crates/rift-core/Cargo.toml
@@ -37,7 +37,7 @@ serde_yaml.workspace = true
 serde_json.workspace = true
 
 # Shared workspace types
-rift-types = { path = "../rift-types" }
+rift-types = { path = "../rift-types", version = "0.1.0" }
 
 # Scripting engines
 rhai.workspace = true

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -44,8 +44,8 @@ serde_yaml.workspace = true
 serde_json.workspace = true
 
 # Shared workspace types + CLI-free engine (issue #203)
-rift-types = { path = "../rift-types" }
-rift-core = { path = "../rift-core", default-features = false }
+rift-types = { path = "../rift-types", version = "0.1.0" }
+rift-core = { path = "../rift-core", version = "0.1.0", default-features = false }
 
 # Stable stub id generation for id-addressed stub ops (issue #202)
 uuid.workspace = true
@@ -95,7 +95,7 @@ serde_json_path = "0.7"
 
 [dev-dependencies]
 # Turn on the failing flow-store backend for backend-outage tests (issue #318)
-rift-core = { path = "../rift-core", default-features = false, features = ["test-backend"] }
+rift-core = { path = "../rift-core", version = "0.1.0", default-features = false, features = ["test-backend"] }
 tempfile = "3.8"
 rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }


### PR DESCRIPTION
Fixes crates.io publishing (issue #474), which was silently broken — `rift-http-proxy` (and the unpublished `rift-core`/`rift-types`) never shipped while releases went green, leaving `rift-http-proxy` frozen at 0.4.0 vs 0.12.0 on GitHub.

Chosen approach: **Option 1** — publish the full dependency chain.

- **Version-qualify internal path deps** so `cargo publish` accepts them: `rift-core`→`rift-types`, and `rift-http-proxy`→`{rift-types, rift-core}` (normal + dev).
- **Publish in dependency order**: `rift-lint` (leaf) → `rift-types` → `rift-core` → `rift-http-proxy`, with a `sleep 30` between for crates.io indexing.
- **Fail loudly**: dropped the `|| echo` masking; publishes run under `set -euo pipefail`. An idempotent skip (only when the exact version already exists on crates.io) keeps re-runs safe without masking real errors.
- **Drift-safe versions**: the release version-bump keeps internal path-dep version requirements in lockstep with the workspace version, and a hard assertion fails the job if any internal dep version wasn't bumped (prevents shipping a stale-but-resolvable dep version green).

Note: Option 1 assumes the `rift-core`/`rift-types` crate names are owned/claimable on crates.io by the release account.

Validation: `cargo package -p rift-types` packages clean; `rift-core`/`rift-http-proxy` now pass the version-requirement gate (fail only at registry resolution, which the ordered publish satisfies); local build unaffected (path precedence); release version-bump sed + assertion validated locally; YAML valid.

Closes #474