### PR TITLE
perf(scripting): MB inject/decorate/predicate hooks run inline on async workers — no spawn_blocking/timeout, fresh Boa Context + full re-parse per call

### DIFF
--- a/crates/rift-core/src/behaviors/transform.rs
+++ b/crates/rift-core/src/behaviors/transform.rs
@@ -12,6 +12,9 @@ pub enum DecorateError {
     JavaScript(String),
     #[error("Could not parse JavaScript decorate function")]
     JsParseFailure,
+    /// The script exceeded its wall-clock deadline on the bounded execution path (issue #476).
+    #[error("decorate script timed out after {0}ms")]
+    Timeout(u64),
 }
 
 /// Execute shell transform command

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -99,6 +99,83 @@ impl Imposter {
         Ok(None)
     }
 
+    /// As [`Self::find_matching_stub_with_client`], but bounded (issue #476): when the stub
+    /// snapshot contains an `inject` predicate — synchronous Boa JavaScript evaluated deep inside
+    /// the matcher — the whole matching pass runs on `spawn_blocking` under a wall-clock deadline,
+    /// so a slow or runaway predicate script cannot stall a tokio worker. Scriptless snapshots
+    /// (the overwhelmingly common case, gated by the precomputed `StubIndex::has_inject` flag)
+    /// take the exact inline path — no clones, no blocking-pool hop, no deadline.
+    ///
+    /// No abort flag: Boa has no per-instruction interrupt, so after a timeout the loop-iteration
+    /// cap (issue #327) is what eventually frees the blocking thread.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn find_matching_stub_with_client_bounded(
+        self: &Arc<Self>,
+        method: &str,
+        path: &str,
+        headers_map: &HashMap<String, String>,
+        query: Option<&str>,
+        body: Option<&str>,
+        request_from: Option<&str>,
+        client_ip: Option<&str>,
+        timeout: std::time::Duration,
+    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
+        if !self.stub_index.load().has_inject() {
+            return self.find_matching_stub_with_client(
+                method,
+                path,
+                headers_map,
+                query,
+                body,
+                request_from,
+                client_ip,
+            );
+        }
+
+        let this = Arc::clone(self);
+        let method = method.to_string();
+        let path = path.to_string();
+        let headers_map = headers_map.clone();
+        let query = query.map(str::to_string);
+        let body = body.map(str::to_string);
+        let request_from = request_from.map(str::to_string);
+        let client_ip = client_ip.map(str::to_string);
+        let handle = tokio::task::spawn_blocking(move || {
+            this.find_matching_stub_with_client(
+                &method,
+                &path,
+                &headers_map,
+                query.as_deref(),
+                body.as_deref(),
+                request_from.as_deref(),
+                client_ip.as_deref(),
+            )
+        });
+        match tokio::time::timeout(timeout, handle).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(join_err)) => Err(anyhow::anyhow!("matching task panicked: {join_err}")),
+            Err(_elapsed) => {
+                let msg = format!(
+                    "predicate inject matching timed out after {}ms",
+                    timeout.as_millis()
+                );
+                tracing::warn!("{msg}");
+                // This route is only taken when the snapshot contains an inject predicate, so
+                // the deadline firing is attributable to predicate injection — shape it as
+                // `PredicateInjectionError` so the handler serves the same Mountebank-style 400
+                // as any other failing predicate inject (not a backend 500).
+                #[cfg(feature = "javascript")]
+                {
+                    Err(crate::scripting::PredicateInjectionError(msg).into())
+                }
+                #[cfg(not(feature = "javascript"))]
+                {
+                    Err(anyhow::anyhow!(msg))
+                }
+            }
+        }
+    }
+
     /// Reference implementation: the pre-#292 linear scan over *all* stubs. Shares every request
     /// derivation and gate with the indexed path above; only the iteration differs. Used solely by
     /// the differential test to prove the index preserves Mountebank first-match-wins exactly.
@@ -410,5 +487,139 @@ impl Imposter {
             return Some(map);
         }
         None
+    }
+}
+
+// =============================================================================================
+// Issue #476: predicate `inject` runs deep inside the synchronous matcher, so the bounded path
+// wraps the WHOLE matching pass in spawn_blocking + timeout — but only for imposters whose stub
+// set actually contains an inject predicate (StubIndex::has_inject), so scriptless imposters
+// keep the exact inline fast path.
+// =============================================================================================
+#[cfg(test)]
+mod bounded_matching_tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn imposter(stubs: serde_json::Value) -> Arc<Imposter> {
+        let cfg = serde_json::from_value(json!({ "port": 0, "protocol": "http", "stubs": stubs }))
+            .expect("valid imposter config");
+        Arc::new(Imposter::new(cfg).expect("test imposter"))
+    }
+
+    fn no_headers() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    // AC3 (happy): an inject predicate matches/misses correctly through the bounded path.
+    #[cfg(feature = "javascript")]
+    #[tokio::test]
+    async fn inject_predicate_matching_bounded_matches() {
+        let imp = imposter(json!([{
+            "predicates": [{ "inject": "function (config) { return config.request.path === '/hit'; }" }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        }]));
+        let matched = imp
+            .find_matching_stub_with_client_bounded(
+                "GET",
+                "/hit",
+                &no_headers(),
+                None,
+                None,
+                None,
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("matcher must not error");
+        assert!(
+            matched.is_some(),
+            "inject predicate returning true must match"
+        );
+
+        let missed = imp
+            .find_matching_stub_with_client_bounded(
+                "GET",
+                "/miss",
+                &no_headers(),
+                None,
+                None,
+                None,
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("matcher must not error");
+        assert!(
+            missed.is_none(),
+            "inject predicate returning false must not match"
+        );
+    }
+
+    // AC3: a runaway inject predicate times out near the deadline instead of blocking a
+    // runtime worker for its full duration.
+    #[cfg(feature = "javascript")]
+    #[tokio::test]
+    async fn inject_predicate_matching_times_out() {
+        let imp = imposter(json!([{
+            "predicates": [{ "inject": "function (config) { var i = 0; while (i < 100000000) { i += 1; } return true; }" }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        }]));
+        let start = std::time::Instant::now();
+        let res = imp
+            .find_matching_stub_with_client_bounded(
+                "GET",
+                "/hang",
+                &no_headers(),
+                None,
+                None,
+                None,
+                None,
+                Duration::from_millis(25),
+            )
+            .await;
+        let err = match res {
+            Err(e) => e,
+            Ok(_) => panic!("a runaway inject predicate must error, not hang the matching pass"),
+        };
+        assert!(
+            err.downcast_ref::<crate::scripting::PredicateInjectionError>()
+                .is_some(),
+            "a matching timeout must be shaped as PredicateInjectionError so the handler \
+             serves the Mountebank-style 400, not a backend 500; got: {err}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(3),
+            "must return near the configured deadline, not after the loop cap"
+        );
+    }
+
+    // AC3 (fast path): a scriptless imposter never routes through spawn_blocking — the gate is
+    // the precomputed has_inject flag, and matching succeeds through the bounded entry point.
+    #[tokio::test]
+    async fn scriptless_matching_bounded_stays_inline() {
+        let imp = imposter(json!([{
+            "predicates": [{ "equals": { "path": "/plain" } }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        }]));
+        assert!(
+            !imp.stub_index.load().has_inject(),
+            "a scriptless stub set must not set the has_inject gate"
+        );
+        let matched = imp
+            .find_matching_stub_with_client_bounded(
+                "GET",
+                "/plain",
+                &no_headers(),
+                None,
+                None,
+                None,
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("matcher must not error");
+        assert!(matched.is_some());
     }
 }

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -579,9 +579,8 @@ mod bounded_matching_tests {
                 Duration::from_millis(25),
             )
             .await;
-        let err = match res {
-            Err(e) => e,
-            Ok(_) => panic!("a runaway inject predicate must error, not hang the matching pass"),
+        let Err(err) = res else {
+            panic!("a runaway inject predicate must error, not hang the matching pass")
         };
         assert!(
             err.downcast_ref::<crate::scripting::PredicateInjectionError>()

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -20,6 +20,20 @@ impl Imposter {
         body: Option<&str>,
         query: Option<&str>,
     ) -> Vec<serde_json::Value> {
+        Self::generate_predicates_impl(generators, method, path, headers, body, query)
+    }
+
+    /// [`Self::generate_predicates_from_request`] without `&self`, so the proxy-recording path
+    /// can run it on `spawn_blocking` (issue #476) — a `predicateGenerators.inject` script must
+    /// not execute (and block on the MB script pool) on a tokio async worker.
+    fn generate_predicates_impl(
+        generators: &[serde_json::Value],
+        method: &str,
+        path: &str,
+        headers: &HashMap<String, String>,
+        body: Option<&str>,
+        query: Option<&str>,
+    ) -> Vec<serde_json::Value> {
         let mut predicates = Vec::new();
 
         for r#gen in generators {
@@ -460,15 +474,61 @@ impl Imposter {
             || proxy_config.add_wait_behavior
             || proxy_config.add_decorate_behavior.is_some()
         {
+            // An `inject` generator executes a JS script; run the generator pass off the async
+            // worker under the script deadline (issue #476). Script-free generator lists (the
+            // common case) keep the inline path — pure predicate building, no script pool.
+            let has_inject_generator = proxy_config
+                .predicate_generators
+                .iter()
+                .any(|g| g.as_object().is_some_and(|o| o.contains_key("inject")));
             let predicates = if !proxy_config.predicate_generators.is_empty() {
-                self.generate_predicates_from_request(
-                    &proxy_config.predicate_generators,
-                    method,
-                    uri.path(),
-                    headers,
-                    body,
-                    uri.query(),
-                )
+                if has_inject_generator {
+                    let generators = proxy_config.predicate_generators.clone();
+                    let method = method.to_string();
+                    let path = uri.path().to_string();
+                    let headers = headers.clone();
+                    let body = body.map(str::to_string);
+                    let query = uri.query().map(str::to_string);
+                    let timeout = std::time::Duration::from_millis(
+                        crate::scripting::resolve_script_timeout_ms(&self.config),
+                    );
+                    let handle = tokio::task::spawn_blocking(move || {
+                        Self::generate_predicates_impl(
+                            &generators,
+                            &method,
+                            &path,
+                            &headers,
+                            body.as_deref(),
+                            query.as_deref(),
+                        )
+                    });
+                    match tokio::time::timeout(timeout, handle).await {
+                        Ok(Ok(preds)) => preds,
+                        // Degrade like a failing generator script (warn + skip its output)
+                        // rather than failing the proxied response the client is waiting on.
+                        Ok(Err(join_err)) => {
+                            warn!("predicate generator task panicked: {join_err}");
+                            vec![]
+                        }
+                        Err(_elapsed) => {
+                            warn!(
+                                "predicate generators timed out after {}ms; recording stub \
+                                 without generated predicates",
+                                timeout.as_millis()
+                            );
+                            vec![]
+                        }
+                    }
+                } else {
+                    self.generate_predicates_from_request(
+                        &proxy_config.predicate_generators,
+                        method,
+                        uri.path(),
+                        headers,
+                        body,
+                        uri.query(),
+                    )
+                }
             } else {
                 // No predicateGenerators, generate empty predicates (matches all requests)
                 vec![]

--- a/crates/rift-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-core/src/imposter/core/stub_index.rs
@@ -66,6 +66,22 @@ pub(crate) struct StubIndex {
     prefix: Vec<(String, Vec<usize>)>,
     contains: Vec<(String, Vec<usize>)>,
     fallback: Vec<usize>,
+    /// Whether any stub's predicate tree contains an `inject` predicate, anywhere (including
+    /// nested under `and`/`or`/`not`). Computed once per snapshot so the request hot path can
+    /// gate the bounded (spawn_blocking) matching route on it for free (issue #476).
+    has_inject: bool,
+}
+
+/// Does this predicate tree contain an `inject` predicate anywhere?
+fn predicate_contains_inject(pred: &Predicate) -> bool {
+    match &pred.operation {
+        PredicateOperation::Inject(_) => true,
+        PredicateOperation::Not(inner) => predicate_contains_inject(inner),
+        PredicateOperation::And(children) | PredicateOperation::Or(children) => {
+            children.iter().any(predicate_contains_inject)
+        }
+        _ => false,
+    }
 }
 
 impl StubIndex {
@@ -86,13 +102,23 @@ impl StubIndex {
             }
         }
 
+        let has_inject = stubs
+            .iter()
+            .any(|s| s.stub.predicates.iter().any(predicate_contains_inject));
+
         StubIndex {
             stubs,
             exact,
             prefix: prefix.into_iter().collect(),
             contains: contains.into_iter().collect(),
             fallback,
+            has_inject,
         }
+    }
+
+    /// Whether any stub in this snapshot uses an `inject` predicate (issue #476).
+    pub(crate) fn has_inject(&self) -> bool {
+        self.has_inject
     }
 
     /// The stub snapshot this index describes.
@@ -375,5 +401,33 @@ mod tests {
             Some(0),
             "the earlier match-all stub must win over the anchored stub"
         );
+    }
+
+    // Issue #476: the has_inject gate — computed once at index build — detects an inject
+    // predicate anywhere in a stub's predicate tree, including nested under and/or/not, and
+    // stays false for scriptless stub sets so they keep the inline matching fast path.
+    #[test]
+    fn has_inject_detects_top_level_and_nested() {
+        let scriptless = StubIndex::build(stub_states(&[
+            json!([{"equals": {"path": "/a"}}]),
+            json!([{"and": [{"equals": {"path": "/b"}}, {"exists": {"query": {"q": true}}}]}]),
+        ]));
+        assert!(!scriptless.has_inject());
+
+        let top_level = StubIndex::build(stub_states(&[
+            json!([{"equals": {"path": "/a"}}]),
+            json!([{"inject": "function (config) { return true; }"}]),
+        ]));
+        assert!(top_level.has_inject());
+
+        let under_and = StubIndex::build(stub_states(&[json!([
+            {"and": [{"equals": {"path": "/a"}}, {"inject": "function (config) { return true; }"}]}
+        ])]));
+        assert!(under_and.has_inject());
+
+        let under_not_in_or = StubIndex::build(stub_states(&[json!([
+            {"or": [{"equals": {"path": "/a"}}, {"not": {"inject": "function (config) { return true; }"}}]}
+        ])]));
+        assert!(under_not_in_or.has_inject());
     }
 }

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -5,7 +5,7 @@
 
 use super::core::Imposter;
 use super::predicates::parse_query_string;
-use super::response::apply_js_or_rhai_decorate;
+use super::response::apply_decorate_bounded;
 use super::types::{
     DebugMatchResult, DebugRequest, DebugResponse, ProxyResponse, RecordedRequest, ResponseMode,
 };
@@ -22,7 +22,7 @@ use crate::scripting::{
     should_inject_bounded_with_ctx, should_inject_bounded_with_ctx_traced,
 };
 #[cfg(feature = "javascript")]
-use crate::scripting::{MountebankRequest, execute_mountebank_inject};
+use crate::scripting::{MountebankRequest, execute_mountebank_inject_bounded};
 use crate::util::{build_response, build_response_with_headers};
 use base64::Engine;
 use bytes::Bytes;
@@ -285,30 +285,70 @@ async fn handle_request_inner(
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
         .unwrap_or(false);
 
+    // Every script execution below (debug-mode matching, predicate inject during matching,
+    // response inject, decorate) shares the imposter's `_rift.scriptEngine.timeoutMs`
+    // wall-clock budget (issue #476), like `_rift.script`.
+    let script_timeout = std::time::Duration::from_millis(
+        crate::scripting::resolve_script_timeout_ms(&imposter.config),
+    );
+
     if is_debug_mode {
-        return handle_debug_request(
-            &imposter,
-            &method,
-            &path,
-            &query_str,
-            &headers_clone,
-            &body_string,
-            client_addr,
-        );
+        // Debug matching evaluates the full predicate set — inject predicates included — so it
+        // runs off the async worker under the script deadline like the data-plane matcher
+        // (issue #476). Unconditional spawn_blocking: this is an opt-in diagnostic path.
+        let debug_imposter = Arc::clone(&imposter);
+        let (dbg_method, dbg_path, dbg_query) = (method.clone(), path.clone(), query_str.clone());
+        let dbg_headers = headers_clone.clone();
+        let dbg_body = body_string.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            handle_debug_request(
+                &debug_imposter,
+                &dbg_method,
+                &dbg_path,
+                &dbg_query,
+                &dbg_headers,
+                &dbg_body,
+                client_addr,
+            )
+        });
+        return match tokio::time::timeout(script_timeout, handle).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(join_err)) => {
+                warn!("debug matching task panicked: {join_err}");
+                Ok(build_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Debug matching failed",
+                ))
+            }
+            Err(_elapsed) => {
+                warn!(
+                    "debug matching timed out after {}ms",
+                    script_timeout.as_millis()
+                );
+                Ok(build_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Debug matching timed out",
+                ))
+            }
+        };
     }
 
     // Get client address info for requestFrom, ip predicates
     let request_from = client_addr.to_string();
     let client_ip = client_addr.ip().to_string();
-    let matched = match imposter.find_matching_stub_with_client(
-        method_str,
-        path_str,
-        &headers_clone,
-        query_opt,
-        body_string.as_deref(),
-        Some(&request_from),
-        Some(&client_ip),
-    ) {
+    let matched = match imposter
+        .find_matching_stub_with_client_bounded(
+            method_str,
+            path_str,
+            &headers_clone,
+            query_opt,
+            body_string.as_deref(),
+            Some(&request_from),
+            Some(&client_ip),
+            script_timeout,
+        )
+        .await
+    {
         Ok(matched) => matched,
         // A backend consulted during matching failed (issue #318), or a predicate-`inject`
         // errored (issue #440): surface it, never fall through to "no match" (which would
@@ -401,12 +441,15 @@ async fn handle_request_inner(
                 body: body_string.clone(),
             };
 
-            match execute_mountebank_inject(
-                &inject_fn,
-                &mb_request,
+            match execute_mountebank_inject_bounded(
+                inject_fn,
+                mb_request,
                 imposter.script_state_key(),
-                stub_state.stub.id.as_deref(),
-            ) {
+                stub_state.stub.id.clone(),
+                script_timeout,
+            )
+            .await
+            {
                 Ok(inject_response) => {
                     // Advance the cycler for this inject response
                     if let Err(e) = imposter.advance_cycler_for_inject(&stub_state) {
@@ -880,21 +923,24 @@ async fn handle_request_inner(
                         .filter(|(k, _)| is_set_cookie(k))
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();
-                    let mut single: HashMap<String, String> = headers
+                    let single: HashMap<String, String> = headers
                         .iter()
                         .filter(|(k, _)| !is_set_cookie(k))
                         .map(|(k, v)| (k.clone(), v.join(", ")))
                         .collect();
-                    match apply_js_or_rhai_decorate(
-                        decorate_script,
-                        &request_context,
-                        &body,
+                    match apply_decorate_bounded(
+                        decorate_script.clone(),
+                        request_context.clone(),
+                        body.clone(),
                         status,
-                        &mut single,
+                        single,
                         imposter.script_state_key(),
-                        stub_state.stub.id.as_deref(),
-                    ) {
-                        Ok((new_body, new_status)) => {
+                        stub_state.stub.id.clone(),
+                        script_timeout,
+                    )
+                    .await
+                    {
+                        Ok((new_body, new_status, single)) => {
                             body = new_body;
                             status = new_status;
                             // Restore the held-aside Set-Cookie lines unless the script set its

--- a/crates/rift-core/src/imposter/response.rs
+++ b/crates/rift-core/src/imposter/response.rs
@@ -417,6 +417,49 @@ pub fn apply_js_or_rhai_decorate(
     }
 }
 
+/// Run [`apply_js_or_rhai_decorate`] off the async worker with a wall-clock deadline
+/// (issue #476) — the same `spawn_blocking` + `tokio::time::timeout` shape as
+/// `scripting::bounded`. Takes and returns the header map by value because the execution moves
+/// to a blocking thread. No abort flag: Boa has no per-instruction interrupt, so after a timeout
+/// the loop-iteration cap (issue #327) is what eventually frees the blocking thread; the client
+/// is released at the deadline either way. The deadline is the imposter's
+/// `resolve_script_timeout_ms` budget, shared with `_rift.script`.
+#[allow(clippy::too_many_arguments)]
+pub async fn apply_decorate_bounded(
+    script: String,
+    request: RequestContext,
+    body: String,
+    status: u16,
+    mut headers: HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<String>,
+    timeout: std::time::Duration,
+) -> Result<(String, u16, HashMap<String, String>), DecorateError> {
+    let timeout_ms = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
+    let handle = tokio::task::spawn_blocking(move || {
+        apply_js_or_rhai_decorate(
+            &script,
+            &request,
+            &body,
+            status,
+            &mut headers,
+            imposter_port,
+            stub_id.as_deref(),
+        )
+        .map(|(body, status)| (body, status, headers))
+    });
+    match tokio::time::timeout(timeout, handle).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(join_err)) => Err(DecorateError::JavaScript(format!(
+            "decorate task panicked: {join_err}"
+        ))),
+        Err(_elapsed) => {
+            tracing::warn!("decorate script timed out after {timeout_ms}ms");
+            Err(DecorateError::Timeout(timeout_ms))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -927,5 +970,58 @@ mod tests {
     fn test_create_stub_recorded_from_none_when_not_provided() {
         let stub = create_stub_from_proxy_response(vec![], 200, &[], b"OK", None, None, None);
         assert!(stub.recorded_from.is_none());
+    }
+
+    // =====================================================================================
+    // Issue #476: decorate runs off the async worker with a wall-clock deadline.
+    // =====================================================================================
+
+    // AC2 (happy): a fast decorate mutates the response through the bounded path.
+    #[cfg(feature = "javascript")]
+    #[tokio::test]
+    async fn mb_decorate_bounded_applies() {
+        let (body, status, _headers) = apply_decorate_bounded(
+            "function (request, response) { response.body = response.body + '-decorated'; }"
+                .to_string(),
+            decorate_req(),
+            "orig".to_string(),
+            200,
+            std::collections::HashMap::new(),
+            test_port(),
+            None,
+            std::time::Duration::from_millis(60_000),
+        )
+        .await
+        .expect("fast decorate");
+        assert_eq!(body, "orig-decorated");
+        assert_eq!(status, 200);
+    }
+
+    // AC2: a runaway decorate yields DecorateError::Timeout near the deadline instead of
+    // blocking a runtime worker for its full duration.
+    #[cfg(feature = "javascript")]
+    #[tokio::test]
+    async fn mb_decorate_bounded_times_out() {
+        let start = std::time::Instant::now();
+        let res = apply_decorate_bounded(
+            "function (request, response) { var i = 0; while (i < 100000000) { i += 1; } }"
+                .to_string(),
+            decorate_req(),
+            "orig".to_string(),
+            200,
+            std::collections::HashMap::new(),
+            test_port(),
+            None,
+            std::time::Duration::from_millis(25),
+        )
+        .await;
+        match res {
+            Err(DecorateError::Timeout(ms)) => assert_eq!(ms, 25),
+            other => panic!("expected DecorateError::Timeout, got {other:?}"),
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(3),
+            "must return near the configured deadline, not after the loop cap"
+        );
     }
 }

--- a/crates/rift-core/src/scripting/bounded.rs
+++ b/crates/rift-core/src/scripting/bounded.rs
@@ -460,4 +460,108 @@ mod tests {
             entry.decision
         );
     }
+
+    // =====================================================================================
+    // Issue #476: Mountebank response-inject hook runs off the async worker with a
+    // wall-clock deadline, through the same spawn_blocking + timeout shape as `_rift.script`.
+    // =====================================================================================
+    #[cfg(feature = "javascript")]
+    mod mb_inject {
+        use super::*;
+        use crate::scripting::{MountebankRequest, execute_mountebank_inject_bounded};
+        use std::collections::HashMap;
+        use std::sync::atomic::AtomicU32;
+
+        // Fresh port per test so parallel tests never share `IMPOSTER_STATE`; range disjoint
+        // from js_engine.rs and imposter/response.rs test ranges.
+        fn test_port() -> u16 {
+            static NEXT: AtomicU32 = AtomicU32::new(42_500);
+            NEXT.fetch_add(1, Ordering::Relaxed) as u16
+        }
+
+        fn mb_req(path: &str) -> MountebankRequest {
+            MountebankRequest {
+                method: "GET".to_string(),
+                path: path.to_string(),
+                query: HashMap::new(),
+                headers: HashMap::new(),
+                body: None,
+            }
+        }
+
+        // Busy-loops long enough that a small wall-clock deadline always fires first; the
+        // loop-iteration cap (#327) later frees the blocking thread.
+        const SLOW_INJECT: &str = "function (config) { var i = 0; while (i < 100000000) { i += 1; } return { statusCode: 200 }; }";
+
+        // AC1 (happy): a fast inject returns its response through the bounded path.
+        #[tokio::test]
+        async fn mb_inject_bounded_returns_response() {
+            let resp = execute_mountebank_inject_bounded(
+                "function (config) { return { statusCode: 201, body: 'from-inject' }; }".into(),
+                mb_req("/a"),
+                test_port(),
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("fast inject");
+            assert_eq!(resp.status_code, 201);
+            assert_eq!(resp.body, "from-inject");
+        }
+
+        // AC1: a runaway inject yields a timeout error near the deadline instead of blocking
+        // a runtime worker for its full duration.
+        #[tokio::test]
+        async fn mb_inject_bounded_times_out() {
+            let start = Instant::now();
+            let res = execute_mountebank_inject_bounded(
+                SLOW_INJECT.into(),
+                mb_req("/hang"),
+                test_port(),
+                None,
+                Duration::from_millis(25),
+            )
+            .await;
+            let err = match res {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("runaway inject must yield an error, not a response"),
+            };
+            assert!(err.contains("timed out"), "got: {err}");
+            assert!(
+                start.elapsed() < Duration::from_secs(3),
+                "must return near the configured deadline, not after the loop cap"
+            );
+        }
+
+        // AC4: per-imposter script state persists across bounded runs — the get→run→save
+        // plumbing (issue #477 locking included) follows execution to the blocking thread.
+        #[tokio::test]
+        async fn mb_inject_bounded_state_persists_across_calls() {
+            let port = test_port();
+            let incr = "function (config) { config.state.count = (config.state.count || 0) + 1; return { statusCode: 200, body: String(config.state.count) }; }";
+            let first = execute_mountebank_inject_bounded(
+                incr.into(),
+                mb_req("/count"),
+                port,
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("first run");
+            let second = execute_mountebank_inject_bounded(
+                incr.into(),
+                mb_req("/count"),
+                port,
+                None,
+                Duration::from_millis(60_000),
+            )
+            .await
+            .expect("second run");
+            assert_eq!(first.body, "1");
+            assert_eq!(
+                second.body, "2",
+                "imposter state must persist across pool-thread runs"
+            );
+        }
+    }
 }

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -274,6 +274,197 @@ pub(crate) fn bounded_js_context() -> Context {
     context
 }
 
+/// Cap on distinct parsed scripts retained per MB pool worker (issue #476). Same clear-when-full
+/// policy as the Rhai `compiled_cache` (#356 B3): comfortably above any realistic imposter
+/// working set, while bounding memory against a churny one.
+const MB_SCRIPT_CACHE_CAPACITY: usize = 64;
+
+/// Per-worker reused Boa realm + parsed-`Script` cache for the Mountebank JS hooks (issue #476).
+///
+/// Building a fresh `Context::default()` constructs the entire JS realm (intrinsics, prototypes)
+/// and `context.eval` re-parses the source — per call, previously the dominant cost of a trivial
+/// MB hook. Boa has no bytecode serialization and a parsed [`boa_engine::Script`] is a `Gc`
+/// handle tied to the realm it was parsed in, so the amortization unit is the pair: one context
+/// per pool worker, plus that context's parsed scripts keyed by source hash.
+///
+/// Owned by each MB pool worker as a **loop local**, never as a Rust `thread_local` — a Boa
+/// `Context` must not be dropped from a TLS destructor: `boa_gc`'s own thread-local heap can be
+/// destroyed first, and the `Gc` handles inside the context then panic in a destructor (process
+/// abort). The worker loop drops it on a live thread instead.
+///
+/// Reusing a realm means one script's writes to JS globals are visible to later scripts on the
+/// same worker — Mountebank parity: MB evals every injection in one shared Node process, so
+/// injected globals leak there too. Every global the hooks *contract* on is re-set per run
+/// (`__config`/`__logger`/state globals; config-decorate re-registers `require()` with a fresh
+/// module cache each run), and the per-imposter state object is rebuilt per run from the
+/// port-keyed `IMPOSTER_STATE` map, so cross-imposter isolation of *state* is unaffected. One
+/// worker-history quirk: only config-decorate registers `require`, so after a worker has run
+/// one, a later inject on the same worker sees a live (stale-cache) `require` global where a
+/// fresh worker would throw `ReferenceError` — inject scripts were never promised `require`,
+/// and MB itself exposes it everywhere, so this is tolerated rather than scrubbed per run.
+struct MbJsThread {
+    context: Context,
+    scripts: MbScriptCache,
+}
+
+impl MbJsThread {
+    fn new() -> Self {
+        Self {
+            context: bounded_js_context(),
+            scripts: std::collections::HashMap::new(),
+        }
+    }
+}
+
+/// Script-source → parsed-`Script` cache for one worker's MB context.
+type MbScriptCache = std::collections::HashMap<u64, (String, boa_engine::Script)>;
+
+/// Test-only observable proving the parsed-`Script` cache works (issue #476 AC5): total parses
+/// (cache misses) per source, across all pool workers.
+#[cfg(test)]
+static MB_PARSE_LOG: std::sync::LazyLock<
+    parking_lot::Mutex<std::collections::HashMap<String, u64>>,
+> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
+
+/// Total parses of every cached source containing `fragment` (test observable; the fragment
+/// avoids coupling the test to the exact executor wrapper text).
+#[cfg(test)]
+pub(crate) fn mb_script_parse_count_containing(fragment: &str) -> u64 {
+    MB_PARSE_LOG
+        .lock()
+        .iter()
+        .filter(|(source, _)| source.contains(fragment))
+        .map(|(_, n)| n)
+        .sum()
+}
+
+/// Evaluate `source` against a worker's reused context, parsing at most once per distinct
+/// source. A hit is source-verified (like `compiled_cache` #356 B4): a `u64` collision would
+/// otherwise evaluate the WRONG script, so a mismatch re-parses instead.
+fn eval_mb_script(
+    context: &mut Context,
+    scripts: &mut MbScriptCache,
+    source: &str,
+) -> JsResult<JsValue> {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    let key = hasher.finish();
+
+    if let Some((cached_source, script)) = scripts.get(&key)
+        && cached_source == source
+    {
+        let script = script.clone();
+        return script.evaluate(context);
+    }
+
+    let script = boa_engine::Script::parse(Source::from_bytes(source.as_bytes()), None, context)?;
+    #[cfg(test)]
+    {
+        *MB_PARSE_LOG.lock().entry(source.to_string()).or_insert(0) += 1;
+    }
+    if scripts.len() >= MB_SCRIPT_CACHE_CAPACITY {
+        scripts.clear();
+    }
+    scripts.insert(key, (source.to_string(), script.clone()));
+    script.evaluate(context)
+}
+
+/// A unit of work for the MB script pool: runs on a worker with that worker's reused context.
+type MbJob = Box<dyn FnOnce(&mut MbJsThread) + Send>;
+
+thread_local! {
+    /// Set on MB pool worker threads, so a reentrant executor call (a native hook re-entering
+    /// an executor mid-job) runs inline on a fresh context instead of deadlocking on its own
+    /// worker's queue.
+    static IS_MB_WORKER: Cell<bool> = const { Cell::new(false) };
+}
+
+/// The dedicated worker pool that executes every Mountebank JS hook (issue #476). Workers own
+/// their [`MbJsThread`] as a loop local (see its doc for why TLS is unsound here) and are reused
+/// for the process lifetime, so realm construction and script parsing amortize across requests.
+/// Sized like the `_rift.script` pool (`script_pool.rs`): half the cores, clamped to [2, 16] —
+/// these are CPU-bound interpreter jobs.
+///
+/// A runaway script occupies its worker until the loop-iteration cap (#327) throws — the same
+/// thread-lingering trade-off as the `spawn_blocking` path (#308), but bounded by the pool size;
+/// callers are released at their wall-clock deadline regardless.
+fn mb_js_pool() -> &'static crossbeam::channel::Sender<MbJob> {
+    static POOL: std::sync::OnceLock<crossbeam::channel::Sender<MbJob>> =
+        std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        // Minimum 4 (not the script pool's 2): a runaway script parks its worker until the loop
+        // cap throws, so with only 2 workers two concurrent runaways would stall ALL MB
+        // scripting on small machines.
+        let workers = (num_cpus::get() / 2).clamp(4, 16);
+        let (tx, rx) = crossbeam::channel::unbounded::<MbJob>();
+        for worker_id in 0..workers {
+            let rx = rx.clone();
+            let spawned = std::thread::Builder::new()
+                .name(format!("mb-js-worker-{worker_id}"))
+                .spawn(move || {
+                    IS_MB_WORKER.set(true);
+                    let mut state = MbJsThread::new();
+                    while let Ok(job) = rx.recv() {
+                        // A panicking job (an engine bug — scripts themselves error, not panic)
+                        // must not kill the worker; its context may be mid-mutation, so rebuild.
+                        let run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            job(&mut state)
+                        }));
+                        if run.is_err() {
+                            tracing::error!("MB script job panicked; rebuilding worker context");
+                            state = MbJsThread::new();
+                        }
+                    }
+                });
+            if let Err(e) = spawned {
+                tracing::error!("failed to spawn MB script worker {worker_id}: {e}");
+            }
+        }
+        tx
+    })
+}
+
+/// Submit a job to the MB script pool. `Err` only if the pool is gone (never in practice: the
+/// sender is a process-lifetime static).
+///
+/// The caller's `tracing` dispatcher travels with the job, so script-logger events (issue #355)
+/// keep routing to whatever subscriber was active at the call site — a thread-scoped capture
+/// included — exactly as they did when the hooks ran inline. (Span *parentage* does not cross
+/// the pool boundary, like any thread hop; the logger events carry the imposter port and stub
+/// id as explicit fields.)
+fn submit_mb_job(job: MbJob) -> Result<()> {
+    let dispatcher = tracing::dispatcher::get_default(Clone::clone);
+    let wrapped: MbJob = Box::new(move |state| {
+        tracing::dispatcher::with_default(&dispatcher, || job(state));
+    });
+    mb_js_pool()
+        .send(wrapped)
+        .map_err(|_| anyhow!("MB script pool is unavailable"))
+}
+
+/// Run `f` on an MB pool worker's reused context and block until it completes. The caller is
+/// always off the async runtime already (a `spawn_blocking` matcher thread, a bounded decorate
+/// thread, or a test); the pool hop is what buys context/parse reuse. `Err` means the job
+/// infrastructure failed (worker panicked mid-job, pool unavailable) — script errors travel
+/// inside `R`. On a reentrant call from a worker itself, runs inline on a fresh context
+/// (dropped safely on the live thread).
+fn with_mb_js_thread<R, F>(f: F) -> Result<R>
+where
+    R: Send + 'static,
+    F: FnOnce(&mut MbJsThread) -> R + Send + 'static,
+{
+    if IS_MB_WORKER.get() {
+        return Ok(f(&mut MbJsThread::new()));
+    }
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    submit_mb_job(Box::new(move |state| {
+        let _ = tx.send(f(state));
+    }))?;
+    rx.recv()
+        .map_err(|_| anyhow!("MB script job failed (worker panicked)"))
+}
+
 /// The top-level function names a JS script declares, for the static entrypoint check (issue
 /// #360 Item 1). Two-phase, deliberately NOT a blind `context.eval` of the raw source:
 ///
@@ -1532,10 +1723,71 @@ pub fn execute_mountebank_inject(
     imposter_port: u16,
     stub_id: Option<&str>,
 ) -> Result<MountebankInjectResponse> {
-    let mut context = bounded_js_context();
+    let inject_fn = inject_fn.to_string();
+    let request = request.clone();
+    let stub_id = stub_id.map(str::to_string);
+    with_mb_js_thread(move |thread| {
+        execute_mountebank_inject_in(
+            thread,
+            &inject_fn,
+            &request,
+            imposter_port,
+            stub_id.as_deref(),
+        )
+    })?
+}
+
+/// Run a Mountebank response-`inject` on the MB script pool with a wall-clock deadline
+/// (issue #476) — the async counterpart of [`execute_mountebank_inject`], mirroring the
+/// `spawn_blocking` + `tokio::time::timeout` shape of `bounded::should_inject_bounded` but
+/// submitting straight to the pool (no blocking thread is parked while the script runs). No
+/// abort flag: Boa exposes no per-instruction interrupt, so after a timeout the loop-iteration
+/// cap (issue #327) is what eventually frees the worker. The deadline is the imposter's
+/// `resolve_script_timeout_ms` budget, shared with `_rift.script`.
+pub async fn execute_mountebank_inject_bounded(
+    inject_fn: String,
+    request: MountebankRequest,
+    imposter_port: u16,
+    stub_id: Option<String>,
+    timeout: std::time::Duration,
+) -> Result<MountebankInjectResponse> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    submit_mb_job(Box::new(move |thread| {
+        let _ = tx.send(execute_mountebank_inject_in(
+            thread,
+            &inject_fn,
+            &request,
+            imposter_port,
+            stub_id.as_deref(),
+        ));
+    }))?;
+    match tokio::time::timeout(timeout, rx).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_recv)) => Err(anyhow!("inject task failed (script worker panicked)")),
+        Err(_elapsed) => {
+            tracing::warn!(
+                "Mountebank inject execution timed out after {}ms",
+                timeout.as_millis()
+            );
+            Err(anyhow!(
+                "inject execution timed out after {}ms",
+                timeout.as_millis()
+            ))
+        }
+    }
+}
+
+fn execute_mountebank_inject_in(
+    thread: &mut MbJsThread,
+    inject_fn: &str,
+    request: &MountebankRequest,
+    imposter_port: u16,
+    stub_id: Option<&str>,
+) -> Result<MountebankInjectResponse> {
+    let MbJsThread { context, scripts } = thread;
 
     // Create request object
-    let request_obj = create_mountebank_request_object(&mut context, request)?;
+    let request_obj = create_mountebank_request_object(&mut *context, request)?;
 
     // Get current (persisted, per-port) state for this imposter — shared across predicate
     // injects, response injects, and decorate for the same imposter (issue #355 Item 0).
@@ -1545,41 +1797,41 @@ pub fn execute_mountebank_inject(
     let cell = imposter_state_cell(imposter_port);
     let mut imposter_state = cell.lock();
     let state_map = imposter_state.clone();
-    let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
+    let state_obj = json_to_js(&mut *context, &Value::Object(state_map))?;
 
     let logger_obj =
-        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+        create_script_logger_object(&mut *context, imposter_port, stub_id.map(str::to_owned))?;
 
     // Build config = { request, state, logger } and flatten request fields onto config itself.
-    let config_obj = create_js_object(&context);
+    let config_obj = create_js_object(&*context);
     config_obj
         .set(
             js_string!("request"),
             request_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
     config_obj
-        .set(js_string!("state"), state_obj.clone(), false, &mut context)
+        .set(js_string!("state"), state_obj.clone(), false, &mut *context)
         .map_err(|e| anyhow!("Failed to set config.state: {e}"))?;
     config_obj
         .set(
             js_string!("logger"),
             logger_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.logger: {e}"))?;
-    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
+    flatten_request_onto(&config_obj, &request_obj, &mut *context)?;
 
     // Set global variables consumed by the wrapper script below.
     let global = context.global_object();
     global
-        .set(js_string!("__config"), config_obj, false, &mut context)
+        .set(js_string!("__config"), config_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set config: {e}"))?;
     global
-        .set(js_string!("__logger"), logger_obj, false, &mut context)
+        .set(js_string!("__logger"), logger_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set logger: {e}"))?;
     // injectState and imposterState are the SAME shared, persisted state object as config.state.
     global
@@ -1587,7 +1839,7 @@ pub fn execute_mountebank_inject(
             js_string!("__injectState"),
             state_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set injectState: {e}"))?;
     global
@@ -1595,7 +1847,7 @@ pub fn execute_mountebank_inject(
             js_string!("__imposterState"),
             state_obj,
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set imposterState: {e}"))?;
 
@@ -1618,21 +1870,20 @@ pub fn execute_mountebank_inject(
     );
 
     // Execute the script
-    let result = context
-        .eval(Source::from_bytes(wrapper_script.as_bytes()))
+    let result = eval_mb_script(context, scripts, &wrapper_script)
         .map_err(|e| anyhow!("Failed to execute inject function: {e}"))?;
 
     // Save updated state back (config.state/injectState/imposterState all alias the same object).
     let updated_state = global
-        .get(js_string!("__imposterState"), &mut context)
+        .get(js_string!("__imposterState"), &mut *context)
         .map_err(|e| anyhow!("Failed to get updated state: {e}"))?;
 
-    if let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state) {
+    if let Ok(Value::Object(map)) = js_to_json(&mut *context, &updated_state) {
         *imposter_state = map;
     }
 
     // Parse the response
-    parse_mountebank_response(&mut context, result)
+    parse_mountebank_response(&mut *context, result)
 }
 
 /// A Mountebank predicate `inject` function failed — an object-build failure or the script
@@ -1660,9 +1911,22 @@ pub fn execute_predicate_inject(
     request: &MountebankRequest,
     imposter_port: u16,
 ) -> anyhow::Result<bool> {
-    let mut context = bounded_js_context();
+    let inject_fn = inject_fn.to_string();
+    let request = request.clone();
+    with_mb_js_thread(move |thread| {
+        execute_predicate_inject_in(thread, &inject_fn, &request, imposter_port)
+    })?
+}
 
-    let request_obj = match create_mountebank_request_object(&mut context, request) {
+fn execute_predicate_inject_in(
+    thread: &mut MbJsThread,
+    inject_fn: &str,
+    request: &MountebankRequest,
+    imposter_port: u16,
+) -> anyhow::Result<bool> {
+    let MbJsThread { context, scripts } = thread;
+
+    let request_obj = match create_mountebank_request_object(&mut *context, request) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build request object: {e}");
@@ -1678,7 +1942,7 @@ pub fn execute_predicate_inject(
     let cell = imposter_state_cell(imposter_port);
     let mut imposter_state = cell.lock();
     let state_map = imposter_state.clone();
-    let state_obj = match json_to_js(&mut context, &Value::Object(state_map)) {
+    let state_obj = match json_to_js(&mut *context, &Value::Object(state_map)) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build state object: {e}");
@@ -1691,7 +1955,7 @@ pub fn execute_predicate_inject(
     // stub_id is left None here: predicate matching operates on a `PredicateOperation` tree and
     // the owning stub's id is not threaded through the matcher without an invasive change to the
     // predicate-matching signatures (issue #355 AC1 note).
-    let logger_obj = match create_script_logger_object(&mut context, imposter_port, None) {
+    let logger_obj = match create_script_logger_object(&mut *context, imposter_port, None) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("inject predicate: failed to build logger object: {e}");
@@ -1701,40 +1965,40 @@ pub fn execute_predicate_inject(
         }
     };
 
-    let config_obj = create_js_object(&context);
+    let config_obj = create_js_object(&*context);
     if config_obj
         .set(
             js_string!("request"),
             request_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .is_err()
         || config_obj
-            .set(js_string!("state"), state_obj.clone(), false, &mut context)
+            .set(js_string!("state"), state_obj.clone(), false, &mut *context)
             .is_err()
         || config_obj
             .set(
                 js_string!("logger"),
                 logger_obj.clone(),
                 false,
-                &mut context,
+                &mut *context,
             )
             .is_err()
-        || flatten_request_onto(&config_obj, &request_obj, &mut context).is_err()
+        || flatten_request_onto(&config_obj, &request_obj, &mut *context).is_err()
     {
         tracing::warn!("inject predicate: failed to build config object");
         return Err(PredicateInjectionError("failed to build config object".to_string()).into());
     }
 
     let global = context.global_object();
-    let _ = global.set(js_string!("__config"), config_obj, false, &mut context);
-    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut context);
+    let _ = global.set(js_string!("__config"), config_obj, false, &mut *context);
+    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut *context);
     let _ = global.set(
         js_string!("__imposterState"),
         state_obj,
         false,
-        &mut context,
+        &mut *context,
     );
 
     let wrapper_script = format!(
@@ -1745,7 +2009,7 @@ pub fn execute_predicate_inject(
         "#
     );
 
-    let result = match context.eval(Source::from_bytes(wrapper_script.as_bytes())) {
+    let result = match eval_mb_script(context, scripts, &wrapper_script) {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!("inject predicate: script execution error: {e}");
@@ -1754,8 +2018,8 @@ pub fn execute_predicate_inject(
     };
 
     // Update the persisted, shared per-port state.
-    if let Ok(updated_state) = global.get(js_string!("__imposterState"), &mut context)
-        && let Ok(Value::Object(map)) = js_to_json(&mut context, &updated_state)
+    if let Ok(updated_state) = global.get(js_string!("__imposterState"), &mut *context)
+        && let Ok(Value::Object(map)) = js_to_json(&mut *context, &updated_state)
     {
         *imposter_state = map;
     }
@@ -1773,9 +2037,29 @@ pub fn execute_predicate_generator_inject(
     request: &MountebankRequest,
     existing_predicates: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
-    let mut context = bounded_js_context();
+    let inject_fn = inject_fn.to_string();
+    let request = request.clone();
+    let existing_predicates = existing_predicates.to_vec();
+    match with_mb_js_thread(move |thread| {
+        execute_predicate_generator_inject_in(thread, &inject_fn, &request, &existing_predicates)
+    }) {
+        Ok(predicates) => predicates,
+        Err(e) => {
+            tracing::warn!("predicateGenerator inject: script pool failure: {e}");
+            Vec::new()
+        }
+    }
+}
 
-    let request_obj = match create_mountebank_request_object(&mut context, request) {
+fn execute_predicate_generator_inject_in(
+    thread: &mut MbJsThread,
+    inject_fn: &str,
+    request: &MountebankRequest,
+    existing_predicates: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
+    let MbJsThread { context, scripts } = thread;
+
+    let request_obj = match create_mountebank_request_object(&mut *context, request) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("predicateGenerator inject: failed to build request object: {e}");
@@ -1783,18 +2067,18 @@ pub fn execute_predicate_generator_inject(
         }
     };
 
-    let predicates_val = match json_to_js(&mut context, &Value::Array(existing_predicates.to_vec()))
-    {
-        Ok(obj) => obj,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: failed to build predicates array: {e}");
-            return Vec::new();
-        }
-    };
+    let predicates_val =
+        match json_to_js(&mut *context, &Value::Array(existing_predicates.to_vec())) {
+            Ok(obj) => obj,
+            Err(e) => {
+                tracing::warn!("predicateGenerator inject: failed to build predicates array: {e}");
+                return Vec::new();
+            }
+        };
 
     // No imposter is running yet during proxy recording, so there is no per-port state to tag
     // the logger with (port 0 placeholder) and no stub id exists yet (stub_id left None).
-    let logger_obj = match create_script_logger_object(&mut context, 0, None) {
+    let logger_obj = match create_script_logger_object(&mut *context, 0, None) {
         Ok(obj) => obj,
         Err(e) => {
             tracing::warn!("predicateGenerator inject: failed to build logger object: {e}");
@@ -1803,13 +2087,13 @@ pub fn execute_predicate_generator_inject(
     };
 
     let global = context.global_object();
-    let _ = global.set(js_string!("__request"), request_obj, false, &mut context);
-    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut context);
+    let _ = global.set(js_string!("__request"), request_obj, false, &mut *context);
+    let _ = global.set(js_string!("__logger"), logger_obj, false, &mut *context);
     let _ = global.set(
         js_string!("__predicates"),
         predicates_val,
         false,
-        &mut context,
+        &mut *context,
     );
 
     let wrapper_script = format!(
@@ -1821,7 +2105,7 @@ pub fn execute_predicate_generator_inject(
         "#
     );
 
-    let result = match context.eval(Source::from_bytes(wrapper_script.as_bytes())) {
+    let result = match eval_mb_script(context, scripts, &wrapper_script) {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!("predicateGenerator inject: script execution error: {e}");
@@ -2146,20 +2430,49 @@ pub fn execute_mountebank_config_decorate(
     imposter_port: u16,
     stub_id: Option<&str>,
 ) -> Result<MountebankDecorateResponse> {
-    let mut context = bounded_js_context();
+    let decorate_fn = decorate_fn.to_string();
+    let request = request.clone();
+    let response_body = response_body.to_string();
+    let response_headers = response_headers.clone();
+    let stub_id = stub_id.map(str::to_string);
+    with_mb_js_thread(move |thread| {
+        execute_mountebank_config_decorate_in(
+            thread,
+            &decorate_fn,
+            &request,
+            &response_body,
+            response_status,
+            &response_headers,
+            imposter_port,
+            stub_id.as_deref(),
+        )
+    })?
+}
+
+fn execute_mountebank_config_decorate_in(
+    thread: &mut MbJsThread,
+    decorate_fn: &str,
+    request: &MountebankRequest,
+    response_body: &str,
+    response_status: u16,
+    response_headers: &std::collections::HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<&str>,
+) -> Result<MountebankDecorateResponse> {
+    let MbJsThread { context, scripts } = thread;
 
     // Create request object
-    let request_obj = create_mountebank_request_object(&mut context, request)?;
+    let request_obj = create_mountebank_request_object(&mut *context, request)?;
 
     // Create response object
-    let response_obj = create_js_object(&context);
+    let response_obj = create_js_object(&*context);
 
     response_obj
         .set(
             js_string!("statusCode"),
             JsValue::from(response_status as i32),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set statusCode: {e}"))?;
 
@@ -2168,24 +2481,24 @@ pub fn execute_mountebank_config_decorate(
             js_string!("body"),
             JsValue::from(js_string!(response_body.to_string())),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set body: {e}"))?;
 
     // Create headers object for response
-    let headers_obj = create_js_object(&context);
+    let headers_obj = create_js_object(&*context);
     for (k, v) in response_headers {
         headers_obj
             .set(
                 js_string!(k.clone()),
                 JsValue::from(js_string!(v.clone())),
                 false,
-                &mut context,
+                &mut *context,
             )
             .map_err(|e| anyhow!("Failed to set header: {e}"))?;
     }
     response_obj
-        .set(js_string!("headers"), headers_obj, false, &mut context)
+        .set(js_string!("headers"), headers_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
 
     // Get current (persisted, per-port) state for this imposter — shared with predicate/response
@@ -2196,18 +2509,18 @@ pub fn execute_mountebank_config_decorate(
     let cell = imposter_state_cell(imposter_port);
     let mut imposter_state = cell.lock();
     let state_map = imposter_state.clone();
-    let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
+    let state_obj = json_to_js(&mut *context, &Value::Object(state_map))?;
     let logger_obj =
-        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+        create_script_logger_object(&mut *context, imposter_port, stub_id.map(str::to_owned))?;
 
     // Build the config object: { request, response, path, state, logger } + flattened request.
-    let config_obj = create_js_object(&context);
+    let config_obj = create_js_object(&*context);
     config_obj
         .set(
             js_string!("request"),
             request_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
     config_obj
@@ -2215,7 +2528,7 @@ pub fn execute_mountebank_config_decorate(
             js_string!("response"),
             JsValue::from(response_obj),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.response: {e}"))?;
     config_obj
@@ -2223,20 +2536,20 @@ pub fn execute_mountebank_config_decorate(
             js_string!("path"),
             JsValue::from(js_string!(request.path.clone())),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.path: {e}"))?;
     config_obj
-        .set(js_string!("state"), state_obj.clone(), false, &mut context)
+        .set(js_string!("state"), state_obj.clone(), false, &mut *context)
         .map_err(|e| anyhow!("Failed to set config.state: {e}"))?;
     config_obj
-        .set(js_string!("logger"), logger_obj, false, &mut context)
+        .set(js_string!("logger"), logger_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set config.logger: {e}"))?;
-    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
+    flatten_request_onto(&config_obj, &request_obj, &mut *context)?;
 
     // Register the CommonJS `require()` global before evaluating the decorate so it (and any
     // module it loads) can use it.
-    register_require(&mut context)?;
+    register_require(&mut *context)?;
 
     // Set global variable
     let global = context.global_object();
@@ -2245,7 +2558,7 @@ pub fn execute_mountebank_config_decorate(
             js_string!("__config"),
             config_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config: {e}"))?;
 
@@ -2260,8 +2573,7 @@ pub fn execute_mountebank_config_decorate(
     );
 
     // Execute the script
-    let result = context
-        .eval(Source::from_bytes(wrapper_script.as_bytes()))
+    let result = eval_mb_script(context, scripts, &wrapper_script)
         .map_err(|e| anyhow!("Failed to execute config decorate function: {e}"))?;
 
     // Parse the modified response
@@ -2271,7 +2583,7 @@ pub fn execute_mountebank_config_decorate(
 
     // Get statusCode
     let status_code = obj
-        .get(js_string!("statusCode"), &mut context)
+        .get(js_string!("statusCode"), &mut *context)
         .ok()
         .and_then(|v| v.as_number())
         .map(|n| n as u16)
@@ -2279,9 +2591,9 @@ pub fn execute_mountebank_config_decorate(
 
     // Get headers
     let mut headers = response_headers.clone();
-    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut context)
+    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut *context)
         && let Some(headers_obj) = headers_val.as_object()
-        && let Ok(keys) = headers_obj.own_property_keys(&mut context)
+        && let Ok(keys) = headers_obj.own_property_keys(&mut *context)
     {
         for key in keys {
             let key_str = match &key {
@@ -2289,7 +2601,7 @@ pub fn execute_mountebank_config_decorate(
                 PropertyKey::Index(i) => i.get().to_string(),
                 PropertyKey::Symbol(_) => continue,
             };
-            if let Ok(val) = headers_obj.get(key.clone(), &mut context)
+            if let Ok(val) = headers_obj.get(key.clone(), &mut *context)
                 && let Some(s) = val.as_string()
             {
                 headers.insert(key_str, s.to_std_string_escaped());
@@ -2299,13 +2611,13 @@ pub fn execute_mountebank_config_decorate(
 
     // Get body
     let body = obj
-        .get(js_string!("body"), &mut context)
+        .get(js_string!("body"), &mut *context)
         .ok()
         .map(|v| {
             if let Some(s) = v.as_string() {
                 s.to_std_string_escaped()
             } else if v.is_object() {
-                let json = js_to_json(&mut context, &v).unwrap_or(Value::Null);
+                let json = js_to_json(&mut *context, &v).unwrap_or(Value::Null);
                 serde_json::to_string(&json).unwrap_or_default()
             } else if v.is_null() || v.is_undefined() {
                 String::new()
@@ -2316,7 +2628,7 @@ pub fn execute_mountebank_config_decorate(
         .unwrap_or_else(|| response_body.to_string());
 
     // Persist any mutation the decorate made to the shared, per-port state.
-    if let Ok(Value::Object(map)) = js_to_json(&mut context, &state_obj) {
+    if let Ok(Value::Object(map)) = js_to_json(&mut *context, &state_obj) {
         *imposter_state = map;
     }
 
@@ -2345,20 +2657,49 @@ pub fn execute_mountebank_decorate(
     imposter_port: u16,
     stub_id: Option<&str>,
 ) -> Result<MountebankDecorateResponse> {
-    let mut context = bounded_js_context();
+    let decorate_fn = decorate_fn.to_string();
+    let request = request.clone();
+    let response_body = response_body.to_string();
+    let response_headers = response_headers.clone();
+    let stub_id = stub_id.map(str::to_string);
+    with_mb_js_thread(move |thread| {
+        execute_mountebank_decorate_in(
+            thread,
+            &decorate_fn,
+            &request,
+            &response_body,
+            response_status,
+            &response_headers,
+            imposter_port,
+            stub_id.as_deref(),
+        )
+    })?
+}
+
+fn execute_mountebank_decorate_in(
+    thread: &mut MbJsThread,
+    decorate_fn: &str,
+    request: &MountebankRequest,
+    response_body: &str,
+    response_status: u16,
+    response_headers: &std::collections::HashMap<String, String>,
+    imposter_port: u16,
+    stub_id: Option<&str>,
+) -> Result<MountebankDecorateResponse> {
+    let MbJsThread { context, scripts } = thread;
 
     // Create request object
-    let request_obj = create_mountebank_request_object(&mut context, request)?;
+    let request_obj = create_mountebank_request_object(&mut *context, request)?;
 
     // Create response object
-    let response_obj = create_js_object(&context);
+    let response_obj = create_js_object(&*context);
 
     response_obj
         .set(
             js_string!("statusCode"),
             JsValue::from(response_status as i32),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set statusCode: {e}"))?;
 
@@ -2367,40 +2708,40 @@ pub fn execute_mountebank_decorate(
             js_string!("body"),
             JsValue::from(js_string!(response_body.to_string())),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set body: {e}"))?;
 
     // Create headers object for response
-    let headers_obj = create_js_object(&context);
+    let headers_obj = create_js_object(&*context);
     for (k, v) in response_headers {
         headers_obj
             .set(
                 js_string!(k.clone()),
                 JsValue::from(js_string!(v.clone())),
                 false,
-                &mut context,
+                &mut *context,
             )
             .map_err(|e| anyhow!("Failed to set header: {e}"))?;
     }
     response_obj
-        .set(js_string!("headers"), headers_obj, false, &mut context)
+        .set(js_string!("headers"), headers_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set headers: {e}"))?;
 
     // Config-first convention (issue #355 Item 0): config stands in for the legacy `request` arg,
     // with request fields flattened onto it, and carries the shared per-port state + native
     // logger. Built even though this entrypoint's legacy convention doesn't take a `config`
     // param, so `function(config, response, ...)`-style scripts also work through this path.
-    let config_obj = create_js_object(&context);
+    let config_obj = create_js_object(&*context);
     config_obj
         .set(
             js_string!("request"),
             request_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set config.request: {e}"))?;
-    flatten_request_onto(&config_obj, &request_obj, &mut context)?;
+    flatten_request_onto(&config_obj, &request_obj, &mut *context)?;
 
     // Get current (persisted, per-port) state for this imposter — shared with predicate/response
     // injects for the same imposter (previously a throwaway `{}` per call; issue #355 Item 0).
@@ -2410,35 +2751,35 @@ pub fn execute_mountebank_decorate(
     let cell = imposter_state_cell(imposter_port);
     let mut imposter_state = cell.lock();
     let state_map = imposter_state.clone();
-    let state_obj = json_to_js(&mut context, &Value::Object(state_map))?;
+    let state_obj = json_to_js(&mut *context, &Value::Object(state_map))?;
     let logger_obj =
-        create_script_logger_object(&mut context, imposter_port, stub_id.map(str::to_owned))?;
+        create_script_logger_object(&mut *context, imposter_port, stub_id.map(str::to_owned))?;
 
     // Set global variables
     let global = context.global_object();
     global
-        .set(js_string!("__request"), request_obj, false, &mut context)
+        .set(js_string!("__request"), request_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set request: {e}"))?;
     global
-        .set(js_string!("__config"), config_obj, false, &mut context)
+        .set(js_string!("__config"), config_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set config: {e}"))?;
     global
         .set(
             js_string!("__response"),
             JsValue::from(response_obj),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set response: {e}"))?;
     global
-        .set(js_string!("__logger"), logger_obj, false, &mut context)
+        .set(js_string!("__logger"), logger_obj, false, &mut *context)
         .map_err(|e| anyhow!("Failed to set logger: {e}"))?;
     global
         .set(
             js_string!("__state"),
             state_obj.clone(),
             false,
-            &mut context,
+            &mut *context,
         )
         .map_err(|e| anyhow!("Failed to set state: {e}"))?;
 
@@ -2454,12 +2795,11 @@ pub fn execute_mountebank_decorate(
     );
 
     // Execute the script
-    let result = context
-        .eval(Source::from_bytes(wrapper_script.as_bytes()))
+    let result = eval_mb_script(context, scripts, &wrapper_script)
         .map_err(|e| anyhow!("Failed to execute decorate function: {e}"))?;
 
     // Persist any mutation the decorate made to the shared, per-port state.
-    if let Ok(Value::Object(map)) = js_to_json(&mut context, &state_obj) {
+    if let Ok(Value::Object(map)) = js_to_json(&mut *context, &state_obj) {
         *imposter_state = map;
     }
 
@@ -2470,7 +2810,7 @@ pub fn execute_mountebank_decorate(
 
     // Get statusCode
     let status_code = obj
-        .get(js_string!("statusCode"), &mut context)
+        .get(js_string!("statusCode"), &mut *context)
         .ok()
         .and_then(|v| v.as_number())
         .map(|n| n as u16)
@@ -2478,9 +2818,9 @@ pub fn execute_mountebank_decorate(
 
     // Get headers
     let mut headers = response_headers.clone();
-    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut context)
+    if let Ok(headers_val) = obj.get(js_string!("headers"), &mut *context)
         && let Some(headers_obj) = headers_val.as_object()
-        && let Ok(keys) = headers_obj.own_property_keys(&mut context)
+        && let Ok(keys) = headers_obj.own_property_keys(&mut *context)
     {
         for key in keys {
             let key_str = match &key {
@@ -2488,7 +2828,7 @@ pub fn execute_mountebank_decorate(
                 PropertyKey::Index(i) => i.get().to_string(),
                 PropertyKey::Symbol(_) => continue,
             };
-            if let Ok(val) = headers_obj.get(key.clone(), &mut context)
+            if let Ok(val) = headers_obj.get(key.clone(), &mut *context)
                 && let Some(s) = val.as_string()
             {
                 headers.insert(key_str, s.to_std_string_escaped());
@@ -2498,13 +2838,13 @@ pub fn execute_mountebank_decorate(
 
     // Get body
     let body = obj
-        .get(js_string!("body"), &mut context)
+        .get(js_string!("body"), &mut *context)
         .ok()
         .map(|v| {
             if let Some(s) = v.as_string() {
                 s.to_std_string_escaped()
             } else if v.is_object() {
-                let json = js_to_json(&mut context, &v).unwrap_or(Value::Null);
+                let json = js_to_json(&mut *context, &v).unwrap_or(Value::Null);
                 serde_json::to_string(&json).unwrap_or_default()
             } else if v.is_null() || v.is_undefined() {
                 String::new()
@@ -3278,6 +3618,28 @@ function respond(ctx) {
         let resp = execute_mountebank_inject(script, &mb_req("GET", "/a-path"), test_port(), None)
             .expect("v2 config convention should run");
         assert_eq!(resp.body, "/a-path");
+    }
+
+    // Issue #476 AC5: the MB wrapper script is parsed at most once per pool worker per source —
+    // reruns of the SAME source hit the parsed-Script cache. The pool has at most 16 workers, so
+    // 64 runs parse at most 16 times with the cache and exactly 64 times without it. The body
+    // marker is unique per run (port-derived), so concurrent tests can't touch this count.
+    #[test]
+    fn mb_script_parse_cached_across_calls() {
+        let port = test_port();
+        let marker = format!("parse-cache-{port}");
+        let script =
+            format!("function(config) {{ return {{ statusCode: 200, body: '{marker}' }}; }}");
+        for _ in 0..64 {
+            let resp = execute_mountebank_inject(&script, &mb_req("GET", "/c"), port, None)
+                .expect("inject run");
+            assert_eq!(resp.body, marker);
+        }
+        let parses = mb_script_parse_count_containing(&marker);
+        assert!(
+            (1..=16).contains(&parses),
+            "64 same-source runs must parse at most once per pool worker (≤16), got {parses}"
+        );
     }
 
     // (b) legacy positional: function(request, state, logger) { ...request.path... }

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -2449,6 +2449,7 @@ pub fn execute_mountebank_config_decorate(
     })?
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_mountebank_config_decorate_in(
     thread: &mut MbJsThread,
     decorate_fn: &str,
@@ -2676,6 +2677,7 @@ pub fn execute_mountebank_decorate(
     })?
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_mountebank_decorate_in(
     thread: &mut MbJsThread,
     decorate_fn: &str,

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -35,7 +35,8 @@ pub(crate) use js_engine::bounded_js_context;
 pub use js_engine::{
     JsEngine, MountebankRequest, PredicateInjectionError, clear_imposter_state,
     compile_js_to_bytecode, execute_mountebank_config_decorate, execute_mountebank_decorate,
-    execute_mountebank_inject, execute_predicate_generator_inject, execute_predicate_inject,
+    execute_mountebank_inject, execute_mountebank_inject_bounded,
+    execute_predicate_generator_inject, execute_predicate_inject,
 };
 #[cfg(feature = "javascript")]
 #[allow(unused_imports)]

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -488,7 +488,10 @@ http(429, #{ error: "rate limited" }).header("Retry-After", "60")
 
 ## Execution Limits
 
-`_rift.script` execution is bounded so a runaway script cannot wedge the engine.
+Script execution is bounded so a runaway script cannot wedge the engine. This applies to
+`_rift.script` **and** to the Mountebank-compatible JavaScript hooks — response `inject`,
+predicate `inject`, and the `decorate` behavior — all of which run off the async workers
+(on a dedicated script-worker pool) under the same deadline.
 
 - **Wall-clock timeout.** Each script runs under a deadline — `_rift.scriptEngine.timeoutMs` if
   configured, otherwise **5000 ms**. Rhai is interrupted mid-run when the deadline passes.
@@ -497,8 +500,17 @@ http(429, #{ error: "rate limited" }).header("Retry-After", "60")
   and a recursion limit of **512**. The client is still released at the wall-clock timeout with an
   error; a pathological nested loop may keep a background worker busy a little longer, but it cannot
   run unbounded.
-- **On timeout or error** — a compile error, a runtime error, or exceeding a bound — the response is
-  `500 Internal Server Error` carrying an `x-rift-script-error: true` header.
+- **On timeout or error** — a compile error, a runtime error, or exceeding a bound — a
+  `_rift.script` failure is a `500 Internal Server Error` carrying an
+  `x-rift-script-error: true` header; a failing Mountebank `inject` (response or predicate) is a
+  `400` with a Mountebank-shaped `{"errors": [...]}` body, and a failing `decorate` serves the
+  undecorated response with an `x-rift-decorate-error: true` header (or a `500` under
+  `strictBehaviors`).
+- **Amortized JavaScript startup.** The Mountebank hooks reuse a per-worker-thread Boa context and
+  a parsed-script cache keyed by source content, so steady-state execution skips both JS realm
+  construction and re-parsing. Like Mountebank itself — which evaluates every injection in one
+  shared Node.js process — scripts on the same worker thread share JS globals; per-imposter
+  `state` isolation is unaffected.
 
 ```json
 {


### PR DESCRIPTION
Routes the Mountebank-compat JS hooks (response `inject`, `decorate`, predicate `inject`) off the tokio async workers onto a dedicated script-worker pool with a wall-clock deadline (`_rift.scriptEngine.timeoutMs`, default 5000ms), and amortizes Boa cost with per-worker reused contexts + a source-hash-keyed parsed-`Script` cache. Scriptless imposters keep the exact inline matching fast path via a precomputed `StubIndex::has_inject` gate; the proxy `predicateGenerators.inject` pass and debug-mode matching are bounded too. Docs updated (`docs/features/scripting.md` Execution Limits). Adjacent findings filed as #498/#499/#500.

Closes #476

Milestone: none (agent-found performance issue).