### PR TITLE
perf(flow-state): offload scenario-FSM Redis I/O to spawn_blocking + fold INCRBY/EXPIRE (#475)

### DIFF
--- a/crates/rift-core/src/backends/inmemory.rs
+++ b/crates/rift-core/src/backends/inmemory.rs
@@ -594,6 +594,13 @@ mod tests {
         );
     }
 
+    // Issue #475: the in-memory store never blocks, so the request path must NOT offload its
+    // calls to spawn_blocking (that hop would be pure overhead on the common backend).
+    #[test]
+    fn in_memory_store_is_not_blocking() {
+        assert!(!InMemoryFlowStore::new(300).is_blocking());
+    }
+
     // A conflicting CAS on a brand-new flow_id must not leak the empty flow map that
     // `entry().or_default()` transiently created.
     #[test]

--- a/crates/rift-core/src/backends/redis.rs
+++ b/crates/rift-core/src/backends/redis.rs
@@ -191,30 +191,38 @@ impl FlowStore for RedisFlowStore {
         self.increment_by(flow_id, key, 1)
     }
 
-    /// Atomic via Redis's own `INCRBY` (issue #358) — a single round trip, so there's no
-    /// interleaving window with a concurrent increment/set the way a get-then-set fallback would
-    /// have.
+    /// Atomic INCRBY + EXPIRE in a single round trip via a server-side Lua script (issue #475),
+    /// mirroring `compare_and_set`. `INCRBY` alone doesn't (re)set the TTL, and issuing a separate
+    /// `EXPIRE` cost a second RTT per increment; folding both into one `EVAL` halves the round
+    /// trips while staying atomic.
     fn increment_by(&self, flow_id: &str, key: &str, by: i64) -> Result<i64> {
+        const INCR_SCRIPT: &str = r#"
+local v = redis.call('INCRBY', KEYS[1], ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+return v
+"#;
         let key_str = self.make_key(flow_id, key);
         let conn = self
             .pool
             .get()
             .map_err(|e| backend_err("flowStore.pool", e))?;
-        let mut conn_guard = conn.lock().unwrap();
 
-        // INCRBY returns the new value
-        let new_value: i64 = conn_guard
-            .incr(&key_str, by)
+        let new_value: i64 = redis::cmd("EVAL")
+            .arg(INCR_SCRIPT)
+            .arg(1)
+            .arg(&key_str)
+            .arg(by)
+            .arg(self.default_ttl_seconds)
+            .query(&mut *conn.lock().unwrap())
             .map_err(|e| backend_err("flowStore.incrementBy", e))?;
 
-        // Set TTL on the key (INCRBY doesn't reset TTL)
-        let _: () = redis::cmd("EXPIRE")
-            .arg(&key_str)
-            .arg(self.default_ttl_seconds)
-            .query(&mut *conn_guard)
-            .map_err(|e| backend_err("flowStore.expire", e))?;
-
         Ok(new_value)
+    }
+
+    /// The synchronous r2d2/`redis::Connection` client blocks the calling thread, so the request
+    /// path must offload these calls to `spawn_blocking` (issue #475).
+    fn is_blocking(&self) -> bool {
+        true
     }
 
     /// Single-round-trip atomic CAS via a server-side Lua script (issue #311): compare

--- a/crates/rift-core/src/extensions/flow_state.rs
+++ b/crates/rift-core/src/extensions/flow_state.rs
@@ -28,6 +28,15 @@ pub trait FlowStore: Send + Sync {
     /// Delete a key from flow state
     fn delete(&self, flow_id: &str, key: &str) -> Result<()>;
 
+    /// Whether calls to this store block the calling thread on synchronous network I/O. The
+    /// request path consults this to decide whether to offload flow-store calls to
+    /// `spawn_blocking`, so a slow or pool-exhausted backend can't stall a tokio worker and
+    /// head-of-line-block every task multiplexed on it (issue #475). In-memory stores never
+    /// block, so the default is `false`; the Redis backend overrides it.
+    fn is_blocking(&self) -> bool {
+        false
+    }
+
     /// Increment a numeric value (returns new value)
     fn increment(&self, flow_id: &str, key: &str) -> Result<i64>;
 

--- a/crates/rift-core/src/imposter/core/matching.rs
+++ b/crates/rift-core/src/imposter/core/matching.rs
@@ -120,7 +120,15 @@ impl Imposter {
         client_ip: Option<&str>,
         timeout: std::time::Duration,
     ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
-        if !self.stub_index.load().has_inject() {
+        let snapshot = self.stub_index.load();
+        let has_inject = snapshot.has_inject();
+        // A scenario-gated stub reads flow state inside the matching pass; on a blocking backend
+        // (Redis) that read must not run on the tokio worker either (issue #475). A scenario-free
+        // snapshot on a blocking backend still takes the inline fast path — no gate read happens.
+        let needs_offload =
+            has_inject || (snapshot.has_scenario_gate() && self.flow_store.is_blocking());
+        drop(snapshot);
+        if !needs_offload {
             return self.find_matching_stub_with_client(
                 method,
                 path,
@@ -151,6 +159,15 @@ impl Imposter {
                 client_ip.as_deref(),
             )
         });
+        // The wall-clock deadline exists to bound a runaway inject *script*. A blocking flow-store
+        // read is bounded by the backend's own connection/command timeout, so when the offload is
+        // purely for the scenario gate (no inject) we await the task without the script deadline.
+        if !has_inject {
+            return match handle.await {
+                Ok(result) => result,
+                Err(join_err) => Err(anyhow::anyhow!("matching task panicked: {join_err}")),
+            };
+        }
         match tokio::time::timeout(timeout, handle).await {
             Ok(Ok(result)) => result,
             Ok(Err(join_err)) => Err(anyhow::anyhow!("matching task panicked: {join_err}")),
@@ -275,6 +292,26 @@ impl Imposter {
                 .and_then(|(_, v)| v.first().cloned())
                 .unwrap_or_else(|| port.to_string()),
             None => port.to_string(),
+        }
+    }
+
+    /// Run a blocking flow-store closure off the tokio worker when the backend actually blocks
+    /// (Redis), otherwise inline. This keeps a slow or pool-exhausted backend from
+    /// head-of-line-blocking the worker thread every request is multiplexed on (issue #475),
+    /// while adding zero overhead for the non-blocking in-memory store (the common case — the
+    /// closure runs directly on the caller with no task hop).
+    pub(crate) async fn run_flow_blocking<T, F>(self: &Arc<Self>, f: F) -> anyhow::Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Self) -> anyhow::Result<T> + Send + 'static,
+    {
+        if self.flow_store.is_blocking() {
+            let imp = Arc::clone(self);
+            tokio::task::spawn_blocking(move || f(&imp))
+                .await
+                .map_err(|e| anyhow::anyhow!("flow-store task panicked: {e}"))?
+        } else {
+            f(self)
         }
     }
 
@@ -510,6 +547,162 @@ mod bounded_matching_tests {
 
     fn no_headers() -> HashMap<String, String> {
         HashMap::new()
+    }
+
+    // Issue #475: run_flow_blocking must be transparent — on the default (non-blocking) backend it
+    // runs the closure inline and returns its result faithfully (Ok value, Err propagated), and it
+    // hands the closure a usable &Imposter so a real flow-store call works through it.
+    #[tokio::test]
+    async fn run_flow_blocking_is_transparent_inline() {
+        let imp = imposter(json!([]));
+        assert!(
+            !imp.flow_store.is_blocking(),
+            "default backend is non-blocking"
+        );
+
+        let value = imp
+            .run_flow_blocking(|_| Ok(42_i64))
+            .await
+            .expect("closure ok");
+        assert_eq!(value, 42);
+
+        let err = imp
+            .run_flow_blocking(|_| Err::<i64, _>(anyhow::anyhow!("boom")))
+            .await
+            .expect_err("closure err propagates");
+        assert!(err.to_string().contains("boom"));
+
+        // The closure receives a working &Imposter: an unset scenario reads the initial state.
+        let state = imp
+            .run_flow_blocking(|i| i.scenario_state("flow-1", "sc"))
+            .await
+            .expect("scenario_state through helper");
+        assert_eq!(state, INITIAL_SCENARIO_STATE);
+    }
+
+    /// A FlowStore that reports `is_blocking() == true` (delegating storage to an in-memory store)
+    /// so the spawn_blocking dispatch path and the blocking-backend offload decision are exercised
+    /// without a real Redis (issue #475).
+    struct BlockingProbeStore {
+        inner: crate::backends::inmemory::InMemoryFlowStore,
+    }
+
+    impl BlockingProbeStore {
+        fn new() -> Self {
+            Self {
+                inner: crate::backends::inmemory::InMemoryFlowStore::new(300),
+            }
+        }
+    }
+
+    impl crate::extensions::flow_state::FlowStore for BlockingProbeStore {
+        fn is_blocking(&self) -> bool {
+            true
+        }
+        fn get(&self, flow_id: &str, key: &str) -> anyhow::Result<Option<serde_json::Value>> {
+            self.inner.get(flow_id, key)
+        }
+        fn set(&self, flow_id: &str, key: &str, value: serde_json::Value) -> anyhow::Result<()> {
+            self.inner.set(flow_id, key, value)
+        }
+        fn exists(&self, flow_id: &str, key: &str) -> anyhow::Result<bool> {
+            self.inner.exists(flow_id, key)
+        }
+        fn delete(&self, flow_id: &str, key: &str) -> anyhow::Result<()> {
+            self.inner.delete(flow_id, key)
+        }
+        fn increment(&self, flow_id: &str, key: &str) -> anyhow::Result<i64> {
+            self.inner.increment(flow_id, key)
+        }
+        fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> anyhow::Result<()> {
+            self.inner.set_ttl(flow_id, ttl_seconds)
+        }
+        fn compare_and_set(
+            &self,
+            flow_id: &str,
+            key: &str,
+            expected: Option<&serde_json::Value>,
+            new: serde_json::Value,
+        ) -> anyhow::Result<crate::extensions::flow_state::CasOutcome> {
+            self.inner.compare_and_set(flow_id, key, expected, new)
+        }
+    }
+
+    fn imposter_with_store(
+        stubs: serde_json::Value,
+        store: Arc<dyn crate::extensions::flow_state::FlowStore>,
+    ) -> Arc<Imposter> {
+        let cfg = serde_json::from_value(json!({ "port": 0, "protocol": "http", "stubs": stubs }))
+            .expect("valid imposter config");
+        let mut imp = Imposter::new(cfg).expect("test imposter");
+        imp.flow_store = store;
+        Arc::new(imp)
+    }
+
+    // Issue #475: on a blocking backend, run_flow_blocking must dispatch the closure to a
+    // spawn_blocking pool thread (off the caller) and still round-trip its result / propagate a
+    // panic as a JoinError-shaped error. This covers the spawn_blocking arm the inline test can't.
+    #[tokio::test]
+    async fn run_flow_blocking_dispatches_off_thread_on_blocking_backend() {
+        let imp = imposter_with_store(json!([]), Arc::new(BlockingProbeStore::new()));
+        assert!(imp.flow_store.is_blocking());
+
+        let caller_thread = std::thread::current().id();
+        let ran_on = imp
+            .run_flow_blocking(|_| Ok(std::thread::current().id()))
+            .await
+            .expect("ok");
+        assert_ne!(
+            ran_on, caller_thread,
+            "a blocking backend must run the closure off the caller thread"
+        );
+
+        assert_eq!(imp.run_flow_blocking(|_| Ok(7_i64)).await.expect("ok"), 7);
+
+        let err = imp
+            .run_flow_blocking(|_| -> anyhow::Result<i64> { panic!("boom-in-task") })
+            .await
+            .expect_err("panic in the blocking task must surface as an error");
+        assert!(
+            err.to_string().contains("flow-store task panicked"),
+            "got: {err}"
+        );
+    }
+
+    // Issue #475: a scenario-gated stub on a blocking backend must still match — the bounded
+    // matcher's `has_scenario_gate && is_blocking` decision offloads the whole pass (incl. the gate
+    // read) to spawn_blocking, taking the no-deadline branch. This is the crux the fix protects.
+    #[tokio::test]
+    async fn scenario_gated_stub_matches_through_blocking_offload() {
+        let imp = imposter_with_store(
+            json!([{
+                "predicates": [{ "equals": { "path": "/x" } }],
+                "scenarioName": "sc",
+                "requiredScenarioState": INITIAL_SCENARIO_STATE,
+                "responses": [{ "is": { "statusCode": 200 } }]
+            }]),
+            Arc::new(BlockingProbeStore::new()),
+        );
+        assert!(imp.stub_index.load().has_scenario_gate());
+        assert!(imp.flow_store.is_blocking());
+
+        let matched = imp
+            .find_matching_stub_with_client_bounded(
+                "GET",
+                "/x",
+                &no_headers(),
+                None,
+                None,
+                None,
+                None,
+                std::time::Duration::from_secs(5),
+            )
+            .await
+            .expect("matching ok");
+        assert!(
+            matched.is_some(),
+            "scenario-gated stub at its initial state must match via the blocking offload path"
+        );
     }
 
     // AC3 (happy): an inject predicate matches/misses correctly through the bounded path.

--- a/crates/rift-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-core/src/imposter/core/stub_index.rs
@@ -70,6 +70,11 @@ pub(crate) struct StubIndex {
     /// nested under `and`/`or`/`not`). Computed once per snapshot so the request hot path can
     /// gate the bounded (spawn_blocking) matching route on it for free (issue #476).
     has_inject: bool,
+    /// Whether any stub is scenario-gated (`requiredScenarioState`). The eligibility gate reads
+    /// flow state during matching; on a blocking backend (Redis) that read must run off the tokio
+    /// worker, so the bounded matcher offloads only when this is set — a scenario-free snapshot
+    /// keeps the inline fast path even on a blocking backend (issue #475).
+    has_scenario_gate: bool,
 }
 
 /// Does this predicate tree contain an `inject` predicate anywhere?
@@ -105,6 +110,9 @@ impl StubIndex {
         let has_inject = stubs
             .iter()
             .any(|s| s.stub.predicates.iter().any(predicate_contains_inject));
+        let has_scenario_gate = stubs
+            .iter()
+            .any(|s| s.stub.required_scenario_state.is_some());
 
         StubIndex {
             stubs,
@@ -113,12 +121,18 @@ impl StubIndex {
             contains: contains.into_iter().collect(),
             fallback,
             has_inject,
+            has_scenario_gate,
         }
     }
 
     /// Whether any stub in this snapshot uses an `inject` predicate (issue #476).
     pub(crate) fn has_inject(&self) -> bool {
         self.has_inject
+    }
+
+    /// Whether any stub in this snapshot is scenario-gated (`requiredScenarioState`, issue #475).
+    pub(crate) fn has_scenario_gate(&self) -> bool {
+        self.has_scenario_gate
     }
 
     /// The stub snapshot this index describes.
@@ -401,6 +415,40 @@ mod tests {
             Some(0),
             "the earlier match-all stub must win over the anchored stub"
         );
+    }
+
+    // Issue #475: the has_scenario_gate flag — computed once at index build — detects a
+    // `requiredScenarioState` stub so the bounded matcher offloads the gate's flow-store read to
+    // spawn_blocking on a blocking backend, while a scenario-free set keeps the inline fast path.
+    #[test]
+    fn has_scenario_gate_detects_required_scenario_state() {
+        let build = |v: Value| {
+            let states: Vec<Arc<StubState>> = v
+                .as_array()
+                .expect("array")
+                .iter()
+                .map(|s| {
+                    Arc::new(StubState::new(
+                        serde_json::from_value(s.clone()).expect("stub"),
+                    ))
+                })
+                .collect();
+            StubIndex::build(Arc::new(states))
+        };
+        let ungated = build(json!([
+            { "predicates": [{"equals": {"path": "/a"}}], "responses": [{"is": {"statusCode": 200}}] }
+        ]));
+        assert!(!ungated.has_scenario_gate());
+
+        let gated = build(json!([
+            {
+                "predicates": [{"equals": {"path": "/a"}}],
+                "scenarioName": "sc",
+                "requiredScenarioState": "started",
+                "responses": [{"is": {"statusCode": 200}}]
+            }
+        ]));
+        assert!(gated.has_scenario_gate());
     }
 
     // Issue #476: the has_inject gate — computed once at index build — detects an inject

--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -360,7 +360,18 @@ async fn handle_request_inner(
         // Resolve flow_id from the same single-value header map the matcher used (headers_clone)
         // so the transition writes the exact key the gate read.
         let scenario_flow_id = imposter.resolve_flow_id(&headers_clone);
-        if let Err(e) = imposter.apply_scenario_transition(&scenario_flow_id, &stub_state.stub) {
+        // Offload the FSM transition to spawn_blocking on a blocking backend (Redis) so it can't
+        // stall the tokio worker; inline on the in-memory backend (issue #475).
+        let transition = {
+            let flow_id = scenario_flow_id.clone();
+            let stub_state = Arc::clone(&stub_state);
+            imposter
+                .run_flow_blocking(move |imp| {
+                    imp.apply_scenario_transition(&flow_id, &stub_state.stub)
+                })
+                .await
+        };
+        if let Err(e) = transition {
             return Ok(backend_error_response(&e));
         }
 
@@ -556,10 +567,18 @@ async fn handle_request_inner(
             // already does. A backend failure here must surface, not silently drop to `None`
             // (this epic's "nothing fails silently" principle).
             let scenario_state = match &stub_state.stub.scenario_name {
-                Some(name) => match imposter.scenario_state(&scenario_flow_id, name) {
-                    Ok(s) => Some(s),
-                    Err(e) => return Ok(backend_error_response(&e)),
-                },
+                Some(name) => {
+                    // Same spawn_blocking offload as the FSM gate/transition (issue #475).
+                    let flow_id = scenario_flow_id.clone();
+                    let name = name.clone();
+                    match imposter
+                        .run_flow_blocking(move |imp| imp.scenario_state(&flow_id, &name))
+                        .await
+                    {
+                        Ok(s) => Some(s),
+                        Err(e) => return Ok(backend_error_response(&e)),
+                    }
+                }
                 None => None,
             };
             let ctx_extra = ScriptCtxExtras {

--- a/crates/rift-http-proxy/tests/redis_backend.rs
+++ b/crates/rift-http-proxy/tests/redis_backend.rs
@@ -176,6 +176,25 @@ mod tests {
         );
     }
 
+    // Issue #475: increment_by folds INCRBY + EXPIRE into one EVAL. Mirror the CAS-expiry test to
+    // pin that the EXPIRE arg isn't dropped — a lost EXPIRE would mean unbounded key growth.
+    #[tokio::test]
+    async fn test_redis_increment_by_key_expires() {
+        let Some((_container, store)) = setup(2).await else {
+            return;
+        };
+
+        assert_eq!(store.increment_by("incttl", "n", 5).unwrap(), 5);
+        assert!(store.exists("incttl", "n").unwrap());
+
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        assert_eq!(
+            store.get("incttl", "n").unwrap(),
+            None,
+            "increment_by key must expire with the store TTL (EXPIRE folded into the EVAL)"
+        );
+    }
+
     #[tokio::test]
     async fn test_redis_cas_expected_present_and_conflict() {
         let Some((_container, store)) = setup(300).await else {


### PR DESCRIPTION
Fixes two flow-state perf problems (issue #475):

- **Blocking Redis on tokio workers**: the scenario-FSM flow-store calls (a synchronous r2d2/`redis::Connection` client) ran inline on the request path — a slow/pool-exhausted Redis head-of-line-blocked every task on that worker. Added `FlowStore::is_blocking()` (Redis `true`, in-memory `false`) and route the three FSM sites — the in-matcher eligibility-gate read, the `newScenarioState` transition, and the script-context state read — through `spawn_blocking` only on a blocking backend, staying inline (zero hop) on the in-memory backend. A precomputed `StubIndex::has_scenario_gate` keeps scenario-free requests on the inline fast path even on Redis.
- **Two RTTs per increment**: `RedisFlowStore::increment_by` did INCRBY then a separate EXPIRE; folded into one `EVAL`, mirroring `compare_and_set`.

Tests: in-memory `is_blocking` false; `run_flow_blocking` transparency (inline + off-thread spawn_blocking dispatch, panic→error); `has_scenario_gate` detection; scenario-gated stub matches via the blocking offload; redis `increment_by` TTL (docker-gated). Verification: `cargo clippy -- -D warnings` clean (default + `--features redis-backend`), `cargo test -p rift-core --lib` 999 passed / 0 failed.

Closes #475