### PR TITLE
bug(behaviors): shellTransform runs a blocking subprocess on the tokio worker

### DIFF
--- a/crates/rift-core/src/imposter/handler.rs
+++ b/crates/rift-core/src/imposter/handler.rs
@@ -1000,7 +1000,24 @@ async fn handle_request_inner(
                 // stdout becomes the new body. Runs on the static `is` path too, not only the
                 // proxy path, and independently of copy/lookup/decorate.
                 for cmd in &parsed_behaviors.shell_transform {
-                    match apply_shell_transform(cmd, &request_context, &body, status) {
+                    // Run the fork/exec/wait off the tokio worker (issue #478): a synchronous
+                    // subprocess run inline would stall the worker for its whole lifetime,
+                    // starving unrelated requests multiplexed on it.
+                    let shell_result = {
+                        let cmd = cmd.clone();
+                        let rc = request_context.clone();
+                        let body_in = body.clone();
+                        tokio::task::spawn_blocking(move || {
+                            apply_shell_transform(&cmd, &rc, &body_in, status)
+                        })
+                        .await
+                        .unwrap_or_else(|e| {
+                            Err(std::io::Error::other(format!(
+                                "shellTransform task panicked: {e}"
+                            )))
+                        })
+                    };
+                    match shell_result {
                         Ok(transformed) => body = transformed,
                         // Keep the body unchanged (issue #269) but signal the failure so it
                         // isn't a silent success (issue #323).

--- a/crates/rift-core/src/proxy/handler.rs
+++ b/crates/rift-core/src/proxy/handler.rs
@@ -578,12 +578,26 @@ async fn handle_yaml_rule(
             if let Some(ref bhvs) = behaviors {
                 for cmd in &bhvs.shell_transform {
                     debug!("Applying shell transform: {}", cmd);
-                    match apply_shell_transform(cmd, &request_context, &processed_body, status) {
-                        Ok(transformed) => {
+                    // Off the tokio worker (issue #478): the synchronous subprocess would
+                    // otherwise stall the worker for its whole lifetime.
+                    let shell_result = {
+                        let cmd = cmd.clone();
+                        let rc = request_context.clone();
+                        let body_in = processed_body.clone();
+                        tokio::task::spawn_blocking(move || {
+                            apply_shell_transform(&cmd, &rc, &body_in, status)
+                        })
+                        .await
+                    };
+                    match shell_result {
+                        Ok(Ok(transformed)) => {
                             processed_body = transformed;
                         }
-                        Err(e) => {
+                        Ok(Err(e)) => {
                             warn!("Shell transform failed: {}", e);
+                        }
+                        Err(join_err) => {
+                            warn!("Shell transform task panicked: {}", join_err);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes issue #478: `apply_shell_transform` runs a synchronous `sh -c` fork/exec/wait, and it was called inline in the imposter and proxy async handlers — so once a stub configured `shellTransform`, every matching request stalled its tokio worker for the whole subprocess lifetime, starving unrelated in-flight requests on that worker.

Wrap each call in `tokio::task::spawn_blocking`, cloning the owned inputs (`cmd`, `RequestContext`, body) into the closure. A task panic maps to the same error path as an ordinary command failure — imposter: strictBehaviors 500 + `x-rift-shelltransform-error`; proxy: warn-and-continue. `apply_shell_transform` itself is unchanged, so shellTransform behavior is byte-identical; the only change is the off-thread hop.

Verification: `cargo clippy -- -D warnings` clean, `cargo test -p rift-core --lib` 999 passed / 0 failed, and the shellTransform e2e tests (issue_269 / issue_323 / issue_375, 11 tests) pass.

Closes #478