### PR TITLE
perf(admin): GET /imposters/:port deep-clones the entire request journal (up to 10k entries) on every read, before filtering

### DIFF
--- a/crates/rift-core/src/imposter/core/recording.rs
+++ b/crates/rift-core/src/imposter/core/recording.rs
@@ -41,6 +41,23 @@ impl Imposter {
         read.entries
     }
 
+    /// Recorded requests matching `keep`, filtered over references before cloning so a `?match=`
+    /// query does not deep-clone the whole journal just to discard most of it (issue #485).
+    pub fn get_recorded_requests_filtered<F: Fn(&RecordedRequest) -> bool>(
+        &self,
+        keep: F,
+    ) -> Vec<RecordedRequest> {
+        let read = self.journal.read_filtered(self.journal_port(), &keep);
+        if !read.complete {
+            tracing::warn!(
+                port = self.journal_port(),
+                entries_served = read.entries.len(),
+                "request journal returned an incomplete read; serving partial results"
+            );
+        }
+        read.entries
+    }
+
     /// Clear recorded requests. Also resets the request count to match Mountebank behavior.
     /// Propagates a backend clear failure (issue #330) so callers never report a clean clear
     /// over stale recorded state.

--- a/crates/rift-core/src/imposter/journal.rs
+++ b/crates/rift-core/src/imposter/journal.rs
@@ -37,6 +37,16 @@ pub trait RequestJournal: Send + Sync {
     /// replacing an imposter clears its port slice.
     fn record(&self, port: u16, flow_id: &str, req: RecordedRequest);
     fn read(&self, port: u16) -> JournalRead;
+    /// Like [`read`](Self::read) but keeps only entries matching `keep`. The default filters the
+    /// full read; backends should override to filter over references BEFORE cloning, so a
+    /// `?match=` query does not deep-clone the whole journal just to discard most of it (#485).
+    fn read_filtered(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) -> JournalRead {
+        let read = self.read(port);
+        JournalRead {
+            entries: read.entries.into_iter().filter(|r| keep(r)).collect(),
+            complete: read.complete,
+        }
+    }
     /// Clears entries AND resets the request count (documented contract, as today).
     ///
     /// Fallible: clearing is a correctness operation whose postcondition ("the data is gone")
@@ -108,6 +118,21 @@ impl RequestJournal for LocalJournal {
         }
     }
 
+    fn read_filtered(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) -> JournalRead {
+        // Filter over references under the read lock so only matching entries are cloned (#485).
+        JournalRead {
+            entries: self
+                .slot(port)
+                .entries
+                .read()
+                .iter()
+                .filter(|(_, req)| keep(req))
+                .map(|(_, req)| req.clone())
+                .collect(),
+            complete: true,
+        }
+    }
+
     fn clear(&self, port: u16) -> anyhow::Result<()> {
         let slot = self.slot(port);
         slot.entries.write().clear();
@@ -159,6 +184,35 @@ mod tests {
         assert_eq!(read.entries.len(), MAX_RECORDED_REQUESTS);
         assert_eq!(read.entries[0].path, "/10", "oldest entries evicted first");
         assert!(read.complete, "the local backend is always complete");
+    }
+
+    // Issue #485: read_filtered returns only entries matching the predicate (same result as
+    // read().filter, but the LocalJournal override clones only the matches).
+    #[test]
+    fn local_read_filtered_keeps_only_matches() {
+        let j = LocalJournal::default();
+        j.record(1, "f", req("/keep/1"));
+        j.record(1, "f", req("/drop/1"));
+        j.record(1, "f", req("/keep/2"));
+
+        let read = j.read_filtered(1, &|r| r.path.starts_with("/keep"));
+        let paths: Vec<&str> = read.entries.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(paths, vec!["/keep/1", "/keep/2"]);
+        assert!(read.complete);
+
+        // Parity with read().filter(...) over the same predicate.
+        let via_read: Vec<String> = j
+            .read(1)
+            .entries
+            .into_iter()
+            .filter(|r| r.path.starts_with("/keep"))
+            .map(|r| r.path)
+            .collect();
+        assert_eq!(paths, via_read);
+
+        // An always-false predicate yields nothing; always-true yields all.
+        assert!(j.read_filtered(1, &|_| false).entries.is_empty());
+        assert_eq!(j.read_filtered(1, &|_| true).entries.len(), 3);
     }
 
     // AC1: note_request counts even when nothing is recorded (recording off).

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -9,8 +9,12 @@ use crate::admin_api::types::{
 use crate::extensions::decorate::backend_error_response;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
-    RecordedRequest, ScriptBaseDir, Stub, StubResponse, resolve_scripts,
+    ScriptBaseDir, Stub, StubResponse, resolve_scripts,
 };
+// `RecordedRequest` is only named in tests now that the `/requests` handler filters before
+// cloning via `get_recorded_requests_filtered` (issue #485).
+#[cfg(test)]
+use crate::imposter::RecordedRequest;
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
 use http_body_util::Full;
@@ -535,11 +539,10 @@ pub async fn handle_get_requests(
     match manager.get_imposter(port) {
         Ok(imposter) => {
             let source = flow_id_source(&imposter);
-            let filtered: Vec<RecordedRequest> = imposter
-                .get_recorded_requests()
-                .into_iter()
-                .filter(|r| request_matches(r, &clauses, &source, port))
-                .collect();
+            // Filter over references before cloning so an unmatched journal entry is never
+            // deep-cloned (issue #485).
+            let filtered = imposter
+                .get_recorded_requests_filtered(|r| request_matches(r, &clauses, &source, port));
             json_response(StatusCode::OK, &filtered)
         }
         Err(e) => e.into(),


### PR DESCRIPTION
Fixes issue #485 (the filter-before-clone half): `GET /imposters/:port/requests?match=` deep-cloned every `RecordedRequest` (up to the 10k cap) under the read lock before the match filter discarded most of them.

Adds `RequestJournal::read_filtered(port, keep)` — `LocalJournal` filters over references under the read lock and clones only matches; the trait default clone-then-filters for other backends — and routes `handle_get_requests` through a `get_recorded_requests_filtered` facade. Output is byte-identical (same filtered set, same order); only the clone count drops.

Scoped out (follow-up, needs a compat decision): the generic `GET /imposters/:port` detail embeds all requests unconditionally — reducing that requires a pagination / opt-in API change.

Verification: `cargo clippy -- -D warnings` clean, `cargo test -p rift-core --lib` (journal + full) green, admin `imposters` handler tests (25) green.

Closes #485