### PR TITLE
fix(proxy): predicateGenerators failure/timeout silently records match-all stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ record.
 
 ## [Unreleased]
 
+### Fixed
+- **Proxy `predicateGenerators.inject` failures no longer record a match-all stub** (#498). When an
+  inject predicate generator fails (script error, invalid output, script-pool failure, or timeout),
+  Rift now skips auto-stub creation instead of silently recording a stub with empty predicates that
+  would shadow every future request. The proxied response is still returned and carries an
+  `x-rift-generator-error` header naming the failure. A generator that legitimately returns `[]` is
+  unchanged.
+
 ## [0.12.0] - 2026-07-09
 
 This release lands the scripting developer-experience redesign (Script API v2, file-based

--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -1069,14 +1069,16 @@ mod tests {
         })];
 
         let headers = HashMap::new();
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "GET",
-            "/API/Users",
-            &headers,
-            None,
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(
+                &generators,
+                "GET",
+                "/API/Users",
+                &headers,
+                None,
+                None,
+            )
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let pred_json = &predicates[0];
@@ -1110,14 +1112,9 @@ mod tests {
         })];
 
         let headers = HashMap::new();
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "POST",
-            "/test",
-            &headers,
-            None,
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(&generators, "POST", "/test", &headers, None, None)
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let pred_json = &predicates[0];
@@ -1141,14 +1138,16 @@ mod tests {
         })];
 
         let headers = HashMap::new();
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "GET",
-            "/orders/123",
-            &headers,
-            None,
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(
+                &generators,
+                "GET",
+                "/orders/123",
+                &headers,
+                None,
+                None,
+            )
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let path_val = predicates[0]["equals"]["path"].as_str().unwrap();
@@ -1169,14 +1168,16 @@ mod tests {
         })];
 
         let headers = HashMap::new();
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "POST",
-            "/test",
-            &headers,
-            Some("token=abc123"),
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(
+                &generators,
+                "POST",
+                "/test",
+                &headers,
+                Some("token=abc123"),
+                None,
+            )
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let body_val = predicates[0]["equals"]["body"].as_str().unwrap();
@@ -1196,14 +1197,16 @@ mod tests {
         })];
 
         let headers = HashMap::new();
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "GET",
-            "/search",
-            &headers,
-            None,
-            Some("q=hello&page=1"),
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(
+                &generators,
+                "GET",
+                "/search",
+                &headers,
+                None,
+                Some("q=hello&page=1"),
+            )
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let pred_json = &predicates[0];
@@ -1240,14 +1243,16 @@ mod tests {
         let generators = vec![json!({ "inject": inject_fn })];
         let headers = HashMap::new();
 
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "GET",
-            "/api/users",
-            &headers,
-            None,
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(
+                &generators,
+                "GET",
+                "/api/users",
+                &headers,
+                None,
+                None,
+            )
+            .expect("predicate generation succeeds");
 
         assert_eq!(predicates.len(), 1);
         let equals = predicates[0].get("equals").expect("should have equals key");
@@ -1272,17 +1277,50 @@ mod tests {
         ];
         let headers = HashMap::new();
 
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "POST",
-            "/orders",
-            &headers,
-            None,
-            None,
-        );
+        let predicates = imposter
+            .generate_predicates_from_request(&generators, "POST", "/orders", &headers, None, None)
+            .expect("predicate generation succeeds");
 
         // matches generator produces 1, inject generator returns 2 (original + new path)
         assert_eq!(predicates.len(), 3);
+    }
+
+    // Issue #498: a failing inject generator must be DISTINGUISHABLE from one that legitimately
+    // produced no predicates. A script error surfaces as `Err` (so the caller can skip auto-stub
+    // creation), while an inject that returns `[]` is `Ok(empty)` (a real, intended empty list).
+    #[cfg(feature = "javascript")]
+    #[test]
+    fn generator_inject_failure_is_distinguishable_from_empty() {
+        let imposter = make_test_imposter();
+        let headers = HashMap::new();
+
+        // A throwing inject → Err, NOT an empty predicate list.
+        let throwing = r#"function(config, logger, predicates) { throw new Error("boom"); }"#;
+        let err = imposter
+            .generate_predicates_from_request(
+                &[json!({ "inject": throwing })],
+                "GET",
+                "/api/users",
+                &headers,
+                None,
+                None,
+            )
+            .expect_err("a throwing generator must fail, not silently return empty predicates");
+        assert_eq!(err.kind(), "script-error");
+
+        // An inject that explicitly returns [] is a legitimate empty result → Ok(empty).
+        let empty = r#"function(config, logger, predicates) { return []; }"#;
+        let preds = imposter
+            .generate_predicates_from_request(
+                &[json!({ "inject": empty })],
+                "GET",
+                "/api/users",
+                &headers,
+                None,
+                None,
+            )
+            .expect("an inject returning [] is a valid empty result, not a failure");
+        assert!(preds.is_empty());
     }
 
     #[test]
@@ -1372,23 +1410,19 @@ mod tests {
         );
     }
 
+    // Issue #498: a malformed inject generator (here, a non-function body) must FAIL rather than
+    // silently return an empty predicate list — the empty list is what produced the match-all stub.
     #[cfg(feature = "javascript")]
     #[test]
-    fn test_generator_inject_bad_function_returns_empty() {
+    fn test_generator_inject_bad_function_returns_err() {
         let imposter = make_test_imposter();
 
         let generators = vec![json!({ "inject": "not a function" })];
         let headers = HashMap::new();
 
-        let predicates = imposter.generate_predicates_from_request(
-            &generators,
-            "GET",
-            "/test",
-            &headers,
-            None,
-            None,
-        );
-
-        assert!(predicates.is_empty());
+        let err = imposter
+            .generate_predicates_from_request(&generators, "GET", "/test", &headers, None, None)
+            .expect_err("a malformed inject generator must fail, not return empty predicates");
+        assert_eq!(err.kind(), "script-error");
     }
 }

--- a/crates/rift-core/src/imposter/core/proxy.rs
+++ b/crates/rift-core/src/imposter/core/proxy.rs
@@ -10,7 +10,11 @@ use crate::imposter::predicates::regex_cache::cached_regex;
 type ForwardedResponse = (u16, Vec<(String, String)>, bytes::Bytes, u64);
 
 impl Imposter {
-    /// Generate predicates from request based on predicateGenerators config
+    /// Generate predicates from request based on predicateGenerators config.
+    ///
+    /// Returns `Err` when an `inject` generator could not produce predicates (script/pool/output
+    /// failure) so the caller can skip auto-stub creation instead of silently recording a match-all
+    /// stub (issue #498). An `Ok(empty)` list means the generators legitimately produced nothing.
     pub(crate) fn generate_predicates_from_request(
         &self,
         generators: &[serde_json::Value],
@@ -19,7 +23,7 @@ impl Imposter {
         headers: &HashMap<String, String>,
         body: Option<&str>,
         query: Option<&str>,
-    ) -> Vec<serde_json::Value> {
+    ) -> Result<Vec<serde_json::Value>, crate::scripting::PredicateGeneratorError> {
         Self::generate_predicates_impl(generators, method, path, headers, body, query)
     }
 
@@ -33,7 +37,7 @@ impl Imposter {
         headers: &HashMap<String, String>,
         body: Option<&str>,
         query: Option<&str>,
-    ) -> Vec<serde_json::Value> {
+    ) -> Result<Vec<serde_json::Value>, crate::scripting::PredicateGeneratorError> {
         let mut predicates = Vec::new();
 
         for r#gen in generators {
@@ -58,7 +62,7 @@ impl Imposter {
                         body: body.map(|b| b.to_string()),
                     };
                     let inject_preds =
-                        execute_predicate_generator_inject(inject_fn, &mb_request, &predicates);
+                        execute_predicate_generator_inject(inject_fn, &mb_request, &predicates)?;
                     predicates.extend(inject_preds);
                 }
                 #[cfg(not(feature = "javascript"))]
@@ -196,7 +200,7 @@ impl Imposter {
             predicates.push(serde_json::Value::Object(predicate));
         }
 
-        predicates
+        Ok(predicates)
     }
 
     /// Insert a generated stub at the specified index
@@ -431,7 +435,7 @@ impl Imposter {
         }
         .await;
 
-        let (status, response_headers, body_bytes, latency_ms) = match forwarded {
+        let (status, mut response_headers, body_bytes, latency_ms) = match forwarded {
             Ok(parts) => parts,
             Err(e) => {
                 if let Some(token) = claim_token {
@@ -481,104 +485,112 @@ impl Imposter {
                 .predicate_generators
                 .iter()
                 .any(|g| g.as_object().is_some_and(|o| o.contains_key("inject")));
-            let predicates = if !proxy_config.predicate_generators.is_empty() {
-                if has_inject_generator {
-                    let generators = proxy_config.predicate_generators.clone();
-                    let method = method.to_string();
-                    let path = uri.path().to_string();
-                    let headers = headers.clone();
-                    let body = body.map(str::to_string);
-                    let query = uri.query().map(str::to_string);
-                    let timeout = std::time::Duration::from_millis(
-                        crate::scripting::resolve_script_timeout_ms(&self.config),
-                    );
-                    let handle = tokio::task::spawn_blocking(move || {
-                        Self::generate_predicates_impl(
-                            &generators,
-                            &method,
-                            &path,
-                            &headers,
-                            body.as_deref(),
-                            query.as_deref(),
+            // `Ok(preds)` = predicates generated (possibly legitimately empty); `Err((token, detail))`
+            // = generation failed and predicates are unknown. On failure we must NOT record a stub:
+            // an empty/partial predicate list matches every future request (issue #498). The failure
+            // token is a short, header-safe category surfaced to the client; `detail` goes to the log.
+            let generation: Result<Vec<serde_json::Value>, (&'static str, String)> =
+                if !proxy_config.predicate_generators.is_empty() {
+                    if has_inject_generator {
+                        let generators = proxy_config.predicate_generators.clone();
+                        let method = method.to_string();
+                        let path = uri.path().to_string();
+                        let headers = headers.clone();
+                        let body = body.map(str::to_string);
+                        let query = uri.query().map(str::to_string);
+                        let timeout = std::time::Duration::from_millis(
+                            crate::scripting::resolve_script_timeout_ms(&self.config),
+                        );
+                        let handle = tokio::task::spawn_blocking(move || {
+                            Self::generate_predicates_impl(
+                                &generators,
+                                &method,
+                                &path,
+                                &headers,
+                                body.as_deref(),
+                                query.as_deref(),
+                            )
+                        });
+                        match tokio::time::timeout(timeout, handle).await {
+                            Ok(Ok(Ok(preds))) => Ok(preds),
+                            Ok(Ok(Err(gen_err))) => Err((gen_err.kind(), gen_err.to_string())),
+                            Ok(Err(join_err)) => {
+                                Err(("task-panic", format!("generator task panicked: {join_err}")))
+                            }
+                            Err(_elapsed) => Err((
+                                "timeout",
+                                format!("timed out after {}ms", timeout.as_millis()),
+                            )),
+                        }
+                    } else {
+                        self.generate_predicates_from_request(
+                            &proxy_config.predicate_generators,
+                            method,
+                            uri.path(),
+                            headers,
+                            body,
+                            uri.query(),
                         )
-                    });
-                    match tokio::time::timeout(timeout, handle).await {
-                        Ok(Ok(preds)) => preds,
-                        // Degrade like a failing generator script (warn + skip its output)
-                        // rather than failing the proxied response the client is waiting on.
-                        Ok(Err(join_err)) => {
-                            warn!("predicate generator task panicked: {join_err}");
-                            vec![]
-                        }
-                        Err(_elapsed) => {
-                            warn!(
-                                "predicate generators timed out after {}ms; recording stub \
-                                 without generated predicates",
-                                timeout.as_millis()
-                            );
-                            vec![]
-                        }
+                        .map_err(|e| (e.kind(), e.to_string()))
                     }
                 } else {
-                    self.generate_predicates_from_request(
-                        &proxy_config.predicate_generators,
-                        method,
+                    // No predicateGenerators, generate empty predicates (matches all requests)
+                    Ok(vec![])
+                };
+
+            match generation {
+                Ok(predicates) => {
+                    let latency_for_stub = proxy_config.add_wait_behavior.then_some(latency_ms);
+
+                    // Note: addDecorateBehavior is added to the SAVED stub's behaviors,
+                    // not applied to the first (live proxy) response. This matches Mountebank's
+                    // behavior. The decoration will be applied when the saved stub is used for
+                    // subsequent requests.
+                    let new_stub = create_stub_from_proxy_response(
+                        predicates,
+                        status,
+                        &response_headers,
+                        &body_bytes,
+                        latency_for_stub,
+                        proxy_config.add_decorate_behavior.clone(),
+                        Some(proxy_config.to.clone()),
+                    );
+
+                    // Insert or append the stub based on proxy mode
+                    // proxyOnce: Insert new stub before the proxy stub
+                    // proxyAlways: Append response to existing stub with matching predicates
+                    let mode = if proxy_config.mode.is_empty() {
+                        "proxyOnce"
+                    } else {
+                        &proxy_config.mode
+                    };
+                    self.insert_or_append_proxy_stub(new_stub, &proxy_config.to, mode);
+                    debug!(
+                        "Generated stub from proxy response for path {} (mode: {})",
                         uri.path(),
-                        headers,
-                        body,
-                        uri.query(),
-                    )
+                        mode
+                    );
                 }
-            } else {
-                // No predicateGenerators, generate empty predicates (matches all requests)
-                vec![]
-            };
-
-            let latency_for_stub = if proxy_config.add_wait_behavior {
-                Some(latency_ms)
-            } else {
-                None
-            };
-
-            // Note: addDecorateBehavior is added to the SAVED stub's behaviors,
-            // not applied to the first (live proxy) response. This matches Mountebank's behavior.
-            // The decoration will be applied when the saved stub is used for subsequent requests.
-
-            let new_stub = create_stub_from_proxy_response(
-                predicates,
-                status,
-                &response_headers,
-                &body_bytes,
-                latency_for_stub,
-                proxy_config.add_decorate_behavior.clone(),
-                Some(proxy_config.to.clone()),
-            );
-
-            // Insert or append the stub based on proxy mode
-            // proxyOnce: Insert new stub before the proxy stub
-            // proxyAlways: Append response to existing stub with matching predicates
-            let mode = if proxy_config.mode.is_empty() {
-                "proxyOnce"
-            } else {
-                &proxy_config.mode
-            };
-            self.insert_or_append_proxy_stub(new_stub, &proxy_config.to, mode);
-            debug!(
-                "Generated stub from proxy response for path {} (mode: {})",
-                uri.path(),
-                mode
-            );
+                Err((token, detail)) => {
+                    // Predicate generation failed — record nothing rather than a match-all stub,
+                    // and mark the proxied response so the failure is client-visible, not a
+                    // server-only warn (issue #498).
+                    warn!(
+                        "predicate generation failed for path {} ({detail}); skipping auto-stub to \
+                         avoid recording a match-all stub",
+                        uri.path()
+                    );
+                    response_headers
+                        .push(("x-rift-generator-error".to_string(), token.to_string()));
+                }
+            }
         }
 
         Ok((
             status,
             response_headers,
             body_bytes.to_vec(),
-            if proxy_config.add_wait_behavior {
-                Some(latency_ms)
-            } else {
-                None
-            },
+            proxy_config.add_wait_behavior.then_some(latency_ms),
         ))
     }
 }

--- a/crates/rift-core/src/imposter/tests.rs
+++ b/crates/rift-core/src/imposter/tests.rs
@@ -4269,3 +4269,126 @@ fn script_bearing_stub_forces_http1_only() {
         "a plain is-response stub must not be forced HTTP/1-only"
     );
 }
+
+// Issue #498: a failing `predicateGenerators.inject` during proxy recording must NOT silently
+// record a match-all stub; instead the auto-stub is skipped and the proxied response is tagged
+// with an `x-rift-generator-error` header so the failure is client-visible.
+#[cfg(all(test, feature = "javascript"))]
+mod proxy_generator_failure_tests {
+    use super::*;
+
+    async fn get(port: u16, path: &str) -> reqwest::Response {
+        reqwest::Client::new()
+            .get(format!("http://127.0.0.1:{port}{path}"))
+            .send()
+            .await
+            .expect("send")
+    }
+
+    /// Upstream imposter that returns 200 for `/gen`.
+    async fn upstream(manager: &ImposterManager, port: u16) {
+        let config = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http", "stubs": [
+                { "predicates": [{ "equals": { "path": "/gen" } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "OK" } }] }
+            ]
+        }))
+        .unwrap();
+        manager
+            .create_imposter(config)
+            .await
+            .expect("create upstream");
+    }
+
+    /// Proxy imposter (proxyOnce) whose single stub proxies to `upstream_port` with one inject
+    /// predicate generator. Starts with exactly one stub (the proxy stub itself).
+    async fn proxy_with_generator(
+        manager: &ImposterManager,
+        port: u16,
+        upstream_port: u16,
+        inject_fn: &str,
+    ) {
+        let config = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http",
+            "stubs": [{ "responses": [{ "proxy": {
+                "to": format!("http://127.0.0.1:{upstream_port}"),
+                "mode": "proxyOnce",
+                "predicateGenerators": [{ "inject": inject_fn }]
+            }}]}]
+        }))
+        .unwrap();
+        manager.create_imposter(config).await.expect("create proxy");
+    }
+
+    #[tokio::test]
+    async fn proxy_generator_failure_skips_stub_and_tags_response() {
+        let manager = ImposterManager::new();
+        upstream(&manager, 19820).await;
+        // A throwing generator: predicates cannot be produced.
+        let throwing = r#"function(config, logger, predicates) { throw new Error("boom"); }"#;
+        proxy_with_generator(&manager, 19821, 19820, throwing).await;
+
+        let resp = get(19821, "/gen").await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "proxied response still returned to client"
+        );
+        assert_eq!(
+            resp.headers()
+                .get("x-rift-generator-error")
+                .and_then(|v| v.to_str().ok()),
+            Some("script-error"),
+            "a generator failure must be surfaced to the client, not only logged"
+        );
+        assert_eq!(resp.text().await.unwrap(), "OK");
+
+        // The proxy imposter must still have ONLY its original proxy stub — no match-all stub
+        // was recorded from the failed generation.
+        let stubs = manager.get_imposter(19821).unwrap().get_stubs();
+        assert_eq!(
+            stubs.len(),
+            1,
+            "no auto-stub may be recorded when predicate generation fails (issue #498)"
+        );
+
+        let _ = manager.delete_imposter(19820).await;
+        let _ = manager.delete_imposter(19821).await;
+    }
+
+    #[tokio::test]
+    async fn proxy_generator_success_records_stub() {
+        let manager = ImposterManager::new();
+        upstream(&manager, 19822).await;
+        // Control: a valid generator produces a real predicate → stub IS recorded, no error header.
+        let ok_fn = r#"function(config, logger, predicates) {
+            return [{ equals: { path: config.request.path } }];
+        }"#;
+        proxy_with_generator(&manager, 19823, 19822, ok_fn).await;
+
+        let resp = get(19823, "/gen").await;
+        assert_eq!(resp.status(), 200);
+        assert!(
+            resp.headers().get("x-rift-generator-error").is_none(),
+            "a successful generator must not tag the response with an error header"
+        );
+        assert_eq!(resp.text().await.unwrap(), "OK");
+
+        // proxyOnce inserts the generated stub before the proxy stub → 2 stubs total, and the
+        // generated stub carries the intended path predicate (not a match-all).
+        let stubs = manager.get_imposter(19823).unwrap().get_stubs();
+        assert_eq!(
+            stubs.len(),
+            2,
+            "a valid generator records exactly one new stub"
+        );
+        let generated = serde_json::to_value(&stubs[0]).unwrap();
+        assert_eq!(
+            generated["predicates"][0]["equals"]["path"], "/gen",
+            "recorded stub matches the generated predicate, not everything"
+        );
+
+        let _ = manager.delete_imposter(19822).await;
+        let _ = manager.delete_imposter(19823).await;
+    }
+}

--- a/crates/rift-core/src/scripting/js_engine.rs
+++ b/crates/rift-core/src/scripting/js_engine.rs
@@ -1,7 +1,7 @@
 use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result};
 use crate::scripting::{
-    FaultDecision, ScriptCtxExtras, ScriptCtxInput, ScriptRequest, ScriptResponseContext,
-    ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
+    FaultDecision, PredicateGeneratorError, ScriptCtxExtras, ScriptCtxInput, ScriptRequest,
+    ScriptResponseContext, ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
 };
 use anyhow::{Result, anyhow};
 use boa_engine::{
@@ -2036,18 +2036,15 @@ pub fn execute_predicate_generator_inject(
     inject_fn: &str,
     request: &MountebankRequest,
     existing_predicates: &[serde_json::Value],
-) -> Vec<serde_json::Value> {
+) -> Result<Vec<serde_json::Value>, PredicateGeneratorError> {
     let inject_fn = inject_fn.to_string();
     let request = request.clone();
     let existing_predicates = existing_predicates.to_vec();
     match with_mb_js_thread(move |thread| {
         execute_predicate_generator_inject_in(thread, &inject_fn, &request, &existing_predicates)
     }) {
-        Ok(predicates) => predicates,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: script pool failure: {e}");
-            Vec::new()
-        }
+        Ok(result) => result,
+        Err(e) => Err(PredicateGeneratorError::Pool(e.to_string())),
     }
 }
 
@@ -2056,35 +2053,23 @@ fn execute_predicate_generator_inject_in(
     inject_fn: &str,
     request: &MountebankRequest,
     existing_predicates: &[serde_json::Value],
-) -> Vec<serde_json::Value> {
+) -> Result<Vec<serde_json::Value>, PredicateGeneratorError> {
     let MbJsThread { context, scripts } = thread;
 
-    let request_obj = match create_mountebank_request_object(&mut *context, request) {
-        Ok(obj) => obj,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: failed to build request object: {e}");
-            return Vec::new();
-        }
-    };
+    let request_obj = create_mountebank_request_object(&mut *context, request).map_err(|e| {
+        PredicateGeneratorError::Script(format!("failed to build request object: {e}"))
+    })?;
 
-    let predicates_val =
-        match json_to_js(&mut *context, &Value::Array(existing_predicates.to_vec())) {
-            Ok(obj) => obj,
-            Err(e) => {
-                tracing::warn!("predicateGenerator inject: failed to build predicates array: {e}");
-                return Vec::new();
-            }
-        };
+    let predicates_val = json_to_js(&mut *context, &Value::Array(existing_predicates.to_vec()))
+        .map_err(|e| {
+            PredicateGeneratorError::Script(format!("failed to build predicates array: {e}"))
+        })?;
 
     // No imposter is running yet during proxy recording, so there is no per-port state to tag
     // the logger with (port 0 placeholder) and no stub id exists yet (stub_id left None).
-    let logger_obj = match create_script_logger_object(&mut *context, 0, None) {
-        Ok(obj) => obj,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: failed to build logger object: {e}");
-            return Vec::new();
-        }
-    };
+    let logger_obj = create_script_logger_object(&mut *context, 0, None).map_err(|e| {
+        PredicateGeneratorError::Script(format!("failed to build logger object: {e}"))
+    })?;
 
     let global = context.global_object();
     let _ = global.set(js_string!("__request"), request_obj, false, &mut *context);
@@ -2105,31 +2090,21 @@ fn execute_predicate_generator_inject_in(
         "#
     );
 
-    let result = match eval_mb_script(context, scripts, &wrapper_script) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: script execution error: {e}");
-            return Vec::new();
-        }
-    };
+    let result = eval_mb_script(context, scripts, &wrapper_script)
+        .map_err(|e| PredicateGeneratorError::Script(format!("script execution error: {e}")))?;
 
-    let json_str = match result.as_string() {
-        Some(s) => s.to_std_string_lossy(),
-        None => {
-            tracing::warn!(
-                "predicateGenerator inject: function did not return a stringifiable value"
-            );
-            return Vec::new();
-        }
-    };
+    let json_str = result
+        .as_string()
+        .map(|s| s.to_std_string_lossy())
+        .ok_or_else(|| {
+            PredicateGeneratorError::Output(
+                "function did not return a stringifiable value".to_string(),
+            )
+        })?;
 
-    match serde_json::from_str::<Vec<serde_json::Value>>(&json_str) {
-        Ok(preds) => preds,
-        Err(e) => {
-            tracing::warn!("predicateGenerator inject: failed to parse returned predicates: {e}");
-            Vec::new()
-        }
-    }
+    serde_json::from_str::<Vec<serde_json::Value>>(&json_str).map_err(|e| {
+        PredicateGeneratorError::Output(format!("failed to parse returned predicates: {e}"))
+    })
 }
 
 /// Request structure for Mountebank inject functions
@@ -3406,6 +3381,67 @@ function respond(ctx) {
             result.err()
         );
         assert_eq!(result.unwrap().body, "logged");
+    }
+
+    // Issue #498: a `predicateGenerators.inject` script error must return `Err(Script)` — NOT a
+    // silent empty Vec that the proxy path would turn into a match-all stub.
+    #[test]
+    fn predicate_generator_inject_script_error_returns_err() {
+        let request = MountebankRequest {
+            method: "GET".to_string(),
+            path: "/api/users".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+
+        let throwing = r#"function(config, logger, predicates) { throw new Error("boom"); }"#;
+        let err = execute_predicate_generator_inject(throwing, &request, &[])
+            .expect_err("a throwing generator must return Err, not empty predicates");
+        assert!(
+            matches!(err, PredicateGeneratorError::Script(_)),
+            "expected Script error, got {err:?}"
+        );
+
+        let ok_fn = r#"function(config, logger, predicates) {
+            return [{ equals: { path: config.request.path } }];
+        }"#;
+        let preds = execute_predicate_generator_inject(ok_fn, &request, &[])
+            .expect("a valid generator returns Ok");
+        assert_eq!(preds.len(), 1);
+    }
+
+    // Issue #498: a generator that EVALUATES fine but returns garbage (a non-array, or nothing) must
+    // map to `Err(Output)` — the pre-fix code degraded both to an empty Vec, silently recording a
+    // match-all stub. Same failure class as a thrown error, via a different arm.
+    #[test]
+    fn predicate_generator_inject_invalid_output_returns_err() {
+        let request = MountebankRequest {
+            method: "GET".to_string(),
+            path: "/api/users".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+        };
+
+        // Returns a number → JSON.stringify gives "5", which does not parse as a predicate array.
+        let non_array = r#"function(config, logger, predicates) { return 5; }"#;
+        let err = execute_predicate_generator_inject(non_array, &request, &[])
+            .expect_err("a non-array return must fail, not silently produce empty predicates");
+        assert!(
+            matches!(err, PredicateGeneratorError::Output(_)),
+            "expected Output error, got {err:?}"
+        );
+
+        // Returns undefined → not stringifiable at all.
+        let no_return = r#"function(config, logger, predicates) { return undefined; }"#;
+        let err = execute_predicate_generator_inject(no_return, &request, &[]).expect_err(
+            "a non-stringifiable return must fail, not silently produce empty predicates",
+        );
+        assert!(
+            matches!(err, PredicateGeneratorError::Output(_)),
+            "expected Output error, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/rift-core/src/scripting/mod.rs
+++ b/crates/rift-core/src/scripting/mod.rs
@@ -75,6 +75,39 @@ pub use entrypoint_check::{EntrypointCheckError, EntrypointMatch, check_entrypoi
 mod trace;
 pub use trace::{ScriptTraceEntry, cap_trace_logs, capture_script_logs, render_decision};
 
+/// Failure of a `predicateGenerators.inject` pass during proxy recording (issue #498).
+///
+/// Distinguishes "predicates could NOT be generated" (infrastructure, script, or malformed
+/// output) from a generator legitimately returning an empty list. Without this distinction the
+/// proxy-recording path collapsed every failure to an empty predicate list and silently recorded
+/// a match-all stub; carrying the failure as an error lets the caller skip auto-stub creation.
+/// Defined unconditionally so the proxy signature resolves without the `javascript` feature.
+#[derive(Debug, thiserror::Error)]
+pub enum PredicateGeneratorError {
+    /// The MB script pool could not run the generator (infrastructure failure).
+    #[error("script pool failure: {0}")]
+    Pool(String),
+    /// The generator script errored while executing.
+    #[error("script execution error: {0}")]
+    Script(String),
+    /// The generator ran but did not return a usable predicate array.
+    #[error("generator produced invalid output: {0}")]
+    Output(String),
+}
+
+impl PredicateGeneratorError {
+    /// Short, stable, header-safe token for the `x-rift-generator-error` response header
+    /// (the full detail goes to the server log, not to the client).
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Pool(_) => "pool-failure",
+            Self::Script(_) => "script-error",
+            Self::Output(_) => "invalid-output",
+        }
+    }
+}
+
 /// Script execution result for fault injection decisions
 #[derive(Debug, Clone)]
 

--- a/docs/mountebank/proxy.md
+++ b/docs/mountebank/proxy.md
@@ -137,6 +137,21 @@ This generates stubs that match method and path, ignoring query and body.
 }
 ```
 
+### Generation Failures
+
+A predicate generator can also be an [`inject`](../features/scripting.md) function that builds
+predicates in JavaScript. If that generation **fails** — the script throws, returns something other
+than a predicate array, the script pool is unavailable, or it exceeds the script timeout — Rift does
+**not** record a stub. Recording a stub with the empty/partial predicate list would produce a
+match-all stub that shadows every future request, so the failure is surfaced instead of hidden:
+
+- **no stub is recorded** for that request (the proxied response is still returned to the client), and
+- the proxied response carries an `x-rift-generator-error` header whose value names the failure —
+  `script-error`, `invalid-output`, `pool-failure`, `timeout`, or `task-panic`.
+
+A generator that legitimately returns an empty array (`[]`) is **not** a failure — it records a
+match-all stub as before. Only genuine generation failures skip recording and set the header.
+
 ---
 
 ## Recording Workflow


### PR DESCRIPTION
When an inject predicate generator fails (script error, invalid output, script-pool failure, or timeout), Rift now skips auto-stub creation instead of silently recording a stub that matches every request. The proxied response is still returned with an `x-rift-generator-error` header naming the failure. A generator that legitimately returns `[]` is unchanged.

Closes #498
Milestone: standalone (agent-found)

Test-coverage note: The timeout/task-panic/pool-failure header tokens are logic-only branches (not deterministically testable without test-only hooks); script-error and invalid-output failure modes are covered by unit and integration tests.