### PR TITLE
ffi: allowInjection option for rift_serve_admin — fix FFI/admin-plane injection asymmetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Run handler error-response integration tests
         run: cargo test -p rift-core --all-features --test handler_error_responses
 
+      # Issue #492: the C-ABI round-trip integration tests (including the allowInjection admin-plane
+      # gate) live in a tests/*.rs binary the `--lib` step skips, so run them explicitly — otherwise
+      # the FFI option wiring has no CI regression signal.
+      - name: Run rift-ffi C-ABI round-trip tests
+        run: cargo test -p rift-ffi --all-features --test round_trip
+
       # Issue #344: a pinned cbindgen so the header regenerate-diff in the smoke test is
       # deterministic (cbindgen output varies across versions) and actually runs (the step
       # skips the diff when cbindgen is absent). Keep the version in sync with the header's.

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -166,6 +166,10 @@ struct ServeOptions {
     metrics_port: Option<u16>,
     config_file: Option<String>,
     config: Option<Value>,
+    /// Gate script/inject imposters submitted THROUGH the admin plane (issue #492). Default false,
+    /// preserving the previous behavior. Direct FFI calls (`rift_create_imposter`, …) are ungated
+    /// by design — the host process is already trusted; this only governs the in-process admin API.
+    allow_injection: Option<bool>,
 }
 
 /// Parse `{"imposters":[...]}` or a bare `[...]` into imposter configs (the reload input shape).
@@ -1125,7 +1129,8 @@ async fn build_admin_plane(
         None => None,
     };
 
-    let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key);
+    let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key)
+        .with_allow_injection(opts.allow_injection.unwrap_or(false));
     if let Some(source) = config_source {
         server = server.with_config_source(source);
     }
@@ -1346,5 +1351,36 @@ mod panic_safety_tests {
         let msg = unsafe { CStr::from_ptr(err).to_string_lossy().into_owned() };
         unsafe { rift_free(err) };
         assert_eq!(msg, "pending-error");
+    }
+}
+
+#[cfg(test)]
+mod serve_options_tests {
+    use super::*;
+
+    // Issue #492: rift_serve_admin gains an `allowInjection` option (camelCase) that gates
+    // script imposters on the embedded admin plane. It must parse to the typed field and default
+    // to None (→ false at the call site) when absent, preserving prior behavior.
+    #[test]
+    fn serve_options_parses_allow_injection() {
+        let on: ServeOptions =
+            serde_json::from_str(r#"{"allowInjection": true}"#).expect("parse allowInjection");
+        assert_eq!(on.allow_injection, Some(true));
+
+        let off: ServeOptions =
+            serde_json::from_str(r#"{"allowInjection": false}"#).expect("parse allowInjection");
+        assert_eq!(off.allow_injection, Some(false));
+
+        let absent: ServeOptions = serde_json::from_str("{}").expect("parse empty options");
+        assert_eq!(
+            absent.allow_injection, None,
+            "absent allowInjection must default to None (false at the call site)"
+        );
+
+        // A wrong-type value is a surfaced serde error, not a silent coercion (like the other opts).
+        assert!(
+            serde_json::from_str::<ServeOptions>(r#"{"allowInjection": "yes"}"#).is_err(),
+            "a non-bool allowInjection must be a parse error, not silently coerced"
+        );
     }
 }

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -205,6 +205,109 @@ fn ffi_serve_admin_exposes_manager_and_control_plane() {
     }
 }
 
+// Issue #492: `allowInjection` in the rift_serve_admin options gates script imposters submitted
+// THROUGH the admin plane. With it set, an inject imposter POSTed to the admin API is accepted;
+// with the default (off), the same POST is rejected with the Mountebank "invalid injection" error.
+// (Direct FFI creation is ungated by design and is not exercised here.)
+#[test]
+fn ffi_serve_admin_allow_injection_gates_the_admin_plane() {
+    unsafe {
+        let inject_imposter = serde_json::json!({
+            "port": 19972, "protocol": "http",
+            "stubs": [{ "responses": [{ "inject": "function (config) { return { statusCode: 200, body: 'hi' }; }" }] }]
+        });
+
+        // allowInjection: true → the admin plane accepts the script imposter.
+        let h_on = rift_start();
+        let admin_on = serve_admin(h_on, r#"{"allowInjection": true}"#);
+        let url_on = admin_on["adminUrl"].as_str().expect("adminUrl").to_string();
+        rt().block_on(async {
+            let resp = reqwest::Client::new()
+                .post(format!("{url_on}/imposters"))
+                .json(&inject_imposter)
+                .send()
+                .await
+                .expect("admin POST reachable");
+            assert!(
+                resp.status().is_success(),
+                "allowInjection=true must accept a script imposter over the admin plane, got {}",
+                resp.status()
+            );
+        });
+        rift_stop(h_on);
+
+        // Default (allowInjection absent → false) → the same POST is rejected as invalid injection.
+        let h_off = rift_start();
+        let admin_off = serve_admin(h_off, "{}");
+        let url_off = admin_off["adminUrl"]
+            .as_str()
+            .expect("adminUrl")
+            .to_string();
+        rt().block_on(async {
+            let mut reject = inject_imposter.clone();
+            reject["port"] = serde_json::json!(19973);
+            let resp = reqwest::Client::new()
+                .post(format!("{url_off}/imposters"))
+                .json(&reject)
+                .send()
+                .await
+                .expect("admin POST reachable");
+            assert_eq!(
+                resp.status(),
+                400,
+                "default (no allowInjection) must reject a script imposter"
+            );
+            let body: serde_json::Value = resp.json().await.expect("json error body");
+            assert_eq!(
+                body["errors"][0]["code"], "invalid injection",
+                "rejection must be the Mountebank invalid-injection error, got: {body}"
+            );
+        });
+        rift_stop(h_off);
+    }
+}
+
+// Issue #492: `allowInjection` gates only imposters submitted THROUGH the running admin plane.
+// A script imposter supplied via rift_serve_admin's own `config` (startup) is applied directly by
+// the manager — the trusted host path — so it is created even with allowInjection off. This pins
+// that intentional asymmetry so a future change can't silently start gating the startup path.
+#[test]
+fn ffi_serve_admin_inline_config_inject_is_ungated() {
+    unsafe {
+        let h = rift_start();
+        let admin = serve_admin(
+            h,
+            r#"{"allowInjection": false, "config": {"imposters": [
+                {"port": 19974, "protocol": "http",
+                 "stubs": [{"responses": [{"inject": "function (config) { return { statusCode: 200, body: 'hi' }; }"}]}]}
+            ]}}"#,
+        );
+        let admin_url = admin["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("admin /imposters reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("imposters array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(
+                ports.contains(&19974),
+                "an inject imposter from the startup `config` must be created even with \
+                 allowInjection off (the trusted host path is ungated), got ports: {ports:?}"
+            );
+        });
+
+        rift_stop(h);
+    }
+}
+
 // AC2: rift_apply_config returns the reload report field names; failed is [{port,error}]; an
 // up-front validation failure returns NULL, sets last_error, and mutates nothing.
 #[test]

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -85,9 +85,15 @@ rift_free(result);
 ```
 
 - **Options JSON** (pass `NULL` or `{}` for all defaults; every field optional):
-  `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null}`.
+  `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false}`.
   `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
   `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
+- **`allowInjection`** (default `false`): whether the admin plane accepts script/`inject` imposters
+  submitted **through it** (`POST /imposters` etc.), mirroring the `--allowInjection` CLI flag.
+  Note the deliberate asymmetry: **direct FFI calls** (`rift_create_imposter`, `rift_replace_stubs`,
+  …) are **ungated** — the host process is already trusted, so script imposters always work over the
+  C-ABI. `allowInjection` only governs the in-process HTTP admin surface; leave it `false` unless you
+  expose that surface to less-trusted callers and want script imposters permitted there too.
 - **Returns** (caller frees): `{"adminPort":...,"adminUrl":"...","metricsPort":...}`, or `NULL` on
   error (bad JSON, bind failure, or already serving — one admin plane per handle).
 


### PR DESCRIPTION
## Summary

The embedded admin plane started by rift_serve_admin defaulted allowInjection to false with no way to change it, so a script/inject imposter POSTed through that plane was rejected even though the host process can create one directly over the C-ABI. Add an allowInjection option (default false) to the rift_serve_admin options JSON, wired to AdminApiServer::with_allow_injection. Direct FFI calls remain ungated by design. Includes a CI step to run the rift-ffi round-trip integration tests, which the --lib job otherwise skips.

Closes #492

Milestone: SDK-M0 (engine prerequisite, #458)