### PR TITLE
feat(admin,ffi): server-side verification endpoint — POST /imposters/{port}/verify with closest-match details

### DIFF
--- a/crates/rift-core/src/imposter/core/mod.rs
+++ b/crates/rift-core/src/imposter/core/mod.rs
@@ -512,6 +512,8 @@ use stub_index::StubIndex;
 mod proxy;
 mod recording;
 mod responses;
+mod verify;
+pub use verify::{ClosestMatch, FailedPredicate, VerifyOptions, VerifyOutcome};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rift-core/src/imposter/core/verify.rs
+++ b/crates/rift-core/src/imposter/core/verify.rs
@@ -1,0 +1,535 @@
+//! Server-side verification (issue #494): count — and optionally return — recorded requests
+//! matching a predicate set, with an optional closest non-match diff.
+//!
+//! This reuses the one true predicate evaluator (`stub_matches_inner`) and the recorded-request
+//! store rather than reimplementing matching per SDK, so `verify(match, times(n))` in every SDK
+//! can defer to the engine instead of shipping the whole journal over the wire and re-evaluating
+//! predicates client-side (where `xpath`/`inject` are impractical).
+
+use super::Imposter;
+use crate::imposter::predicates::stub_matches_inner;
+use crate::imposter::types::{Predicate, PredicateOperation, RecordedRequest};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+
+/// Verification request — the body of `POST /imposters/{port}/verify`. `predicates` are AND'd
+/// (the same implicit-AND the request hot path applies to a stub's predicates).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyOptions {
+    #[serde(default)]
+    pub predicates: Vec<Predicate>,
+    /// Scope the count to one space, resolved via the imposter's `flow_id_source` — the same
+    /// scoping `GET /savedRequests?match=flow_id=…` applies.
+    #[serde(default)]
+    pub flow_id: Option<String>,
+    /// Return the matching requests, not just the count.
+    #[serde(default)]
+    pub include_requests: bool,
+    /// Return the best-scoring non-match with per-clause failure details (for diff rendering).
+    #[serde(default)]
+    pub include_closest: bool,
+}
+
+/// Verification result. `requests`/`closest` are present only when the corresponding option was set.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyOutcome {
+    /// Recorded requests (in flow scope) matching every predicate.
+    pub matched: usize,
+    /// Total recorded requests in flow scope, matched or not.
+    pub total: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<Vec<RecordedRequest>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closest: Option<ClosestMatch>,
+}
+
+/// The non-matching request that satisfied the most predicate clauses, with the clauses it failed.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClosestMatch {
+    pub request: RecordedRequest,
+    pub failed_predicates: Vec<FailedPredicate>,
+}
+
+/// One predicate the closest request failed, paired with the request's actual value(s) for the
+/// fields that predicate references — the raw material for a readable diff.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedPredicate {
+    pub predicate: Predicate,
+    pub actual: Value,
+}
+
+impl Imposter {
+    /// Count (and optionally return) recorded requests matching every predicate, scoped to
+    /// `flow_id` when set. Reuses the live predicate evaluator and recorded-request store — no new
+    /// state. An `inject` predicate that fails propagates as `Err` (the issue #440 contract the
+    /// request hot path also honors) rather than being silently counted as a non-match.
+    pub fn verify(&self, opts: &VerifyOptions) -> anyhow::Result<VerifyOutcome> {
+        let scoped = self.get_recorded_requests_filtered(|r| match &opts.flow_id {
+            Some(flow_id) => self.resolve_flow_id_recorded(&r.headers) == *flow_id,
+            None => true,
+        });
+        let total = scoped.len();
+
+        let mut matched = Vec::new();
+        let mut non_matches = Vec::new();
+        for req in scoped {
+            if self.request_matches_predicates(&req, &opts.predicates)? {
+                matched.push(req);
+            } else if opts.include_closest {
+                non_matches.push(req);
+            }
+        }
+
+        let closest = if opts.include_closest {
+            self.closest_non_match(non_matches, &opts.predicates)?
+        } else {
+            None
+        };
+
+        let matched_count = matched.len();
+        Ok(VerifyOutcome {
+            matched: matched_count,
+            total,
+            requests: opts.include_requests.then_some(matched),
+            closest,
+        })
+    }
+
+    /// Evaluate all `predicates` (implicit AND) against a recorded request, adapting the stored
+    /// shape back to the matcher's inputs: the multi-value header map collapses to the single-value
+    /// view live matching uses, and the already-parsed query map is threaded directly so no query
+    /// string is re-encoded.
+    fn request_matches_predicates(
+        &self,
+        req: &RecordedRequest,
+        predicates: &[Predicate],
+    ) -> anyhow::Result<bool> {
+        let headers = collapse_headers(&req.headers);
+        let form = Self::parse_form_data(&headers, req.body.as_deref());
+        let body_json = req
+            .body
+            .as_deref()
+            .and_then(|b| serde_json::from_str::<Value>(b).ok());
+        let client_ip = client_ip_of(req);
+        stub_matches_inner(
+            predicates,
+            &req.method,
+            &req.path,
+            None,
+            &headers,
+            req.body.as_deref(),
+            Some(&req.request_from),
+            client_ip.as_deref(),
+            form.as_ref(),
+            self.script_state_key(),
+            body_json.as_ref(),
+            Some(&req.query),
+        )
+    }
+
+    /// The non-matching request satisfying the most top-level predicate clauses (ties → most
+    /// recent, i.e. latest in the oldest-first journal), with the per-clause failure details a
+    /// caller renders as a diff. `None` when there are no non-matches or no predicates to score.
+    fn closest_non_match(
+        &self,
+        non_matches: Vec<RecordedRequest>,
+        predicates: &[Predicate],
+    ) -> anyhow::Result<Option<ClosestMatch>> {
+        if non_matches.is_empty() || predicates.is_empty() {
+            return Ok(None);
+        }
+
+        let mut best: Option<(usize, RecordedRequest)> = None;
+        for req in non_matches {
+            let mut satisfied = 0;
+            for predicate in predicates {
+                if self.request_matches_predicates(&req, std::slice::from_ref(predicate))? {
+                    satisfied += 1;
+                }
+            }
+            // `>=` so a later (more recent — the journal is oldest-first) request wins on a tie.
+            let replace = match &best {
+                None => true,
+                Some((best_score, _)) => satisfied >= *best_score,
+            };
+            if replace {
+                best = Some((satisfied, req));
+            }
+        }
+
+        let (_, request) = best.expect("non_matches is non-empty");
+        let mut failed_predicates = Vec::new();
+        for predicate in predicates {
+            if !self.request_matches_predicates(&request, std::slice::from_ref(predicate))? {
+                failed_predicates.push(FailedPredicate {
+                    predicate: predicate.clone(),
+                    actual: actual_projection(&request, predicate),
+                });
+            }
+        }
+        Ok(Some(ClosestMatch {
+            request,
+            failed_predicates,
+        }))
+    }
+}
+
+/// The client IP an `ip` predicate matches against, recovered from the recorded `request_from`
+/// (`ip:port`). Live matching passes `client_addr.ip()` separately from `request_from`; the journal
+/// stores only the combined `ip:port`, so parse it back to a `SocketAddr` and take the IP. `None`
+/// (compared against `""`, never matching) only when `request_from` isn't a parseable socket
+/// address — the same "no client info" outcome the convenience matcher path produces.
+fn client_ip_of(req: &RecordedRequest) -> Option<String> {
+    req.request_from
+        .parse::<std::net::SocketAddr>()
+        .ok()
+        .map(|addr| addr.ip().to_string())
+}
+
+/// Collapse the recorded multi-value header map to the single-value view the matcher expects,
+/// taking the last value per header to mirror how live matching's single-value map is built (a
+/// `HashMap` collect over the request headers keeps the last of duplicate-named headers).
+fn collapse_headers(headers: &HashMap<String, Vec<String>>) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(k, v)| v.last().map(|last| (k.clone(), last.clone())))
+        .collect()
+}
+
+/// The request's actual values for the fields a failed predicate references, as a JSON object —
+/// the raw material for a readable diff. For a field-based op (`equals`/`contains`/…) only the
+/// referenced fields are projected; for a compound (`and`/`or`/`not`), an `inject`, or a
+/// selector-based predicate no single field is implicated, so the whole request is returned.
+fn actual_projection(req: &RecordedRequest, predicate: &Predicate) -> Value {
+    if predicate.parameters.selector.is_some() {
+        return request_view(req);
+    }
+    let fields = match &predicate.operation {
+        PredicateOperation::Equals(f)
+        | PredicateOperation::DeepEquals(f)
+        | PredicateOperation::Contains(f)
+        | PredicateOperation::StartsWith(f)
+        | PredicateOperation::EndsWith(f)
+        | PredicateOperation::Matches(f)
+        | PredicateOperation::Exists(f) => f,
+        PredicateOperation::Not(_)
+        | PredicateOperation::Or(_)
+        | PredicateOperation::And(_)
+        | PredicateOperation::Inject(_) => return request_view(req),
+    };
+    let mut out = Map::new();
+    for key in fields.keys() {
+        if let Some(value) = request_field(req, key) {
+            out.insert(key.clone(), value);
+        }
+    }
+    Value::Object(out)
+}
+
+/// A canonical JSON view of the whole recorded request (used when a predicate implicates no single
+/// field).
+fn request_view(req: &RecordedRequest) -> Value {
+    let mut m = Map::new();
+    m.insert("method".to_string(), json!(req.method));
+    m.insert("path".to_string(), json!(req.path));
+    m.insert("query".to_string(), json!(req.query));
+    m.insert("headers".to_string(), json!(req.headers));
+    m.insert("requestFrom".to_string(), json!(req.request_from));
+    if let Some(body) = &req.body {
+        m.insert("body".to_string(), json!(body));
+    }
+    Value::Object(m)
+}
+
+/// The recorded request's value for a single predicate field key (Mountebank field names).
+fn request_field(req: &RecordedRequest, key: &str) -> Option<Value> {
+    match key {
+        "method" => Some(json!(req.method)),
+        "path" => Some(json!(req.path)),
+        "query" => Some(json!(req.query)),
+        "headers" => Some(json!(req.headers)),
+        "body" => Some(json!(req.body)),
+        "requestFrom" => Some(json!(req.request_from)),
+        // The `ip` predicate matches against the bare IP (`client_ip_of`), so report that as the
+        // actual — not the `ip:port` `request_from` the matcher never compares against.
+        "ip" => Some(json!(client_ip_of(req).unwrap_or_default())),
+        "form" => {
+            let headers = collapse_headers(&req.headers);
+            Some(json!(
+                Imposter::parse_form_data(&headers, req.body.as_deref()).unwrap_or_default()
+            ))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imposter::types::ImposterConfig;
+    use serde_json::json;
+
+    fn imposter(flow_id_source: Option<&str>) -> Imposter {
+        let mut cfg = json!({ "port": 0, "protocol": "http", "recordRequests": true, "stubs": [] });
+        if let Some(src) = flow_id_source {
+            cfg["_rift"] = json!({ "flowState": { "flowIdSource": src } });
+        }
+        let config: ImposterConfig = serde_json::from_value(cfg).expect("config");
+        Imposter::new(config).expect("imposter")
+    }
+
+    fn rec(
+        method: &str,
+        path: &str,
+        headers: &[(&str, &str)],
+        body: Option<&str>,
+    ) -> RecordedRequest {
+        let mut hs: HashMap<String, Vec<String>> = HashMap::new();
+        for (k, v) in headers {
+            hs.entry((*k).to_string())
+                .or_default()
+                .push((*v).to_string());
+        }
+        RecordedRequest {
+            request_from: "127.0.0.1:5000".to_string(),
+            method: method.to_string(),
+            path: path.to_string(),
+            query: HashMap::new(),
+            headers: hs,
+            body: body.map(str::to_string),
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn preds(v: Value) -> Vec<Predicate> {
+        serde_json::from_value(v).expect("predicates")
+    }
+
+    #[test]
+    fn matched_and_total_count_all_predicates_anded() {
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/a", &[], None));
+        imp.record_request(&rec("POST", "/a", &[], None));
+        imp.record_request(&rec("GET", "/b", &[], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "method": "GET", "path": "/a" } }])),
+            ..Default::default()
+        };
+        let out = imp.verify(&opts).expect("verify");
+        assert_eq!(out.total, 3);
+        assert_eq!(out.matched, 1);
+        assert!(out.requests.is_none(), "requests omitted unless requested");
+        assert!(out.closest.is_none(), "closest omitted unless requested");
+    }
+
+    #[test]
+    fn empty_predicates_match_everything() {
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/a", &[], None));
+        imp.record_request(&rec("GET", "/b", &[], None));
+        let out = imp.verify(&VerifyOptions::default()).expect("verify");
+        assert_eq!(out.matched, 2);
+        assert_eq!(out.total, 2);
+    }
+
+    #[test]
+    fn include_requests_returns_the_matching_requests() {
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/keep", &[], None));
+        imp.record_request(&rec("GET", "/drop", &[], None));
+        imp.record_request(&rec("GET", "/keep", &[], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "path": "/keep" } }])),
+            include_requests: true,
+            ..Default::default()
+        };
+        let out = imp.verify(&opts).expect("verify");
+        let reqs = out.requests.expect("requests present");
+        assert_eq!(reqs.len(), 2);
+        assert!(reqs.iter().all(|r| r.path == "/keep"));
+    }
+
+    #[test]
+    fn closest_picks_most_satisfied_clauses_and_reports_failures() {
+        let imp = imposter(None);
+        // Satisfies neither clause.
+        imp.record_request(&rec("DELETE", "/x", &[], None));
+        // Satisfies method only (1 of 2) — the closest.
+        imp.record_request(&rec("GET", "/x", &[], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([
+                { "equals": { "method": "GET" } },
+                { "equals": { "path": "/wanted" } }
+            ])),
+            include_closest: true,
+            ..Default::default()
+        };
+        let out = imp.verify(&opts).expect("verify");
+        assert_eq!(out.matched, 0);
+        let closest = out.closest.expect("closest present");
+        assert_eq!(closest.request.path, "/x");
+        assert_eq!(closest.request.method, "GET");
+        // Only the path clause failed; the method clause was satisfied.
+        assert_eq!(closest.failed_predicates.len(), 1);
+        assert_eq!(closest.failed_predicates[0].actual, json!({ "path": "/x" }));
+    }
+
+    #[test]
+    fn closest_breaks_ties_toward_the_most_recent() {
+        let imp = imposter(None);
+        // Both satisfy the method clause (1 of 1 failing overall since path never matches),
+        // so the tie is broken toward the later-recorded request.
+        imp.record_request(&rec("GET", "/first", &[], None));
+        imp.record_request(&rec("GET", "/second", &[], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([
+                { "equals": { "method": "GET" } },
+                { "equals": { "path": "/never" } }
+            ])),
+            include_closest: true,
+            ..Default::default()
+        };
+        let out = imp.verify(&opts).expect("verify");
+        let closest = out.closest.expect("closest present");
+        assert_eq!(
+            closest.request.path, "/second",
+            "ties resolve to most recent"
+        );
+    }
+
+    #[test]
+    fn flow_id_scopes_total_and_matched() {
+        let imp = imposter(Some("header:X-Space"));
+        imp.record_request(&rec("GET", "/a", &[("X-Space", "blue")], None));
+        imp.record_request(&rec("GET", "/a", &[("X-Space", "green")], None));
+        imp.record_request(&rec("GET", "/a", &[("X-Space", "blue")], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "path": "/a" } }])),
+            flow_id: Some("blue".to_string()),
+            ..Default::default()
+        };
+        let out = imp.verify(&opts).expect("verify");
+        assert_eq!(out.total, 2, "total is scoped to the flow");
+        assert_eq!(out.matched, 2);
+    }
+
+    #[test]
+    fn flow_id_scopes_under_the_default_imposter_port_source() {
+        // With no flow_id_source declared, every request's flow is the imposter port ("0" here).
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/a", &[], None));
+        imp.record_request(&rec("GET", "/a", &[], None));
+
+        let matching = VerifyOptions {
+            flow_id: Some("0".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(imp.verify(&matching).expect("verify").total, 2);
+
+        let other = VerifyOptions {
+            flow_id: Some("999".to_string()),
+            ..Default::default()
+        };
+        let out = imp.verify(&other).expect("verify");
+        assert_eq!(out.total, 0, "a non-matching flow scopes everything out");
+        assert_eq!(out.matched, 0);
+    }
+
+    #[test]
+    fn ip_predicate_matches_against_the_recorded_client_ip() {
+        // Regression: the `ip` field must compare against the bare IP recovered from `request_from`
+        // (`ip:port`), not an empty string — otherwise every `ip` predicate silently mis-counts.
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/a", &[], None)); // request_from = 127.0.0.1:5000
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "ip": "127.0.0.1" } }])),
+            ..Default::default()
+        };
+        assert_eq!(imp.verify(&opts).expect("verify").matched, 1);
+    }
+
+    #[test]
+    fn multi_value_header_collapses_to_the_last_value() {
+        // A header recorded with two values collapses to its last, mirroring live matching's
+        // single-value view.
+        let imp = imposter(None);
+        imp.record_request(&rec(
+            "GET",
+            "/a",
+            &[("X-Dup", "first"), ("X-Dup", "second")],
+            None,
+        ));
+
+        let last = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "headers": { "X-Dup": "second" } } }])),
+            ..Default::default()
+        };
+        assert_eq!(imp.verify(&last).expect("verify").matched, 1);
+
+        let first = VerifyOptions {
+            predicates: preds(json!([{ "equals": { "headers": { "X-Dup": "first" } } }])),
+            ..Default::default()
+        };
+        assert_eq!(
+            imp.verify(&first).expect("verify").matched,
+            0,
+            "the shadowed first value must not match"
+        );
+    }
+
+    #[test]
+    fn closest_actual_falls_back_to_the_whole_request_for_a_compound_predicate() {
+        // A compound (`or`) predicate implicates no single field, so `actual` is the whole-request
+        // view rather than a field-keyed projection.
+        let imp = imposter(None);
+        imp.record_request(&rec("GET", "/c", &[], None));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([
+                { "or": [{ "equals": { "path": "/a" } }, { "equals": { "path": "/b" } }] }
+            ])),
+            include_closest: true,
+            ..Default::default()
+        };
+        let closest = imp.verify(&opts).expect("verify").closest.expect("closest");
+        assert_eq!(closest.failed_predicates.len(), 1);
+        let actual = &closest.failed_predicates[0].actual;
+        assert!(
+            actual.get("method").is_some() && actual.get("path").is_some(),
+            "compound predicate reports the whole request view, got {actual}"
+        );
+    }
+
+    #[test]
+    fn closest_actual_falls_back_to_the_whole_request_for_a_selector_predicate() {
+        // A jsonpath/xpath selector rewrites the effective body, so no single request field is
+        // implicated — `actual` is the whole-request view.
+        let imp = imposter(None);
+        imp.record_request(&rec("POST", "/a", &[], Some(r#"{"foo":"bar"}"#)));
+
+        let opts = VerifyOptions {
+            predicates: preds(json!([
+                { "equals": { "body": "nope" }, "jsonpath": { "selector": "$.foo" } }
+            ])),
+            include_closest: true,
+            ..Default::default()
+        };
+        let closest = imp.verify(&opts).expect("verify").closest.expect("closest");
+        let actual = &closest.failed_predicates[0].actual;
+        assert!(
+            actual.get("method").is_some() && actual.get("headers").is_some(),
+            "selector predicate reports the whole request view, got {actual}"
+        );
+    }
+}

--- a/crates/rift-core/src/imposter/mod.rs
+++ b/crates/rift-core/src/imposter/mod.rs
@@ -52,6 +52,7 @@ pub mod journal;
 pub use journal::{JournalRead, LocalJournal, RequestJournal};
 
 pub use core::Imposter;
+pub use core::{ClosestMatch, FailedPredicate, VerifyOptions, VerifyOutcome};
 
 // Re-export the imposter request handler (single-port gateway dispatch, issue #212)
 pub use handler::{handle_imposter_request, handle_imposter_request_decorated};

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -83,6 +83,24 @@ char *rift_recorded(RiftHandle *h, uint16_t port);
 char *rift_stub_warnings(RiftHandle *h, uint16_t port);
 
 /**
+ * Verify recorded requests against a predicate set server-side (issue #494), returning the JSON
+ * `{"matched","total","requests"?,"closest"?}` envelope the caller frees with [`rift_free`]. The
+ * `body_json` is the same `POST /imposters/{port}/verify` body:
+ * `{"predicates":[…],"flowId"?,"includeRequests"?,"includeClosest"?}`. This lets an embedded SDK
+ * count matches through the engine's one true predicate evaluator (including `xpath`/`inject`,
+ * impractical client-side) instead of shipping the whole journal over the wire. Unlike the admin
+ * HTTP endpoint, an `inject` predicate is NOT gated here: the direct C-ABI caller is the trusted
+ * in-process embedder, matching how `rift_replace_stubs` accepts inject stubs.
+ *
+ * Returns null on any error (null/unknown handle or port, invalid JSON, a failing `inject`
+ * predicate, or encode failure), with the reason in `rift_last_error`.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `body_json` must be null or a valid C string.
+ */
+char *rift_verify(RiftHandle *h, uint16_t port, const char *body_json);
+
+/**
  * Get a scenario/flow-state value as a JSON envelope `{"found","flowId","key","value"}` the caller
  * frees with [`rift_free`]. `found` disambiguates an absent key from a failure: a missing key is a
  * non-error outcome (`{"found":false,"value":null}`), while a null pointer is returned **only** on a

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -33,7 +33,7 @@
 //! emits a `tracing` event.
 
 use parking_lot::Mutex;
-use rift_core::imposter::{ApplyReport, ImposterConfig, ImposterManager, Stub};
+use rift_core::imposter::{ApplyReport, ImposterConfig, ImposterManager, Stub, VerifyOptions};
 use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
 use rift_core::proxy::truststore::{TrustStorePassword, ca_pem, export_jks, export_pkcs12};
 use rift_http_proxy::admin_api::{AdminApiServer, RunningAdminApi};
@@ -382,6 +382,68 @@ pub unsafe extern "C" fn rift_stub_warnings(h: *mut RiftHandle, port: u16) -> *m
             Err(e) => {
                 set_last_error(format!("rift_stub_warnings: encode failed: {e}"));
                 warn!(error = %e, port, "rift_stub_warnings: failed to encode warnings");
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Verify recorded requests against a predicate set server-side (issue #494), returning the JSON
+/// `{"matched","total","requests"?,"closest"?}` envelope the caller frees with [`rift_free`]. The
+/// `body_json` is the same `POST /imposters/{port}/verify` body:
+/// `{"predicates":[…],"flowId"?,"includeRequests"?,"includeClosest"?}`. This lets an embedded SDK
+/// count matches through the engine's one true predicate evaluator (including `xpath`/`inject`,
+/// impractical client-side) instead of shipping the whole journal over the wire. Unlike the admin
+/// HTTP endpoint, an `inject` predicate is NOT gated here: the direct C-ABI caller is the trusted
+/// in-process embedder, matching how `rift_replace_stubs` accepts inject stubs.
+///
+/// Returns null on any error (null/unknown handle or port, invalid JSON, a failing `inject`
+/// predicate, or encode failure), with the reason in `rift_last_error`.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `body_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_verify(
+    h: *mut RiftHandle,
+    port: u16,
+    body_json: *const c_char,
+) -> *mut c_char {
+    ffi_guard!("rift_verify", std::ptr::null_mut(), unsafe {
+        clear_last_error();
+        let (Some(handle), Some(s)) = (handle(h), c_str(body_json)) else {
+            set_last_error("rift_verify: null handle or body pointer");
+            warn!("rift_verify: null handle or body pointer");
+            return std::ptr::null_mut();
+        };
+        let opts = match serde_json::from_str::<VerifyOptions>(s) {
+            Ok(o) => o,
+            Err(e) => {
+                set_last_error(format!("rift_verify: invalid verify JSON: {e}"));
+                warn!(error = %e, "rift_verify: invalid verify JSON");
+                return std::ptr::null_mut();
+            }
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_verify: {e}"));
+                warn!(error = %e, port, "rift_verify: no such imposter");
+                return std::ptr::null_mut();
+            }
+        };
+        let outcome = match imposter.verify(&opts) {
+            Ok(o) => o,
+            Err(e) => {
+                set_last_error(format!("rift_verify: {e}"));
+                warn!(error = %e, port, "rift_verify: predicate evaluation failed");
+                return std::ptr::null_mut();
+            }
+        };
+        match serde_json::to_string(&outcome) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_verify: encode failed: {e}"));
+                warn!(error = %e, port, "rift_verify: failed to encode outcome");
                 std::ptr::null_mut()
             }
         }

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -68,6 +68,74 @@ fn ffi_round_trip() {
     }
 }
 
+/// Issue #494: server-side verification over the C-ABI — record two requests, then count matches
+/// through `rift_verify` (the engine's one true predicate evaluator) and inspect the closest
+/// non-match diff.
+#[test]
+fn ffi_verify_round_trip() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null());
+
+        let config =
+            cstr(r#"{ "port": 19997, "protocol": "http", "recordRequests": true, "stubs": [] }"#);
+        let port = rift_create_imposter(h, config.as_ptr());
+        assert_eq!(port, 19997);
+
+        let stubs = cstr(
+            r#"[{ "predicates": [], "responses": [{ "is": { "statusCode": 200, "body": "ok" } }] }]"#,
+        );
+        assert_eq!(rift_replace_stubs(h, port, stubs.as_ptr()), 0);
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            reqwest::get("http://127.0.0.1:19997/wanted")
+                .await
+                .expect("get");
+            reqwest::get("http://127.0.0.1:19997/other")
+                .await
+                .expect("get");
+        });
+
+        // Count requests to /wanted, asking for the closest non-match diff.
+        let body = cstr(
+            r#"{"predicates":[{"equals":{"path":"/wanted"}}],"includeRequests":true,"includeClosest":true}"#,
+        );
+        let out = take_json(rift_verify(h, port, body.as_ptr()));
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["matched"], 1);
+        assert_eq!(v["total"], 2);
+        assert_eq!(v["requests"].as_array().unwrap().len(), 1);
+        assert_eq!(v["requests"][0]["path"], "/wanted");
+        // The closest non-match is /other, failing the single path clause.
+        assert_eq!(v["closest"]["request"]["path"], "/other");
+        assert_eq!(
+            v["closest"]["failedPredicates"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(
+            v["closest"]["failedPredicates"][0]["actual"]["path"],
+            "/other"
+        );
+
+        // Error paths: null handle/body, unknown port, malformed JSON → null (+ last_error).
+        assert!(rift_verify(std::ptr::null_mut(), port, body.as_ptr()).is_null());
+        assert!(rift_verify(h, port, std::ptr::null()).is_null());
+        assert!(
+            rift_verify(h, 12345, body.as_ptr()).is_null(),
+            "unknown port → null"
+        );
+        let bad = cstr("not json");
+        assert!(
+            rift_verify(h, port, bad.as_ptr()).is_null(),
+            "malformed JSON → null"
+        );
+
+        assert_eq!(rift_delete_all(h), 0);
+        rift_stop(h);
+    }
+}
+
 #[test]
 fn ffi_null_and_error_paths() {
     unsafe {

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -9,7 +9,7 @@ use crate::admin_api::types::{
 use crate::extensions::decorate::backend_error_response;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
-    ScriptBaseDir, Stub, StubResponse, resolve_scripts,
+    ScriptBaseDir, Stub, StubResponse, VerifyOptions, resolve_scripts,
 };
 // `RecordedRequest` is only named in tests now that the `/requests` handler filters before
 // cloning via `get_recorded_requests_filtered` (issue #485).
@@ -127,6 +127,12 @@ pub(crate) fn reject_stubs_if_injection_disallowed(
     if allow_injection || !stubs_contain_script_surface(stubs) {
         return None;
     }
+    Some(injection_disallowed_response())
+}
+
+/// The Mountebank-compatible `400 invalid injection` response returned when a request carries a
+/// scripting surface (`inject`, decorate, …) but `--allowInjection` is off.
+fn injection_disallowed_response() -> Response<Full<Bytes>> {
     let body = serde_json::json!({
         "errors": [{
             "code": "invalid injection",
@@ -135,11 +141,11 @@ pub(crate) fn reject_stubs_if_injection_disallowed(
         }]
     })
     .to_string();
-    Some(build_response_with_headers(
+    build_response_with_headers(
         StatusCode::BAD_REQUEST,
         [("Content-Type", "application/json")],
         body,
-    ))
+    )
 }
 
 /// Reject a whole imposter config when its stubs carry a scripting surface and `--allowInjection`
@@ -574,6 +580,69 @@ pub async fn handle_clear_requests(
             }
             handle_get(port, None, base_url, manager).await
         }
+        Err(e) => e.into(),
+    }
+}
+
+/// POST /imposters/:port/verify - count (and optionally return) recorded requests matching a
+/// predicate set, with an optional closest non-match diff (issue #494). The engine owns the one
+/// true predicate evaluator, so every SDK's `verify(match, times(n))` defers here instead of
+/// re-implementing matching (and shipping the whole journal over the wire just to count it).
+pub async fn handle_verify(
+    port: u16,
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
+    let body = match collect_body(req).await {
+        Ok(b) => b,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
+    // An `inject` predicate evaluates synchronous Boa JavaScript that can run away (issue #476);
+    // evaluate the whole verify on the blocking pool so it never head-of-line-blocks a tokio
+    // worker. Like the live matcher (#476) there's no abort flag — Boa's loop-iteration cap (#327)
+    // eventually frees the blocking thread. A non-inject verify pays only a cheap task hop, fine
+    // since verify is not a per-request hot path.
+    tokio::task::spawn_blocking(move || verify_response(port, &body, &manager, allow_injection))
+        .await
+        .unwrap_or_else(|e| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("verify task failed: {e}"),
+            )
+        })
+}
+
+/// The body of [`handle_verify`] over already-collected bytes, so the parse/gate/evaluate path is
+/// unit-testable without a `Request<Incoming>`.
+fn verify_response(
+    port: u16,
+    body: &[u8],
+    manager: &ImposterManager,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
+    let opts: VerifyOptions = match serde_json::from_slice(body) {
+        Ok(o) => o,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("Invalid verify JSON: {e}"),
+            );
+        }
+    };
+    // An `inject` predicate evaluates Boa JavaScript — a scripting surface gated by
+    // `--allowInjection` for untrusted admin clients (issue #355), the same gate the stub
+    // endpoints apply before accepting an inject predicate.
+    if !allow_injection && opts.predicates.iter().any(predicate_has_inject) {
+        return injection_disallowed_response();
+    }
+    match manager.get_imposter(port) {
+        Ok(imposter) => match imposter.verify(&opts) {
+            Ok(outcome) => json_response(StatusCode::OK, &outcome),
+            // A failing `inject` predicate is the only error path (issue #440); it is caused by the
+            // caller-supplied predicate, so it maps to 400 rather than a server fault.
+            Err(e) => error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        },
         Err(e) => e.into(),
     }
 }
@@ -1150,5 +1219,98 @@ mod requests_filter_tests {
             "malformed DELETE must not clear anything"
         );
         let _ = m.delete_imposter(19741).await;
+    }
+}
+
+#[cfg(test)]
+mod verify_tests {
+    use super::*;
+    use http_body_util::BodyExt;
+    use std::collections::HashMap;
+
+    fn rec(method: &str, path: &str) -> RecordedRequest {
+        RecordedRequest {
+            request_from: "127.0.0.1:5000".to_string(),
+            method: method.to_string(),
+            path: path.to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    async fn manager_with(port: u16, recorded: &[RecordedRequest]) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new());
+        let cfg = serde_json::json!({
+            "port": port, "protocol": "http", "recordRequests": true, "stubs": []
+        });
+        let config = serde_json::from_value(cfg).expect("config");
+        manager.create_imposter(config).await.expect("create");
+        let imposter = manager.get_imposter(port).expect("imposter");
+        for r in recorded {
+            imposter.record_request(r);
+        }
+        manager
+    }
+
+    async fn body_json(resp: Response<Full<Bytes>>) -> serde_json::Value {
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    #[tokio::test]
+    async fn verify_counts_matched_and_total() {
+        let m = manager_with(
+            19751,
+            &[rec("GET", "/a"), rec("POST", "/a"), rec("GET", "/b")],
+        )
+        .await;
+        let body = br#"{"predicates":[{"equals":{"method":"GET"}}]}"#;
+        let resp = verify_response(19751, body, &m, false);
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["matched"], 2);
+        assert_eq!(json["total"], 3);
+        assert!(json.get("requests").is_none());
+        let _ = m.delete_imposter(19751).await;
+    }
+
+    #[tokio::test]
+    async fn verify_include_requests_and_closest() {
+        let m = manager_with(19752, &[rec("GET", "/a"), rec("DELETE", "/z")]).await;
+        let body = br#"{"predicates":[{"equals":{"method":"GET"}}],"includeRequests":true,"includeClosest":true}"#;
+        let resp = verify_response(19752, body, &m, false);
+        let json = body_json(resp).await;
+        assert_eq!(json["matched"], 1);
+        assert_eq!(json["requests"].as_array().expect("requests").len(), 1);
+        assert_eq!(json["closest"]["request"]["path"], "/z");
+        let _ = m.delete_imposter(19752).await;
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_inject_predicate_without_allow_injection() {
+        let m = manager_with(19753, &[rec("GET", "/a")]).await;
+        let body = br#"{"predicates":[{"inject":"function(){return true;}"}]}"#;
+        let resp = verify_response(19753, body, &m, false);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let json = body_json(resp).await;
+        assert_eq!(json["errors"][0]["code"], "invalid injection");
+        let _ = m.delete_imposter(19753).await;
+    }
+
+    #[tokio::test]
+    async fn verify_bad_json_is_400() {
+        let m = manager_with(19754, &[]).await;
+        let resp = verify_response(19754, b"not json", &m, false);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let _ = m.delete_imposter(19754).await;
+    }
+
+    #[tokio::test]
+    async fn verify_unknown_imposter_is_404() {
+        let m = Arc::new(ImposterManager::new());
+        let resp = verify_response(19755, br#"{"predicates":[]}"#, &m, false);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -27,6 +27,8 @@ enum ImposterRoute {
     StubById(String),
     /// DELETE /imposters/:port/savedRequests
     SavedRequests,
+    /// POST /imposters/:port/verify (issue #494)
+    Verify,
     /// DELETE /imposters/:port/savedProxyResponses
     SavedProxyResponses,
     /// POST /imposters/:port/enable
@@ -54,6 +56,7 @@ impl ImposterRoute {
             ["stubs", "by-id", id] => Some(ImposterRoute::StubById((*id).to_string())),
             ["stubs", index_str] => index_str.parse().ok().map(ImposterRoute::StubByIndex),
             ["savedRequests"] | ["requests"] => Some(ImposterRoute::SavedRequests),
+            ["verify"] => Some(ImposterRoute::Verify),
             ["savedProxyResponses"] => Some(ImposterRoute::SavedProxyResponses),
             ["enable"] => Some(ImposterRoute::Enable),
             ["disable"] => Some(ImposterRoute::Disable),
@@ -353,6 +356,11 @@ async fn route_imposter(
         }
         (&Method::DELETE, ImposterRoute::SavedRequests) => {
             imposters::handle_clear_requests(port, query, base_url, manager).await
+        }
+
+        // /imposters/:port/verify (issue #494)
+        (&Method::POST, ImposterRoute::Verify) => {
+            imposters::handle_verify(port, req, manager, allow_injection).await
         }
 
         // /imposters/:port/savedProxyResponses

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -363,6 +363,55 @@ Multiple `match` clauses are AND-ed together.
 
 ---
 
+### POST /imposters/{port}/verify
+
+Count — and optionally return — recorded requests matching a predicate set, evaluated by the
+engine's own predicate engine rather than re-implemented per client. This is what an SDK's
+`verify(match, times(n))` calls instead of fetching `savedRequests` and re-evaluating predicates
+locally (where operators like `xpath`/`inject` are impractical) or shipping the whole journal over
+the wire just to count it.
+
+**Request body:**
+```json
+{
+  "predicates": [ { "equals": { "path": "/api/users" } } ],
+  "flowId": "tenant-a",
+  "includeRequests": false,
+  "includeClosest": false
+}
+```
+- `predicates` — standard Mountebank/Rift predicate objects, AND-ed together (same semantics as a
+  stub's `predicates`).
+- `flowId` *(optional)* — scope the count to one space, resolved via the imposter's
+  `flow_id_source` (the same scoping as `match=flow_id=<Value>` on `savedRequests`).
+- `includeRequests` *(optional, default `false`)* — return the matching requests, not just the count.
+- `includeClosest` *(optional, default `false`)* — return the best-scoring non-match — the request
+  satisfying the most predicate clauses (ties resolve to the most recent) — with per-clause failure
+  details, for rendering a readable diff on a failed verification.
+
+An `inject` predicate requires the server to be started with `--allowInjection`; otherwise the
+request is rejected with `400 invalid injection` (the same gate the stub endpoints apply).
+
+**Response:**
+```json
+{
+  "matched": 2,
+  "total": 17,
+  "requests": [ /* present only with includeRequests */ ],
+  "closest": {
+    "request": { /* the closest non-matching recorded request */ },
+    "failedPredicates": [
+      { "predicate": { "equals": { "path": "/api/users" } }, "actual": { "path": "/api/orders" } }
+    ]
+  }
+}
+```
+`matched` counts requests matching every predicate; `total` is the number of recorded requests in
+scope (after any `flowId` filter). `requests`/`closest` are present only when the corresponding
+option is set.
+
+---
+
 ### DELETE /imposters/{port}/savedRequests
 
 Clear recorded requests. Also available under the alias `DELETE /imposters/{port}/requests`.

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -43,6 +43,7 @@ rift_stop(h);                     // stop and free
 | `rift_delete_imposter` | `int rift_delete_imposter(RiftHandle* h, uint16_t port)` | `0` on success, `-1` on error. |
 | `rift_delete_all` | `int rift_delete_all(RiftHandle* h)` | `0` on success, `-1` on error. |
 | `rift_recorded` | `char* rift_recorded(RiftHandle* h, uint16_t port)` | Recorded requests as a JSON string (**caller frees** with `rift_free`), or `NULL` on error. |
+| `rift_verify` | `char* rift_verify(RiftHandle* h, uint16_t port, const char* body_json)` | Server-side verification: given `{"predicates":[…],"flowId"?,"includeRequests"?,"includeClosest"?}` (the [`POST /verify`](../api/index.md#post-impostersportverify) body), returns `{"matched","total","requests"?,"closest"?}` as JSON (**caller frees**), or `NULL` on error. Unlike the HTTP endpoint, `inject` predicates are **not** gated — the in-process embedder is trusted. |
 | `rift_stub_warnings` | `char* rift_stub_warnings(RiftHandle* h, uint16_t port)` | [Stub-analysis warnings](../features/stub-analysis.md) (duplicate/shadowed/catch-all) as a JSON array (**caller frees**), or `NULL` on error. |
 | `rift_apply_config` | `char* rift_apply_config(RiftHandle* h, const char* json)` | Reconcile the full imposter set (like `POST /admin/reload`); returns the apply report JSON (caller frees). |
 

--- a/scripts/verify-ffi-cdylib.sh
+++ b/scripts/verify-ffi-cdylib.sh
@@ -22,6 +22,8 @@ SYMBOLS=(
   rift_last_error
   # issue #423: stub-analysis warnings over the C-ABI
   rift_stub_warnings
+  # issue #494: server-side verification (predicate-count + closest-match)
+  rift_verify
 )
 
 # Issue #344: the checked-in C header is the ABI's source of truth — assert it matches a fresh


### PR DESCRIPTION
Adds a server-side verification endpoint `POST /imposters/{port}/verify` plus a `rift_verify` FFI symbol, reusing the engine's predicate evaluator and recorded-request journal — no new state. Counts matching recorded requests, optionally returns them (`includeRequests`) and the closest non-match diff (`includeClosest`, with per-clause `failedPredicates`). `flowId` scopes like `savedRequests`.

Includes admin + core + FFI tests (cbindgen header regenerated, symbol added to the C-ABI smoke list) and docs (admin API + FFI reference).

Closes #494

Part of SDK-M0 (epic #458).