### PR TITLE
ffi: admin long-tail symbols — list/get imposters, stub surgery, journal clear, enable/disable, scenarios

### DIFF
--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -101,6 +101,129 @@ char *rift_stub_warnings(RiftHandle *h, uint16_t port);
 char *rift_verify(RiftHandle *h, uint16_t port, const char *body_json);
 
 /**
+ * List imposters. `options_json` (null = defaults): `{"replayable":bool,"removeProxies":bool}`.
+ * Replayable returns `{"imposters":[<ImposterConfig>,...]}` (the same projection the admin
+ * `?replayable=true` route serves); otherwise a Mountebank-style summary
+ * `{"imposters":[{"protocol","port","name"?,"numberOfRequests","enabled"},...]}`, skipping any
+ * imposter with no assigned port (mirroring `handle_list`'s summary branch). Returns (caller
+ * frees with [`rift_free`]) null on any error (null handle or malformed options JSON).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+ */
+char *rift_list_imposters(RiftHandle *h, const char *options_json);
+
+/**
+ * Get one imposter. `options_json` — same shape as [`rift_list_imposters`]. Replayable returns
+ * the single `ImposterConfig` (same `removeProxies` projection); otherwise a detail object
+ * `{"protocol","port","name"?,"numberOfRequests","enabled","recordRequests","stubs","requests"}`.
+ * Returns (caller frees) null on any error (null handle, unknown port, or malformed options).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+ */
+char *rift_get_imposter(RiftHandle *h, uint16_t port, const char *options_json);
+
+/**
+ * Add a stub to `port`. `index < 0` appends; otherwise it is inserted at that position (mirrors
+ * the admin route's `index` query param). No injection gating — direct FFI is the trusted
+ * embedder, like [`rift_replace_stubs`] — and no stub id is auto-generated. Returns `0` on
+ * success, `-1` on any error (null handle/pointer, invalid stub JSON, or the manager's own error,
+ * e.g. a duplicate id).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `stub_json` must be null or a valid C string.
+ */
+int32_t rift_add_stub(RiftHandle *h, uint16_t port, const char *stub_json, int32_t index);
+
+/**
+ * Get a single stub by ref: `{"index":N}` or `{"id":"..."}`. Returns (caller frees) the bare
+ * `Stub` JSON, or null on any error (null handle/pointer, malformed ref JSON, out-of-range index,
+ * or unknown id).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `ref_json` must be null or a valid C string.
+ */
+char *rift_get_stub(RiftHandle *h, uint16_t port, const char *ref_json);
+
+/**
+ * Update (replace) a stub addressed by ref (`{"index":N}` or `{"id":"..."}`) with `stub_json`.
+ * Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `ref_json`/`stub_json` must be null or valid C strings.
+ */
+int32_t rift_update_stub(RiftHandle *h, uint16_t port, const char *ref_json, const char *stub_json);
+
+/**
+ * Delete a stub addressed by ref (`{"index":N}` or `{"id":"..."}`). Returns `0` on success, `-1`
+ * on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `ref_json` must be null or a valid C string.
+ */
+int32_t rift_delete_stub(RiftHandle *h, uint16_t port, const char *ref_json);
+
+/**
+ * Clear all recorded requests for `port`. Returns `0` on success, `-1` on any error (null handle
+ * or unknown port).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+int32_t rift_clear_recorded(RiftHandle *h, uint16_t port);
+
+/**
+ * Clear saved proxy responses for `port`. Returns `0` on success, `-1` on any error (null handle
+ * or unknown port).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+int32_t rift_clear_proxy_recordings(RiftHandle *h, uint16_t port);
+
+/**
+ * Enable (`enabled != 0`) or disable an imposter. Returns `0` on success, `-1` on any error (null
+ * handle or unknown port).
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+int32_t rift_set_imposter_enabled(RiftHandle *h, uint16_t port, int32_t enabled);
+
+/**
+ * List scenario states for `flow_id` (null → the imposter's default flow) as JSON
+ * `{"flowId","scenarios":[{"name","state"}]}`. Returns (caller frees) null on any error (null
+ * handle, unknown port, or a scenario-state backend error).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+ */
+char *rift_scenarios(RiftHandle *h, uint16_t port, const char *flow_id);
+
+/**
+ * Set a scenario's state from JSON `{"state":"...","flowId":"..."?}` (`flowId` optional → the
+ * imposter's default flow). Returns `0` on success, `-1` on any error (null handle/pointers,
+ * missing `state`, unknown port, or a backend error).
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `name`/`state_json` must be null or valid C strings.
+ */
+int32_t rift_set_scenario_state(RiftHandle *h,
+                                uint16_t port,
+                                const char *name,
+                                const char *state_json);
+
+/**
+ * Reset all scenario states for `flow_id` (null → the imposter's default flow) back to their
+ * initial state. Returns `0` on success, `-1` on any error.
+ *
+ * # Safety
+ * `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+ */
+int32_t rift_reset_scenarios(RiftHandle *h, uint16_t port, const char *flow_id);
+
+/**
  * Get a scenario/flow-state value as a JSON envelope `{"found","flowId","key","value"}` the caller
  * frees with [`rift_free`]. `found` disambiguates an absent key from a failure: a missing key is a
  * non-error outcome (`{"found":false,"value":null}`), while a null pointer is returned **only** on a

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -33,10 +33,14 @@
 //! emits a `tracing` event.
 
 use parking_lot::Mutex;
-use rift_core::imposter::{ApplyReport, ImposterConfig, ImposterManager, Stub, VerifyOptions};
+use rift_core::imposter::{
+    ApplyReport, Imposter, ImposterConfig, ImposterManager, Stub, VerifyOptions,
+};
 use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
 use rift_core::proxy::truststore::{TrustStorePassword, ca_pem, export_jks, export_pkcs12};
-use rift_http_proxy::admin_api::{AdminApiServer, RunningAdminApi};
+use rift_http_proxy::admin_api::{
+    AdminApiServer, RunningAdminApi, filter_proxy_responses, filter_proxy_stubs,
+};
 use rift_http_proxy::config_loader::{self, ConfigSource};
 use rift_http_proxy::intercept::InterceptListener;
 use rift_http_proxy::intercept_rules::{InterceptRule, InterceptRules, InterceptState};
@@ -150,6 +154,60 @@ fn into_c_string(s: String) -> *mut c_char {
                 "internal error: response contained an interior NUL byte ({e})"
             ));
             std::ptr::null_mut()
+        }
+    }
+}
+
+/// Parse an optional JSON options object: `p` null yields `T::default()`; a non-null pointer is
+/// parsed and any failure (invalid UTF-8 or invalid JSON) sets `last_error` (prefixed with
+/// `fn_name`) and returns `None`. Shared by the `rift_list_imposters`/`rift_get_imposter`
+/// `{"replayable","removeProxies"}` projection (issue #491).
+///
+/// # Safety
+/// `p` must be null or a valid NUL-terminated C string.
+unsafe fn parse_opts<T: serde::de::DeserializeOwned + Default>(
+    p: *const c_char,
+    fn_name: &str,
+) -> Option<T> {
+    unsafe {
+        if p.is_null() {
+            return Some(T::default());
+        }
+        let Some(s) = c_str(p) else {
+            set_last_error(format!("{fn_name}: options is not valid UTF-8"));
+            return None;
+        };
+        match serde_json::from_str(s) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                set_last_error(format!("{fn_name}: invalid options JSON: {e}"));
+                None
+            }
+        }
+    }
+}
+
+/// Resolve a nullable `flow_id` C-string arg (issue #491): null → the imposter's default flow; a
+/// valid string → itself; a non-null but invalid-UTF-8 pointer → `None` after recording an error,
+/// so the caller surfaces a sentinel rather than silently acting on the WRONG (default) flow.
+///
+/// # Safety
+/// `flow_id` must be null or a valid NUL-terminated C string.
+unsafe fn resolve_flow_arg(
+    flow_id: *const c_char,
+    imposter: &Imposter,
+    fn_name: &str,
+) -> Option<String> {
+    unsafe {
+        if flow_id.is_null() {
+            return Some(imposter.resolve_flow_id(&std::collections::HashMap::new()));
+        }
+        match c_str(flow_id) {
+            Some(s) => Some(s.to_string()),
+            None => {
+                set_last_error(format!("{fn_name}: flow_id is not valid UTF-8"));
+                None
+            }
         }
     }
 }
@@ -447,6 +505,583 @@ pub unsafe extern "C" fn rift_verify(
                 std::ptr::null_mut()
             }
         }
+    })
+}
+
+// ── Admin long tail over direct C-ABI: imposter list/get, stub surgery, clear/enable, scenarios
+// (issue #491) ────────────────────────────────────────────────────────────────────────────────
+// Each function calls the same `ImposterManager`/`Imposter` method the corresponding admin-HTTP
+// handler calls (`crates/rift-http-proxy/src/admin_api/handlers/imposters.rs`/`scenarios.rs`) and
+// builds the same JSON shape, so an embedder gets full admin parity with zero loopback HTTP.
+
+/// A stub reference: `{"index":N}` (position) or `{"id":"..."}` (stable id) — the two ways
+/// `rift_get_stub`/`rift_update_stub`/`rift_delete_stub` address a stub.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum StubRef {
+    Index { index: usize },
+    Id { id: String },
+}
+
+/// `rift_list_imposters`/`rift_get_imposter` options (all optional, default `false`): `replayable`
+/// returns the full `ImposterConfig` projection instead of the summary/detail shape;
+/// `removeProxies` (with `replayable`) strips proxy responses via the SAME
+/// [`filter_proxy_responses`] the admin `?replayable=true&removeProxies=true` route uses.
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct ImposterProjection {
+    replayable: bool,
+    remove_proxies: bool,
+}
+
+/// List imposters. `options_json` (null = defaults): `{"replayable":bool,"removeProxies":bool}`.
+/// Replayable returns `{"imposters":[<ImposterConfig>,...]}` (the same projection the admin
+/// `?replayable=true` route serves); otherwise a Mountebank-style summary
+/// `{"imposters":[{"protocol","port","name"?,"numberOfRequests","enabled"},...]}`, skipping any
+/// imposter with no assigned port (mirroring `handle_list`'s summary branch). Returns (caller
+/// frees with [`rift_free`]) null on any error (null handle or malformed options JSON).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_list_imposters(
+    h: *mut RiftHandle,
+    options_json: *const c_char,
+) -> *mut c_char {
+    ffi_guard!("rift_list_imposters", std::ptr::null_mut(), unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_list_imposters: null handle");
+            return std::ptr::null_mut();
+        };
+        let Some(opts) = parse_opts::<ImposterProjection>(options_json, "rift_list_imposters")
+        else {
+            return std::ptr::null_mut();
+        };
+        let imposters = handle.manager.list_imposters();
+        let body = if opts.replayable {
+            let configs: Vec<ImposterConfig> = imposters
+                .iter()
+                .map(|i| {
+                    if opts.remove_proxies {
+                        filter_proxy_responses(&i.config)
+                    } else {
+                        i.config.clone()
+                    }
+                })
+                .collect();
+            json!({ "imposters": configs })
+        } else {
+            let summaries: Vec<Value> = imposters
+                .iter()
+                .filter_map(|i| {
+                    i.config.port.map(|port| {
+                        let mut entry = json!({
+                            "protocol": i.config.protocol,
+                            "port": port,
+                            "numberOfRequests": i.get_request_count(),
+                            "enabled": i.is_enabled(),
+                        });
+                        if let Some(name) = &i.config.name {
+                            entry["name"] = json!(name);
+                        }
+                        entry
+                    })
+                })
+                .collect();
+            json!({ "imposters": summaries })
+        };
+        match serde_json::to_string(&body) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_list_imposters: encode failed: {e}"));
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Get one imposter. `options_json` — same shape as [`rift_list_imposters`]. Replayable returns
+/// the single `ImposterConfig` (same `removeProxies` projection); otherwise a detail object
+/// `{"protocol","port","name"?,"numberOfRequests","enabled","recordRequests","stubs","requests"}`.
+/// Returns (caller frees) null on any error (null handle, unknown port, or malformed options).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_get_imposter(
+    h: *mut RiftHandle,
+    port: u16,
+    options_json: *const c_char,
+) -> *mut c_char {
+    ffi_guard!("rift_get_imposter", std::ptr::null_mut(), unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_get_imposter: null handle");
+            return std::ptr::null_mut();
+        };
+        let Some(opts) = parse_opts::<ImposterProjection>(options_json, "rift_get_imposter") else {
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_get_imposter: {e}"));
+                warn!(error = %e, port, "rift_get_imposter: no such imposter");
+                return std::ptr::null_mut();
+            }
+        };
+        let body = if opts.replayable {
+            let config = if opts.remove_proxies {
+                filter_proxy_responses(&imposter.config)
+            } else {
+                imposter.config.clone()
+            };
+            match serde_json::to_value(&config) {
+                Ok(v) => v,
+                Err(e) => {
+                    set_last_error(format!("rift_get_imposter: encode failed: {e}"));
+                    return std::ptr::null_mut();
+                }
+            }
+        } else {
+            // Honor `removeProxies` on the detail view too, filtering the LIVE stubs — the admin
+            // `GET /imposters/{port}?removeProxies=true` applies it regardless of `replayable`.
+            let stubs = if opts.remove_proxies {
+                filter_proxy_stubs(imposter.get_stubs())
+            } else {
+                imposter.get_stubs()
+            };
+            let mut detail = json!({
+                "protocol": imposter.config.protocol,
+                "port": port,
+                "numberOfRequests": imposter.get_request_count(),
+                "enabled": imposter.is_enabled(),
+                "recordRequests": imposter.config.record_requests,
+                "stubs": stubs,
+                "requests": imposter.get_recorded_requests(),
+            });
+            if let Some(name) = &imposter.config.name {
+                detail["name"] = json!(name);
+            }
+            detail
+        };
+        match serde_json::to_string(&body) {
+            Ok(json) => into_c_string(json),
+            Err(e) => {
+                set_last_error(format!("rift_get_imposter: encode failed: {e}"));
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Add a stub to `port`. `index < 0` appends; otherwise it is inserted at that position (mirrors
+/// the admin route's `index` query param). No injection gating — direct FFI is the trusted
+/// embedder, like [`rift_replace_stubs`] — and no stub id is auto-generated. Returns `0` on
+/// success, `-1` on any error (null handle/pointer, invalid stub JSON, or the manager's own error,
+/// e.g. a duplicate id).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `stub_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_add_stub(
+    h: *mut RiftHandle,
+    port: u16,
+    stub_json: *const c_char,
+    index: i32,
+) -> i32 {
+    ffi_guard!("rift_add_stub", -1, unsafe {
+        clear_last_error();
+        let (Some(handle), Some(s)) = (handle(h), c_str(stub_json)) else {
+            set_last_error("rift_add_stub: null handle or stub pointer");
+            return -1;
+        };
+        let stub = match serde_json::from_str::<Stub>(s) {
+            Ok(v) => v,
+            Err(e) => {
+                set_last_error(format!("rift_add_stub: invalid stub JSON: {e}"));
+                return -1;
+            }
+        };
+        let idx = if index < 0 {
+            None
+        } else {
+            Some(index as usize)
+        };
+        match handle
+            .runtime
+            .block_on(handle.manager.add_stub(port, stub, idx))
+        {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_add_stub: {e}"));
+                warn!(error = %e, port, "rift_add_stub failed");
+                -1
+            }
+        }
+    })
+}
+
+/// Get a single stub by ref: `{"index":N}` or `{"id":"..."}`. Returns (caller frees) the bare
+/// `Stub` JSON, or null on any error (null handle/pointer, malformed ref JSON, out-of-range index,
+/// or unknown id).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `ref_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_get_stub(
+    h: *mut RiftHandle,
+    port: u16,
+    ref_json: *const c_char,
+) -> *mut c_char {
+    ffi_guard!("rift_get_stub", std::ptr::null_mut(), unsafe {
+        clear_last_error();
+        let (Some(handle), Some(s)) = (handle(h), c_str(ref_json)) else {
+            set_last_error("rift_get_stub: null handle or ref pointer");
+            return std::ptr::null_mut();
+        };
+        let stub_ref = match serde_json::from_str::<StubRef>(s) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("rift_get_stub: invalid ref JSON: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+        let result = match stub_ref {
+            StubRef::Index { index } => handle.manager.get_stub(port, index),
+            StubRef::Id { id } => handle.manager.get_stub_by_id(port, &id),
+        };
+        match result {
+            Ok(stub) => match serde_json::to_string(&stub) {
+                Ok(json) => into_c_string(json),
+                Err(e) => {
+                    set_last_error(format!("rift_get_stub: encode failed: {e}"));
+                    std::ptr::null_mut()
+                }
+            },
+            Err(e) => {
+                set_last_error(format!("rift_get_stub: {e}"));
+                warn!(error = %e, port, "rift_get_stub failed");
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Update (replace) a stub addressed by ref (`{"index":N}` or `{"id":"..."}`) with `stub_json`.
+/// Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `ref_json`/`stub_json` must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_update_stub(
+    h: *mut RiftHandle,
+    port: u16,
+    ref_json: *const c_char,
+    stub_json: *const c_char,
+) -> i32 {
+    ffi_guard!("rift_update_stub", -1, unsafe {
+        clear_last_error();
+        let (Some(handle), Some(rs), Some(ss)) = (handle(h), c_str(ref_json), c_str(stub_json))
+        else {
+            set_last_error("rift_update_stub: null handle or string pointer");
+            return -1;
+        };
+        let stub_ref = match serde_json::from_str::<StubRef>(rs) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("rift_update_stub: invalid ref JSON: {e}"));
+                return -1;
+            }
+        };
+        let stub = match serde_json::from_str::<Stub>(ss) {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(format!("rift_update_stub: invalid stub JSON: {e}"));
+                return -1;
+            }
+        };
+        let result = match stub_ref {
+            StubRef::Index { index } => handle
+                .runtime
+                .block_on(handle.manager.replace_stub(port, index, stub)),
+            StubRef::Id { id } => handle
+                .runtime
+                .block_on(handle.manager.replace_stub_by_id(port, &id, stub)),
+        };
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_update_stub: {e}"));
+                warn!(error = %e, port, "rift_update_stub failed");
+                -1
+            }
+        }
+    })
+}
+
+/// Delete a stub addressed by ref (`{"index":N}` or `{"id":"..."}`). Returns `0` on success, `-1`
+/// on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `ref_json` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_delete_stub(
+    h: *mut RiftHandle,
+    port: u16,
+    ref_json: *const c_char,
+) -> i32 {
+    ffi_guard!("rift_delete_stub", -1, unsafe {
+        clear_last_error();
+        let (Some(handle), Some(s)) = (handle(h), c_str(ref_json)) else {
+            set_last_error("rift_delete_stub: null handle or ref pointer");
+            return -1;
+        };
+        let stub_ref = match serde_json::from_str::<StubRef>(s) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("rift_delete_stub: invalid ref JSON: {e}"));
+                return -1;
+            }
+        };
+        let result = match stub_ref {
+            StubRef::Index { index } => handle
+                .runtime
+                .block_on(handle.manager.delete_stub(port, index)),
+            StubRef::Id { id } => handle
+                .runtime
+                .block_on(handle.manager.delete_stub_by_id(port, &id)),
+        };
+        match result {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_delete_stub: {e}"));
+                warn!(error = %e, port, "rift_delete_stub failed");
+                -1
+            }
+        }
+    })
+}
+
+/// Clear all recorded requests for `port`. Returns `0` on success, `-1` on any error (null handle
+/// or unknown port).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_clear_recorded(h: *mut RiftHandle, port: u16) -> i32 {
+    ffi_guard!("rift_clear_recorded", -1, unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_clear_recorded: null handle");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_clear_recorded: {e}"));
+                return -1;
+            }
+        };
+        match imposter.clear_recorded_requests() {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_clear_recorded: {e}"));
+                warn!(error = %e, port, "rift_clear_recorded failed");
+                -1
+            }
+        }
+    })
+}
+
+/// Clear saved proxy responses for `port`. Returns `0` on success, `-1` on any error (null handle
+/// or unknown port).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_clear_proxy_recordings(h: *mut RiftHandle, port: u16) -> i32 {
+    ffi_guard!("rift_clear_proxy_recordings", -1, unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_clear_proxy_recordings: null handle");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_clear_proxy_recordings: {e}"));
+                return -1;
+            }
+        };
+        imposter.clear_proxy_responses();
+        0
+    })
+}
+
+/// Enable (`enabled != 0`) or disable an imposter. Returns `0` on success, `-1` on any error (null
+/// handle or unknown port).
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_set_imposter_enabled(
+    h: *mut RiftHandle,
+    port: u16,
+    enabled: i32,
+) -> i32 {
+    ffi_guard!("rift_set_imposter_enabled", -1, unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_set_imposter_enabled: null handle");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_set_imposter_enabled: {e}"));
+                return -1;
+            }
+        };
+        imposter.set_enabled(enabled != 0);
+        0
+    })
+}
+
+/// List scenario states for `flow_id` (null → the imposter's default flow) as JSON
+/// `{"flowId","scenarios":[{"name","state"}]}`. Returns (caller frees) null on any error (null
+/// handle, unknown port, or a scenario-state backend error).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_scenarios(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+) -> *mut c_char {
+    ffi_guard!("rift_scenarios", std::ptr::null_mut(), unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_scenarios: null handle");
+            return std::ptr::null_mut();
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_scenarios: {e}"));
+                warn!(error = %e, port, "rift_scenarios: no such imposter");
+                return std::ptr::null_mut();
+            }
+        };
+        let Some(flow) = resolve_flow_arg(flow_id, &imposter, "rift_scenarios") else {
+            return std::ptr::null_mut();
+        };
+        let mut scenarios = Vec::new();
+        for name in imposter.scenario_names() {
+            match imposter.scenario_state(&flow, &name) {
+                Ok(state) => scenarios.push(json!({ "name": name, "state": state })),
+                Err(e) => {
+                    set_last_error(format!("rift_scenarios: {e}"));
+                    warn!(error = %e, port, "rift_scenarios failed");
+                    return std::ptr::null_mut();
+                }
+            }
+        }
+        into_c_string(json!({ "flowId": flow, "scenarios": scenarios }).to_string())
+    })
+}
+
+/// Set a scenario's state from JSON `{"state":"...","flowId":"..."?}` (`flowId` optional → the
+/// imposter's default flow). Returns `0` on success, `-1` on any error (null handle/pointers,
+/// missing `state`, unknown port, or a backend error).
+///
+/// # Safety
+/// `h` must be a live handle (or null); `name`/`state_json` must be null or valid C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_set_scenario_state(
+    h: *mut RiftHandle,
+    port: u16,
+    name: *const c_char,
+    state_json: *const c_char,
+) -> i32 {
+    ffi_guard!("rift_set_scenario_state", -1, unsafe {
+        clear_last_error();
+        let (Some(handle), Some(name), Some(s)) = (handle(h), c_str(name), c_str(state_json))
+        else {
+            set_last_error("rift_set_scenario_state: null handle or string pointer");
+            return -1;
+        };
+        let payload = match serde_json::from_str::<Value>(s) {
+            Ok(v) => v,
+            Err(e) => {
+                set_last_error(format!("rift_set_scenario_state: invalid state JSON: {e}"));
+                return -1;
+            }
+        };
+        let Some(state) = payload.get("state").and_then(|v| v.as_str()) else {
+            set_last_error("rift_set_scenario_state: missing required field: state");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_set_scenario_state: {e}"));
+                return -1;
+            }
+        };
+        let flow = payload
+            .get("flowId")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| imposter.resolve_flow_id(&std::collections::HashMap::new()));
+        match imposter.set_scenario_state(&flow, name, state) {
+            Ok(()) => 0,
+            Err(e) => {
+                set_last_error(format!("rift_set_scenario_state: {e}"));
+                warn!(error = %e, port, "rift_set_scenario_state failed");
+                -1
+            }
+        }
+    })
+}
+
+/// Reset all scenario states for `flow_id` (null → the imposter's default flow) back to their
+/// initial state. Returns `0` on success, `-1` on any error.
+///
+/// # Safety
+/// `h` must be a live handle (or null); `flow_id` must be null or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_reset_scenarios(
+    h: *mut RiftHandle,
+    port: u16,
+    flow_id: *const c_char,
+) -> i32 {
+    ffi_guard!("rift_reset_scenarios", -1, unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_reset_scenarios: null handle");
+            return -1;
+        };
+        let imposter = match handle.manager.get_imposter(port) {
+            Ok(i) => i,
+            Err(e) => {
+                set_last_error(format!("rift_reset_scenarios: {e}"));
+                return -1;
+            }
+        };
+        let Some(flow) = resolve_flow_arg(flow_id, &imposter, "rift_reset_scenarios") else {
+            return -1;
+        };
+        for name in imposter.scenario_names() {
+            if let Err(e) = imposter.delete_scenario_state(&flow, &name) {
+                set_last_error(format!("rift_reset_scenarios: {e}"));
+                warn!(error = %e, port, "rift_reset_scenarios failed");
+                return -1;
+            }
+        }
+        0
     })
 }
 

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1559,3 +1559,360 @@ fn ffi_intercept_rejects_unknown_ca_option() {
         rift_stop(h);
     }
 }
+
+// ===========================================================================
+// Issue #491: admin long-tail symbols over the direct C-ABI — list/get imposters,
+// stub surgery (add/get/update/delete by index or id), clear recorded / proxy
+// recordings, enable/disable, and scenario list/set-state/reset. Each mirrors an
+// admin route by calling the same ImposterManager/Imposter method.
+// ===========================================================================
+
+#[test]
+fn ffi_admin_longtail_round_trip() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null());
+
+        let config = cstr(
+            r#"{ "port": 19960, "protocol": "http", "recordRequests": true,
+                 "stubs": [ { "id": "s1", "scenarioName": "order",
+                              "requiredScenarioState": "Started",
+                              "predicates": [{ "equals": { "path": "/a" } }],
+                              "responses": [{ "is": { "statusCode": 200, "body": "a" } }] } ] }"#,
+        );
+        let port = rift_create_imposter(h, config.as_ptr());
+        assert_eq!(port, 19960);
+
+        // 1. list imposters (summary form) — no _links, just the domain projection
+        let list = take_json(rift_list_imposters(h, std::ptr::null()));
+        let lv: serde_json::Value = serde_json::from_str(&list).unwrap();
+        assert_eq!(lv["imposters"][0]["port"], 19960);
+        assert_eq!(lv["imposters"][0]["enabled"], true);
+        assert!(lv["imposters"][0]["numberOfRequests"].is_number());
+
+        // 1b. list imposters (replayable) — full configs carrying stubs
+        let opts = cstr(r#"{"replayable":true}"#);
+        let listr = take_json(rift_list_imposters(h, opts.as_ptr()));
+        let lrv: serde_json::Value = serde_json::from_str(&listr).unwrap();
+        assert!(lrv["imposters"][0]["stubs"].is_array());
+
+        // 2. get one imposter (detail) + replayable projection
+        let det = take_json(rift_get_imposter(h, port, std::ptr::null()));
+        let dv: serde_json::Value = serde_json::from_str(&det).unwrap();
+        assert_eq!(dv["port"], 19960);
+        assert_eq!(dv["recordRequests"], true);
+        assert_eq!(dv["stubs"].as_array().unwrap().len(), 1);
+        let repl_opts = cstr(r#"{"replayable":true}"#);
+        let rep = take_json(rift_get_imposter(h, port, repl_opts.as_ptr()));
+        let rv: serde_json::Value = serde_json::from_str(&rep).unwrap();
+        assert_eq!(rv["port"], 19960);
+        assert!(rv["stubs"].is_array());
+
+        // 3. add one stub (append, index -1)
+        let new_stub = cstr(
+            r#"{ "id": "s2", "predicates": [{ "equals": { "path": "/b" } }],
+                 "responses": [{ "is": { "statusCode": 201, "body": "b" } }] }"#,
+        );
+        assert_eq!(rift_add_stub(h, port, new_stub.as_ptr(), -1), 0);
+        let det2 = take_json(rift_get_imposter(h, port, std::ptr::null()));
+        let dv2: serde_json::Value = serde_json::from_str(&det2).unwrap();
+        assert_eq!(dv2["stubs"].as_array().unwrap().len(), 2, "stub appended");
+
+        // 4. get stub by index and by id
+        let by_idx = take_json(rift_get_stub(h, port, cstr(r#"{"index":1}"#).as_ptr()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&by_idx).unwrap()["id"],
+            "s2"
+        );
+        let by_id = take_json(rift_get_stub(h, port, cstr(r#"{"id":"s1"}"#).as_ptr()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&by_id).unwrap()["id"],
+            "s1"
+        );
+
+        // 5. update stub (by id)
+        let updated = cstr(
+            r#"{ "id": "s2", "predicates": [{ "equals": { "path": "/b2" } }],
+                 "responses": [{ "is": { "statusCode": 202, "body": "b2" } }] }"#,
+        );
+        assert_eq!(
+            rift_update_stub(h, port, cstr(r#"{"id":"s2"}"#).as_ptr(), updated.as_ptr()),
+            0
+        );
+
+        // 6. delete stub (by index) → back to one stub
+        assert_eq!(
+            rift_delete_stub(h, port, cstr(r#"{"index":1}"#).as_ptr()),
+            0
+        );
+        let det3 = take_json(rift_get_imposter(h, port, std::ptr::null()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&det3).unwrap()["stubs"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // 7. record a request, then clear recorded
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            reqwest::get("http://127.0.0.1:19960/a").await.expect("get");
+        });
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&take_json(rift_recorded(h, port)))
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(rift_clear_recorded(h, port), 0);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&take_json(rift_recorded(h, port)))
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .len(),
+            0,
+            "recorded cleared"
+        );
+
+        // 8. clear proxy recordings (no-op here, but must succeed)
+        assert_eq!(rift_clear_proxy_recordings(h, port), 0);
+
+        // 9. enable/disable
+        assert_eq!(rift_set_imposter_enabled(h, port, 0), 0);
+        let disabled = take_json(rift_get_imposter(h, port, std::ptr::null()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&disabled).unwrap()["enabled"],
+            false
+        );
+        assert_eq!(rift_set_imposter_enabled(h, port, 1), 0);
+
+        // 10-12. scenarios: set state, list, reset
+        assert_eq!(
+            rift_set_scenario_state(
+                h,
+                port,
+                cstr("order").as_ptr(),
+                cstr(r#"{"state":"paid"}"#).as_ptr()
+            ),
+            0
+        );
+        let scen = take_json(rift_scenarios(h, port, std::ptr::null()));
+        let sv: serde_json::Value = serde_json::from_str(&scen).unwrap();
+        let order = sv["scenarios"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == "order")
+            .expect("order scenario present");
+        assert_eq!(order["state"], "paid");
+        assert_eq!(rift_reset_scenarios(h, port, std::ptr::null()), 0);
+        let scen2 = take_json(rift_scenarios(h, port, std::ptr::null()));
+        let sv2: serde_json::Value = serde_json::from_str(&scen2).unwrap();
+        let order2 = sv2["scenarios"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == "order")
+            .expect("order scenario present");
+        assert_eq!(order2["state"], "Started", "reset returns to initial state");
+
+        rift_stop(h);
+    }
+}
+
+#[test]
+fn ffi_admin_longtail_error_paths() {
+    unsafe {
+        // null handle → sentinels + last_error
+        assert!(rift_list_imposters(std::ptr::null_mut(), std::ptr::null()).is_null());
+        assert!(rift_get_imposter(std::ptr::null_mut(), 1, std::ptr::null()).is_null());
+        assert_eq!(
+            rift_add_stub(std::ptr::null_mut(), 1, std::ptr::null(), -1),
+            -1
+        );
+        assert_eq!(rift_clear_recorded(std::ptr::null_mut(), 1), -1);
+        assert_eq!(rift_set_imposter_enabled(std::ptr::null_mut(), 1, 1), -1);
+
+        let h = rift_start();
+        // unknown port → sentinels
+        assert!(rift_get_imposter(h, 12345, std::ptr::null()).is_null());
+        assert_eq!(rift_clear_recorded(h, 12345), -1);
+        assert_eq!(rift_set_imposter_enabled(h, 12345, 1), -1);
+
+        // create an imposter with no stubs for ref/JSON error paths
+        let cfg = cstr(r#"{ "port": 19961, "protocol": "http", "stubs": [] }"#);
+        assert_eq!(rift_create_imposter(h, cfg.as_ptr()), 19961);
+        // out-of-range stub index → null
+        assert!(rift_get_stub(h, 19961, cstr(r#"{"index":99}"#).as_ptr()).is_null());
+        // malformed ref JSON → null
+        assert!(rift_get_stub(h, 19961, cstr("not json").as_ptr()).is_null());
+        // malformed stub JSON on add → -1
+        assert_eq!(rift_add_stub(h, 19961, cstr("not json").as_ptr(), -1), -1);
+        rift_stop(h);
+    }
+}
+
+#[test]
+fn ffi_admin_longtail_projections_and_edges() {
+    unsafe {
+        let h = rift_start();
+        // Imposter with a pure-proxy stub + a regular stub, to exercise removeProxies stripping.
+        let cfg = cstr(
+            r#"{ "port": 19962, "protocol": "http", "recordRequests": true, "stubs": [
+                 { "id": "p", "predicates": [{ "equals": { "path": "/px" } }],
+                   "responses": [{ "proxy": { "to": "http://127.0.0.1:1", "mode": "proxyOnce" } }] },
+                 { "id": "r", "responses": [{ "is": { "statusCode": 200, "body": "r" } }] } ] }"#,
+        );
+        let port = rift_create_imposter(h, cfg.as_ptr());
+        assert_eq!(port, 19962);
+
+        let stub_count = |json: &str, replayable_wrapper: bool| -> usize {
+            let v: serde_json::Value = serde_json::from_str(json).unwrap();
+            if replayable_wrapper {
+                v["imposters"][0]["stubs"].as_array().unwrap().len()
+            } else {
+                v["stubs"].as_array().unwrap().len()
+            }
+        };
+
+        // list, replayable: both stubs present; +removeProxies: the pure-proxy stub is dropped.
+        let l_all = take_json(rift_list_imposters(
+            h,
+            cstr(r#"{"replayable":true}"#).as_ptr(),
+        ));
+        assert_eq!(stub_count(&l_all, true), 2);
+        let l_np = take_json(rift_list_imposters(
+            h,
+            cstr(r#"{"replayable":true,"removeProxies":true}"#).as_ptr(),
+        ));
+        assert_eq!(
+            stub_count(&l_np, true),
+            1,
+            "removeProxies strips the proxy stub (list)"
+        );
+
+        // get, replayable + removeProxies — replayable returns the bare config (top-level stubs).
+        let g_np = take_json(rift_get_imposter(
+            h,
+            port,
+            cstr(r#"{"replayable":true,"removeProxies":true}"#).as_ptr(),
+        ));
+        assert_eq!(stub_count(&g_np, false), 1);
+        // get, DETAIL (non-replayable) + removeProxies — must ALSO strip, matching the admin route.
+        let g_detail_np = take_json(rift_get_imposter(
+            h,
+            port,
+            cstr(r#"{"removeProxies":true}"#).as_ptr(),
+        ));
+        assert_eq!(
+            stub_count(&g_detail_np, false),
+            1,
+            "removeProxies strips on the detail view too"
+        );
+        let g_detail = take_json(rift_get_imposter(h, port, std::ptr::null()));
+        assert_eq!(
+            stub_count(&g_detail, false),
+            2,
+            "no removeProxies keeps both"
+        );
+
+        // A misspelled option key is a hard error (deny_unknown_fields), not a silent default.
+        assert!(rift_list_imposters(h, cstr(r#"{"repayable":true}"#).as_ptr()).is_null());
+        assert!(rift_get_imposter(h, port, cstr(r#"{"bogus":true}"#).as_ptr()).is_null());
+
+        // Stub addressing: exercise the OTHER StubRef branch of update/delete than the main test.
+        // update by INDEX (main test does update by id):
+        let upd =
+            cstr(r#"{ "id": "r", "responses": [{ "is": { "statusCode": 204, "body": "" } }] }"#);
+        assert_eq!(
+            rift_update_stub(h, port, cstr(r#"{"index":1}"#).as_ptr(), upd.as_ptr()),
+            0
+        );
+        // add at an EXPLICIT index 0 (main test appends with -1), then confirm order:
+        let ins = cstr(r#"{ "id": "first", "responses": [{ "is": { "statusCode": 200 } }] }"#);
+        assert_eq!(rift_add_stub(h, port, ins.as_ptr(), 0), 0);
+        let after = take_json(rift_get_stub(h, port, cstr(r#"{"index":0}"#).as_ptr()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&after).unwrap()["id"],
+            "first",
+            "explicit index 0 inserts at the front"
+        );
+        // delete by ID (main test deletes by index):
+        assert_eq!(
+            rift_delete_stub(h, port, cstr(r#"{"id":"first"}"#).as_ptr()),
+            0
+        );
+        // unknown id → null
+        assert!(rift_get_stub(h, port, cstr(r#"{"id":"nope"}"#).as_ptr()).is_null());
+
+        rift_stop(h);
+    }
+}
+
+#[test]
+fn ffi_admin_longtail_scenario_and_flow_edges() {
+    unsafe {
+        let h = rift_start();
+        let cfg = cstr(
+            r#"{ "port": 19963, "protocol": "http", "stubs": [
+                 { "scenarioName": "order", "requiredScenarioState": "Started",
+                   "responses": [{ "is": { "statusCode": 200 } }] } ] }"#,
+        );
+        let port = rift_create_imposter(h, cfg.as_ptr());
+        assert_eq!(port, 19963);
+
+        // missing "state" field → -1 with a specific message.
+        assert_eq!(
+            rift_set_scenario_state(h, port, cstr("order").as_ptr(), cstr("{}").as_ptr()),
+            -1
+        );
+
+        // Explicit flowId isolates state from the default flow.
+        assert_eq!(
+            rift_set_scenario_state(
+                h,
+                port,
+                cstr("order").as_ptr(),
+                cstr(r#"{"state":"paid","flowId":"tenant-a"}"#).as_ptr(),
+            ),
+            0
+        );
+        let scen_a = take_json(rift_scenarios(h, port, cstr("tenant-a").as_ptr()));
+        let va: serde_json::Value = serde_json::from_str(&scen_a).unwrap();
+        assert_eq!(va["flowId"], "tenant-a");
+        assert_eq!(va["scenarios"][0]["state"], "paid");
+        // The default flow is untouched (still initial "Started").
+        let scen_def = take_json(rift_scenarios(h, port, std::ptr::null()));
+        let vd: serde_json::Value = serde_json::from_str(&scen_def).unwrap();
+        assert_eq!(
+            vd["scenarios"][0]["state"], "Started",
+            "default flow isolated from tenant-a"
+        );
+
+        // Error-path coverage for the symbols the happy-path test only exercises positively.
+        assert!(
+            rift_update_stub(std::ptr::null_mut(), 1, std::ptr::null(), std::ptr::null()) == -1
+        );
+        assert!(rift_delete_stub(std::ptr::null_mut(), 1, std::ptr::null()) == -1);
+        assert_eq!(rift_clear_proxy_recordings(std::ptr::null_mut(), 1), -1);
+        assert!(rift_scenarios(std::ptr::null_mut(), 1, std::ptr::null()).is_null());
+        assert_eq!(
+            rift_set_scenario_state(std::ptr::null_mut(), 1, std::ptr::null(), std::ptr::null()),
+            -1
+        );
+        assert_eq!(
+            rift_reset_scenarios(std::ptr::null_mut(), 1, std::ptr::null()),
+            -1
+        );
+        // unknown port
+        assert!(rift_scenarios(h, 12345, std::ptr::null()).is_null());
+        assert_eq!(rift_clear_proxy_recordings(h, 12345), -1);
+        assert_eq!(rift_reset_scenarios(h, 12345, std::ptr::null()), -1);
+
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -666,15 +666,19 @@ pub async fn handle_clear_proxy_responses(
 // Helper functions
 // =============================================================================
 
-/// Filter out proxy responses from stubs
-fn filter_proxy_responses(config: &ImposterConfig) -> ImposterConfig {
+/// Filter out proxy responses from stubs. `pub` (not just `pub(crate)`) so the FFI layer
+/// (issue #491) can apply the SAME `removeProxies` projection the admin handlers use, instead of
+/// re-implementing it and risking drift.
+pub fn filter_proxy_responses(config: &ImposterConfig) -> ImposterConfig {
     let mut filtered = config.clone();
     filtered.stubs = filter_proxy_stubs(config.stubs.clone());
     filtered
 }
 
-/// Filter proxy responses from a list of stubs
-fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter::Stub> {
+/// Filter proxy responses from a list of stubs. `pub` so the FFI `rift_get_imposter` detail view
+/// (issue #491) applies the SAME `removeProxies` projection this crate's `handle_get` applies to
+/// its live `get_stubs()`, rather than re-implementing it.
+pub fn filter_proxy_stubs(stubs: Vec<crate::imposter::Stub>) -> Vec<crate::imposter::Stub> {
     stubs
         .into_iter()
         .filter_map(|stub| {

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -14,6 +14,7 @@ mod router;
 mod server;
 pub mod types;
 
+pub use handlers::imposters::{filter_proxy_responses, filter_proxy_stubs};
 pub use server::{AdminApiServer, RunningAdminApi};
 
 /// Default port for the Mountebank-compatible admin API.

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -47,11 +47,12 @@ rift_stop(h);                     // stop and free
 | `rift_stub_warnings` | `char* rift_stub_warnings(RiftHandle* h, uint16_t port)` | [Stub-analysis warnings](../features/stub-analysis.md) (duplicate/shadowed/catch-all) as a JSON array (**caller frees**), or `NULL` on error. |
 | `rift_apply_config` | `char* rift_apply_config(RiftHandle* h, const char* json)` | Reconcile the full imposter set (like `POST /admin/reload`); returns the apply report JSON (caller frees). |
 
-## Admin long tail over FFI (scenario state + correlated spaces)
+## Admin long tail over FFI
 
-The admin "long tail" — scenario/flow-state and the correlated per-space stub plane — has direct
-C-ABI entry points, so an embedder can drive it with **zero loopback HTTP** (no `rift_serve_admin`).
-Each mirrors the corresponding admin-HTTP handler exactly (same `ImposterManager` calls, same JSON):
+The admin "long tail" — scenario/flow-state, the correlated per-space stub plane, imposter list/get,
+stub surgery, and scenario management — has direct C-ABI entry points, so an embedder can drive it
+with **zero loopback HTTP** (no `rift_serve_admin`). Each mirrors the corresponding admin-HTTP
+handler exactly (same `ImposterManager`/`Imposter` calls, same JSON):
 
 | Function | Signature | Returns |
 |---|---|---|
@@ -67,6 +68,26 @@ Each mirrors the corresponding admin-HTTP handler exactly (same `ImposterManager
 with `found:false` (a normal outcome, `rift_last_error` untouched), and `NULL` is reserved strictly
 for a genuine error — so a consumer treats `found:false` as "unset" and `NULL` as a read failure,
 with no need to parse `rift_last_error`.
+
+The rest of the admin long tail — imposter list/get, stub surgery (add/get/update/delete, by index
+or id), clearing recorded/proxy recordings, enable/disable, and scenario list/set-state/reset — is
+likewise direct C-ABI, each calling the same `ImposterManager`/`Imposter` method the corresponding
+admin-HTTP handler calls:
+
+| Function | Signature | Returns |
+|---|---|---|
+| `rift_list_imposters` | `char* rift_list_imposters(RiftHandle* h, const char* options_json)` | JSON `{"imposters":[...]}` (**caller frees**), or `NULL` on error. `options_json` (`NULL` = defaults): `{"replayable":false,"removeProxies":false}`. `replayable` returns full `ImposterConfig`s (the same `removeProxies` projection the admin `?replayable=true` route serves); otherwise a summary shape `{"protocol","port","name"?,"numberOfRequests","enabled"}` per imposter (imposters with no assigned port are skipped). |
+| `rift_get_imposter` | `char* rift_get_imposter(RiftHandle* h, uint16_t port, const char* options_json)` | Same `options_json` shape as `rift_list_imposters`. Replayable returns the single `ImposterConfig`; otherwise a detail object `{"protocol","port","name"?,"numberOfRequests","enabled","recordRequests","stubs","requests"}` (**caller frees**), or `NULL` on error. |
+| `rift_add_stub` | `int rift_add_stub(RiftHandle* h, uint16_t port, const char* stub_json, int32_t index)` | `0` on success, `-1` on error. `index < 0` appends; otherwise inserts at that position. No stub id is auto-generated; no injection gating (the direct C-ABI is the trusted embedder, like `rift_replace_stubs`). |
+| `rift_get_stub` | `char* rift_get_stub(RiftHandle* h, uint16_t port, const char* ref_json)` | The bare `Stub` JSON (**caller frees**), or `NULL` on error (out-of-range index, unknown id, or malformed ref). `ref_json` is `{"index":N}` or `{"id":"..."}`. |
+| `rift_update_stub` | `int rift_update_stub(RiftHandle* h, uint16_t port, const char* ref_json, const char* stub_json)` | `0` on success, `-1` on error. Replaces the stub addressed by `ref_json` with `stub_json`. |
+| `rift_delete_stub` | `int rift_delete_stub(RiftHandle* h, uint16_t port, const char* ref_json)` | `0` on success, `-1` on error. |
+| `rift_clear_recorded` | `int rift_clear_recorded(RiftHandle* h, uint16_t port)` | `0` on success, `-1` on error. Clears all recorded requests for the imposter. |
+| `rift_clear_proxy_recordings` | `int rift_clear_proxy_recordings(RiftHandle* h, uint16_t port)` | `0` on success, `-1` on error. Clears saved proxy responses. |
+| `rift_set_imposter_enabled` | `int rift_set_imposter_enabled(RiftHandle* h, uint16_t port, int32_t enabled)` | `0` on success, `-1` on error. `enabled != 0` enables; `0` disables. |
+| `rift_scenarios` | `char* rift_scenarios(RiftHandle* h, uint16_t port, const char* flow_id)` | JSON `{"flowId","scenarios":[{"name","state"}]}` (**caller frees**), or `NULL` on error. `flow_id` may be `NULL` for the imposter's default flow. |
+| `rift_set_scenario_state` | `int rift_set_scenario_state(RiftHandle* h, uint16_t port, const char* name, const char* state_json)` | `0` on success, `-1` on error (including a missing `state` field). `state_json`: `{"state":"...","flowId":"..."?}` (`flowId` optional → default flow). |
+| `rift_reset_scenarios` | `int rift_reset_scenarios(RiftHandle* h, uint16_t port, const char* flow_id)` | `0` on success, `-1` on error. Resets every scenario for `flow_id` (`NULL` → default flow) back to its initial state. |
 
 Errors set `rift_last_error` like the data-plane functions. Together with the data plane
 (`rift_create_imposter`/`rift_replace_stubs`/`rift_recorded`/`rift_delete_imposter`), these cover the

--- a/scripts/verify-ffi-cdylib.sh
+++ b/scripts/verify-ffi-cdylib.sh
@@ -24,6 +24,19 @@ SYMBOLS=(
   rift_stub_warnings
   # issue #494: server-side verification (predicate-count + closest-match)
   rift_verify
+  # issue #491: admin long tail — list/get imposters, stub surgery, clear/enable, scenarios
+  rift_list_imposters
+  rift_get_imposter
+  rift_add_stub
+  rift_get_stub
+  rift_update_stub
+  rift_delete_stub
+  rift_clear_recorded
+  rift_clear_proxy_recordings
+  rift_set_imposter_enabled
+  rift_scenarios
+  rift_set_scenario_state
+  rift_reset_scenarios
 )
 
 # Issue #344: the checked-in C header is the ABI's source of truth — assert it matches a fresh


### PR DESCRIPTION
Adds 12 additive C-ABI v2 FFI symbols mirroring the admin long-tail routes (list/get imposters with replayable/removeProxies projections, add/get/update/delete stub by index or id, clear recorded, clear proxy recordings, enable/disable, scenario list/set-state/reset). Each delegates to the same ImposterManager/Imposter method the admin handler calls and returns the same domain JSON — reusing the admin removeProxies projection so the surfaces can't drift. Injection is ungated over the trusted in-process FFI (consistent with rift_replace_stubs).

cbindgen header regenerated (all 12 in the C-ABI symbol smoke list), docs/embedding/ffi.md extended, and round_trip.rs covers every symbol's happy path plus error/sentinel and projection edge cases.

Closes #491

Part of the SDK program (epic #458).