### PR TITLE
feat(conformance): publish sdk-conformance corpus as a release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,18 @@ jobs:
       - name: Run rift-ffi C-ABI round-trip tests
         run: cargo test -p rift-ffi --all-features --test round_trip
 
+      # Issue #460: the published sdk-conformance-<ver>.tar.gz corpus must serve and its `_verify`
+      # transcripts must hold on this commit (and `manifest.json` must match the fixtures on disk).
+      # This gate binary is also skipped by the `--lib` step, so run it explicitly — it's what keeps
+      # the release artifact verified rather than hoped, and catches DSL/engine drift at the source.
+      - name: Run SDK conformance corpus replay gate
+        run: cargo test -p rift-http-proxy --all-features --test corpus_replay
+
+      # Issue #460: prove the corpus packager (release step) works end-to-end — version stamping,
+      # tar structure, fixture-count round-trip — without needing an engine build.
+      - name: SDK conformance packager self-test
+        run: ./scripts/gen-sdk-conformance.sh --self-test
+
       # Issue #344: a pinned cbindgen so the header regenerate-diff in the smoke test is
       # deterministic (cbindgen output varies across versions) and actually runs (the step
       # skips the diff when cbindgen is absent). Keep the version in sync with the header's.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,6 +424,17 @@ jobs:
           ./scripts/gen-ffi-manifest.sh "${{ steps.version.outputs.VERSION }}" artifacts ffi-manifest.json
           cat ffi-manifest.json
 
+      # Issue #460: package sdk-conformance-<version>.tar.gz — the corpus every Rift SDK's CI
+      # replays over embedded and remote transports (imposter fixtures + `_verify` transcripts +
+      # README replay contract), version-locked to this engine release. The corpus is proven to
+      # serve + verify on this commit by `tests/corpus_replay.rs`; here we just stamp the version
+      # and package it (with a .sha256) so SDKs download the exact fixtures for the engine they pin.
+      - name: Generate SDK conformance corpus
+        run: |
+          ./scripts/gen-sdk-conformance.sh "${{ steps.version.outputs.VERSION }}" \
+            "sdk-conformance-${{ steps.version.outputs.VERSION }}.tar.gz"
+          ls -l sdk-conformance-*.tar.gz*
+
       - name: Generate release notes
         id: notes
         run: |
@@ -532,6 +543,8 @@ jobs:
             artifacts/**/*.dylib
             artifacts/**/*.dll
             ffi-manifest.json
+            sdk-conformance-*.tar.gz
+            sdk-conformance-*.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rift-core",
+ "rift-lint",
  "rift-types",
  "rustls",
  "rustls-pemfile",

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -96,6 +96,8 @@ serde_json_path = "0.7"
 [dev-dependencies]
 # Turn on the failing flow-store backend for backend-outage tests (issue #318)
 rift-core = { path = "../rift-core", version = "0.1.0", default-features = false, features = ["test-backend"] }
+# Corpus lint gate (issue #460): lint every vendored fixture via the library API.
+rift-lint = { path = "../rift-lint", version = "0.1.0" }
 tempfile = "3.8"
 rcgen = "0.13"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/rift-http-proxy/tests/corpus_replay.rs
+++ b/crates/rift-http-proxy/tests/corpus_replay.rs
@@ -1,0 +1,320 @@
+//! Issue #460: the vendored SDK-conformance corpus — published per release as
+//! `sdk-conformance-<version>.tar.gz` and replayed by every SDK's CI — must serve and its
+//! `_verify` transcripts must hold on THIS engine commit. This is the engine-side invariant that
+//! keeps the published artifact *verified*, not merely hoped: it mirrors the reference replayer the
+//! README documents (`rift-verify --skip-dynamic --verify-dynamic`) over the whole corpus, guards
+//! `manifest.json` against drift from the fixtures on disk, and proves the *packaged* tarball (not
+//! just the source tree) still serves after `cp`/`jq`/re-tar.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const SERVER: &str = env!("CARGO_BIN_EXE_rift-http-proxy");
+const VERIFY: &str = env!("CARGO_BIN_EXE_rift-verify");
+/// The closed set of capability gates a fixture may declare in `manifest.json` `requires`
+/// (extended additively). An SDK CI skips a fixture only when it lacks a declared capability.
+const CLOSED_CAPS: &[&str] = &["injection", "proxy", "redis", "https", "shell"];
+
+/// `<repo>/sdk-conformance` (this test lives in `<repo>/crates/rift-http-proxy`).
+fn sdk_conformance_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../sdk-conformance")
+        .canonicalize()
+        .expect("sdk-conformance directory exists")
+}
+
+/// Every fixture's imposters/*.json path under `<corpus>/imposters`, sorted.
+fn fixture_files(corpus: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(corpus.join("imposters"))
+        .expect("read imposters dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("json"))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn corpus_lints_clean() {
+    let dir = sdk_conformance_dir().join("corpus/imposters");
+    let result = rift_lint::lint_directory(&dir, &rift_lint::LintOptions::default());
+    assert!(
+        result.files_checked >= 15,
+        "expected the full corpus (>=15 fixtures), linted {}",
+        result.files_checked
+    );
+    assert!(
+        !result.has_errors(),
+        "corpus fixtures must lint clean, found {} error(s): {:#?}",
+        result.errors,
+        result
+            .issues
+            .iter()
+            .filter(|i| matches!(i.severity, rift_lint::Severity::Error))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn manifest_is_consistent() {
+    let root = sdk_conformance_dir();
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(root.join("manifest.json")).expect("read manifest"),
+    )
+    .expect("manifest is valid JSON");
+
+    assert_eq!(manifest["schemaVersion"], 1, "schemaVersion must be 1");
+    assert!(
+        manifest["engineVersion"].is_string(),
+        "engineVersion must be present (stamped at packaging time)"
+    );
+    let fixtures = manifest["fixtures"].as_array().expect("fixtures array");
+
+    // Every fixture on disk is listed exactly once, and every listed file exists.
+    let mut listed: Vec<String> = fixtures
+        .iter()
+        .map(|f| {
+            f["file"]
+                .as_str()
+                .expect("fixture.file is a string")
+                .to_string()
+        })
+        .collect();
+    listed.sort();
+    let corpus = root.join("corpus");
+    let mut on_disk: Vec<String> = fixture_files(&corpus)
+        .iter()
+        .map(|p| {
+            format!(
+                "corpus/imposters/{}",
+                p.file_name().unwrap().to_str().unwrap()
+            )
+        })
+        .collect();
+    on_disk.sort();
+    assert_eq!(
+        listed, on_disk,
+        "manifest must list every corpus fixture exactly once"
+    );
+
+    // Structural + SEMANTIC checks: the manifest's port/requires/hasVerify must match the fixture's
+    // actual content, so a fixture edited on one side without the other can't drift past the gate
+    // (an SDK trusts these fields to decide what to skip and how to replay).
+    let mut ports = std::collections::HashSet::new();
+    for f in fixtures {
+        let file = f["file"].as_str().unwrap();
+        let path = root.join(file);
+        assert!(
+            path.exists(),
+            "manifest references {file}, which does not exist"
+        );
+        let fixture: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let raw = serde_json::to_string(&fixture).unwrap();
+
+        let port = f["port"].as_u64().expect("fixture.port is a number");
+        assert!(ports.insert(port), "duplicate port {port} across fixtures");
+        assert_eq!(
+            Some(port),
+            fixture["port"].as_u64(),
+            "{file}: manifest port {port} disagrees with the fixture's own port"
+        );
+
+        for cap in f["requires"]
+            .as_array()
+            .expect("fixture.requires is an array")
+        {
+            let cap = cap.as_str().expect("capability is a string");
+            assert!(
+                CLOSED_CAPS.contains(&cap),
+                "fixture {file} declares unknown capability {cap:?} (closed set: {CLOSED_CAPS:?})"
+            );
+        }
+        let requires: Vec<&str> = f["requires"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c.as_str().unwrap())
+            .collect();
+
+        // hasVerify ⇔ the fixture actually carries a `_verify` block.
+        let has_verify_field = f["hasVerify"].as_bool().expect("hasVerify is a bool");
+        assert_eq!(
+            has_verify_field,
+            raw.contains("\"_verify\""),
+            "{file}: manifest hasVerify={has_verify_field} disagrees with the fixture content"
+        );
+
+        // A scripting surface (inject/decorate/shellTransform/JS-wait/_rift.script) ⇒ requires
+        // injection; a proxy response ⇒ requires proxy. Under-declaring these would make an SDK
+        // lane wrongly RUN a fixture it can't support.
+        let needs_injection = raw.contains("\"inject\"")
+            || raw.contains("\"decorate\"")
+            || raw.contains("\"shellTransform\"")
+            || raw.contains("\"wait\": \"function")
+            || (raw.contains("\"_rift\"") && raw.contains("\"script\""));
+        if needs_injection {
+            assert!(
+                requires.contains(&"injection"),
+                "{file} uses a scripting surface but does not declare requires:[injection]"
+            );
+        }
+        if raw.contains("\"proxy\"") {
+            assert!(
+                requires.contains(&"proxy"),
+                "{file} has a proxy response but does not declare requires:[proxy]"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn corpus_serves_and_verify_holds() {
+    let corpus = sdk_conformance_dir().join("corpus");
+    serve_and_verify(&corpus).await;
+}
+
+/// Issue #460 AC-f: the *packaged* tarball (not just the source tree) must still serve. Packaging
+/// does real transforms — `cp -R`, a `jq` rewrite of `manifest.json`, and a re-tar under a
+/// version-prefixed root — any of which could silently drop a fixture or a `data/`/injection file.
+/// Run the packager, extract, and replay against the extracted `corpus/`.
+#[tokio::test]
+async fn packaged_corpus_serves_and_verify_holds() {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/gen-sdk-conformance.sh");
+    let work = tempfile::tempdir().expect("tempdir");
+    let tarball = work.path().join("sdk-conformance-0.0.0-test.tar.gz");
+
+    let pkg = std::process::Command::new("bash")
+        .arg(&script)
+        .arg("0.0.0-test")
+        .arg(&tarball)
+        .output()
+        .expect("run gen-sdk-conformance.sh");
+    assert!(
+        pkg.status.success(),
+        "packaging failed:\n{}",
+        String::from_utf8_lossy(&pkg.stderr)
+    );
+
+    let status = std::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(work.path())
+        .status()
+        .expect("extract tarball");
+    assert!(status.success(), "tar extraction failed");
+
+    let extracted_corpus = work.path().join("sdk-conformance-0.0.0-test/corpus");
+    assert!(
+        extracted_corpus.join("imposters").is_dir(),
+        "packaged tarball is missing corpus/imposters"
+    );
+    serve_and_verify(&extracted_corpus).await;
+}
+
+/// Serve every fixture under `<corpus>/imposters` from cwd = `<corpus>` (so relative `data/` paths
+/// resolve) with `--allowInjection`, then assert `rift-verify --skip-dynamic --verify-dynamic`
+/// exits 0 and every `_verify` block on disk actually replayed (not a corpus-global no-op).
+async fn serve_and_verify(corpus: &Path) {
+    let files = fixture_files(corpus);
+    let imposters: Vec<serde_json::Value> = files
+        .iter()
+        .map(|f| serde_json::from_str(&std::fs::read_to_string(f).unwrap()).unwrap())
+        .collect();
+    let expected = imposters.len();
+    // The number of `_verify` blocks across the corpus; each replayed block prints a `_verify[0]`
+    // step, so a fixture whose annotation stops being honored drops this count.
+    let expected_verify_blocks: usize = files
+        .iter()
+        .map(|f| {
+            std::fs::read_to_string(f)
+                .unwrap()
+                .matches("\"_verify\"")
+                .count()
+        })
+        .sum();
+
+    let config = serde_json::json!({ "imposters": imposters });
+    let tmp = tempfile::NamedTempFile::new().expect("temp config");
+    std::fs::write(tmp.path(), serde_json::to_vec(&config).unwrap()).unwrap();
+
+    let admin_port = port_check::free_local_port().expect("a free local port");
+    let admin_url = format!("http://127.0.0.1:{admin_port}");
+    // Capture the server's own stdout+stderr so a startup crash is diagnosable, not a blind timeout.
+    let log = tempfile::NamedTempFile::new().expect("server log file");
+    let log_out = log.reopen().expect("reopen log");
+    let log_err = log.reopen().expect("reopen log");
+
+    let mut server = tokio::process::Command::new(SERVER)
+        .arg("--configfile")
+        .arg(tmp.path())
+        .args(["--port", &admin_port.to_string(), "--allowInjection"])
+        .current_dir(corpus)
+        .stdout(std::process::Stdio::from(log_out))
+        .stderr(std::process::Stdio::from(log_err))
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn rift server");
+
+    let ready =
+        wait_for_imposters(&mut server, &admin_url, expected, Duration::from_secs(30)).await;
+    if !ready {
+        let _ = server.kill().await;
+        panic!(
+            "server did not load {expected} imposters within 30s.\nserver log:\n{}",
+            std::fs::read_to_string(log.path()).unwrap_or_default()
+        );
+    }
+
+    let out = tokio::process::Command::new(VERIFY)
+        .args([
+            "--admin-url",
+            &admin_url,
+            "--skip-dynamic",
+            "--verify-dynamic",
+        ])
+        .output()
+        .await
+        .expect("run rift-verify");
+    let _ = server.kill().await;
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "rift-verify must exit 0 over the corpus at {}.\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        corpus.display()
+    );
+    // Every `_verify` block on disk must have actually replayed — guards against a fixture's
+    // annotation silently ceasing to be honored while other fixtures keep the run green.
+    let replayed = format!("{stdout}{stderr}").matches("_verify[0]").count();
+    assert!(
+        replayed >= expected_verify_blocks,
+        "expected {expected_verify_blocks} _verify block(s) to replay, saw {replayed}:\n{stdout}"
+    );
+}
+
+/// Poll `GET /imposters` until at least `expected` imposters are loaded, failing fast if the server
+/// process dies first (rather than blindly waiting out the timeout).
+async fn wait_for_imposters(
+    server: &mut tokio::process::Child,
+    admin_url: &str,
+    expected: usize,
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some(_status)) = server.try_wait() {
+            return false; // server exited before it was ready — caller surfaces the log
+        }
+        if let Ok(resp) = reqwest::get(format!("{admin_url}/imposters")).await
+            && let Ok(v) = resp.json::<serde_json::Value>().await
+            && v["imposters"].as_array().map_or(0, Vec::len) >= expected
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    false
+}

--- a/docs/embedding/sdk-conformance.md
+++ b/docs/embedding/sdk-conformance.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: SDK conformance corpus
+parent: Embedding & SPI
+nav_order: 4
+---
+
+# SDK conformance corpus
+
+Every Rift release publishes **`sdk-conformance-<version>.tar.gz`** as a GitHub release asset. It is
+the shared corpus that every official Rift SDK (rift-java, rift-go, rift-scala, rift-node) replays in
+its CI to prove its typed DSL stays in lockstep with the engine grammar — a fixture the DSL cannot
+express is a red SDK build (RFC-003 §9.2, risk R1).
+
+The corpus is **engine-canonical**: it is vendored in this repo under `sdk-conformance/`, alongside
+the `_verify` schema and its reference replayer `rift-verify`, and is version-locked to the release
+it ships with. An engine CI gate (`crates/rift-http-proxy/tests/corpus_replay.rs`) replays the whole
+corpus on every commit, so a published artifact is always verified rather than merely hoped.
+
+## Artifact layout
+
+```
+sdk-conformance-<version>/
+├── README.md            # the normative replay contract (packaged in the tarball)
+├── manifest.json        # { schemaVersion, engineVersion, fixtures[] }
+└── corpus/
+    ├── imposters/NN-name.json   # imposter config, optionally with `_verify` transcripts
+    ├── data/…                   # data files referenced as `data/<file>` (cwd = corpus/)
+    └── fixtures/injection/*.{js,cjs}
+```
+
+`manifest.json` indexes each fixture with its `port`, a `name`, a `requires` capability list (closed
+set: `injection`, `proxy`, `redis`, `https`, `shell`), and `hasVerify`. `engineVersion` equals the
+Rift release — the corpus and engine move together, so an SDK pinning engine `X.Y.Z` downloads
+`sdk-conformance-X.Y.Z.tar.gz` from that release.
+
+## The replay contract (for SDK authors)
+
+For each fixture, an SDK conformance suite must:
+
+1. **Express it through the typed DSL** and assert the DSL's serialized output deep-equals the
+   fixture (a fixture the DSL cannot express is a red build).
+2. **Serve and replay** — create the imposter and, when it has a `_verify` sequence, drive each
+   request and assert each expectation. The reference semantics are
+   `rift-verify --skip-dynamic --verify-dynamic`; when in doubt, assert what it asserts.
+3. **Run both transports** it supports — embedded (C-ABI / FFI) and remote (admin API) — with
+   identical assertions.
+4. **Skip a fixture only** when its `requires` names a capability the lane lacks (e.g. an
+   `injection` fixture without `--allowInjection`), never ad hoc.
+
+The full contract ships in the tarball's `README.md`. See also the
+[`_verify` annotations]({{ site.baseurl }}/configuration/cli/) documented for `rift-verify`.
+
+## Adding a fixture
+
+Fixtures are numbered and append-only (`NN-name.json`, never renumbered). Add the next free number,
+register it in `sdk-conformance/manifest.json`, and the engine gate enforces that it serves and its
+`_verify` transcripts hold before it can ship. Seed material lives in the engine's
+`tests/compatibility` and `examples/`.

--- a/scripts/gen-sdk-conformance.sh
+++ b/scripts/gen-sdk-conformance.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Package sdk-conformance-<version>.tar.gz (issue #460): the vendored SDK-conformance corpus that
+# every official Rift SDK's CI replays over embedded and remote transports. The tarball unpacks to a
+# single versioned root `sdk-conformance-<version>/` containing README.md, manifest.json (with the
+# real engineVersion stamped in — the checked-in copy carries a `0.0.0-dev` placeholder), and the
+# corpus/ tree. A `.sha256` sidecar is emitted alongside so consumers can verify the download.
+#
+# The corpus itself is engine-canonical and is proven to serve + verify on this commit by
+# `crates/rift-http-proxy/tests/corpus_replay.rs`; this script only packages it.
+#
+# Usage:
+#   scripts/gen-sdk-conformance.sh <version> [output.tar.gz]   # package the corpus
+#   scripts/gen-sdk-conformance.sh --self-test                 # prove the packager works
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$REPO_ROOT/sdk-conformance"
+
+# Clean up temp dirs on ANY exit (including an early `set -e`/`fail()` abort) so nothing leaks.
+# Assigned directly (not via a command-substitution helper, which would run in a subshell and never
+# reach these). `return 0` so the trap never poisons the script's exit status.
+STAGE_DIR=""
+WORK_DIR=""
+cleanup() {
+  [ -n "$STAGE_DIR" ] && rm -rf "$STAGE_DIR"
+  [ -n "$WORK_DIR" ] && rm -rf "$WORK_DIR"
+  return 0
+}
+trap cleanup EXIT
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+
+# Portable sha256 (Linux coreutils vs macOS/BSD).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"
+  else shasum -a 256 "$1"
+  fi
+}
+
+# Package $SRC_DIR into <out> as `sdk-conformance-<version>/…`, stamping engineVersion=<version>.
+package() {
+  local version="$1" out="${2:-sdk-conformance-$1.tar.gz}"
+  [ -n "$version" ] || fail "version argument is required"
+  [ -d "$SRC_DIR" ] || fail "corpus source not found: $SRC_DIR"
+  [ -f "$SRC_DIR/manifest.json" ] || fail "manifest.json missing under $SRC_DIR"
+  [ -d "$SRC_DIR/corpus/imposters" ] || fail "corpus/imposters missing under $SRC_DIR"
+  command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+  # Absolutize the output path before we cd around.
+  mkdir -p "$(dirname "$out")"
+  out="$(cd "$(dirname "$out")" && pwd)/$(basename "$out")"
+
+  local stage root
+  stage="$(mktemp -d)"; STAGE_DIR="$stage"
+  root="$stage/sdk-conformance-$version"
+  mkdir -p "$root"
+
+  cp "$SRC_DIR/README.md" "$root/"
+  cp -R "$SRC_DIR/corpus" "$root/"
+  # Stamp the real engine version into the packaged manifest (checked-in copy is a placeholder).
+  jq --arg v "$version" '.engineVersion = $v' "$SRC_DIR/manifest.json" > "$root/manifest.json"
+
+  tar -czf "$out" -C "$stage" "sdk-conformance-$version"
+  ( cd "$(dirname "$out")" && sha256_of "$(basename "$out")" > "$(basename "$out").sha256" )
+
+  echo "[ok] wrote $out"
+  echo "[ok] wrote $out.sha256"
+}
+
+# Prove the packager end-to-end: version is stamped, structure is intact, and every corpus fixture
+# survives the round-trip. No engine build required.
+self_test() {
+  local work ver="9.9.9-selftest"
+  work="$(mktemp -d)"; WORK_DIR="$work"
+
+  package "$ver" "$work/out.tar.gz"
+  [ -f "$work/out.tar.gz" ] || fail "tarball not produced"
+  [ -f "$work/out.tar.gz.sha256" ] || fail "checksum not produced"
+
+  tar -xzf "$work/out.tar.gz" -C "$work"
+  local extracted="$work/sdk-conformance-$ver"
+  [ -f "$extracted/README.md" ] || fail "README.md missing from tarball"
+  [ -f "$extracted/manifest.json" ] || fail "manifest.json missing from tarball"
+  [ -d "$extracted/corpus/imposters" ] || fail "corpus/imposters missing from tarball"
+
+  local stamped
+  stamped="$(jq -r '.engineVersion' "$extracted/manifest.json")"
+  [ "$stamped" = "$ver" ] || fail "engineVersion not stamped (got '$stamped', want '$ver')"
+
+  local disk pkg
+  disk="$(find "$SRC_DIR/corpus/imposters" -name '*.json' | wc -l | tr -d ' ')"
+  pkg="$(find "$extracted/corpus/imposters" -name '*.json' | wc -l | tr -d ' ')"
+  [ "$disk" = "$pkg" ] || fail "fixture count drift (disk=$disk, packaged=$pkg)"
+  local listed
+  listed="$(jq '.fixtures | length' "$extracted/manifest.json")"
+  [ "$listed" = "$pkg" ] || fail "manifest lists $listed fixtures but $pkg are packaged"
+
+  echo "[ok] self-test passed ($pkg fixtures, version stamped, checksum written)"
+}
+
+main() {
+  case "${1:-}" in
+    --self-test) self_test ;;
+    "" | -h | --help)
+      echo "Usage: $0 <version> [output.tar.gz] | $0 --self-test" >&2
+      exit 1
+      ;;
+    *) package "$@" ;;
+  esac
+}
+
+main "$@"

--- a/sdk-conformance/README.md
+++ b/sdk-conformance/README.md
@@ -1,0 +1,95 @@
+# Rift SDK conformance corpus
+
+This directory is published per Rift release as **`sdk-conformance-<version>.tar.gz`** (a GitHub
+release asset). Every official Rift SDK (rift-java, rift-go, rift-scala, rift-node) replays this
+corpus in its CI. It is the single source of truth for **DSL ↔ engine parity**: a fixture the SDK's
+typed DSL cannot express is a red SDK build (RFC-003 §9.2, risk R1).
+
+The corpus is **engine-canonical**: it lives here, in the engine repo, alongside the `_verify`
+schema (issue #251) and its reference replayer `rift-verify`, and is version-locked to the engine
+release it ships with. An engine CI gate (`crates/rift-http-proxy/tests/corpus_replay.rs`) replays
+the whole corpus on every commit, so a published artifact is verified, never merely hoped.
+
+## Layout
+
+```
+sdk-conformance-<version>/
+├── README.md            # this file — the normative replay contract
+├── manifest.json        # machine-readable index (schemaVersion, engineVersion, fixtures[])
+└── corpus/
+    ├── imposters/NN-name.json   # a standard Mountebank/Rift imposter config, optionally with
+    │                            #   `_verify` (expected request/response transcripts) and `_behaviors`
+    ├── data/…                   # data files referenced by fixtures as `data/<file>` (cwd = corpus/)
+    └── fixtures/injection/*.{js,cjs}   # JS decorate/inject modules referenced by injection fixtures
+```
+
+Paths inside a fixture (e.g. `"path": "data/products.csv"`) are **relative to `corpus/`** — the
+replayer's working directory must be `corpus/`. Do not rewrite them; embedded lanes that cannot set
+a working directory should absolutize them at load time against the extracted `corpus/` root.
+
+## `manifest.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "engineVersion": "X.Y.Z",
+  "fixtures": [
+    { "file": "corpus/imposters/05-scripting-engines.json", "port": 4505,
+      "name": "05 · Scripting engines", "requires": ["injection"], "hasVerify": false }
+  ]
+}
+```
+
+- **`engineVersion`** — the Rift release this corpus ships with. Corpus version **==** engine
+  release version; there is no independent corpus versioning.
+- **`requires`** — capability gates from the closed set
+  `["injection", "proxy", "redis", "https", "shell"]`. An SDK CI may skip a fixture **only** when
+  its lane lacks a capability the fixture declares — never ad hoc. (`injection` fixtures need the
+  engine started with `--allowInjection`; `proxy` fixtures need an upstream — `rift-verify` stands
+  up its own; `https`/`redis`/`shell` gate on TLS / a Redis backend / a host shell.)
+- **`hasVerify`** — the fixture carries a `_verify` sequence (see below).
+
+## The replay contract
+
+For each fixture in `manifest.json`, an SDK conformance suite MUST:
+
+1. **DSL-expressibility gate.** Parse the fixture JSON and reconstruct the imposter through the
+   SDK's typed DSL. The DSL's serialized output must **deep-equal** the fixture (JSON object key
+   order is irrelevant). Permitted normalizations are exactly those `rift-lint` treats as
+   equivalent — chiefly omitted-vs-explicit defaults (e.g. an absent `protocol` normalizing to
+   `"http"`). A fixture that **cannot** be expressed through the typed DSL is a **red build**: it
+   means the DSL has drifted from the engine grammar.
+
+2. **Serve & replay.** Create the imposter (from the DSL-built form) and, when the fixture has a
+   `_verify` sequence, drive each `sequence[].request` in order and assert each `sequence[].expect`.
+   The `_verify` schema is engine-native (see `docs/configuration/cli.md` and
+   `docs/features/stub-analysis.md`); `expect` keys include `status` and `bodyContains`. When in
+   doubt about semantics, assert exactly what the reference replayer asserts:
+
+   ```
+   rift-verify --admin-url <admin> --skip-dynamic --verify-dynamic
+   ```
+
+   (`--skip-dynamic` skips inject/proxy/script stubs in the *static* pass; `--verify-dynamic`
+   replays the `_verify` sequences and asserts deterministic `_rift.fault` outcomes.) It exits
+   non-zero iff any assertion fails.
+
+3. **Both transports.** Run the same fixtures with the same assertions over every transport the SDK
+   supports — **embedded** (C-ABI / FFI) and **remote** (admin API). A fixture must behave
+   identically on each.
+
+4. **Capability skips only per the manifest.** Skip a fixture solely because its `requires` names a
+   capability the lane lacks (e.g. an embedded lane on a platform without the cdylib, per the
+   release FFI manifest; an `injection` fixture when the lane runs without `--allowInjection`).
+   Never skip a fixture for any other reason.
+
+5. **Versioning.** An SDK pinning engine `X.Y.Z` downloads `sdk-conformance-X.Y.Z.tar.gz` from that
+   engine release and replays it. The corpus and the engine move together.
+
+## Extending the corpus
+
+Fixtures are **numbered and append-only** (`NN-name.json`, never renumbered) so a fixture's identity
+is stable across versions. Add a new fixture with the next free number, register it in
+`manifest.json` (with its `port`, `requires`, and `hasVerify`), and the engine gate
+(`corpus_replay.rs`) will enforce that it serves and its `_verify` transcripts hold before it can
+ship. Seed material for new fixtures lives in the engine's `tests/compatibility` and `examples/`.

--- a/sdk-conformance/corpus/data/products.csv
+++ b/sdk-conformance/corpus/data/products.csv
@@ -1,0 +1,4 @@
+id,name,price,category
+123,Widget,9.99,tools
+456,Gadget,19.99,electronics
+789,Gizmo,4.50,toys

--- a/sdk-conformance/corpus/fixtures/injection/appendExecutionId.cjs
+++ b/sdk-conformance/corpus/fixtures/injection/appendExecutionId.cjs
@@ -1,0 +1,48 @@
+// Verbatim from cof-primary/RENUW-renuw-mimeo-solo/services/Renuw_API_Executor/
+//   v1/postAPIRequest/injection/appendExecutionId.cjs
+//
+// Migration probe: a Mountebank `decorate` module loaded via require(). Exercises
+//   - config.path         (shorthand request path on the decorate config)
+//   - config.request.headers
+//   - config.response.body as a STRING mutated via JSON.parse/JSON.stringify
+// See scripts/conformance-migration.sh (RENUW · Renuw_API_Executor).
+module.exports = function (config) {
+    // Extract execution ID from request URL
+    var executionId = null;
+
+    if (config.path) {
+        var urlParts = config.path.split('/');
+        var lastSegment = urlParts[urlParts.length - 1];
+
+        // Check if last segment is a valid UUID (36 characters)
+        if (lastSegment && lastSegment.length === 36) {
+            executionId = lastSegment;
+        }
+    }
+
+    // Only proceed if we have an execution ID
+    if (!executionId) {
+        return;
+    }
+
+    // Parse existing response body
+    var body = {};
+    if (config.response.body) {
+        try {
+            body = JSON.parse(config.response.body);
+        } catch (e) {
+            body = {};
+        }
+    }
+
+    // Add executionId to response body
+    body.executionId = executionId;
+
+    // Update response
+    config.response.statusCode = 200;
+    config.response.body = JSON.stringify(body);
+
+    // Ensure headers object exists and set content type
+    config.response.headers = config.response.headers || {};
+    config.response.headers['Content-Type'] = 'application/json';
+};

--- a/sdk-conformance/corpus/fixtures/injection/injection.cjs
+++ b/sdk-conformance/corpus/fixtures/injection/injection.cjs
@@ -1,0 +1,23 @@
+// Verbatim from cof-primary/auto-digital-digi-rtl-mimeo-solo/services/Kaizen/
+//   injection_files/injection.cjs
+//
+// Migration probe: a `decorate` module loaded via require(). Exercises
+//   - config.request.body  + config.response.body (both STRING, JSON.parse'd)
+//   - copies the requested variant attribute onto every response buyRateVariant
+// See scripts/conformance-migration.sh (auto-digital · Kaizen).
+module.exports = function (config) {
+  const req = config.request;
+  const res = config.response;
+  const reqBody = JSON.parse(req.body);
+  const requestedVariant = reqBody.variant.variantAttribute;
+  const respBody = JSON.parse(res.body);
+  if (!respBody.buyRateVariants) {
+    return;
+  }
+  for (const variant of respBody.buyRateVariants) {
+    if (variant.variantAttribute) {
+      variant.variantAttribute = requestedVariant;
+    }
+  }
+  res.body = JSON.stringify(respBody);
+};

--- a/sdk-conformance/corpus/fixtures/injection/testInjection.cjs
+++ b/sdk-conformance/corpus/fixtures/injection/testInjection.cjs
@@ -1,0 +1,10 @@
+// Stand-in for cof-primary/RENUW-renuw-mimeo-solo/.../injection_files/testInjection.cjs
+// (the hand-written scaffold template references it but ships no body). Minimal,
+// faithful to the scaffold's intent: stamp a header proving the require() ran.
+//
+// Migration probe: decorate via `(config) => { require(...)(config); }`.
+// See scripts/conformance-migration.sh (RENUW · imposter scaffold).
+module.exports = function (config) {
+  config.response.headers = config.response.headers || {};
+  config.response.headers['X-Injected-By'] = 'testInjection.cjs';
+};

--- a/sdk-conformance/corpus/fixtures/injection/timeShift.js
+++ b/sdk-conformance/corpus/fixtures/injection/timeShift.js
@@ -1,0 +1,47 @@
+// Verbatim from cof-primary/RENUW-renuw-mimeo-solo/services/
+//   COAFPerformanceDeclineLookupLlds/v1/url/injection/timeShift.js
+//
+// Migration probe: a `decorate` module loaded via require(). Exercises
+//   - config.stub.scenarioName  (scenario name available to the decorate)
+//   - config.response.body as a PARSED OBJECT (datasetRecords array walk)
+// The scenario name (…_less_than_48_hours) drives the hour offset it stamps
+// onto lldsRecordCreatedTime. See scripts/conformance-migration.sh (RENUW · COAF).
+module.exports = function (config) {
+    // scenario name usually available as config.stub.scenarioName in decorate
+    const scenarioName =
+        (config && config.stub && config.stub.scenarioName ? config.stub.scenarioName : "").toLowerCase();
+
+    // Map scenario name patterns -> hour offsets
+    let hours = null;
+
+    if (scenarioName.includes("less_than_24_hours")) {
+        hours = 12;
+    } else if (scenarioName.includes("less_than_48_hours")) {
+        hours = 36;
+    } else if (scenarioName.includes("equals_to_48_hours")) {
+        hours = 48;
+    } else if (scenarioName.includes("more_than_48_hours")) {
+        hours = 50;
+    }
+
+    // If scenario doesn't match any time pattern, do nothing
+    if (hours === null) {
+        return;
+    }
+
+    const dt = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+    // Update only when field exists
+    if (
+        config.response &&
+        config.response.body &&
+        config.response.body.datasetRecords &&
+        Array.isArray(config.response.body.datasetRecords)
+    ) {
+        config.response.body.datasetRecords.forEach((r) => {
+            if (r && Object.prototype.hasOwnProperty.call(r, "lldsRecordCreatedTime")) {
+                r.lldsRecordCreatedTime = dt;
+            }
+        });
+    }
+};

--- a/sdk-conformance/corpus/imposters/01-basic-rest.json
+++ b/sdk-conformance/corpus/imposters/01-basic-rest.json
@@ -1,0 +1,78 @@
+{
+  "port": 4501,
+  "protocol": "http",
+  "name": "01 · Basic REST API",
+  "recordRequests": true,
+  "defaultResponse": {
+    "statusCode": 404,
+    "headers": { "Content-Type": "application/json" },
+    "body": { "error": "not found", "hint": "see README for the route list" }
+  },
+  "stubs": [
+    {
+      "name": "Health check",
+      "predicates": [{ "equals": { "method": "GET", "path": "/health" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "OK" } }]
+    },
+    {
+      "name": "List products (JSON array body)",
+      "predicates": [{ "equals": { "method": "GET", "path": "/api/products" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": [
+            { "id": 123, "name": "Widget", "price": 9.99 },
+            { "id": 456, "name": "Gadget", "price": 19.99 }
+          ]
+        }
+      }]
+    },
+    {
+      "name": "Get one product by numeric id (regex path)",
+      "predicates": [{
+        "and": [
+          { "equals": { "method": "GET" } },
+          { "matches": { "path": "^/api/products/\\d+$" } }
+        ]
+      }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "id": 123, "name": "Widget", "price": 9.99 }
+        }
+      }]
+    },
+    {
+      "name": "Create product",
+      "predicates": [{ "equals": { "method": "POST", "path": "/api/products" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 201,
+          "headers": { "Content-Type": "application/json", "Location": "/api/products/999" },
+          "body": { "id": 999, "message": "created" }
+        }
+      }]
+    },
+    {
+      "name": "Delete product (no content)",
+      "predicates": [{
+        "and": [
+          { "equals": { "method": "DELETE" } },
+          { "matches": { "path": "^/api/products/\\d+$" } }
+        ]
+      }],
+      "responses": [{ "is": { "statusCode": 204 } }]
+    },
+    {
+      "name": "Response cycling — three responses served round-robin",
+      "predicates": [{ "equals": { "method": "GET", "path": "/api/rotating" } }],
+      "responses": [
+        { "is": { "statusCode": 200, "body": { "served": "first" } } },
+        { "is": { "statusCode": 200, "body": { "served": "second" } } },
+        { "is": { "statusCode": 200, "body": { "served": "third" } } }
+      ]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/02-predicates.json
+++ b/sdk-conformance/corpus/imposters/02-predicates.json
@@ -1,0 +1,89 @@
+{
+  "port": 4502,
+  "protocol": "http",
+  "name": "02 · Predicate Showcase",
+  "recordRequests": true,
+  "defaultResponse": {
+    "statusCode": 400,
+    "headers": { "Content-Type": "application/json" },
+    "body": { "error": "no predicate matched", "hint": "see README §02 for matching requests" }
+  },
+  "stubs": [
+    {
+      "name": "equals — exact path + method",
+      "predicates": [{ "equals": { "method": "GET", "path": "/eq" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals" } } }]
+    },
+    {
+      "name": "equals caseSensitive=false — /CaSe matches /case",
+      "predicates": [{ "equals": { "path": "/case" }, "caseSensitive": false }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals-caseInsensitive" } } }]
+    },
+    {
+      "name": "deepEquals — query must be EXACTLY {a:1}",
+      "predicates": [{ "deepEquals": { "query": { "a": "1" } }, "caseSensitive": true }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "deepEquals" } } }]
+    },
+    {
+      "name": "contains — body contains 'needle'",
+      "predicates": [{ "contains": { "body": "needle" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "contains" } } }]
+    },
+    {
+      "name": "startsWith — path starts with /start",
+      "predicates": [{ "startsWith": { "path": "/start" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "startsWith" } } }]
+    },
+    {
+      "name": "endsWith — path ends with /end",
+      "predicates": [{ "endsWith": { "path": "/end" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "endsWith" } } }]
+    },
+    {
+      "name": "matches — regex path /id/<digits>",
+      "predicates": [{ "matches": { "path": "^/id/[0-9]+$" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "matches" } } }]
+    },
+    {
+      "name": "exists — Authorization header present",
+      "predicates": [{ "exists": { "headers": { "Authorization": true } } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "exists-header" } } }]
+    },
+    {
+      "name": "or — path is /red OR /blue",
+      "predicates": [{
+        "or": [
+          { "equals": { "path": "/red" } },
+          { "equals": { "path": "/blue" } }
+        ]
+      }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "or" } } }]
+    },
+    {
+      "name": "not — path is /open and has NO Authorization header",
+      "predicates": [{
+        "and": [
+          { "equals": { "path": "/open" } },
+          { "not": { "exists": { "headers": { "Authorization": true } } } }
+        ]
+      }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "not" } } }]
+    },
+    {
+      "name": "jsonpath — JSON body where $.type == 'order'",
+      "predicates": [{
+        "equals": { "body": "order" },
+        "jsonpath": { "selector": "$.type" }
+      }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "jsonpath" } } }]
+    },
+    {
+      "name": "xpath — XML body where //user/@role == 'admin'",
+      "predicates": [{
+        "equals": { "body": "admin" },
+        "xpath": { "selector": "string(//user/@role)" }
+      }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "xpath" } } }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/03-behaviors.json
+++ b/sdk-conformance/corpus/imposters/03-behaviors.json
@@ -1,0 +1,108 @@
+{
+  "port": 4503,
+  "protocol": "http",
+  "name": "03 · Behaviors (wait, repeat, decorate, copy, lookup)",
+  "recordRequests": true,
+  "stubs": [
+    {
+      "name": "wait — fixed 1500ms delay",
+      "predicates": [{ "equals": { "path": "/slow" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": { "note": "delayed 1.5s" } },
+        "_behaviors": { "wait": 1500 }
+      }]
+    },
+    {
+      "name": "wait — random delay between 200ms and 1200ms",
+      "predicates": [{ "equals": { "path": "/slow-range" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": { "note": "delayed 200-1200ms" } },
+        "_behaviors": { "wait": { "min": 200, "max": 1200 } }
+      }]
+    },
+    {
+      "name": "repeat — fail 503 twice, then 200 (sequence cycles)",
+      "predicates": [{ "equals": { "path": "/retry-me" } }],
+      "responses": [
+        {
+          "is": { "statusCode": 503, "body": { "error": "try again" } },
+          "_behaviors": { "repeat": 2 }
+        },
+        { "is": { "statusCode": 200, "body": { "ok": true } } }
+      ]
+    },
+    {
+      "name": "decorate — JS post-processes the response (adds a header) [needs --allow-injection]",
+      "predicates": [{ "equals": { "path": "/decorated" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "decorated": false }
+        },
+        "_behaviors": {
+          "decorate": "function (request, response) { response.headers['X-Decorated-By'] = 'rift'; response.body = response.body.replace('false', 'true'); }"
+        }
+      }]
+    },
+    {
+      "name": "copy — pull the numeric id out of the path into the body",
+      "predicates": [{ "matches": { "path": "^/orders/\\d+$" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json", "X-Order-Id": "${orderId}" },
+          "body": { "orderId": "${orderId}", "status": "shipped" }
+        },
+        "_behaviors": {
+          "copy": {
+            "from": "path",
+            "into": "${orderId}",
+            "using": { "method": "regex", "selector": "/orders/(\\d+)" }
+          }
+        }
+      }]
+    },
+    {
+      "name": "copy — pull a query parameter (?user=) into the response",
+      "predicates": [{ "equals": { "path": "/greet" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "greeting": "hello ${user}" }
+        },
+        "_behaviors": {
+          "copy": {
+            "from": { "query": "user" },
+            "into": "${user}",
+            "using": { "method": "regex", "selector": "(.*)" }
+          }
+        }
+      }]
+    },
+    {
+      "name": "lookup — enrich the response from data/products.csv by id in the path",
+      "predicates": [{ "matches": { "path": "^/catalog/\\d+$" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": {
+            "id": "${row}[id]",
+            "name": "${row}[name]",
+            "price": "${row}[price]",
+            "category": "${row}[category]"
+          }
+        },
+        "_behaviors": {
+          "lookup": {
+            "key": { "from": "path", "using": { "method": "regex", "selector": "/catalog/(\\d+)" } },
+            "fromDataSource": { "csv": { "path": "data/products.csv", "keyColumn": "id" } },
+            "into": "${row}"
+          }
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/04-fault-injection.json
+++ b/sdk-conformance/corpus/imposters/04-fault-injection.json
@@ -1,0 +1,88 @@
+{
+  "port": 4504,
+  "protocol": "http",
+  "name": "04 · Fault Injection (_rift.fault)",
+  "recordRequests": true,
+  "stubs": [
+    {
+      "name": "Latency — always add 500-2000ms",
+      "predicates": [{ "equals": { "path": "/faults/latency" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "endpoint": "/faults/latency", "note": "random latency 500-2000ms" }
+        },
+        "_rift": { "fault": { "latency": { "probability": 1.0, "minMs": 500, "maxMs": 2000 } } }
+      }]
+    },
+    {
+      "name": "Latency — 50% chance of a fixed 1s delay",
+      "predicates": [{ "equals": { "path": "/faults/sometimes-slow" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "endpoint": "/faults/sometimes-slow", "note": "50% chance of +1000ms" }
+        },
+        "_rift": { "fault": { "latency": { "probability": 0.5, "ms": 1000 } } }
+      }]
+    },
+    {
+      "name": "Error — 30% chance of a 503 instead of the happy body",
+      "predicates": [{ "equals": { "path": "/faults/flaky" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "endpoint": "/faults/flaky", "note": "30% chance of 503" }
+        },
+        "_rift": {
+          "fault": {
+            "error": {
+              "probability": 0.3,
+              "status": 503,
+              "body": "{\"error\":\"service temporarily unavailable\",\"code\":\"FLAKY\"}"
+            }
+          }
+        }
+      }]
+    },
+    {
+      "name": "Combined — 70% latency AND 20% error (chaos)",
+      "predicates": [{ "equals": { "path": "/faults/chaos" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "endpoint": "/faults/chaos", "note": "70% latency + 20% error" }
+        },
+        "_rift": {
+          "fault": {
+            "latency": { "probability": 0.7, "minMs": 200, "maxMs": 800 },
+            "error": { "probability": 0.2, "status": 500, "body": "{\"error\":\"internal chaos\"}" }
+          }
+        }
+      }]
+    },
+    {
+      "name": "TCP — reset the connection (no HTTP response at all)",
+      "predicates": [{ "equals": { "path": "/faults/tcp-reset" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "you will never see this" },
+        "_rift": { "fault": { "tcp": "CONNECTION_RESET_BY_PEER" } }
+      }]
+    },
+    {
+      "name": "Baseline — no fault, for comparison",
+      "predicates": [{ "equals": { "path": "/faults/healthy" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "status": "healthy", "note": "no faults injected" }
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/05-scripting-engines.json
+++ b/sdk-conformance/corpus/imposters/05-scripting-engines.json
@@ -1,0 +1,48 @@
+{
+  "port": 4505,
+  "protocol": "http",
+  "name": "05 · Scripting Engines (rhai, javascript)",
+  "recordRequests": true,
+  "_rift": {
+    "flowState": { "backend": "inmemory", "ttlSeconds": 600 }
+  },
+  "stubs": [
+    {
+      "name": "Rhai — stateful counter (ctx.state)",
+      "predicates": [{ "equals": { "method": "GET", "path": "/rhai/counter" } }],
+      "responses": [{
+        "_rift": {
+          "script": {
+            "engine": "rhai",
+            "code": "fn respond(ctx) { let count = ctx.state.incr_by(\"count\", 1); http(200, #{engine: \"rhai\", count: count}) }"
+          }
+        }
+      }]
+    },
+    {
+      "name": "JavaScript inject — counter [needs --allow-injection]",
+      "predicates": [{ "equals": { "method": "GET", "path": "/js/counter" } }],
+      "responses": [{
+        "inject": "function (config, state) { state.count = (state.count || 0) + 1; return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ engine: 'javascript', count: state.count }) }; }"
+      }]
+    },
+    {
+      "name": "JavaScript inject — echo the request [needs --allow-injection]",
+      "predicates": [{ "equals": { "method": "POST", "path": "/js/echo" } }],
+      "responses": [{
+        "inject": "function (config, state) { var req = config.request || config; return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ engine: 'javascript', method: req.method, path: req.path, body: req.body }) }; }"
+      }]
+    },
+    {
+      "name": "Health — lists the engines this imposter exercises",
+      "predicates": [{ "equals": { "method": "GET", "path": "/health" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "status": "ok", "engines": ["rhai", "javascript"] }
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/06-stateful-retry.json
+++ b/sdk-conformance/corpus/imposters/06-stateful-retry.json
@@ -1,0 +1,47 @@
+{
+  "port": 4506,
+  "protocol": "http",
+  "name": "06 · Stateful Retry Simulation (flow state)",
+  "recordRequests": true,
+  "_rift": {
+    "flowState": { "backend": "inmemory", "ttlSeconds": 300, "flowIdSource": "header:X-Flow-Id" }
+  },
+  "stubs": [
+    {
+      "name": "Fail the first 2 attempts with 503, succeed on the 3rd (keyed by X-Flow-Id)",
+      "predicates": [{ "equals": { "method": "GET", "path": "/api/resource" } }],
+      "responses": [{
+        "_rift": {
+          "script": {
+            "engine": "rhai",
+            "code": "fn respond(ctx) { let attempts = ctx.state.incr_by(\"attempts\", 1); if attempts <= 2 { http(503, #{error: \"service unavailable\", attempt: attempts}).header(\"Retry-After\", \"1\").header(\"X-Attempt\", `${attempts}`) } else { http(200, #{ok: true, succeededOnAttempt: attempts}).header(\"X-Attempt\", `${attempts}`) } }"
+          }
+        }
+      }]
+    },
+    {
+      "name": "Inspect the current attempt count for a flow",
+      "predicates": [{ "equals": { "method": "GET", "path": "/api/attempts" } }],
+      "responses": [{
+        "_rift": {
+          "script": {
+            "engine": "rhai",
+            "code": "fn respond(ctx) { let flow_id = ctx.request.header(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = ctx.state.get_or(\"attempts\", 0); http(200, #{flowId: flow_id, attempts: attempts}) }"
+          }
+        }
+      }]
+    },
+    {
+      "name": "Reset the attempt counter for a flow",
+      "predicates": [{ "equals": { "method": "DELETE", "path": "/api/reset" } }],
+      "responses": [{
+        "_rift": {
+          "script": {
+            "engine": "rhai",
+            "code": "fn respond(ctx) { let flow_id = ctx.request.header(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; ctx.state.delete(\"attempts\"); http(200, #{message: \"reset\", flowId: flow_id}) }"
+          }
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/07-proxy-record.json
+++ b/sdk-conformance/corpus/imposters/07-proxy-record.json
@@ -1,0 +1,34 @@
+{
+  "port": 4507,
+  "protocol": "http",
+  "name": "07 · Proxy + Record/Replay",
+  "recordRequests": true,
+  "stubs": [
+    {
+      "name": "Proxy everything to the 01-basic-rest imposter and record each first response",
+      "predicates": [{ "matches": { "path": "^/api/.*" } }],
+      "responses": [{
+        "proxy": {
+          "to": "http://localhost:4501",
+          "mode": "proxyOnce",
+          "predicateGenerators": [{ "matches": { "method": true, "path": true } }]
+        }
+      }]
+    },
+    {
+      "name": "Local info route (not proxied)",
+      "predicates": [{ "equals": { "method": "GET", "path": "/info" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": {
+            "note": "GET /api/* is proxied to http://localhost:4501 (imposter 01).",
+            "mode": "proxyOnce — first call hits upstream and is recorded; later calls replay the recorded stub.",
+            "tip": "After a few calls, GET http://localhost:2525/imposters/4507 to see the auto-generated stubs."
+          }
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/10-correlated-isolation.json
+++ b/sdk-conformance/corpus/imposters/10-correlated-isolation.json
@@ -1,0 +1,32 @@
+{
+  "port": 4510,
+  "protocol": "http",
+  "name": "10 · Correlated isolation (one port, partitioned by a header)",
+  "recordRequests": true,
+  "_rift": {
+    "flowState": {
+      "backend": "inmemory",
+      "ttlSeconds": 300,
+      "flowIdSource": "header:X-Mock-Space"
+    }
+  },
+  "stubs": [
+    {
+      "name": "space=alice — only matches requests with X-Mock-Space: alice",
+      "space": "alice",
+      "predicates": [{ "equals": { "path": "/data" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice", "items": [1, 2] } } }]
+    },
+    {
+      "name": "space=bob — isolated from alice",
+      "space": "bob",
+      "predicates": [{ "equals": { "path": "/data" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "bob", "items": [9] } } }]
+    },
+    {
+      "name": "global (no space) — matches any caller",
+      "predicates": [{ "equals": { "path": "/health" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "OK" } }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/11-headers-and-templates.json
+++ b/sdk-conformance/corpus/imposters/11-headers-and-templates.json
@@ -1,0 +1,31 @@
+{
+  "port": 4511,
+  "protocol": "http",
+  "name": "11 · Multi-value headers, date templates, defaultResponse/defaultForward, CORS",
+  "allowCORS": true,
+  "defaultForward": "http://localhost:4501",
+  "stubs": [
+    {
+      "name": "multi-value headers — two Set-Cookie lines on the wire (#238)",
+      "predicates": [{ "equals": { "path": "/cookies" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Set-Cookie": ["sessionId=abc", "theme=dark"], "X-Single": "one" },
+          "body": "two cookies set"
+        }
+      }]
+    },
+    {
+      "name": "serve-time date templates — {{DAYS+N}}/{{MONTHS+N}}/{{NOW}} (#195)",
+      "predicates": [{ "equals": { "path": "/token" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": "{\"issued\":\"{{NOW}}\",\"expires\":\"{{DAYS+30}}\",\"renewal\":\"{{MONTHS+12}}\"}"
+        }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/13-js-config-decorate.json
+++ b/sdk-conformance/corpus/imposters/13-js-config-decorate.json
@@ -1,0 +1,35 @@
+{
+  "port": 4513,
+  "protocol": "http",
+  "name": "13 · decorate conventions — Mountebank JS `config =>` and Rhai (#191)",
+  "stubs": [
+    {
+      "name": "Mountebank JS arrow: config => { config.response... }",
+      "predicates": [{ "equals": { "path": "/js-arrow" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "{\"v\":1}" },
+        "_behaviors": {
+          "decorate": "config => { config.response.headers['X-Decorated-By'] = 'config-arrow'; config.response.statusCode = 202; }"
+        }
+      }]
+    },
+    {
+      "name": "Mountebank JS function(config) form — reads config.request",
+      "predicates": [{ "equals": { "path": "/js-fn" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "replaced" },
+        "_behaviors": {
+          "decorate": "function(config) { config.response.body = 'method-was-' + config.request.method; }"
+        }
+      }]
+    },
+    {
+      "name": "Rhai decorate (Rift-native) — unchanged",
+      "predicates": [{ "equals": { "path": "/rhai" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "orig" },
+        "_behaviors": { "decorate": "response.body = \"rhai-\" + request.path;" }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/14-verify-annotations.json
+++ b/sdk-conformance/corpus/imposters/14-verify-annotations.json
@@ -1,0 +1,38 @@
+{
+  "port": 4514,
+  "protocol": "http",
+  "name": "14 · _verify annotations (rift-verify --verify-dynamic)",
+  "stubs": [
+    {
+      "name": "repeat:2 cycle, asserted by a _verify sequence",
+      "predicates": [{ "equals": { "path": "/retry" } }],
+      "responses": [
+        { "is": { "statusCode": 503, "body": "unavailable" }, "_behaviors": { "repeat": 2 } },
+        { "is": { "statusCode": 200, "body": "ok" } }
+      ],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/retry" }, "expect": { "status": 503, "bodyContains": "unavailable" } },
+          { "request": { "path": "/retry" }, "expect": { "status": 503 } },
+          { "request": { "path": "/retry" }, "expect": { "status": 200, "bodyContains": "ok" } },
+          { "request": { "path": "/retry" }, "expect": { "status": 503 } }
+        ]
+      }
+    },
+    {
+      "name": "copy (request-derived) decorate, asserted by _verify",
+      "predicates": [{ "matches": { "path": "^/orders/[0-9]+$" } }],
+      "responses": [
+        {
+          "is": { "statusCode": 200, "body": "id=${ID}" },
+          "_behaviors": { "copy": { "from": "path", "into": "${ID}", "using": { "method": "regex", "selector": "/orders/([0-9]+)" } } }
+        }
+      ],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/orders/77" }, "expect": { "status": 200, "bodyContains": "id=77" } }
+        ]
+      }
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/15-predicate-modifiers.json
+++ b/sdk-conformance/corpus/imposters/15-predicate-modifiers.json
@@ -1,0 +1,38 @@
+{
+  "port": 4515,
+  "protocol": "http",
+  "name": "15 · Predicate modifiers (issue #254 §D1)",
+  "recordRequests": true,
+  "defaultResponse": {
+    "statusCode": 404,
+    "headers": { "Content-Type": "application/json" },
+    "body": { "error": "no predicate matched" }
+  },
+  "stubs": [
+    {
+      "name": "contains — body contains 'needle'",
+      "predicates": [{ "contains": { "body": "needle" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "contains" } }]
+    },
+    {
+      "name": "endsWith — path ends with /end",
+      "predicates": [{ "endsWith": { "path": "/end" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "endsWith" } }]
+    },
+    {
+      "name": "except — strip digits before comparing path to /v",
+      "predicates": [{ "equals": { "path": "/v" }, "except": "[0-9]+" }],
+      "responses": [{ "is": { "statusCode": 200, "body": "except" } }]
+    },
+    {
+      "name": "deepEquals — query must be EXACTLY {a:1} (extra keys rejected)",
+      "predicates": [{ "deepEquals": { "query": { "a": "1" } } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "deep" } }]
+    },
+    {
+      "name": "exists:false — header X-Skip must be ABSENT",
+      "predicates": [{ "exists": { "headers": { "X-Skip": false } } }, { "equals": { "path": "/noskip" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "absent" } }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/16-behaviors-advanced.json
+++ b/sdk-conformance/corpus/imposters/16-behaviors-advanced.json
@@ -1,0 +1,48 @@
+{
+  "port": 4516,
+  "protocol": "http",
+  "name": "16 · Advanced behaviors (issue #254 §D3)",
+  "recordRequests": true,
+  "stubs": [
+    {
+      "name": "copy — from a request header into the body",
+      "predicates": [{ "equals": { "path": "/from-header" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "headers": { "Content-Type": "application/json" }, "body": { "requestId": "${rid}" } },
+        "_behaviors": { "copy": { "from": { "headers": "X-Request-Id" }, "into": "${rid}", "using": { "method": "regex", "selector": ".*" } } }
+      }]
+    },
+    {
+      "name": "copy — extract a JSON field from the body via jsonpath",
+      "predicates": [{ "equals": { "path": "/from-json" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "who=${who}" },
+        "_behaviors": { "copy": { "from": "body", "into": "${who}", "using": { "method": "jsonpath", "selector": "$.user.name" } } }
+      }]
+    },
+    {
+      "name": "lookup — enrich the response from products.csv by id",
+      "predicates": [{ "matches": { "path": "^/catalog/[0-9]+$" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "headers": { "Content-Type": "application/json" }, "body": { "name": "${row}[name]", "price": "${row}[price]" } },
+        "_behaviors": { "lookup": { "key": { "from": "path", "using": { "method": "regex", "selector": "/catalog/([0-9]+)" } }, "fromDataSource": { "csv": { "path": "data/products.csv", "keyColumn": "id" } }, "into": "${row}" } }
+      }]
+    },
+    {
+      "name": "wait — JS function returning a fixed delay",
+      "predicates": [{ "equals": { "path": "/slow-fn" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "waited" },
+        "_behaviors": { "wait": "function(){ return 400; }" }
+      }]
+    },
+    {
+      "name": "decorate — Rhai native, mutate response body in place",
+      "predicates": [{ "equals": { "path": "/decorate-rhai" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "orig" },
+        "_behaviors": { "decorate": "response.body = \"rhai-decorated\";" }
+      }]
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/17-faults-and-binary.json
+++ b/sdk-conformance/corpus/imposters/17-faults-and-binary.json
@@ -1,0 +1,34 @@
+{
+  "port": 4517,
+  "protocol": "http",
+  "name": "17 · Extended faults — error body/headers, latency range (issue #254 §D5)",
+  "recordRequests": true,
+  "stubs": [
+    {
+      "name": "error fault — custom status, body and headers",
+      "predicates": [{ "equals": { "path": "/err" } }],
+      "responses": [{
+        "is": { "statusCode": 200 },
+        "_rift": { "fault": { "error": { "probability": 1.0, "status": 503, "body": "DOWN", "headers": { "Retry-After": "30" } } } }
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/err" }, "expect": { "status": 503, "bodyContains": "DOWN" } }
+        ]
+      }
+    },
+    {
+      "name": "latency fault — random range 300-600ms",
+      "predicates": [{ "equals": { "path": "/slow" } }],
+      "responses": [{
+        "is": { "statusCode": 200, "body": "slow" },
+        "_rift": { "fault": { "latency": { "probability": 1.0, "minMs": 300, "maxMs": 600 } } }
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/slow" }, "expect": { "status": 200, "bodyContains": "slow" } }
+        ]
+      }
+    }
+  ]
+}

--- a/sdk-conformance/corpus/imposters/20-mimeo-solo-compat.json
+++ b/sdk-conformance/corpus/imposters/20-mimeo-solo-compat.json
@@ -1,0 +1,137 @@
+{
+  "port": 4520,
+  "protocol": "http",
+  "name": "20 · mimeo-solo migration compat — Mountebank forms real cof-primary repos use",
+  "allowCORS": true,
+  "recordRequests": true,
+  "stubs": [
+    {
+      "scenarioName": "OAuth2 Token (ledger/bank-debit) — matches predicate, string body, _mode:text",
+      "predicates": [{ "matches": { "path": "/oauth2/token", "method": "POST" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": "{\"token_type\":\"Bearer\",\"access_token\":\"dummyToken\",\"expires_in\":1296000}",
+          "_mode": "text"
+        }
+      }]
+    },
+    {
+      "scenarioName": "THub Transactions (ledger) — anchored regex path (rift-verify-synthesizable; the raw [a-zA-Z0-9+=%/]+ char-class variant is driven dynamically in conformance-migration.sh)",
+      "predicates": [{ "matches": { "path": "^/deposits/accounts/[0-9]+/transactions$", "method": "GET" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": "{\"entries\":[{\"transactionId\":\"11037\",\"transactionAmount\":50000,\"currencyCode\":\"USD\"}]}",
+          "_mode": "text"
+        }
+      }]
+    },
+    {
+      "scenarioName": "Transaction Recorder (bank-transaction) — STRING statusCode + _behaviors object wait-fn",
+      "predicates": [
+        { "deepEquals": { "method": "POST" } },
+        { "deepEquals": { "path": "/transaction" } }
+      ],
+      "responses": [{
+        "is": {
+          "statusCode": "200",
+          "headers": { "Content-Type": "application/json" },
+          "body": "{\"message\":\"Transaction recorded successfully\"}"
+        },
+        "_behaviors": {
+          "wait": "function(){var min = Math.ceil(0); var max = Math.floor(0); var num = Math.floor(Math.random() * (max - min + 1)); return num + min;}"
+        }
+      }]
+    },
+    {
+      "scenarioName": "LLDS retrieve (saffron) — rooted jsonpath selector routing",
+      "predicates": [
+        { "equals": { "body": "3U5mJmLnK" }, "jsonpath": { "selector": "$.searchValue" } },
+        { "deepEquals": { "method": "POST" } },
+        { "equals": { "path": "/llds/retrieve-dataset" } }
+      ],
+      "responses": [{
+        "is": {
+          "statusCode": "200",
+          "headers": { "Content-Type": "application/json" },
+          "body": "{\"requestCorrelationId\":\"test\",\"datasetRecords\":[]}"
+        }
+      }]
+    },
+    {
+      "scenarioName": "Valuation (Inventory/RENUW) — rules alias + rooted jsonpath + equals-on-headers routing + delayRange + inline decorate (real rules+decorate shape)",
+      "rules": [
+        { "equals": { "body": "4T1BF3EK5BU211477" }, "jsonpath": { "selector": "$.bookValueRequests[0].valuationByVin.vin" } },
+        { "equals": { "method": "POST" } },
+        { "equals": { "headers": { "Client-Correlation-ID": "79a89f32-122a-4c85-bbcd-3da069d25f28" } } }
+      ],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json;v=3" },
+          "body": "{\"status\":\"SUCCESS\",\"maximumLimit\":50}"
+        },
+        "_behaviors": {
+          "decorate": "config => { config.response.headers['X-Valuation-Source'] = 'NADA'; }"
+        }
+      }],
+      "delayRange": [{ "min": "0", "max": "0" }],
+      "_verify": {
+        "sequence": [
+          {
+            "request": {
+              "method": "POST",
+              "path": "/valuation",
+              "headers": { "Client-Correlation-ID": "79a89f32-122a-4c85-bbcd-3da069d25f28" },
+              "body": "{\"bookValueRequests\":[{\"valuationByVin\":{\"vin\":\"4T1BF3EK5BU211477\"}}]}"
+            },
+            "expect": { "status": 200, "bodyContains": "SUCCESS" }
+          }
+        ]
+      }
+    },
+    {
+      "scenarioName": "hello-world (RENUW scaffold) — behaviors ARRAY [wait, decorate] + proxy:null alongside is",
+      "predicates": [
+        { "deepEquals": { "path": "/hello-world" } },
+        { "deepEquals": { "method": "GET" } }
+      ],
+      "responses": [{
+        "behaviors": [
+          { "wait": "function(){ return 0; }" },
+          { "decorate": "config => { config.response.headers['X-Injected-By'] = 'behaviors-array'; }" }
+        ],
+        "is": {
+          "statusCode": "200",
+          "headers": { "Content-type": "application/json", "Accept": "application/json;v=1" },
+          "body": "{\"message\": \"Hello world from Mimeo Solo!\"}"
+        },
+        "proxy": null
+      }]
+    },
+    {
+      "scenarioName": "Promote offer 204 (auto-digital) — contains predicate + STRING statusCode 204 + empty body",
+      "predicates": [
+        { "contains": { "path": "204204" } },
+        { "deepEquals": { "method": "POST" } }
+      ],
+      "responses": [{
+        "behaviors": [{ "wait": "function(){ return 0; }" }],
+        "is": {
+          "statusCode": "204",
+          "headers": { "Content-Type": "application/json" },
+          "body": ""
+        },
+        "proxy": null
+      }]
+    },
+    {
+      "scenarioName": "418 catch-all (ledger) — matches:/*",
+      "predicates": [{ "matches": { "path": "/*" } }],
+      "responses": [{ "is": { "statusCode": 418, "body": "No matching scenario found." } }]
+    }
+  ]
+}

--- a/sdk-conformance/manifest.json
+++ b/sdk-conformance/manifest.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": 1,
+  "engineVersion": "0.0.0-dev",
+  "fixtures": [
+    {
+      "file": "corpus/imposters/01-basic-rest.json",
+      "port": 4501,
+      "name": "01 \u00b7 Basic REST API",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/02-predicates.json",
+      "port": 4502,
+      "name": "02 \u00b7 Predicate Showcase",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/03-behaviors.json",
+      "port": 4503,
+      "name": "03 \u00b7 Behaviors (wait, repeat, decorate, copy, lookup)",
+      "requires": [
+        "injection"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/04-fault-injection.json",
+      "port": 4504,
+      "name": "04 \u00b7 Fault Injection (_rift.fault)",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/05-scripting-engines.json",
+      "port": 4505,
+      "name": "05 \u00b7 Scripting Engines (rhai, javascript)",
+      "requires": [
+        "injection"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/06-stateful-retry.json",
+      "port": 4506,
+      "name": "06 \u00b7 Stateful Retry Simulation (flow state)",
+      "requires": [
+        "injection"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/07-proxy-record.json",
+      "port": 4507,
+      "name": "07 \u00b7 Proxy + Record/Replay",
+      "requires": [
+        "proxy"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/10-correlated-isolation.json",
+      "port": 4510,
+      "name": "10 \u00b7 Correlated isolation (one port, partitioned by a header)",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/11-headers-and-templates.json",
+      "port": 4511,
+      "name": "11 \u00b7 Multi-value headers, date templates, defaultResponse/defaultForward, CORS",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/13-js-config-decorate.json",
+      "port": 4513,
+      "name": "13 \u00b7 decorate conventions \u2014 Mountebank JS `config =>` and Rhai (#191)",
+      "requires": [
+        "injection"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/14-verify-annotations.json",
+      "port": 4514,
+      "name": "14 \u00b7 _verify annotations (rift-verify --verify-dynamic)",
+      "requires": [],
+      "hasVerify": true
+    },
+    {
+      "file": "corpus/imposters/15-predicate-modifiers.json",
+      "port": 4515,
+      "name": "15 \u00b7 Predicate modifiers (issue #254 \u00a7D1)",
+      "requires": [],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/16-behaviors-advanced.json",
+      "port": 4516,
+      "name": "16 \u00b7 Advanced behaviors (issue #254 \u00a7D3)",
+      "requires": [
+        "injection"
+      ],
+      "hasVerify": false
+    },
+    {
+      "file": "corpus/imposters/17-faults-and-binary.json",
+      "port": 4517,
+      "name": "17 \u00b7 Extended faults \u2014 error body/headers, latency range (issue #254 \u00a7D5)",
+      "requires": [],
+      "hasVerify": true
+    },
+    {
+      "file": "corpus/imposters/20-mimeo-solo-compat.json",
+      "port": 4520,
+      "name": "20 \u00b7 mimeo-solo migration compat \u2014 Mountebank forms real cof-primary repos use",
+      "requires": [
+        "injection",
+        "proxy"
+      ],
+      "hasVerify": true
+    }
+  ]
+}


### PR DESCRIPTION
Publishes `sdk-conformance-<version>.tar.gz` per release — the shared corpus every official Rift SDK's CI replays over embedded and remote transports to catch DSL/engine drift (RFC-003 §9.2, risk R1).

Design decision (see the issue's design comment): the corpus is **engine-canonical** and vendored into `sdk-conformance/` (from the rift-conformance repo), not generated from `tests/compatibility` — it lives where the `_verify` schema and its reference replayer `rift-verify` live and is version-locked to the engine.

- `sdk-conformance/{corpus,manifest.json,README.md}` — 15 fixtures + `data/` + injection modules; README is the normative replay contract.
- `tests/corpus_replay.rs` — engine CI gate: the whole corpus serves + every `_verify` transcript holds on this commit; `manifest.json` matches the fixtures (port/requires/hasVerify); and the **packaged** tarball still serves after extract.
- `scripts/gen-sdk-conformance.sh` + `release.yml` — stamp the engine version and attach `sdk-conformance-<ver>.tar.gz` + `.sha256`.
- `ci.yml` — runs the gate + the packager self-test.
- Docs: `docs/embedding/sdk-conformance.md`.

Unblocks rift-java#7/#14 (and the rift-scala/go/node conformance harnesses) once a release ships the asset.

Closes #460

Part of SDK-M0 (epic #458, task 0.2).