### PR TITLE
feat(admin): SSE stream for recorded requests + imposter events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ record.
 
 ### Added
 
+- **Admin SSE stream — push request tails instead of polling.** `GET /events` (and the
+  handle-scoped alias `GET /imposters/{port}/savedRequests/stream`) streams recorded requests and
+  imposter lifecycle changes as Server-Sent Events, so an SDK request tail (`ZStream`/`fs2.Stream`,
+  Go channels, async iterators) gets pushed events instead of paying a poll interval. Filterable by
+  `types=requests,lifecycle`, `port=`, and the same `match=` clauses as `savedRequests`; gated by
+  the admin API key like every other admin route; heartbeat comments keep idle streams alive.
+  Publishing is a no-op when nobody is subscribed, so the request hot path is untouched unless a
+  client is connected. Lossy-but-loud under backpressure: a slow consumer gets a `lagged` event
+  rather than stalling the engine. Each `request` event carries its journal `index`, so a client
+  that lagged or reconnected reconciles with `savedRequests?since=<index>` instead of re-polling the
+  whole journal. Older engines return `404`, which is the SDK's capability probe — polling remains
+  the supported fallback and the source of truth (v1 does not replay).
 - **`savedRequests` cursor — tail an imposter's recorded requests without re-fetching the journal.**
   `GET /imposters/{port}/savedRequests?since=<index>` now serves only the requests newer than a
   cursor, so an SDK request-tail costs O(new entries) per poll instead of O(journal) with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -27,7 +27,8 @@ futures.workspace = true
 # HTTP
 hyper = { version = "1.5", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-http-body-util = "0.1"
+# `channel` (issue #461 SSE body) pulls only tokio, already a dependency — no new crate in the tree.
+http-body-util = { version = "0.1", features = ["channel"] }
 tower = { version = "0.5", features = ["full"] }
 # Pin the rustls crypto provider to `ring` everywhere. hyper-rustls/tokio-rustls
 # default to the `aws-lc-rs` provider, whose C build (aws-lc-sys) fails to compile

--- a/crates/rift-http-proxy/src/admin_api/handlers/events.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/events.rs
@@ -1,0 +1,298 @@
+//! Admin SSE stream handler (issue #461): `GET /events` and the `GET
+//! /imposters/{port}/savedRequests/stream` alias. Subscribes to the manager's `AdminEventBus` and
+//! forwards recorded-request + imposter-lifecycle events as Server-Sent Events, filtered by
+//! `types`/`port`/`match`, with a heartbeat and lossy-but-loud backpressure (`lagged` events). The
+//! stream is a push upgrade of `GET /savedRequests` polling; a gap/`lagged` means "reconcile via
+//! polling" — v1 does not replay.
+
+use bytes::Bytes;
+use http_body_util::{
+    BodyExt, Full,
+    channel::{Channel, Sender},
+    combinators::BoxBody,
+};
+use hyper::{Response, StatusCode};
+use rift_mock_core::imposter::{AdminEvent, AdminEventKind, ImposterManager};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
+use tokio_util::sync::CancellationToken;
+
+use crate::admin_api::request_filter::{MatchClause, parse_match_clauses};
+
+/// The boxed body type the admin service unifies over (a `Full` error response or a streaming
+/// `Channel`), so `route_request`'s `Response<Full<Bytes>>` and this streaming response share a type.
+pub(crate) type AdminBody = BoxBody<Bytes, hyper::Error>;
+
+const HEARTBEAT: Duration = Duration::from_secs(15);
+/// Write-side buffer for the SSE channel; a client this far behind on the socket causes the
+/// forwarder to block on `send_data`, which in turn lets the broadcast bus lag (→ `lagged`).
+const CHANNEL_BUFFER: usize = 16;
+
+/// Parsed `/events` query parameters.
+struct StreamParams {
+    requests: bool,
+    lifecycle: bool,
+    port: Option<u16>,
+    clauses: Vec<MatchClause>,
+}
+
+/// Classify an admin path as a stream target: `Some(None)` for `/events`, `Some(Some(port))` for the
+/// `/imposters/{port}/savedRequests/stream` alias, `None` otherwise.
+pub(crate) fn stream_target(path: &str) -> Option<Option<u16>> {
+    if path == "/events" {
+        return Some(None);
+    }
+    let rest = path.strip_prefix("/imposters/")?;
+    let segments: Vec<&str> = rest.split('/').collect();
+    match segments.as_slice() {
+        [port, "savedRequests", "stream"] => port.parse::<u16>().ok().map(Some),
+        _ => None,
+    }
+}
+
+/// Handle a stream request. `forced_port` is `Some` for the alias (which pre-binds the port and
+/// streams only request events). Returns a 400/404 error body on invalid params/unknown port,
+/// otherwise a `text/event-stream` whose forwarder task runs until the client disconnects or
+/// `cancel` fires (server shutdown).
+pub(crate) fn handle_stream(
+    manager: &Arc<ImposterManager>,
+    query: Option<&str>,
+    forced_port: Option<u16>,
+    cancel: CancellationToken,
+) -> Response<AdminBody> {
+    let params = match parse_params(query, forced_port) {
+        Ok(p) => p,
+        Err((code, msg)) => return error_response(code, &msg),
+    };
+    if let Some(port) = params.port
+        && manager.get_imposter(port).is_err()
+    {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            &format!("no imposter on port {port}"),
+        );
+    }
+
+    let bus = Arc::clone(manager.event_bus());
+    let mut rx = bus.subscribe();
+    let start_seq = bus.seq();
+    let (mut tx, body) = Channel::<Bytes, hyper::Error>::new(CHANNEL_BUFFER);
+
+    tokio::spawn(async move {
+        let hello = serde_json::json!({
+            "engineVersion": env!("CARGO_PKG_VERSION"),
+            "seq": start_seq,
+            "types": type_list(&params),
+            "port": params.port,
+        });
+        if !send_frame(&mut tx, &cancel, sse_frame("hello", None, &hello)).await {
+            return;
+        }
+        let mut heartbeat = tokio::time::interval(HEARTBEAT);
+        heartbeat.tick().await; // the first tick is immediate — consume it so ping doesn't fire now
+        loop {
+            // Pick the next frame to send. A `continue` skips a filtered-out event; a `break` ends
+            // the stream (shutdown or the bus closing).
+            let frame = tokio::select! {
+                () = cancel.cancelled() => break,
+                _ = heartbeat.tick() => Bytes::from_static(b": ping\n\n"),
+                recv = rx.recv() => match recv {
+                    Ok(event) => match render(&event, &params) {
+                        Some(frame) => frame,
+                        None => continue,
+                    },
+                    Err(RecvError::Lagged(n)) => {
+                        sse_frame("lagged", None, &serde_json::json!({ "missed": n }))
+                    }
+                    Err(RecvError::Closed) => break,
+                },
+            };
+            if !send_frame(&mut tx, &cancel, frame).await {
+                break;
+            }
+        }
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        // Defeat proxy/response buffering so events reach the client immediately.
+        .header("X-Accel-Buffering", "no")
+        .body(body.boxed())
+        .expect("SSE response builds from a static status + headers")
+}
+
+/// Send one SSE frame, abandoning it if the server is shutting down. `send_data` blocks when a
+/// stalled client fills the channel buffer, so racing it against `cancel` keeps a slow or silent
+/// reader from pinning the forwarder task (and its connection) past graceful shutdown. Returns
+/// `false` (stop the stream) on cancellation or a client disconnect.
+async fn send_frame(
+    tx: &mut Sender<Bytes, hyper::Error>,
+    cancel: &CancellationToken,
+    frame: Bytes,
+) -> bool {
+    tokio::select! {
+        () = cancel.cancelled() => false,
+        result = tx.send_data(frame) => result.is_ok(),
+    }
+}
+
+/// Parse `types` (comma list of `requests`/`lifecycle`, default both), `port`, and `match=` clauses.
+/// For the alias (`forced_port` set), the stream is request-only and `types` is ignored.
+fn parse_params(
+    query: Option<&str>,
+    forced_port: Option<u16>,
+) -> Result<StreamParams, (StatusCode, String)> {
+    let clauses =
+        parse_match_clauses(query).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let mut requests = true;
+    let mut lifecycle = true;
+    let mut port = forced_port;
+    let alias = forced_port.is_some();
+
+    for pair in query.unwrap_or("").split('&').filter(|s| !s.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "types" if !alias => {
+                requests = false;
+                lifecycle = false;
+                for t in value.split(',').filter(|s| !s.is_empty()) {
+                    match t {
+                        "requests" => requests = true,
+                        "lifecycle" => lifecycle = true,
+                        other => {
+                            return Err((
+                                StatusCode::BAD_REQUEST,
+                                format!(
+                                    "unknown types value '{other}' (expected requests|lifecycle)"
+                                ),
+                            ));
+                        }
+                    }
+                }
+            }
+            "port" if !alias => {
+                port =
+                    Some(value.parse().map_err(|_| {
+                        (StatusCode::BAD_REQUEST, format!("invalid port: {value}"))
+                    })?);
+            }
+            _ => {}
+        }
+    }
+    if alias {
+        requests = true;
+        lifecycle = false;
+    }
+    Ok(StreamParams {
+        requests,
+        lifecycle,
+        port,
+        clauses,
+    })
+}
+
+fn type_list(params: &StreamParams) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if params.requests {
+        out.push("requests");
+    }
+    if params.lifecycle {
+        out.push("lifecycle");
+    }
+    out
+}
+
+/// Render an event to an SSE frame, applying the type/port/match filters. `None` = filtered out.
+fn render(event: &AdminEvent, params: &StreamParams) -> Option<Bytes> {
+    match &event.kind {
+        AdminEventKind::Lifecycle { action, port } => {
+            if !params.lifecycle {
+                return None;
+            }
+            // A concrete-port lifecycle event is dropped when it isn't the filtered port; a global
+            // event (AllDeleted, port None) always passes.
+            if let (Some(filter), Some(p)) = (params.port, port)
+                && *p != filter
+            {
+                return None;
+            }
+            let mut data = serde_json::json!({ "action": action.as_str() });
+            if let Some(p) = port {
+                data["port"] = serde_json::json!(p);
+            }
+            Some(sse_frame("imposter", Some(event.seq), &data))
+        }
+        AdminEventKind::Request {
+            port,
+            flow_id,
+            index,
+            request,
+        } => {
+            if !params.requests {
+                return None;
+            }
+            if let Some(filter) = params.port
+                && *port != filter
+            {
+                return None;
+            }
+            if !event_matches(&params.clauses, flow_id, request) {
+                return None;
+            }
+            let mut data =
+                serde_json::json!({ "port": port, "flowId": flow_id, "request": request });
+            // Omitted entirely when the journal backend has no stable indices (issue #603), so
+            // its absence is the same capability probe the polling side uses.
+            if let Some(index) = index {
+                data["index"] = serde_json::json!(index);
+            }
+            Some(sse_frame("request", Some(event.seq), &data))
+        }
+    }
+}
+
+/// Apply `match=` clauses to a request event. `flow_id=` compares the event's flow id — resolved at
+/// record time from the imposter's `flow_id_source` (a `header:` source falls back to the port when
+/// the header is absent, matching `rift-verify`'s record-time semantics) — and `header:` checks the
+/// recorded request's (multi-value) headers. This mirrors `GET /savedRequests?match=` except for the
+/// header-absent edge, where `savedRequests` resolves the flow to "no match" at query time.
+fn event_matches(
+    clauses: &[MatchClause],
+    flow_id: &str,
+    request: &rift_mock_core::imposter::RecordedRequest,
+) -> bool {
+    clauses.iter().all(|clause| match clause {
+        MatchClause::FlowId(value) => flow_id == value,
+        MatchClause::Header { name, value } => request
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .is_some_and(|(_, values)| values.iter().any(|v| v == value)),
+    })
+}
+
+fn sse_frame(event: &str, id: Option<u64>, data: &serde_json::Value) -> Bytes {
+    let mut frame = format!("event: {event}\n");
+    if let Some(id) = id {
+        frame.push_str(&format!("id: {id}\n"));
+    }
+    frame.push_str(&format!("data: {data}\n\n"));
+    Bytes::from(frame)
+}
+
+fn error_response(code: StatusCode, message: &str) -> Response<AdminBody> {
+    let body = serde_json::json!({ "error": message }).to_string();
+    Response::builder()
+        .status(code)
+        .header("Content-Type", "application/json")
+        .body(
+            Full::new(Bytes::from(body))
+                .map_err(|never| match never {})
+                .boxed(),
+        )
+        .expect("error response builds from a static status + headers")
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/mod.rs
@@ -1,5 +1,6 @@
 //! Request handlers for the Admin API.
 
+pub mod events;
 pub mod imposters;
 pub mod intercept;
 pub mod scenarios;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -1,11 +1,12 @@
 //! Admin API server.
 
+use crate::admin_api::handlers::events::{self, AdminBody};
 use crate::admin_api::router::route_request;
 use crate::config_loader::ConfigSource;
 use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
 use crate::intercept_control::InterceptControl;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
@@ -224,12 +225,14 @@ async fn accept_loop(
         let conn_cancel = cancel.clone();
 
         tracker.spawn(async move {
+            let stream_cancel = conn_cancel.clone();
             let service = service_fn(move |req| {
                 let manager = Arc::clone(&manager);
                 let api_key = api_key.clone();
                 let config_source = config_source.clone();
                 let intercept = intercept.clone();
                 let scripts_dir = scripts_dir.clone();
+                let stream_cancel = stream_cancel.clone();
                 async move {
                     // Per-request annotation scope + response decorator (issue #318):
                     // every response through this listener — including the `/__rift/`
@@ -251,8 +254,20 @@ async fn accept_loop(
                                 .and_then(|v| v.to_str().ok())
                                 .unwrap_or("");
                             if !api_key_matches(auth, key.as_str()) {
-                                return Ok::<_, hyper::Error>(unauthorized_response());
+                                return Ok::<_, hyper::Error>(box_full(unauthorized_response()));
                             }
+                        }
+                        // Admin SSE stream (issue #461): `/events` + the
+                        // `/imposters/{port}/savedRequests/stream` alias. Runs AFTER the auth gate
+                        // above, and BEFORE the `Full<Bytes>` router so the streaming body type never
+                        // touches the router or its handlers.
+                        if let Some(forced_port) = events::stream_target(req.uri().path()) {
+                            return Ok::<_, hyper::Error>(events::handle_stream(
+                                &manager,
+                                req.uri().query(),
+                                forced_port,
+                                stream_cancel,
+                            ));
                         }
                         route_request(
                             req,
@@ -263,6 +278,7 @@ async fn accept_loop(
                             scripts_dir,
                         )
                         .await
+                        .map(box_full)
                     })
                     .await;
                     let mut response = result?;
@@ -321,6 +337,13 @@ async fn accept_loop(
 /// mismatch is; the length check it performs first is not secret.
 fn api_key_matches(provided: &str, expected: &str) -> bool {
     provided.as_bytes().ct_eq(expected.as_bytes()).into()
+}
+
+/// Box a `Full<Bytes>` response into the streaming-unified `AdminBody` (issue #461), so the normal
+/// router path and the SSE stream path share one response type. `Full`'s error is `Infallible`, so
+/// the `map_err` closure is unreachable.
+fn box_full(resp: Response<Full<Bytes>>) -> Response<AdminBody> {
+    resp.map(|body| body.map_err(|never| match never {}).boxed())
 }
 
 fn unauthorized_response() -> Response<Full<Bytes>> {

--- a/crates/rift-http-proxy/tests/admin_sse.rs
+++ b/crates/rift-http-proxy/tests/admin_sse.rs
@@ -1,0 +1,576 @@
+//! Issue #461: the admin SSE stream (`GET /events`, `GET /imposters/{port}/savedRequests/stream`)
+//! must push recorded-request and imposter-lifecycle events to subscribers, filtered by
+//! `types`/`port`/`match`, gated by the admin API key, lossy-but-loud under backpressure, and
+//! closed cleanly on shutdown. These black-box tests drive a real in-process admin server over a
+//! raw TCP socket (reqwest here has no `stream` feature) so the SSE framing is exercised end to end.
+
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::imposter::ImposterManager;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// A parsed SSE frame: `event:`/`data:`/`id:` lines, or a `:` comment (heartbeat).
+#[derive(Debug, Default, Clone)]
+struct Frame {
+    event: Option<String>,
+    data: String,
+    id: Option<String>,
+    comment: Option<String>,
+}
+
+/// A live SSE connection over a raw socket, reading frames incrementally.
+struct Sse {
+    stream: TcpStream,
+    buf: String,
+}
+
+impl Sse {
+    /// Open `GET <path>` against the admin server, optionally with an `Authorization` header, and
+    /// consume the response head. Returns the connection plus the HTTP status line.
+    async fn connect(addr: SocketAddr, path: &str, auth: Option<&str>) -> (Self, String) {
+        let mut stream = TcpStream::connect(addr).await.expect("connect admin");
+        let auth_line = auth
+            .map(|k| format!("Authorization: {k}\r\n"))
+            .unwrap_or_default();
+        let req = format!(
+            "GET {path} HTTP/1.1\r\nHost: {addr}\r\n{auth_line}Accept: text/event-stream\r\nConnection: keep-alive\r\n\r\n"
+        );
+        stream
+            .write_all(req.as_bytes())
+            .await
+            .expect("write request");
+
+        // Read until the end of the response head (\r\n\r\n).
+        let mut raw = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut byte))
+                .await
+                .expect("head read timeout")
+                .expect("head read");
+            if n == 0 {
+                break;
+            }
+            raw.push(byte[0]);
+            if raw.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let head = String::from_utf8_lossy(&raw).into_owned();
+        let status = head.lines().next().unwrap_or_default().to_string();
+        (
+            Self {
+                stream,
+                buf: String::new(),
+            },
+            head_with_status(head, status.clone()),
+        )
+    }
+
+    /// Read the next SSE frame (blocks separated by a blank line), or `None` on timeout/EOF.
+    async fn next_frame(&mut self, timeout: Duration) -> Option<Frame> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(idx) = self.buf.find("\n\n") {
+                let block: String = self.buf.drain(..idx + 2).collect();
+                return Some(parse_frame(&block));
+            }
+            let remaining = deadline.checked_duration_since(tokio::time::Instant::now())?;
+            let mut chunk = [0u8; 4096];
+            let n = tokio::time::timeout(remaining, self.stream.read(&mut chunk))
+                .await
+                .ok()?
+                .ok()?;
+            if n == 0 {
+                return None; // EOF
+            }
+            self.buf.push_str(&String::from_utf8_lossy(&chunk[..n]));
+        }
+    }
+
+    /// Read frames until one with `event == name` arrives (skipping heartbeats/others), or timeout.
+    async fn wait_for(&mut self, name: &str, timeout: Duration) -> Option<Frame> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.checked_duration_since(tokio::time::Instant::now())?;
+            let f = self.next_frame(remaining).await?;
+            if f.event.as_deref() == Some(name) {
+                return Some(f);
+            }
+        }
+    }
+}
+
+fn head_with_status(_head: String, status: String) -> String {
+    status
+}
+
+fn parse_frame(block: &str) -> Frame {
+    let mut f = Frame::default();
+    let mut data_lines = Vec::new();
+    for line in block.lines() {
+        if let Some(rest) = line.strip_prefix(':') {
+            f.comment = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("event:") {
+            f.event = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("id:") {
+            f.id = Some(rest.trim().to_string());
+        }
+    }
+    f.data = data_lines.join("\n");
+    f
+}
+
+fn json(f: &Frame) -> serde_json::Value {
+    serde_json::from_str(&f.data).unwrap_or(serde_json::Value::Null)
+}
+
+async fn start_server(
+    api_key: Option<&str>,
+) -> (
+    SocketAddr,
+    Arc<ImposterManager>,
+    rift_http_proxy::admin_api::RunningAdminApi,
+) {
+    let manager = Arc::new(ImposterManager::new());
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let server = AdminApiServer::new(addr, manager.clone(), api_key.map(str::to_string));
+    let running = server.bind().await.expect("bind admin");
+    (running.local_addr(), manager, running)
+}
+
+async fn create(manager: &ImposterManager, config: serde_json::Value) -> u16 {
+    let cfg = serde_json::from_value(config).expect("valid config");
+    manager.create_imposter(cfg).await.expect("create imposter")
+}
+
+#[tokio::test]
+async fn hello_event_on_connect() {
+    let (addr, _mgr, running) = start_server(None).await;
+    let (mut sse, status) = Sse::connect(addr, "/events", None).await;
+    assert!(status.contains("200"), "expected 200, got {status:?}");
+    let hello = sse
+        .wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello frame");
+    let v = json(&hello);
+    assert!(
+        v["engineVersion"].is_string(),
+        "hello carries engineVersion: {v}"
+    );
+    assert!(v["seq"].is_number(), "hello carries seq: {v}");
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn lifecycle_events_created_and_deleted() {
+    let (addr, mgr, running) = start_server(None).await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=lifecycle", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    let port = create(
+        &mgr,
+        serde_json::json!({"port":18801,"protocol":"http","stubs":[]}),
+    )
+    .await;
+    let created = sse
+        .wait_for("imposter", Duration::from_secs(5))
+        .await
+        .expect("created event");
+    assert_eq!(json(&created)["action"], "created");
+    assert_eq!(json(&created)["port"], port);
+
+    mgr.delete_imposter(port).await.expect("delete");
+    let deleted = sse
+        .wait_for("imposter", Duration::from_secs(5))
+        .await
+        .expect("deleted event");
+    assert_eq!(json(&deleted)["action"], "deleted");
+    assert_eq!(json(&deleted)["port"], port);
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn request_event_matches_saved_requests() {
+    let (addr, mgr, running) = start_server(None).await;
+    let iport = create(
+        &mgr,
+        serde_json::json!({"port":18802,"protocol":"http","recordRequests":true,
+            "stubs":[{"responses":[{"is":{"statusCode":200,"body":"ok"}}]}]}),
+    )
+    .await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=requests", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    reqwest::get(format!("http://127.0.0.1:{iport}/hello?q=1"))
+        .await
+        .expect("drive request");
+    let ev = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    let v = json(&ev);
+    assert_eq!(v["port"], iport);
+    assert_eq!(v["request"]["path"], "/hello");
+    assert_eq!(v["request"]["method"], "GET");
+
+    // The embedded request JSON must equal the savedRequests projection.
+    let saved: serde_json::Value =
+        reqwest::get(format!("http://{addr}/imposters/{iport}/savedRequests"))
+            .await
+            .expect("saved")
+            .json()
+            .await
+            .expect("saved json");
+    assert_eq!(
+        v["request"], saved[0],
+        "SSE request JSON must equal the savedRequests entry"
+    );
+    running.shutdown().await;
+}
+
+// Issue #603 + #461: the `index` on a request event is the same journal index the polling side
+// hands out, so a client that lags or reconnects can reconcile with `?since=<index>` instead of
+// re-polling the whole journal. This is the join between the push and pull halves of the tail.
+#[tokio::test]
+async fn request_event_index_matches_savedrequests_cursor() {
+    let (addr, mgr, running) = start_server(None).await;
+    let iport = create(
+        &mgr,
+        serde_json::json!({"port":18814,"protocol":"http","recordRequests":true,
+            "stubs":[{"responses":[{"is":{"statusCode":200,"body":"ok"}}]}]}),
+    )
+    .await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=requests", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    let mut indices = Vec::new();
+    for n in 1..=3 {
+        reqwest::get(format!("http://127.0.0.1:{iport}/r{n}"))
+            .await
+            .expect("drive request");
+        let ev = sse
+            .wait_for("request", Duration::from_secs(5))
+            .await
+            .expect("request event");
+        indices.push(json(&ev)["index"].as_u64().expect("index on the event"));
+    }
+    assert_eq!(indices, vec![1, 2, 3], "1-based, sequential, per port");
+
+    // The cursor the polling side reports must agree with the last index the stream delivered.
+    let resp = reqwest::get(format!("http://{addr}/imposters/{iport}/savedRequests"))
+        .await
+        .expect("saved");
+    let next = resp
+        .headers()
+        .get("x-rift-next-index")
+        .expect("cursor header")
+        .to_str()
+        .expect("header utf8")
+        .to_string();
+    assert_eq!(
+        next, "3",
+        "the poll cursor agrees with the streamed indices"
+    );
+
+    // Reconciling from the second event's index returns exactly what came after it — the
+    // canonical lag/reconnect recovery, without a full re-poll.
+    let after: serde_json::Value = reqwest::get(format!(
+        "http://{addr}/imposters/{iport}/savedRequests?since={}",
+        indices[1]
+    ))
+    .await
+    .expect("since")
+    .json()
+    .await
+    .expect("since json");
+    assert_eq!(after.as_array().expect("array").len(), 1);
+    assert_eq!(after[0]["path"], "/r3");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn types_lifecycle_suppresses_request_events() {
+    let (addr, mgr, running) = start_server(None).await;
+    let iport = create(
+        &mgr,
+        serde_json::json!({"port":18803,"protocol":"http","recordRequests":true,
+            "stubs":[{"responses":[{"is":{"statusCode":200}}]}]}),
+    )
+    .await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=lifecycle", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    reqwest::get(format!("http://127.0.0.1:{iport}/x"))
+        .await
+        .expect("drive request");
+    // No request event should arrive on a lifecycle-only stream; a short read must not yield one.
+    let f = sse.wait_for("request", Duration::from_secs(1)).await;
+    assert!(f.is_none(), "types=lifecycle must suppress request events");
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn port_filter_scopes_request_events() {
+    let (addr, mgr, running) = start_server(None).await;
+    let a = create(&mgr, serde_json::json!({"port":18804,"protocol":"http","recordRequests":true,"stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    let b = create(&mgr, serde_json::json!({"port":18805,"protocol":"http","recordRequests":true,"stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    let (mut sse, _s) = Sse::connect(addr, &format!("/events?types=requests&port={a}"), None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    // A request to the OTHER imposter must not appear; a request to the scoped one must.
+    reqwest::get(format!("http://127.0.0.1:{b}/other"))
+        .await
+        .expect("req b");
+    reqwest::get(format!("http://127.0.0.1:{a}/mine"))
+        .await
+        .expect("req a");
+    let ev = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    assert_eq!(json(&ev)["port"], a);
+    assert_eq!(
+        json(&ev)["request"]["path"],
+        "/mine",
+        "must skip the other imposter's request"
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn match_flow_id_filter_scopes_request_events() {
+    let (addr, mgr, running) = start_server(None).await;
+    // Flow id derives from a header, so two requests with different X-Space values land in
+    // different flows — the same scoping `GET /savedRequests?match=flow_id=` applies.
+    let iport = create(
+        &mgr,
+        serde_json::json!({"port":18806,"protocol":"http","recordRequests":true,
+            "_rift":{"flowState":{"flowIdSource":"header:X-Space"}},
+            "stubs":[{"responses":[{"is":{"statusCode":200}}]}]}),
+    )
+    .await;
+    let (mut sse, _s) =
+        Sse::connect(addr, "/events?types=requests&match=flow_id%3Dblue", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    let client = reqwest::Client::new();
+    client
+        .get(format!("http://127.0.0.1:{iport}/green"))
+        .header("X-Space", "green")
+        .send()
+        .await
+        .expect("green");
+    client
+        .get(format!("http://127.0.0.1:{iport}/blue"))
+        .header("X-Space", "blue")
+        .send()
+        .await
+        .expect("blue");
+    let ev = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    assert_eq!(json(&ev)["flowId"], "blue");
+    assert_eq!(
+        json(&ev)["request"]["path"],
+        "/blue",
+        "must skip the green-flow request"
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn unauthorized_without_api_key() {
+    let (addr, _mgr, running) = start_server(Some("s3cret")).await;
+    let (_sse, status) = Sse::connect(addr, "/events", None).await;
+    assert!(
+        status.contains("401"),
+        "expected 401 without key, got {status:?}"
+    );
+    // With the key it connects.
+    let (mut ok, status_ok) = Sse::connect(addr, "/events", Some("s3cret")).await;
+    assert!(
+        status_ok.contains("200"),
+        "expected 200 with key, got {status_ok:?}"
+    );
+    ok.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello with key");
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn lagged_event_on_backpressure() {
+    let (addr, mgr, running) = start_server(None).await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=lifecycle", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    // Stall the reader and flood the bus past its capacity so the slow subscriber lags.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    for _ in 0..2000u32 {
+        mgr.event_bus().publish_lifecycle(
+            rift_mock_core::imposter::ImposterAction::StubsChanged,
+            Some(19999),
+        );
+    }
+    // Now drain: a `lagged` frame must appear, and the stream keeps going (not closed).
+    let lagged = sse
+        .wait_for("lagged", Duration::from_secs(5))
+        .await
+        .expect("lagged frame");
+    assert!(
+        json(&lagged)["missed"].as_u64().unwrap_or(0) >= 1,
+        "lagged reports missed>=1"
+    );
+    // The stream must CONTINUE after lagging (not silently die): a fresh event still arrives.
+    mgr.event_bus().publish_lifecycle(
+        rift_mock_core::imposter::ImposterAction::Created,
+        Some(17777),
+    );
+    let after = sse
+        .wait_for("imposter", Duration::from_secs(5))
+        .await
+        .expect("an event must still arrive after a lagged frame");
+    assert!(
+        json(&after)["action"].is_string(),
+        "stream stays alive after lagged: {}",
+        json(&after)
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn alias_endpoint_streams_scoped_requests() {
+    let (addr, mgr, running) = start_server(None).await;
+    let a = create(&mgr, serde_json::json!({"port":18810,"protocol":"http","recordRequests":true,"stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    let b = create(&mgr, serde_json::json!({"port":18811,"protocol":"http","recordRequests":true,"stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    // The alias auto-scopes to its port and streams request events without any query params.
+    let (mut sse, status) =
+        Sse::connect(addr, &format!("/imposters/{a}/savedRequests/stream"), None).await;
+    assert!(status.contains("200"), "alias returns 200, got {status:?}");
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    reqwest::get(format!("http://127.0.0.1:{b}/other"))
+        .await
+        .expect("req b");
+    reqwest::get(format!("http://127.0.0.1:{a}/mine"))
+        .await
+        .expect("req a");
+    let ev = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    assert_eq!(json(&ev)["port"], a, "alias auto-scopes to its own port");
+    assert_eq!(json(&ev)["request"]["path"], "/mine");
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn no_types_param_streams_both_families_with_monotonic_ids() {
+    let (addr, mgr, running) = start_server(None).await;
+    let (mut sse, _s) = Sse::connect(addr, "/events", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    // Default (no types=) streams BOTH families: a lifecycle event and a request event.
+    let iport = create(&mgr, serde_json::json!({"port":18812,"protocol":"http","recordRequests":true,"stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    let created = sse
+        .wait_for("imposter", Duration::from_secs(5))
+        .await
+        .expect("lifecycle event");
+    assert_eq!(json(&created)["action"], "created");
+    reqwest::get(format!("http://127.0.0.1:{iport}/x"))
+        .await
+        .expect("drive");
+    let req = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    // `id:` is present and strictly increasing across events (the reconnect contract).
+    let id_created: u64 = created.id.as_deref().unwrap().parse().unwrap();
+    let id_req: u64 = req.id.as_deref().unwrap().parse().unwrap();
+    assert!(
+        id_req > id_created,
+        "ids strictly increase: {id_created} -> {id_req}"
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn error_branches_return_400_and_404() {
+    let (addr, _mgr, running) = start_server(None).await;
+    // Unknown port → 404.
+    let (_a, s404) = Sse::connect(addr, "/events?port=59999", None).await;
+    assert!(s404.contains("404"), "unknown port → 404, got {s404:?}");
+    // Bad types value → 400.
+    let (_b, s400) = Sse::connect(addr, "/events?types=bogus", None).await;
+    assert!(s400.contains("400"), "bad types → 400, got {s400:?}");
+    // Alias with a nonexistent port → 404.
+    let (_c, s404b) = Sse::connect(addr, "/imposters/59998/savedRequests/stream", None).await;
+    assert!(
+        s404b.contains("404"),
+        "alias unknown port → 404, got {s404b:?}"
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn no_request_event_when_record_requests_disabled() {
+    let (addr, mgr, running) = start_server(None).await;
+    // recordRequests omitted (defaults false): the request is neither journaled nor streamed.
+    let iport = create(&mgr, serde_json::json!({"port":18813,"protocol":"http","stubs":[{"responses":[{"is":{"statusCode":200}}]}]})).await;
+    let (mut sse, _s) = Sse::connect(addr, "/events?types=requests", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+    reqwest::get(format!("http://127.0.0.1:{iport}/x"))
+        .await
+        .expect("drive");
+    let f = sse.wait_for("request", Duration::from_secs(1)).await;
+    assert!(f.is_none(), "no request event when recordRequests is off");
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_closes_stream_cleanly() {
+    let (addr, _mgr, running) = start_server(None).await;
+    let (mut sse, _s) = Sse::connect(addr, "/events", None).await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+    running.shutdown().await;
+    // After shutdown the socket must reach EOF promptly (no hang): next_frame returns None.
+    let closed = tokio::time::timeout(
+        Duration::from_secs(5),
+        sse.next_frame(Duration::from_secs(5)),
+    )
+    .await;
+    assert!(
+        matches!(closed, Ok(None)),
+        "stream must close (EOF) on shutdown, got {closed:?}"
+    );
+}

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -134,6 +134,9 @@ pub struct Imposter {
     /// [`LocalProxyStore`] for this imposter's mode, or the embedder's shared store injected
     /// via [`ImposterManager::with_proxy_store`](crate::imposter::ImposterManager::with_proxy_store).
     pub(crate) proxy_store: Arc<dyn ProxyRecordingStore>,
+    /// Admin SSE event bus (issue #461), shared from the manager so recorded requests fan out to
+    /// streaming clients. `None` for a standalone imposter (no manager) — then nothing is published.
+    pub(crate) event_bus: Option<Arc<super::events::AdminEventBus>>,
     /// Recorded-request storage (issue #314); defaults to a private LocalJournal,
     /// or the embedder's shared journal injected via the manager.
     pub(crate) journal: Arc<dyn crate::imposter::journal::RequestJournal>,
@@ -224,6 +227,7 @@ impl Imposter {
             stub_index,
             stubs_write: Mutex::new(()),
             proxy_store: Arc::new(LocalProxyStore::new(proxy_mode)),
+            event_bus: None,
             journal: journal
                 .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
             enabled: AtomicBool::new(true),

--- a/crates/rift-mock-core/src/imposter/core/recording.rs
+++ b/crates/rift-mock-core/src/imposter/core/recording.rs
@@ -20,8 +20,19 @@ impl Imposter {
             return None;
         }
         let flow_id = self.resolve_flow_id_recorded(&req.headers);
-        self.journal
-            .record_indexed(self.journal_port(), &flow_id, req.clone())
+        let index = self
+            .journal
+            .record_indexed(self.journal_port(), &flow_id, req.clone());
+        // Fan the recorded request out to the admin SSE stream (issue #461). Guard on an active
+        // subscriber first so the hot path never clones the request for nobody. The journal
+        // index rides along (issue #603) so a client that reconnects or lags can reconcile with
+        // `?since=<index>` instead of re-polling the whole journal.
+        if let Some(bus) = &self.event_bus
+            && bus.has_subscribers()
+        {
+            bus.publish_request(self.journal_port(), flow_id, index, req.clone());
+        }
+        index
     }
 
     /// Read recorded requests with the backend's completeness flag intact, so embedders

--- a/crates/rift-mock-core/src/imposter/events.rs
+++ b/crates/rift-mock-core/src/imposter/events.rs
@@ -1,0 +1,206 @@
+//! Admin event bus (issue #461): a broadcast of recorded-request and imposter-lifecycle events that
+//! powers the admin SSE stream (`GET /events`). Owned by the [`ImposterManager`](super::ImposterManager);
+//! publishing is a cheap no-op whenever nobody is subscribed (the SSE endpoint is the only
+//! subscriber), so it adds nothing to the request hot path unless a client is actively streaming.
+//!
+//! Backpressure is lossy-but-loud: the channel is bounded, and a subscriber that falls behind
+//! observes `RecvError::Lagged(n)` (surfaced to the client as a `lagged` SSE event) rather than the
+//! engine blocking or buffering unboundedly — the client reconciles the gap via `GET /savedRequests`.
+
+use crate::imposter::types::RecordedRequest;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::broadcast;
+
+/// Broadcast capacity: a slow subscriber this far behind starts dropping oldest events (→ `Lagged`).
+const CAPACITY: usize = 1024;
+
+/// An imposter lifecycle transition. Mirrors [`ImposterEvent`](super::ImposterEvent) but is a
+/// distinct type so the SSE wire format is not coupled to the embedder-facing event enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImposterAction {
+    Created,
+    Replaced,
+    StubsChanged,
+    Deleted,
+    AllDeleted,
+}
+
+impl ImposterAction {
+    /// The `action` string in the SSE `imposter` event payload.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Replaced => "replaced",
+            Self::StubsChanged => "stubsChanged",
+            Self::Deleted => "deleted",
+            Self::AllDeleted => "allDeleted",
+        }
+    }
+}
+
+/// A single admin event, tagged with a monotonic sequence number (the SSE `id:`), so a client that
+/// reconnects can tell — via `Last-Event-ID` — that it missed events (v1 does not replay; the gap
+/// is the signal to reconcile via polling).
+#[derive(Debug, Clone)]
+pub struct AdminEvent {
+    pub seq: u64,
+    pub kind: AdminEventKind,
+}
+
+/// The two event families the stream carries.
+#[derive(Debug, Clone)]
+pub enum AdminEventKind {
+    /// An imposter was created/replaced/deleted (`port` is absent only for `AllDeleted`).
+    Lifecycle {
+        action: ImposterAction,
+        port: Option<u16>,
+    },
+    /// A request was recorded against `port` (only when `recordRequests: true`), tagged with its
+    /// resolved `flow_id`. `request` is byte-identical to the `savedRequests` projection.
+    ///
+    /// `index` is the entry's journal index (issue #603), or `None` when the backend has no
+    /// stable indices. It lets a client that lagged or reconnected reconcile with
+    /// `?since=<index>` instead of re-polling the whole journal.
+    ///
+    /// The request is boxed because a broadcast ring slot is sized by the largest variant: left
+    /// inline, every one of the bus's 1024 slots would carry a `RecordedRequest`'s worth of
+    /// bytes even when it holds a ~5-byte lifecycle event.
+    Request {
+        port: u16,
+        flow_id: String,
+        index: Option<u64>,
+        request: Box<RecordedRequest>,
+    },
+}
+
+/// Broadcast of admin events for the SSE stream.
+#[derive(Debug)]
+pub struct AdminEventBus {
+    tx: broadcast::Sender<Arc<AdminEvent>>,
+    seq: AtomicU64,
+    /// Serializes (sequence assignment + broadcast send) so that `id:` delivery order always equals
+    /// assignment order — `publish` is called concurrently from lifecycle (`emit`) and per-request
+    /// (`record_request`) paths, and without this a later `seq` could be `send`-ed first, delivering
+    /// events out of order and breaking the monotonic-`id:` reconnect contract.
+    send_lock: parking_lot::Mutex<()>,
+}
+
+impl Default for AdminEventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AdminEventBus {
+    #[must_use]
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(CAPACITY);
+        Self {
+            tx,
+            seq: AtomicU64::new(0),
+            send_lock: parking_lot::Mutex::new(()),
+        }
+    }
+
+    /// The most recently issued sequence number (0 before any event) — sent in the `hello` frame so
+    /// a client knows where the stream starts.
+    #[must_use]
+    pub fn seq(&self) -> u64 {
+        self.seq.load(Ordering::Relaxed)
+    }
+
+    /// Subscribe a new SSE stream. Each subscriber gets every event published after this call.
+    #[must_use]
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<AdminEvent>> {
+        self.tx.subscribe()
+    }
+
+    /// True when at least one SSE stream is subscribed — the publish-side fast-path guard that keeps
+    /// the request hot path allocation-free when nobody is streaming.
+    #[must_use]
+    pub fn has_subscribers(&self) -> bool {
+        self.tx.receiver_count() > 0
+    }
+
+    /// Publish an imposter lifecycle event (called from `ImposterManager::emit`).
+    pub fn publish_lifecycle(&self, action: ImposterAction, port: Option<u16>) {
+        self.publish(AdminEventKind::Lifecycle { action, port });
+    }
+
+    /// Publish a recorded-request event (called from `Imposter::record_request`). The caller checks
+    /// [`has_subscribers`](Self::has_subscribers) first so it never clones a request for nobody.
+    pub fn publish_request(
+        &self,
+        port: u16,
+        flow_id: String,
+        index: Option<u64>,
+        request: RecordedRequest,
+    ) {
+        self.publish(AdminEventKind::Request {
+            port,
+            flow_id,
+            index,
+            request: Box::new(request),
+        });
+    }
+
+    fn publish(&self, kind: AdminEventKind) {
+        // No SSE client: don't burn a sequence number or a broadcast slot.
+        if self.tx.receiver_count() == 0 {
+            return;
+        }
+        // Assign the sequence and send under one lock so `id:` order == delivery order even under
+        // concurrent publishers. `send` is non-blocking (no `.await`), so this is a brief hold.
+        let _guard = self.send_lock.lock();
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed) + 1;
+        // A send error means every receiver dropped between the check and here — nothing to do.
+        let _ = self.tx.send(Arc::new(AdminEvent { seq, kind }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec() -> RecordedRequest {
+        RecordedRequest {
+            request_from: "127.0.0.1:5000".to_string(),
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query: Default::default(),
+            headers: Default::default(),
+            body: None,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_subscribers_means_no_publish() {
+        // AC9: with nobody streaming, publishing must not advance the sequence (the hot-path guard).
+        let bus = AdminEventBus::new();
+        assert!(!bus.has_subscribers());
+        bus.publish_lifecycle(ImposterAction::Created, Some(1));
+        bus.publish_request(1, "f".to_string(), Some(1), rec());
+        assert_eq!(bus.seq(), 0, "no subscribers → no sequence consumed");
+    }
+
+    #[tokio::test]
+    async fn subscriber_receives_and_seq_advances() {
+        let bus = AdminEventBus::new();
+        let mut rx = bus.subscribe();
+        assert!(bus.has_subscribers());
+        bus.publish_lifecycle(ImposterAction::Deleted, Some(7));
+        let ev = rx.recv().await.expect("event");
+        assert_eq!(ev.seq, 1);
+        assert!(matches!(
+            ev.kind,
+            AdminEventKind::Lifecycle {
+                action: ImposterAction::Deleted,
+                port: Some(7)
+            }
+        ));
+        assert_eq!(bus.seq(), 1);
+    }
+}

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -139,6 +139,10 @@ pub struct ImposterManager {
     /// drain before returning anyway with a warning (issue #596). Never configurable at runtime;
     /// overridable only in tests via [`Self::with_conn_drain`].
     conn_drain: Duration,
+    /// Broadcast of lifecycle + recorded-request events for the admin SSE stream (issue #461).
+    /// Created unconditionally (a `broadcast::Sender` with no receivers is ~free); publishing is a
+    /// no-op until a client subscribes.
+    event_bus: Arc<super::events::AdminEventBus>,
 }
 
 /// Default bound for the post-delete connection drain (issue #596). Generous: normal graceful
@@ -167,6 +171,7 @@ impl ImposterManager {
             request_journal: None,
             proxy_store: None,
             conn_drain: DEFAULT_CONN_DRAIN,
+            event_bus: Arc::new(super::events::AdminEventBus::new()),
         }
     }
 
@@ -268,6 +273,23 @@ impl ImposterManager {
         if let Some(listener) = &self.event_listener {
             listener.on_event(&event);
         }
+        // Additionally fan the event out to the admin SSE bus (issue #461) — separate from the
+        // single-slot embedder listener above, which callers may already hold.
+        use super::events::ImposterAction;
+        let (action, port) = match event {
+            ImposterEvent::Created(p) => (ImposterAction::Created, Some(p)),
+            ImposterEvent::Replaced(p) => (ImposterAction::Replaced, Some(p)),
+            ImposterEvent::StubsChanged(p) => (ImposterAction::StubsChanged, Some(p)),
+            ImposterEvent::Deleted(p) => (ImposterAction::Deleted, Some(p)),
+            ImposterEvent::AllDeleted => (ImposterAction::AllDeleted, None),
+        };
+        self.event_bus.publish_lifecycle(action, port);
+    }
+
+    /// The admin event bus (issue #461), for the SSE stream handler to subscribe to.
+    #[must_use]
+    pub fn event_bus(&self) -> &Arc<super::events::AdminEventBus> {
+        &self.event_bus
     }
 
     /// Resolve the TLS acceptor for an HTTPS imposter by precedence: inline imposter cert/key →
@@ -382,6 +404,9 @@ impl ImposterManager {
         if let Some(store) = &self.proxy_store {
             imposter.proxy_store = Arc::clone(store);
         }
+
+        // Share the admin event bus so recorded requests fan out to the SSE stream (issue #461).
+        imposter.event_bus = Some(Arc::clone(&self.event_bus));
 
         // Create shutdown channel for this imposter
         let (shutdown_tx, _) = broadcast::channel(1);

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -17,6 +17,7 @@
 //! - `core`: Core Imposter struct and implementation
 
 mod core;
+pub mod events;
 mod fault_io;
 mod handler;
 mod manager;
@@ -67,6 +68,7 @@ pub use crate::extensions::flow_state::FlowStoreProvider;
 pub use manager::{ImposterManager, TlsDefaults};
 
 // Re-export incremental reconciliation types (issue #316)
+pub use events::{AdminEvent, AdminEventBus, AdminEventKind, ImposterAction};
 pub use reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, stub_key};
 
 // Re-export predicate utilities (used in tests and for external consumers)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -498,6 +498,68 @@ state intact.
 
 ---
 
+## Events (Server-Sent Events)
+
+### GET /events
+
+A [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) stream of
+recorded requests and imposter lifecycle changes — a push upgrade of polling `GET /savedRequests`,
+for live request tails (`ZStream`/`fs2.Stream`, Go channels, async iterators). Gated by the admin
+API key like every other admin route. Older engines return `404`, so an SDK probes this endpoint and
+falls back to polling.
+
+**Query parameters:**
+- `types=requests,lifecycle` — which event families to stream (default: both).
+- `port=<port>` — restrict to one imposter.
+- `match=header:<Name>=<Value>` / `match=flow_id=<Value>` — filter **request** events (AND-ed).
+  `flow_id=` compares the request's record-time resolved flow id (per the imposter's
+  `flow_id_source`); a `header:`-source imposter whose request lacks that header falls back to the
+  port, which `GET /savedRequests?match=flow_id=` treats as "no match" instead — the only edge where
+  the two disagree.
+
+**Event stream** (`Content-Type: text/event-stream`):
+```
+event: hello
+data: {"engineVersion":"X.Y.Z","seq":42,"types":["requests","lifecycle"],"port":null}
+
+event: request
+id: 43
+data: {"port":3000,"flowId":"tenant-a","index":12,"request":{ …RecordedRequest, identical to savedRequests… }}
+
+event: imposter
+id: 44
+data: {"action":"created|replaced|stubsChanged|deleted|allDeleted","port":3000}
+
+event: lagged
+data: {"missed":7}
+
+: ping    ← comment heartbeat every 15s
+```
+
+- **Request events require `recordRequests: true`** — the stream is a tail *of recorded requests*,
+  exactly like `savedRequests`, not a tap of all traffic.
+- The `id:` is a monotonic sequence number spanning **both** event families. **v1 does not replay:**
+  on reconnect, a gap in `id:` (or a `lagged` event, emitted when a slow consumer falls behind the
+  bounded buffer) means "reconcile via `GET /savedRequests`". The stream is lossy-but-loud by
+  design; polling remains the source of truth.
+- **`index`** on a request event is that entry's journal index — the same cursor the polling side
+  reports as `x-rift-next-index` (see [Tailing with a cursor](#tailing-with-a-cursor)). It is what
+  makes reconciling cheap: pass the last `index` you saw as `?since=<index>` and get only what you
+  missed, instead of re-polling the whole journal and de-duplicating by content. Omitted when the
+  journal backend has no stable indices — the same capability probe as the polling side's missing
+  header.
+
+**Canonical tail:** connect → `hello` → baseline `GET /savedRequests` (keep `x-rift-next-index`) →
+consume events, tracking `index` → on `lagged` or a reconnect gap, `GET /savedRequests?since=<last
+index>` to fill the hole, then resume.
+
+### GET /imposters/{port}/savedRequests/stream
+
+Sugar alias for `GET /events?types=requests&port={port}` — a handle-scoped request tail that mirrors
+the `savedRequests` polling endpoint one-to-one.
+
+---
+
 ## Scenarios
 
 Declarative state machines (Mountebank/WireMock style) gate stubs by `requiredScenarioState` and


### PR DESCRIPTION
Adds `GET /events` (plus the handle-scoped alias `GET /imposters/{port}/savedRequests/stream`) — a Server-Sent Events push upgrade of `savedRequests` polling, for live request tails (`ZStream`/`fs2.Stream`, Go channels, async iterators). An `AdminEventBus` (a tokio broadcast owned by `ImposterManager`) fans imposter lifecycle events and recorded requests to subscribers; publishing is a no-op when nobody is streaming, so the request hot path is untouched unless a client is connected.

Filtered by `types`/`port`/`match` (same semantics as `savedRequests`), gated by the admin API key, and lossy-but-loud under backpressure: a slow consumer gets a `lagged` event rather than stalling the engine. Older engines 404, which is the SDK capability probe — polling stays the supported fallback and the source of truth (v1 does not replay).

Each `request` event carries its journal `index` (#603), so a client that lagged or reconnected reconciles with `savedRequests?since=<index>` instead of re-polling the whole journal and de-duplicating by content. That closes the one loose end in the v1 lossy-but-loud contract. `index` is omitted when the journal backend has no stable indices — the same probe the polling side uses.

**Un-parked and rebased.** This PR was parked pending a consuming SDK; #603 documents that demand (rift-scala shaped its stream signatures for a drop-in SSE swap; rift-node#26 waits on this). Rebased onto #603's merge (`aa4f7d7`) — picks up the `rift-core` → `rift-mock-core` rename and `server.rs` drift from #546/#548 (the constant-time API-key comparison is preserved), and adds the `index` amendment.

Verified: clippy clean on the default and `--no-default-features` lanes (cache-busted rebuild); 1778 workspace tests pass, including 14 SSE gate tests — one of which correlates a streamed event's `index` against the `x-rift-next-index` poll cursor and reconciles via `?since=`.

Closes #461