### PR TITLE
ci: integration tests under tests/ never run — main CI job uses cargo test --lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,28 +49,12 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      # `--lib` runs only library unit tests; every `tests/*.rs` integration binary (the handler
+      # contract tests, the FFI round-trip, the corpus-replay gate, admin_api_integration, …) runs
+      # in the dedicated `integration-tests` job below (issue #510). This job stays fast and matrixed
+      # over stable+beta for the unit surface; the integration surface runs once on stable.
       - name: Run unit tests
         run: cargo test --workspace --all-features --lib
-
-      # Issue #500: the handler script-failure contract tests run in their own integration binary
-      # (a separate process with its own MB JS script pool) rather than in the `--lib` set, so they
-      # don't contend for the shared pool with the timing-sensitive bounded-matcher unit tests. The
-      # `--lib` step above skips every `tests/*.rs` binary, so run this one explicitly.
-      - name: Run handler error-response integration tests
-        run: cargo test -p rift-core --all-features --test handler_error_responses
-
-      # Issue #492: the C-ABI round-trip integration tests (including the allowInjection admin-plane
-      # gate) live in a tests/*.rs binary the `--lib` step skips, so run them explicitly — otherwise
-      # the FFI option wiring has no CI regression signal.
-      - name: Run rift-ffi C-ABI round-trip tests
-        run: cargo test -p rift-ffi --all-features --test round_trip
-
-      # Issue #460: the published sdk-conformance-<ver>.tar.gz corpus must serve and its `_verify`
-      # transcripts must hold on this commit (and `manifest.json` must match the fixtures on disk).
-      # This gate binary is also skipped by the `--lib` step, so run it explicitly — it's what keeps
-      # the release artifact verified rather than hoped, and catches DSL/engine drift at the source.
-      - name: Run SDK conformance corpus replay gate
-        run: cargo test -p rift-http-proxy --all-features --test corpus_replay
 
       # Issue #460: prove the corpus packager (release step) works end-to-end — version stamping,
       # tar structure, fixture-count round-trip — without needing an engine build.
@@ -87,6 +71,45 @@ jobs:
       # and that the checked-in header matches, before the per-platform release matrix relies on it.
       - name: rift-ffi C-ABI smoke test
         run: ./scripts/verify-ffi-cdylib.sh
+
+  # Issue #510: the matrix `test` job runs `--lib` only, so every `tests/*.rs` integration binary
+  # (admin_api_integration, verify_dynamic, the issue_* handler contracts, the FFI round-trip, the
+  # corpus-replay gate, …) never ran in CI — a regression in those contracts would ship green. This
+  # job runs the whole integration surface with `--tests`. `--workspace` covers only the six
+  # `crates/*` members, so the docker-bound `rift-compatibility-tests` crate and the benchmark are
+  # excluded automatically (they keep their own dedicated jobs); redis_backend self-provisions a
+  # container via testcontainers and mountebank_compatibility spawns its own server, so both run on
+  # the Docker-enabled runner without extra setup. Runs on stable only (the unit surface already
+  # covers beta) to keep the heavier integration run off the critical path.
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run integration tests (tests/*.rs binaries)
+        run: cargo test --workspace --all-features --tests
 
   # Issue #420: the truststore keytool tests are #[ignore]d (they need a JDK on PATH), so the
   # matrix `test` job never runs them and the PKCS#12/JKS JVM-loadability guarantee has no CI

--- a/crates/rift-http-proxy/tests/corpus_replay.rs
+++ b/crates/rift-http-proxy/tests/corpus_replay.rs
@@ -168,7 +168,10 @@ fn manifest_is_consistent() {
     }
 }
 
+// Serialized against `packaged_corpus_serves_and_verify_holds`: both serve the whole corpus on its
+// fixtures' fixed ports (4501–4520), so running them concurrently races on those binds and flakes.
 #[tokio::test]
+#[serial_test::serial(corpus)]
 async fn corpus_serves_and_verify_holds() {
     let corpus = sdk_conformance_dir().join("corpus");
     serve_and_verify(&corpus).await;
@@ -179,6 +182,7 @@ async fn corpus_serves_and_verify_holds() {
 /// version-prefixed root — any of which could silently drop a fixture or a `data/`/injection file.
 /// Run the packager, extract, and replay against the extracted `corpus/`.
 #[tokio::test]
+#[serial_test::serial(corpus)]
 async fn packaged_corpus_serves_and_verify_holds() {
     let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/gen-sdk-conformance.sh");
     let work = tempfile::tempdir().expect("tempdir");

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -19,14 +19,23 @@ mod js_validator {
     pub fn validate_javascript(script: &str) -> Result<(), super::JsSyntaxError> {
         let mut context = Context::default();
 
-        // Mountebank uses function expressions that need to be wrapped
+        // Mountebank inject/decorate scripts are anonymous function *expressions*
+        // (`function(args){…}` or `function (args){…}`), which are a syntax error when Boa parses
+        // them as a top-level statement (a function *declaration* needs a name). Wrap them as an
+        // expression so Boa parses them. An anonymous function is `function` followed by optional
+        // whitespace and then `(` — the earlier `!contains("function ")` heuristic wrongly treated
+        // the common `function (args)` form (a space before the parens) as named, leaving it
+        // unwrapped and mis-flagged as a syntax error.
         let script_trimmed = script.trim();
-        let wrapped =
-            if script_trimmed.starts_with("function") && !script_trimmed.contains("function ") {
-                format!("var __fn = ({script_trimmed})")
-            } else {
-                script_trimmed.to_string()
-            };
+        let is_anonymous_function_expr = script_trimmed
+            .strip_prefix("function")
+            .map(str::trim_start)
+            .is_some_and(|rest| rest.starts_with('('));
+        let wrapped = if is_anonymous_function_expr {
+            format!("var __fn = ({script_trimmed})")
+        } else {
+            script_trimmed.to_string()
+        };
 
         match context.eval(Source::from_bytes(&wrapped)) {
             Ok(_) => Ok(()),
@@ -1253,6 +1262,26 @@ mod js_behavior_tests {
             assert!(
                 !has_code(&lint_decorate(script), "W009"),
                 "W009 fired for: {script}"
+            );
+        }
+    }
+
+    #[test]
+    fn e028_not_fired_for_anonymous_function_expressions() {
+        // Mountebank inject/decorate scripts are anonymous function expressions. Both the
+        // no-space and space-before-parens forms are valid and the engine runs them; the JS
+        // syntax validator must wrap them as expressions rather than mis-flag `function (args)`
+        // as a nameless declaration (E028). Meaningful under the `javascript` feature; a no-op
+        // otherwise.
+        for script in [
+            "function(config, state) { state.n = (state.n||0)+1; return { statusCode: 200 }; }",
+            "function (config, state) { state.n = (state.n||0)+1; return { statusCode: 200 }; }",
+            "function (request, response) { response.headers['X-D'] = 'r'; }",
+            "function(){ return 0; }",
+        ] {
+            assert!(
+                !has_code(&lint(script), "E028"),
+                "E028 (JS syntax error) wrongly fired for a valid anonymous function: {script}"
             );
         }
     }


### PR DESCRIPTION
The main test job runs `cargo test --workspace --all-features --lib`, which excludes every `tests/*.rs` integration binary — so a large body of integration coverage (admin_api_integration, verify_dynamic, the `issue_*` handler-contract tests, the FFI round-trip, the corpus-replay gate, …) never ran in CI. A regression in those contracts would ship green.

Adds a dedicated `integration-tests` job running `cargo test --workspace --all-features --tests`. Because `--workspace` covers only the six `crates/*` members, the docker-bound `rift-compatibility-tests` crate and the benchmark are excluded automatically (they keep their dedicated jobs); `redis_backend` self-provisions a testcontainers container and `mountebank_compatibility` spawns its own server, so both run on the Docker-enabled runner without extra setup. Runs on stable only to keep the heavier integration run off the critical path. Removes the three now-redundant per-file integration steps.

Verified locally: all integration binaries compile (`cargo test --workspace --all-features --tests --no-run`), and the motivating gap tests pass (the four `issue_*` handler contracts + `admin_api_integration`).

Closes #510