### PR TITLE
admin: runtime intercept lifecycle — POST/DELETE /intercept for connect/spawn transport parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ record.
 
 ## [Unreleased]
 
+### Added
+- **Runtime intercept lifecycle over the admin API** (#493): `POST /intercept` starts the TLS-MITM
+  intercept listener at runtime (201 with `{interceptPort, interceptUrl}`, 409 if already running),
+  `GET /intercept` reports it (404 when not running), and `DELETE /intercept` stops it (204,
+  idempotent). The endpoints are available on every server — a server started **without**
+  `--intercept-port` can now enable intercept at runtime (SDK connect/spawn transport parity). The
+  CLI flag, the FFI, and these routes all drive one shared listener, so a listener started by any
+  surface is visible to the others. New FFI symbol `rift_stop_intercept` mirrors `DELETE /intercept`,
+  and `rift_serve_admin` now serves the full `/intercept*` surface against the handle's listener
+  (previously it 404'd). All endpoints are gated by `--apikey` like other admin routes.
+
 ### Changed
 - **Case-insensitive `contains`/`startsWith`/`endsWith` predicates now fold ASCII only** (#480), for
   consistency with `equals` (already ASCII case-insensitive) and to avoid a per-request allocation on

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -317,6 +317,18 @@ char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
 char *rift_start_intercept(RiftHandle *h, const char *options_json);
 
 /**
+ * Stop the intercept listener started by [`rift_start_intercept`] (or over the embedded admin
+ * plane's `POST /intercept`), releasing its port and dropping its rules + CA — RFC-003 parity with
+ * `DELETE /intercept`. Idempotent: stopping when nothing is running is a successful no-op. Returns
+ * `0` on success, `-1` only on a null handle or a caught panic. A subsequent
+ * [`rift_start_intercept`] without CA paths mints a fresh CA, so re-export the CA afterwards.
+ *
+ * # Safety
+ * `h` must be a live handle (or null).
+ */
+int32_t rift_stop_intercept(RiftHandle *h);
+
+/**
  * Add one intercept rule (a bare object) or many (a JSON array) — same shape the
  * `/intercept/rules` admin route accepts. Returns `0` on success, `-1` on any error.
  *

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -36,20 +36,21 @@ use parking_lot::Mutex;
 use rift_core::imposter::{
     ApplyReport, Imposter, ImposterConfig, ImposterManager, Stub, VerifyOptions,
 };
-use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
 use rift_core::proxy::truststore::{TrustStorePassword, ca_pem, export_jks, export_pkcs12};
 use rift_http_proxy::admin_api::{
     AdminApiServer, RunningAdminApi, filter_proxy_responses, filter_proxy_stubs,
 };
 use rift_http_proxy::config_loader::{self, ConfigSource};
-use rift_http_proxy::intercept::InterceptListener;
-use rift_http_proxy::intercept_rules::{InterceptRule, InterceptRules, InterceptState};
+use rift_http_proxy::intercept_control::{
+    InterceptControl, InterceptStartError, InterceptStartOptions, InterceptStatus,
+};
+use rift_http_proxy::intercept_rules::InterceptRule;
 use rift_http_proxy::server::{RunningMetrics, bind_metrics_server};
 use serde_json::{Value, json};
 use std::cell::RefCell;
 use std::ffi::{CStr, CString, c_char};
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
 use tracing::warn;
@@ -105,20 +106,16 @@ pub struct RiftHandle {
     runtime: Runtime,
     manager: Arc<ImposterManager>,
     admin: Mutex<Option<AdminPlane>>,
-    intercept: Mutex<Option<InterceptPlane>>,
+    /// The handle's single intercept plane, shared with its embedded admin plane (issue #493): a
+    /// listener started via `rift_start_intercept` is visible to `GET /intercept` on the admin
+    /// plane, and vice versa — one slot, driven by both the C-ABI and the HTTP surface.
+    intercept: InterceptControl,
 }
 
 /// The admin API (and optional metrics server) serving in-process for a handle (issue #343).
 struct AdminPlane {
     admin: RunningAdminApi,
     metrics: Option<RunningMetrics>,
-}
-
-/// The intercept/TLS-MITM listener serving in-process for a handle, plus the shared
-/// [`InterceptState`] (rule store + CA) its control-plane functions mutate/export (issue #410).
-struct InterceptPlane {
-    listener: InterceptListener,
-    state: InterceptState,
 }
 
 /// Borrow the handle from a raw pointer, or `None` if null.
@@ -250,7 +247,7 @@ pub extern "C" fn rift_start() -> *mut RiftHandle {
                 runtime,
                 manager: Arc::new(ImposterManager::new()),
                 admin: Mutex::new(None),
-                intercept: Mutex::new(None),
+                intercept: InterceptControl::default(),
             })),
             Err(e) => {
                 set_last_error(format!("rift_start: runtime creation failed: {e}"));
@@ -1365,19 +1362,6 @@ pub unsafe extern "C" fn rift_space_recorded(
 // Start an intercept forward-proxy on the handle's runtime and drive its rule store + CA export
 // entirely over C-ABI — no loopback HTTP admin plane needed. One listener per handle.
 
-/// `rift_start_intercept` options (all optional): the bind host and port, plus an optional
-/// caller-provided intercept CA (`caCertPath`/`caKeyPath`, PEM file paths — both or neither).
-/// `deny_unknown_fields` so a misspelled key (e.g. `caCertpath`) is a hard error, not a silent
-/// fallback to a fresh ephemeral CA that would defeat the caller's intended CA reuse.
-#[derive(serde::Deserialize, Default)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct InterceptOptions {
-    host: Option<String>,
-    port: Option<u16>,
-    ca_cert_path: Option<String>,
-    ca_key_path: Option<String>,
-}
-
 /// A single rule or a batch — `rift_intercept_add_rules` accepts either shape.
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
@@ -1410,8 +1394,8 @@ pub unsafe extern "C" fn rift_start_intercept(
             set_last_error("rift_start_intercept: null handle");
             return std::ptr::null_mut();
         };
-        let opts: InterceptOptions = if options_json.is_null() {
-            InterceptOptions::default()
+        let opts: InterceptStartOptions = if options_json.is_null() {
+            InterceptStartOptions::default()
         } else {
             match c_str(options_json) {
                 Some(s) => match serde_json::from_str(s) {
@@ -1428,65 +1412,60 @@ pub unsafe extern "C" fn rift_start_intercept(
             }
         };
 
-        // Hold the slot across build+set so a concurrent call can't race two listeners into
-        // existence (one intercept listener per handle).
-        let mut slot = handle.intercept.lock();
-        if slot.is_some() {
-            set_last_error(
-                "rift_start_intercept: already started (one intercept listener per handle)",
-            );
-            return std::ptr::null_mut();
-        }
-
-        let host = opts.host.as_deref().unwrap_or("127.0.0.1");
-        let addr: std::net::SocketAddr = match format!("{host}:{}", opts.port.unwrap_or(0)).parse()
-        {
-            Ok(a) => a,
-            Err(e) => {
-                set_last_error(format!("rift_start_intercept: invalid host/port: {e}"));
-                return std::ptr::null_mut();
-            }
-        };
-        let ca = match CertificateAuthority::load_or_generate(
-            opts.ca_cert_path.as_deref().map(Path::new),
-            opts.ca_key_path.as_deref().map(Path::new),
-        ) {
-            Ok(ca) => Arc::new(ca),
-            Err(e) => {
-                // `{e:#}` so the chained cause (missing file, bad PEM, mismatched pair) reaches the
-                // caller — `rift_last_error` is their only diagnostic channel.
-                set_last_error(format!("rift_start_intercept: CA setup failed: {e:#}"));
-                warn!(error = %e, "rift_start_intercept: CA setup failed");
-                return std::ptr::null_mut();
-            }
-        };
-        let rules = InterceptRules::new();
-        let resolver = Arc::new(SniCertResolver::new(ca.clone()));
-        let listener =
-            match handle
-                .runtime
-                .block_on(InterceptListener::bind(addr, resolver, rules.clone()))
-            {
-                Ok(l) => l,
+        // The shared control serializes concurrent starts and handles CA load + bind; map its
+        // typed errors back to the exact `last_error` strings the SDKs match on.
+        match handle.runtime.block_on(handle.intercept.start(opts)) {
+            Ok(addr) => match serde_json::to_string(&InterceptStatus::from_addr(addr)) {
+                Ok(json) => into_c_string(json),
                 Err(e) => {
-                    set_last_error(format!("rift_start_intercept: bind failed: {e}"));
-                    warn!(error = %e, "rift_start_intercept: bind failed");
-                    return std::ptr::null_mut();
+                    set_last_error(format!("rift_start_intercept: encode failed: {e}"));
+                    std::ptr::null_mut()
                 }
-            };
-        // Derive both fields from the real bound address so the URL reflects the actual host
-        // (and OS-assigned port), not a hardcoded loopback.
-        let local_addr = listener.local_addr();
-        let response = json!({
-            "interceptPort": local_addr.port(),
-            "interceptUrl": format!("http://{local_addr}"),
-        })
-        .to_string();
-        *slot = Some(InterceptPlane {
-            listener,
-            state: InterceptState { rules, ca },
-        });
-        into_c_string(response)
+            },
+            Err(e) => {
+                let msg = match &e {
+                    InterceptStartError::AlreadyRunning => {
+                        "rift_start_intercept: already started (one intercept listener per handle)"
+                            .to_string()
+                    }
+                    InterceptStartError::InvalidAddr(s) => {
+                        format!("rift_start_intercept: invalid host/port: {s}")
+                    }
+                    // `{err:#}` so the chained cause (missing file, bad PEM, mismatched pair)
+                    // reaches the caller — `rift_last_error` is their only diagnostic channel.
+                    // (`InterceptControl::start` already `warn!`s the CA/bind failure server-side.)
+                    InterceptStartError::Ca(err) => {
+                        format!("rift_start_intercept: CA setup failed: {err:#}")
+                    }
+                    InterceptStartError::Bind(err) => {
+                        format!("rift_start_intercept: bind failed: {err}")
+                    }
+                };
+                set_last_error(msg);
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Stop the intercept listener started by [`rift_start_intercept`] (or over the embedded admin
+/// plane's `POST /intercept`), releasing its port and dropping its rules + CA — RFC-003 parity with
+/// `DELETE /intercept`. Idempotent: stopping when nothing is running is a successful no-op. Returns
+/// `0` on success, `-1` only on a null handle or a caught panic. A subsequent
+/// [`rift_start_intercept`] without CA paths mints a fresh CA, so re-export the CA afterwards.
+///
+/// # Safety
+/// `h` must be a live handle (or null).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rift_stop_intercept(h: *mut RiftHandle) -> i32 {
+    ffi_guard!("rift_stop_intercept", -1, unsafe {
+        clear_last_error();
+        let Some(handle) = handle(h) else {
+            set_last_error("rift_stop_intercept: null handle");
+            return -1;
+        };
+        handle.runtime.block_on(handle.intercept.stop());
+        0
     })
 }
 
@@ -1513,16 +1492,15 @@ pub unsafe extern "C" fn rift_intercept_add_rules(
                 return -1;
             }
         };
-        let slot = handle.intercept.lock();
-        let Some(plane) = slot.as_ref() else {
+        let Some(state) = handle.intercept.state() else {
             set_last_error("rift_intercept_add_rules: intercept not started");
             return -1;
         };
         match parsed {
-            RuleOrRules::One(rule) => plane.state.rules.add(rule),
+            RuleOrRules::One(rule) => state.rules.add(rule),
             RuleOrRules::Many(rules) => {
                 for rule in rules {
-                    plane.state.rules.add(rule);
+                    state.rules.add(rule);
                 }
             }
         }
@@ -1542,12 +1520,11 @@ pub unsafe extern "C" fn rift_intercept_clear_rules(h: *mut RiftHandle) -> i32 {
             set_last_error("rift_intercept_clear_rules: null handle");
             return -1;
         };
-        let slot = handle.intercept.lock();
-        let Some(plane) = slot.as_ref() else {
+        let Some(state) = handle.intercept.state() else {
             set_last_error("rift_intercept_clear_rules: intercept not started");
             return -1;
         };
-        plane.state.rules.clear();
+        state.rules.clear();
         0
     })
 }
@@ -1565,12 +1542,11 @@ pub unsafe extern "C" fn rift_intercept_list_rules(h: *mut RiftHandle) -> *mut c
             set_last_error("rift_intercept_list_rules: null handle");
             return std::ptr::null_mut();
         };
-        let slot = handle.intercept.lock();
-        let Some(plane) = slot.as_ref() else {
+        let Some(state) = handle.intercept.state() else {
             set_last_error("rift_intercept_list_rules: intercept not started");
             return std::ptr::null_mut();
         };
-        match serde_json::to_string(&plane.state.rules.list()) {
+        match serde_json::to_string(&state.rules.list()) {
             Ok(json) => into_c_string(json),
             Err(e) => {
                 set_last_error(format!("rift_intercept_list_rules: encode failed: {e}"));
@@ -1593,12 +1569,11 @@ pub unsafe extern "C" fn rift_intercept_ca_pem(h: *mut RiftHandle) -> *mut c_cha
             set_last_error("rift_intercept_ca_pem: null handle");
             return std::ptr::null_mut();
         };
-        let slot = handle.intercept.lock();
-        let Some(plane) = slot.as_ref() else {
+        let Some(state) = handle.intercept.state() else {
             set_last_error("rift_intercept_ca_pem: intercept not started");
             return std::ptr::null_mut();
         };
-        into_c_string(ca_pem(&plane.state.ca))
+        into_c_string(ca_pem(&state.ca))
     })
 }
 
@@ -1636,15 +1611,14 @@ pub unsafe extern "C" fn rift_intercept_export_truststore(
                 }
             }
         };
-        let slot = handle.intercept.lock();
-        let Some(plane) = slot.as_ref() else {
+        let Some(state) = handle.intercept.state() else {
             set_last_error("rift_intercept_export_truststore: intercept not started");
             return -1;
         };
         let pw = TrustStorePassword::new(password);
         let bytes = match format {
-            "pkcs12" => export_pkcs12(&plane.state.ca, &pw),
-            "jks" => export_jks(&plane.state.ca, &pw),
+            "pkcs12" => export_pkcs12(&state.ca, &pw),
+            "jks" => export_jks(&state.ca, &pw),
             other => {
                 set_last_error(format!(
                     "rift_intercept_export_truststore: unknown format '{other}' (want pkcs12/jks)"
@@ -1826,8 +1800,13 @@ async fn build_admin_plane(
         None => None,
     };
 
+    // Share the handle's intercept slot with the admin plane (issue #493) so `rift_serve_admin`
+    // serves the full `/intercept*` surface against the same listener the C-ABI drives: a
+    // `rift_start_intercept` is then visible to `GET /intercept`, and `POST /intercept` feeds
+    // `rift_intercept_add_rules` — a double-start across surfaces 409s/-1s consistently.
     let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key)
-        .with_allow_injection(opts.allow_injection.unwrap_or(false));
+        .with_allow_injection(opts.allow_injection.unwrap_or(false))
+        .with_intercept(handle.intercept.clone());
     if let Some(source) = config_source {
         server = server.with_config_source(source);
     }
@@ -1977,10 +1956,9 @@ pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
             return;
         }
         let handle = Box::from_raw(h);
-        // Ordering (issue #343/#410): admin/metrics + intercept listeners down first, then the
+        // Ordering (issue #343/#410/#493): admin/metrics + intercept listeners down first, then the
         // manager.
         let plane = handle.admin.lock().take();
-        let intercept = handle.intercept.lock().take();
         handle.runtime.block_on(async {
             if let Some(plane) = plane {
                 plane.admin.shutdown().await;
@@ -1988,9 +1966,7 @@ pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
                     metrics.shutdown().await;
                 }
             }
-            if let Some(intercept) = intercept {
-                intercept.listener.shutdown().await;
-            }
+            handle.intercept.stop().await;
             handle.manager.shutdown().await;
         });
     })

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1335,6 +1335,92 @@ fn ffi_stop_shuts_down_intercept() {
     }
 }
 
+/// Issue #493 (AC8): `rift_stop_intercept` stops the listener started by `rift_start_intercept`,
+/// frees the port, is idempotent (a second stop with nothing running still returns 0), and rejects
+/// a null handle with -1.
+#[test]
+fn ffi_stop_intercept_symbol() {
+    unsafe {
+        let h = rift_start();
+        let started: serde_json::Value =
+            serde_json::from_str(&take_json(rift_start_intercept(h, std::ptr::null()))).unwrap();
+        let port = started["interceptPort"].as_u64().unwrap() as u16;
+
+        assert_eq!(rift_stop_intercept(h), 0, "stop a running listener -> 0");
+        assert!(
+            rt().block_on(admin_refused(port)),
+            "intercept port is freed after rift_stop_intercept"
+        );
+        // Control calls now report "not started" again.
+        assert!(rift_intercept_ca_pem(h).is_null());
+        // Idempotent: stopping with nothing running is still success.
+        assert_eq!(rift_stop_intercept(h), 0, "idempotent stop -> 0");
+        // Null handle -> -1.
+        assert_eq!(rift_stop_intercept(std::ptr::null_mut()), -1);
+
+        rift_stop(h);
+    }
+}
+
+/// Issue #493 (AC8): the embedded admin plane (`rift_serve_admin`) shares the handle's intercept
+/// slot — a listener started over the C-ABI is visible to `GET /intercept`, and a second start over
+/// the admin `POST /intercept` conflicts (409). Previously `/intercept*` always 404'd there.
+#[test]
+fn ffi_serve_admin_shares_intercept_slot() {
+    unsafe {
+        let h = rift_start();
+        let info = serve_admin(h, "{}");
+        let admin_url = info["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        // Before any start, GET /intercept over the embedded admin plane -> 404 (served, not the
+        // old "no intercept surface" 404-everything).
+        let before = rt().block_on(async {
+            reqwest::get(format!("{admin_url}/intercept"))
+                .await
+                .unwrap()
+                .status()
+                .as_u16()
+        });
+        assert_eq!(before, 404, "GET /intercept before start -> 404");
+
+        // Start over the C-ABI.
+        let started: serde_json::Value =
+            serde_json::from_str(&take_json(rift_start_intercept(h, std::ptr::null()))).unwrap();
+        let port = started["interceptPort"].as_u64().unwrap() as u16;
+
+        // The admin plane now sees the FFI-started listener (shared slot).
+        let (status, body): (u16, serde_json::Value) = rt().block_on(async {
+            let r = reqwest::get(format!("{admin_url}/intercept"))
+                .await
+                .unwrap();
+            let s = r.status().as_u16();
+            (s, r.json().await.unwrap())
+        });
+        assert_eq!(
+            status, 200,
+            "GET /intercept sees the C-ABI-started listener"
+        );
+        assert_eq!(body["interceptPort"].as_u64().unwrap() as u16, port);
+
+        // A double-start across surfaces conflicts: POST /intercept over admin -> 409.
+        let conflict = rt().block_on(async {
+            reqwest::Client::new()
+                .post(format!("{admin_url}/intercept"))
+                .send()
+                .await
+                .unwrap()
+                .status()
+                .as_u16()
+        });
+        assert_eq!(
+            conflict, 409,
+            "POST /intercept while C-ABI listener runs -> 409"
+        );
+
+        rift_stop(h);
+    }
+}
+
 /// Issue #425: the start response's interceptUrl reflects the ACTUAL bound host, not a hardcoded
 /// 127.0.0.1. A non-loopback bind (0.0.0.0) must surface as the bound address; the loopback default
 /// is unchanged.

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -1,10 +1,17 @@
-//! Intercept rule CRUD + CA/truststore export admin handlers (epic #394, slice 4/5).
+//! Intercept runtime lifecycle + rule CRUD + CA/truststore export admin handlers (epic #394 slice
+//! 4/5; runtime lifecycle issue #493).
 //!
-//! Everything here lives under `/intercept/...` and is only reachable when the server was built
-//! `with_intercept(...)` (i.e. the intercept listener is actually running) — see
-//! `admin_api::router::route_request`.
+//! Everything here lives under `/intercept`. The lifecycle verbs (`POST`/`GET`/`DELETE /intercept`)
+//! start, report, and stop the listener over the shared [`InterceptControl`] slot, so intercept can
+//! be enabled at runtime on any server — not only one started with `--intercept-port`. The rule
+//! CRUD + CA/truststore sub-routes operate on the running listener's [`InterceptState`] and keep
+//! `404`-ing when no listener is running. All of this is only reachable when the server was built
+//! `with_intercept(...)` — see `admin_api::router::route_request`.
 
 use crate::admin_api::types::{collect_body, error_response, json_response};
+use crate::intercept_control::{
+    InterceptControl, InterceptStartError, InterceptStartOptions, InterceptStatus,
+};
 use crate::intercept_rules::{InterceptRule, InterceptState};
 use bytes::Bytes;
 use http_body_util::Full;
@@ -15,27 +22,123 @@ use serde::Serialize;
 
 const DEFAULT_TRUSTSTORE_PASSWORD: &str = "changeit";
 
-/// Dispatch a `/intercept/...` admin request. Returns `None` for any other path so the caller
-/// falls through to its normal routing (e.g. `404`).
+/// Dispatch a `/intercept...` admin request. Returns `None` for any unmatched path/method so the
+/// caller falls through to its normal `404` handling — including the rule/CA sub-routes when no
+/// listener is running (`control.state()` is `None`).
 pub async fn route(
     method: &Method,
     path: &str,
     query: Option<&str>,
     req: Request<Incoming>,
-    state: &InterceptState,
+    control: &InterceptControl,
 ) -> Option<Response<Full<Bytes>>> {
     let rest = path.strip_prefix("/intercept")?;
     let resp = match (method, rest) {
-        (&Method::POST, "/rules") => handle_add_rules(req, state).await,
-        (&Method::GET, "/rules") => handle_list_rules(state),
-        (&Method::DELETE, "/rules") => handle_clear_rules(state),
-        (&Method::GET, "/ca.pem") => handle_ca_pem(state),
-        (&Method::GET, "/truststore.p12") => handle_truststore_p12(query, state),
-        (&Method::GET, "/truststore.jks") => handle_truststore_jks(query, state),
-        // Unmatched `/intercept/...` sub-path: let the caller apply its own 404 handling.
+        // Runtime lifecycle (issue #493) — operate on the shared slot, listener or not.
+        (&Method::POST, "") => handle_start(req, control).await,
+        (&Method::GET, "") => handle_status(control),
+        (&Method::DELETE, "") => handle_stop(control).await,
+        // Rule CRUD + CA/truststore — need a running listener's state. When none is running these
+        // are a known route with an actionable body ("not running"), not the generic 404 an unknown
+        // sub-path gets below — mirroring `GET /intercept`.
+        (&Method::POST, "/rules") => match control.state() {
+            Some(state) => handle_add_rules(req, &state).await,
+            None => not_running(),
+        },
+        (&Method::GET, "/rules") => match control.state() {
+            Some(state) => handle_list_rules(&state),
+            None => not_running(),
+        },
+        (&Method::DELETE, "/rules") => match control.state() {
+            Some(state) => handle_clear_rules(&state),
+            None => not_running(),
+        },
+        (&Method::GET, "/ca.pem") => match control.state() {
+            Some(state) => handle_ca_pem(&state),
+            None => not_running(),
+        },
+        (&Method::GET, "/truststore.p12") => match control.state() {
+            Some(state) => handle_truststore_p12(query, &state),
+            None => not_running(),
+        },
+        (&Method::GET, "/truststore.jks") => match control.state() {
+            Some(state) => handle_truststore_jks(query, &state),
+            None => not_running(),
+        },
+        // Unmatched `/intercept...` path/method: let the caller apply its own 404 handling.
         _ => return None,
     };
     Some(resp)
+}
+
+/// The `404` an intercept sub-route returns when no listener is running — the same actionable body
+/// `GET /intercept` uses, rather than a bare "Not Found".
+fn not_running() -> Response<Full<Bytes>> {
+    error_response(StatusCode::NOT_FOUND, "intercept listener not running")
+}
+
+/// `POST /intercept` — start the listener. Body is optional: absent, empty, or `{}` all mean
+/// defaults (`127.0.0.1:0`, fresh in-memory CA). `201` with the [`InterceptStatus`] body on
+/// success, `409` when already running, `400` for a bad body / options / CA / bind.
+async fn handle_start(req: Request<Incoming>, control: &InterceptControl) -> Response<Full<Bytes>> {
+    let body = match collect_body(req).await {
+        Ok(b) => b,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
+    start_from_bytes(&body, control).await
+}
+
+/// Parse start options from a (possibly empty) JSON body and drive `control.start`. Split out from
+/// `handle_start` so the `201`/`409`/`400` mapping is unit-testable without a `Request<Incoming>`.
+async fn start_from_bytes(body: &[u8], control: &InterceptControl) -> Response<Full<Bytes>> {
+    let opts: InterceptStartOptions = if body.is_empty() {
+        InterceptStartOptions::default()
+    } else {
+        match serde_json::from_slice(body) {
+            Ok(o) => o,
+            Err(e) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid intercept start options: {e}"),
+                );
+            }
+        }
+    };
+    match control.start(opts).await {
+        Ok(addr) => json_response(StatusCode::CREATED, &InterceptStatus::from_addr(addr)),
+        Err(e) => {
+            let status = match e {
+                InterceptStartError::AlreadyRunning => StatusCode::CONFLICT,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            error_response(status, &e.to_string())
+        }
+    }
+}
+
+/// `GET /intercept` — `200` with the [`InterceptStatus`] of the running listener (whatever surface
+/// started it), or `404` when none is running.
+fn handle_status(control: &InterceptControl) -> Response<Full<Bytes>> {
+    match control.status() {
+        Some(addr) => json_response(StatusCode::OK, &InterceptStatus::from_addr(addr)),
+        None => not_running(),
+    }
+}
+
+/// `DELETE /intercept` — stop the listener and drop its rules + CA. Always `204`, idempotent: a
+/// delete with nothing running is a successful no-op. A subsequent `POST` without CA paths mints a
+/// fresh CA, so clients must re-export `/intercept/ca.pem` after a restart.
+async fn handle_stop(control: &InterceptControl) -> Response<Full<Bytes>> {
+    control.stop().await;
+    Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .body(Full::new(Bytes::new()))
+        .unwrap_or_else(|_| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to build response",
+            )
+        })
 }
 
 /// A single rule or a batch — `POST /intercept/rules` accepts either shape.
@@ -319,6 +422,86 @@ mod tests {
         assert_eq!(resp.text().await.unwrap(), "admin-brewed");
 
         listener.shutdown().await;
+    }
+
+    // ── Runtime lifecycle handlers (issue #493) ────────────────────────────────────────────────
+
+    // A #[tokio::test]-safe body reader (the sync `body_string` spins its own runtime, which panics
+    // inside an async test).
+    async fn read_body(resp: Response<Full<Bytes>>) -> String {
+        use http_body_util::BodyExt;
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    /// The status body of a running listener — deserialized so the parts under test read cleanly.
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct StatusBody {
+        intercept_port: u16,
+        intercept_url: String,
+    }
+
+    #[tokio::test]
+    async fn start_status_stop_handler_matrix() {
+        let control = InterceptControl::default();
+
+        // GET before start → 404.
+        assert_eq!(handle_status(&control).status(), StatusCode::NOT_FOUND);
+
+        // POST empty body → 201 with an OS-assigned port.
+        let started = start_from_bytes(b"", &control).await;
+        assert_eq!(started.status(), StatusCode::CREATED);
+        let body: StatusBody = serde_json::from_str(&read_body(started).await).unwrap();
+        assert!(body.intercept_port > 0);
+        assert!(body.intercept_url.starts_with("http://"));
+
+        // GET while running → 200, same port.
+        let status = handle_status(&control);
+        assert_eq!(status.status(), StatusCode::OK);
+        let got: StatusBody = serde_json::from_str(&read_body(status).await).unwrap();
+        assert_eq!(got.intercept_port, body.intercept_port);
+
+        // POST while running → 409.
+        assert_eq!(
+            start_from_bytes(b"{}", &control).await.status(),
+            StatusCode::CONFLICT
+        );
+
+        // DELETE → 204, then GET → 404 (idempotent second DELETE also 204).
+        assert_eq!(handle_stop(&control).await.status(), StatusCode::NO_CONTENT);
+        assert_eq!(handle_status(&control).status(), StatusCode::NOT_FOUND);
+        assert_eq!(handle_stop(&control).await.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_unknown_field_and_bad_json() {
+        let control = InterceptControl::default();
+        assert_eq!(
+            start_from_bytes(br#"{"caCertpath":"x"}"#, &control)
+                .await
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            start_from_bytes(b"{not json", &control).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert!(
+            control.status().is_none(),
+            "a rejected start must not leave a listener"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_serialized_body_is_deserializable_status() {
+        // AC8/parity: the 201 body round-trips through the same shape the FFI returns.
+        let control = InterceptControl::default();
+        let resp = start_from_bytes(b"", &control).await;
+        let json = read_body(resp).await;
+        assert!(json.contains("interceptPort"));
+        assert!(json.contains("interceptUrl"));
+        control.stop().await;
     }
 
     fn body_bytes(resp: Response<Full<Bytes>>) -> Vec<u8> {

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -6,7 +6,7 @@ use crate::admin_api::handlers::{imposters, intercept, scenarios, stubs, system}
 use crate::admin_api::types::{error_response, get_base_url, not_found};
 use crate::config_loader::ConfigSource;
 use crate::imposter::ImposterManager;
-use crate::intercept_rules::InterceptState;
+use crate::intercept_control::InterceptControl;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
@@ -77,7 +77,7 @@ pub async fn route_request(
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
-    intercept: Option<Arc<InterceptState>>,
+    intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
@@ -87,13 +87,14 @@ pub async fn route_request(
 
     debug!("Admin API: {} {}", method, path);
 
-    // Intercept control-plane routes (epic #394 slice 4): only reachable when an intercept
-    // listener is actually running (i.e. the server was built `with_intercept(...)`). Nothing
-    // else in `route_by_path` handles `/intercept`, so an unmatched sub-path or a missing
-    // intercept state both fall through to the ordinary 404.
+    // Intercept routes (epic #394 slice 4 + runtime lifecycle #493): reachable whenever the server
+    // was built `with_intercept(...)`. The lifecycle verbs (`POST`/`GET`/`DELETE /intercept`)
+    // operate on the shared control slot listener-or-not; the rule/CA sub-routes 404 until a
+    // listener is running. Nothing else in `route_by_path` handles `/intercept`, so an unmatched
+    // sub-path/method or a control-less server both fall through to the ordinary 404.
     if path == "/intercept" || path.starts_with("/intercept/") {
         let resp = match intercept.as_ref() {
-            Some(state) => intercept::route(&method, &path, query.as_deref(), req, state)
+            Some(control) => intercept::route(&method, &path, query.as_deref(), req, control)
                 .await
                 .unwrap_or_else(not_found),
             None => not_found(),

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -4,7 +4,7 @@ use crate::admin_api::router::route_request;
 use crate::config_loader::ConfigSource;
 use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
-use crate::intercept_rules::InterceptState;
+use crate::intercept_control::InterceptControl;
 use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::service::service_fn;
@@ -30,7 +30,7 @@ pub struct AdminApiServer {
     api_key: Option<Arc<String>>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
-    intercept: Option<Arc<InterceptState>>,
+    intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
 }
 
@@ -64,12 +64,14 @@ impl AdminApiServer {
         self
     }
 
-    /// Wire the `/intercept/...` admin routes (rule CRUD + CA/truststore export, epic #394 slice
-    /// 4) to `state`. Without this, `/intercept/...` responds `404` — the admin server has no
-    /// intercept surface unless an embedder explicitly opts in.
+    /// Wire the `/intercept` admin routes to the shared [`InterceptControl`] slot: the runtime
+    /// lifecycle verbs (`POST`/`GET`/`DELETE /intercept`, issue #493) plus rule CRUD + CA/truststore
+    /// export (epic #394 slice 4). The control may be empty (no listener yet) — the lifecycle
+    /// endpoints still work and can start one. Without this call, all of `/intercept*` responds
+    /// `404` — the admin server has no intercept surface unless an embedder explicitly opts in.
     #[must_use]
-    pub fn with_intercept(mut self, state: Arc<InterceptState>) -> Self {
-        self.intercept = Some(state);
+    pub fn with_intercept(mut self, control: InterceptControl) -> Self {
+        self.intercept = Some(control);
         self
     }
 
@@ -202,7 +204,7 @@ async fn accept_loop(
     api_key: Option<Arc<String>>,
     config_source: Option<Arc<ConfigSource>>,
     allow_injection: bool,
-    intercept: Option<Arc<InterceptState>>,
+    intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
     cancel: CancellationToken,
     tracker: TaskTracker,

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -1,0 +1,289 @@
+//! Shared runtime lifecycle for the intercept/TLS-MITM listener (issue #493).
+//!
+//! One process (or one FFI handle) owns at most a single intercept plane. Historically the three
+//! surfaces that could start it — the `--intercept-port` CLI flag, the `rift_start_intercept` FFI
+//! call, and (read-only) the `/intercept/*` admin routes — each held the listener differently and
+//! could not be driven at runtime over the admin API. [`InterceptControl`] promotes the FFI's
+//! `InterceptPlane` shape into a single cloneable slot that all three share, so start/stop/status
+//! become one implementation and `POST`/`GET`/`DELETE /intercept` can manage the same listener a
+//! CLI flag or FFI call started.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::intercept::InterceptListener;
+use crate::intercept_rules::{InterceptRules, InterceptState};
+use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
+use serde::Serialize;
+
+/// A running intercept plane: the listener plus the control-plane [`InterceptState`] (rule store +
+/// CA) the admin routes and FFI mutate/export.
+pub struct InterceptPlane {
+    pub listener: InterceptListener,
+    pub state: InterceptState,
+}
+
+/// Shared, mutable slot for the process's (or FFI handle's) single intercept plane. Cheap to clone
+/// (an `Arc` inside). The `std` mutex is never held across an `.await` (see [`InterceptControl::start`]);
+/// poisoning is recovered rather than propagated, like [`InterceptRules`].
+#[derive(Clone, Default)]
+pub struct InterceptControl(Arc<Mutex<Option<InterceptPlane>>>);
+
+/// Start options — the exact shape (and serde attributes) of the FFI's former `InterceptOptions`,
+/// so the admin `POST /intercept` body and `rift_start_intercept` parse identically.
+/// `deny_unknown_fields` so a misspelled `caCertpath` is a hard error, not a silent fresh-CA
+/// fallback that would defeat the caller's intended CA reuse.
+#[derive(serde::Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InterceptStartOptions {
+    /// Bind host, default `127.0.0.1`.
+    pub host: Option<String>,
+    /// Bind port, default `0` (OS-assigned).
+    pub port: Option<u16>,
+    pub ca_cert_path: Option<String>,
+    /// Both-or-neither with `ca_cert_path`.
+    pub ca_key_path: Option<String>,
+}
+
+/// The running-listener status shared by `POST`/`GET /intercept` and `rift_start_intercept` — the
+/// same field names and derivation so every surface returns a byte-compatible body.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterceptStatus {
+    pub intercept_port: u16,
+    pub intercept_url: String,
+}
+
+impl InterceptStatus {
+    /// Derive both fields from the *real* bound address (OS-assigned port resolved). A `0.0.0.0`
+    /// bind surfaces verbatim — dial a concrete interface.
+    pub fn from_addr(addr: SocketAddr) -> Self {
+        Self {
+            intercept_port: addr.port(),
+            intercept_url: format!("http://{addr}"),
+        }
+    }
+}
+
+/// Why an intercept `start` failed. The variants map 1:1 to the admin status codes (only
+/// [`InterceptStartError::AlreadyRunning`] is a `409`; the rest are `400`) and to the FFI's
+/// existing `rift_start_intercept: ...` `last_error` strings.
+#[derive(Debug, thiserror::Error)]
+pub enum InterceptStartError {
+    #[error("intercept listener already running (one per process)")]
+    AlreadyRunning,
+    #[error("invalid host/port: {0}")]
+    InvalidAddr(String),
+    // `{0:#}` keeps the anyhow chain (missing file, bad PEM, mismatched pair). Never file contents.
+    #[error("CA setup failed: {0:#}")]
+    Ca(#[source] anyhow::Error),
+    #[error("bind failed: {0}")]
+    Bind(#[source] anyhow::Error),
+}
+
+impl InterceptControl {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<InterceptPlane>> {
+        self.0.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// True if a listener currently occupies the slot. A sync helper so the (`!Send`) `std`
+    /// mutex guard never spans an `.await` in [`start`](Self::start).
+    fn is_occupied(&self) -> bool {
+        self.lock().is_some()
+    }
+
+    /// Install a freshly-bound plane, or hand the listener back if the slot filled in the meantime
+    /// (a concurrent start won the race). Sync so the guard is confined to this frame.
+    fn install(&self, plane: InterceptPlane) -> Result<(), InterceptListener> {
+        let mut slot = self.lock();
+        if slot.is_some() {
+            return Err(plane.listener);
+        }
+        *slot = Some(plane);
+        Ok(())
+    }
+
+    /// Bind and install the listener. Fails with [`InterceptStartError::AlreadyRunning`] if the
+    /// slot is occupied — including when it was occupied by the CLI flag or the FFI.
+    ///
+    /// The `std` mutex is never held across the async bind/shutdown: pre-check → bind (unlocked) →
+    /// install-or-hand-back. Two concurrent starts therefore end with exactly one listener and one
+    /// `AlreadyRunning`, and the loser's just-bound listener is shut down rather than leaked.
+    pub async fn start(
+        &self,
+        opts: InterceptStartOptions,
+    ) -> Result<SocketAddr, InterceptStartError> {
+        if self.is_occupied() {
+            return Err(InterceptStartError::AlreadyRunning);
+        }
+
+        let host = opts.host.as_deref().unwrap_or("127.0.0.1");
+        let addr: SocketAddr = format!("{host}:{}", opts.port.unwrap_or(0))
+            .parse()
+            .map_err(|e| InterceptStartError::InvalidAddr(format!("{e}")))?;
+        // Log CA/bind failures here so every surface (FFI, admin `POST /intercept`, CLI flag) gets a
+        // server-side trail — not just the FFI, which used to `warn!` these on its own.
+        let ca = Arc::new(
+            CertificateAuthority::load_or_generate(
+                opts.ca_cert_path.as_deref().map(Path::new),
+                opts.ca_key_path.as_deref().map(Path::new),
+            )
+            .map_err(|e| {
+                tracing::warn!(error = %e, "intercept start: CA setup failed");
+                InterceptStartError::Ca(e)
+            })?,
+        );
+        let rules = InterceptRules::new();
+        let resolver = Arc::new(SniCertResolver::new(ca.clone()));
+        let listener = InterceptListener::bind(addr, resolver, rules.clone())
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, "intercept start: bind failed");
+                InterceptStartError::Bind(e)
+            })?;
+        let bound = listener.local_addr();
+
+        match self.install(InterceptPlane {
+            listener,
+            state: InterceptState { rules, ca },
+        }) {
+            Ok(()) => Ok(bound),
+            Err(listener) => {
+                listener.shutdown().await;
+                Err(InterceptStartError::AlreadyRunning)
+            }
+        }
+    }
+
+    /// Take the plane out of the slot and shut its listener down. Returns whether a listener was
+    /// actually running (an idempotent no-op, returning `false`, otherwise).
+    pub async fn stop(&self) -> bool {
+        // Scope the guard so it is dropped before the `.await` below (it is `!Send`).
+        let taken = { self.lock().take() };
+        match taken {
+            Some(plane) => {
+                plane.listener.shutdown().await;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Bound address of the running listener, if any.
+    pub fn status(&self) -> Option<SocketAddr> {
+        self.lock().as_ref().map(|p| p.listener.local_addr())
+    }
+
+    /// A clone of the running plane's [`InterceptState`] for the rules/CA/truststore handlers.
+    /// Cheap: `InterceptState` is `Arc`-backed rules + an `Arc` CA.
+    pub fn state(&self) -> Option<InterceptState> {
+        self.lock().as_ref().map(|p| p.state.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> InterceptStartOptions {
+        InterceptStartOptions::default()
+    }
+
+    #[tokio::test]
+    async fn start_status_stop_roundtrip() {
+        let control = InterceptControl::default();
+        assert!(control.status().is_none());
+        assert!(control.state().is_none());
+
+        let addr = control.start(defaults()).await.expect("start");
+        assert_eq!(control.status(), Some(addr));
+        assert!(addr.port() > 0, "OS assigned a real port");
+        assert!(control.state().is_some());
+
+        assert!(control.stop().await, "stop reports it was running");
+        assert!(control.status().is_none());
+        assert!(control.state().is_none());
+    }
+
+    #[tokio::test]
+    async fn double_start_is_already_running() {
+        let control = InterceptControl::default();
+        control.start(defaults()).await.expect("first start");
+        let err = control.start(defaults()).await.expect_err("second start");
+        assert!(matches!(err, InterceptStartError::AlreadyRunning));
+        control.stop().await;
+    }
+
+    #[tokio::test]
+    async fn stop_is_idempotent() {
+        let control = InterceptControl::default();
+        assert!(!control.stop().await, "stop on empty slot is a no-op");
+        control.start(defaults()).await.expect("start");
+        assert!(control.stop().await);
+        assert!(!control.stop().await, "second stop is a no-op");
+    }
+
+    #[tokio::test]
+    async fn ca_paths_must_be_both_or_neither() {
+        let control = InterceptControl::default();
+        let opts = InterceptStartOptions {
+            ca_cert_path: Some("only-cert.pem".to_string()),
+            ..Default::default()
+        };
+        let err = control.start(opts).await.expect_err("half CA pair");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+        assert!(control.status().is_none(), "no listener left behind");
+    }
+
+    #[tokio::test]
+    async fn bad_ca_path_is_ca_error() {
+        let control = InterceptControl::default();
+        let opts = InterceptStartOptions {
+            ca_cert_path: Some("/no/such/cert.pem".to_string()),
+            ca_key_path: Some("/no/such/key.pem".to_string()),
+            ..Default::default()
+        };
+        let err = control.start(opts).await.expect_err("missing CA files");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+    }
+
+    #[tokio::test]
+    async fn occupied_port_is_bind_error() {
+        // AC6: a port already in use surfaces as a `Bind` error (mapped to 400 at the handler).
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+        let port = occupied.local_addr().unwrap().port();
+        let control = InterceptControl::default();
+        let opts = InterceptStartOptions {
+            port: Some(port),
+            ..Default::default()
+        };
+        let err = control.start(opts).await.expect_err("port already bound");
+        assert!(matches!(err, InterceptStartError::Bind(_)));
+        assert!(control.status().is_none(), "no listener left behind");
+    }
+
+    #[tokio::test]
+    async fn deny_unknown_fields() {
+        let err = serde_json::from_str::<InterceptStartOptions>(r#"{"caCertpath":"x"}"#)
+            .expect_err("misspelled field must be rejected");
+        assert!(
+            err.to_string().contains("caCertpath") || err.to_string().contains("unknown field")
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_starts_bind_exactly_one_listener() {
+        let control = InterceptControl::default();
+        let (a, b) = tokio::join!(control.start(defaults()), control.start(defaults()));
+        let winners = [&a, &b].iter().filter(|r| r.is_ok()).count();
+        let losers = [&a, &b].iter().filter(|r| r.is_err()).count();
+        assert_eq!(winners, 1, "exactly one start wins");
+        assert_eq!(losers, 1, "exactly one start loses");
+        // The winner's port is the one installed; the loser's listener was shut down, not leaked.
+        let installed = control.status().expect("a listener is installed");
+        let won = a.or(b).expect("the Ok addr");
+        assert_eq!(installed, won, "the installed listener is the winner's");
+        control.stop().await;
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -28,6 +28,10 @@ pub mod intercept;
 // Intercept rules (predicate match -> serve/forward) + admin control state (epic #394 slice 4)
 pub mod intercept_rules;
 
+// Shared runtime lifecycle (start/stop/status) for the intercept listener, driven by the CLI
+// flag, the admin `/intercept` routes, and the FFI over one cloneable slot (issue #493)
+pub mod intercept_control;
+
 // Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
 pub mod config_loader;
 

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -10,10 +10,8 @@ use crate::extensions::metrics;
 use crate::imposter::{
     ImposterConfig, ImposterManager, ScriptBaseDir, TlsDefaults, resolve_scripts,
 };
-use crate::intercept::InterceptListener;
-use crate::intercept_rules::{InterceptRules, InterceptState};
+use crate::intercept_control::{InterceptControl, InterceptStartOptions};
 use clap::{Parser, Subcommand};
-use rift_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -377,39 +375,43 @@ impl ServerBuilder {
             server = server.with_config_source(ConfigSource::Dir(datadir));
         }
 
-        // Optional intercept/TLS-MITM listener (epic #394). The rule store and CA are shared with
-        // the admin server so `/intercept/*` verbs configure the same listener.
-        let intercept = match cli.intercept_port {
-            Some(intercept_port) => {
-                let ca = Arc::new(CertificateAuthority::load_or_generate(
-                    cli.intercept_ca_cert.as_deref(),
-                    cli.intercept_ca_key.as_deref(),
-                )?);
-                let rules = InterceptRules::new();
-                server = server.with_intercept(Arc::new(InterceptState {
-                    rules: rules.clone(),
-                    ca: ca.clone(),
-                }));
-                let intercept_addr: SocketAddr = format!("{host}:{intercept_port}").parse()?;
-                let resolver = Arc::new(SniCertResolver::new(ca));
-                let listener = InterceptListener::bind(intercept_addr, resolver, rules).await?;
-                info!(
-                    "Rift intercept proxy listening (HTTPS forward-proxy) on {}",
-                    listener.local_addr()
-                );
-                Some(listener)
-            }
-            None => None,
-        };
+        // Intercept/TLS-MITM listener (epic #394 + runtime lifecycle #493). The control slot is
+        // always created and handed to the admin server, so `POST/GET/DELETE /intercept` work on
+        // every standalone server — flag or no flag (the issue's goal for the connect transport).
+        // `--intercept-port` just eagerly starts the same listener the API would; a start error
+        // still aborts startup, as before.
+        let intercept = InterceptControl::default();
+        if let Some(intercept_port) = cli.intercept_port {
+            intercept
+                .start(InterceptStartOptions {
+                    host: Some(host.to_string()),
+                    port: Some(intercept_port),
+                    ca_cert_path: cli
+                        .intercept_ca_cert
+                        .as_deref()
+                        .map(|p| p.to_string_lossy().into_owned()),
+                    ca_key_path: cli
+                        .intercept_ca_key
+                        .as_deref()
+                        .map(|p| p.to_string_lossy().into_owned()),
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("intercept: {e}"))?;
+            info!(
+                "Rift intercept proxy listening (HTTPS forward-proxy) on {}",
+                intercept
+                    .status()
+                    .expect("intercept listener bound after a successful start")
+            );
+        }
+        server = server.with_intercept(intercept.clone());
 
         let admin = match server.bind().await {
             Ok(admin) => admin,
             Err(e) => {
                 // Don't orphan the listeners already started if the admin bind fails — start() is
                 // an embedding seam and callers may retry after an error.
-                if let Some(intercept) = intercept {
-                    intercept.shutdown().await;
-                }
+                intercept.stop().await;
                 if let Some(metrics) = metrics {
                     metrics.shutdown().await;
                 }
@@ -429,7 +431,7 @@ impl ServerBuilder {
 pub struct RunningServer {
     admin: RunningAdminApi,
     metrics: Option<RunningMetrics>,
-    intercept: Option<InterceptListener>,
+    intercept: InterceptControl,
 }
 
 impl RunningServer {
@@ -443,10 +445,11 @@ impl RunningServer {
         self.metrics.as_ref().map(RunningMetrics::local_addr)
     }
 
-    /// The bound intercept-proxy address, if an intercept listener was started
-    /// (resolves a `:0` request to the assigned port).
+    /// The bound intercept-proxy address, if an intercept listener is running — whether started by
+    /// `--intercept-port` or later over `POST /intercept` (resolves a `:0` request to the assigned
+    /// port).
     pub fn intercept_addr(&self) -> Option<SocketAddr> {
-        self.intercept.as_ref().map(InterceptListener::local_addr)
+        self.intercept.status()
     }
 
     /// Run until the admin API accept loop exits — the binary's `run()` behavior. The metrics
@@ -455,15 +458,15 @@ impl RunningServer {
         self.admin.join().await
     }
 
-    /// Stop accepting on both listeners, giving in-flight connections a bounded grace.
+    /// Stop accepting on all listeners, giving in-flight connections a bounded grace. Stops
+    /// whatever intercept listener is running at shutdown time, including one started over the API
+    /// after this server was bound.
     pub async fn shutdown(self) {
         self.admin.shutdown().await;
         if let Some(metrics) = self.metrics {
             metrics.shutdown().await;
         }
-        if let Some(intercept) = self.intercept {
-            intercept.shutdown().await;
-        }
+        self.intercept.stop().await;
     }
 }
 
@@ -701,6 +704,9 @@ async fn load_imposters_from_datadir(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The CA load/generate logic now lives behind `InterceptControl::start`; these tests still
+    // exercise `CertificateAuthority` directly (its contract is unchanged).
+    use rift_core::proxy::intercept_ca::CertificateAuthority;
 
     #[test]
     fn test_no_parse_flag_accepted() {

--- a/crates/rift-http-proxy/tests/intercept_runtime_lifecycle.rs
+++ b/crates/rift-http-proxy/tests/intercept_runtime_lifecycle.rs
@@ -1,0 +1,371 @@
+//! Runtime intercept lifecycle over the admin API (issue #493): `POST`/`GET`/`DELETE /intercept`
+//! start, report, and stop the TLS-MITM listener at runtime — so the connect transport can enable
+//! intercept without the server having been started with `--intercept-port`.
+//!
+//! Covers acceptance criteria 1–7. AC8 (FFI parity) lives in `crates/rift-ffi/tests/round_trip.rs`.
+
+use clap::Parser;
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::imposter::ImposterManager;
+use rift_http_proxy::intercept_control::InterceptControl;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use std::sync::Arc;
+
+/// Bind an admin server with the intercept surface wired to a fresh (empty) control — the connect
+/// transport's "server started without `--intercept-port`" case. Returns the base URL + the handle.
+async fn admin_without_intercept_flag() -> (String, rift_http_proxy::admin_api::RunningAdminApi) {
+    let manager = Arc::new(ImposterManager::new());
+    let admin = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .with_intercept(InterceptControl::default())
+        .bind()
+        .await
+        .expect("admin binds");
+    let base = format!("http://{}", admin.local_addr());
+    (base, admin)
+}
+
+/// A reqwest client that proxies HTTPS through `intercept_url` and trusts only `ca_pem` — the SUT's
+/// view of the intercept proxy.
+fn trusting_client(intercept_url: &str, ca_pem: &str) -> reqwest::Client {
+    reqwest::Client::builder()
+        .proxy(reqwest::Proxy::https(intercept_url).unwrap())
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap()
+}
+
+/// AC1–4, 6: full lifecycle on a server started WITHOUT `--intercept-port`.
+#[tokio::test]
+async fn lifecycle_on_server_started_without_flag() {
+    let (base, admin) = admin_without_intercept_flag().await;
+    let c = reqwest::Client::new();
+
+    // AC1: GET before start → 404.
+    assert_eq!(
+        c.get(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    // Rule/CA routes 404 while no listener runs.
+    assert_eq!(
+        c.get(format!("{base}/intercept/ca.pem"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    // AC1: POST empty body → 201 with an OS-assigned port.
+    let started = c.post(format!("{base}/intercept")).send().await.unwrap();
+    assert_eq!(started.status(), 201);
+    let body: serde_json::Value = started.json().await.unwrap();
+    let port = body["interceptPort"].as_u64().expect("interceptPort") as u16;
+    assert!(port > 0);
+    let intercept_url = body["interceptUrl"].as_str().unwrap().to_string();
+    assert_eq!(intercept_url, format!("http://127.0.0.1:{port}"));
+
+    // AC1: GET now → 200, same body.
+    let got = c.get(format!("{base}/intercept")).send().await.unwrap();
+    assert_eq!(got.status(), 200);
+    let got_body: serde_json::Value = got.json().await.unwrap();
+    assert_eq!(got_body["interceptPort"].as_u64().unwrap() as u16, port);
+
+    // AC1: /intercept/rules + /intercept/ca.pem now work, and interception is end-to-end.
+    let rule =
+        r#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"runtime-brew"}}}"#;
+    assert_eq!(
+        c.post(format!("{base}/intercept/rules"))
+            .body(rule)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        201
+    );
+    let ca_resp = c
+        .get(format!("{base}/intercept/ca.pem"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ca_resp.status(), 200);
+    let ca_pem = ca_resp.text().await.unwrap();
+    assert!(ca_pem.starts_with("-----BEGIN CERTIFICATE-----"));
+
+    let sut = trusting_client(&intercept_url, &ca_pem);
+    let intercepted = sut
+        .get("https://cdn.example.com/x")
+        .send()
+        .await
+        .expect("intercepted");
+    assert_eq!(intercepted.status(), 418);
+    assert_eq!(intercepted.text().await.unwrap(), "runtime-brew");
+
+    // AC2: POST while running → 409 with the standard error envelope.
+    let conflict = c.post(format!("{base}/intercept")).send().await.unwrap();
+    assert_eq!(conflict.status(), 409);
+    let env: serde_json::Value = conflict.json().await.unwrap();
+    assert!(
+        env["errors"][0]["message"].is_string(),
+        "standard error envelope"
+    );
+
+    // AC6: unknown option field / half CA pair → 400.
+    assert_eq!(
+        c.post(format!("{base}/intercept"))
+            .body(r#"{"nope":1}"#)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        400,
+        "unknown field is a 400 (a fresh POST after the 409 above still sees a running listener; \
+         but a malformed body is rejected before the already-running check)"
+    );
+
+    // AC3: DELETE → 204; afterwards GET → 404, rules → 404, and the port is released.
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+    assert_eq!(
+        c.get(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    let rules_404 = c
+        .get(format!("{base}/intercept/rules"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rules_404.status(), 404);
+    // Finding: the sub-route gives an actionable body, not a bare "Not Found".
+    let rules_404_env: serde_json::Value = rules_404.json().await.unwrap();
+    assert_eq!(
+        rules_404_env["errors"][0]["message"].as_str(),
+        Some("intercept listener not running")
+    );
+
+    // AC3: a new POST pinning the just-freed port succeeds (port actually released).
+    let repin = c
+        .post(format!("{base}/intercept"))
+        .body(format!(r#"{{"port":{port}}}"#))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(repin.status(), 201, "the released port can be rebound");
+    let repin_body: serde_json::Value = repin.json().await.unwrap();
+    assert_eq!(repin_body["interceptPort"].as_u64().unwrap() as u16, port);
+
+    // AC4: DELETE, then DELETE again with nothing running → both 204 (idempotent).
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+
+    admin.shutdown().await;
+}
+
+/// AC6: a half-supplied CA pair is a 400 (validated before binding).
+#[tokio::test]
+async fn start_with_half_ca_pair_is_bad_request() {
+    let (base, admin) = admin_without_intercept_flag().await;
+    let c = reqwest::Client::new();
+    let resp = c
+        .post(format!("{base}/intercept"))
+        .body(r#"{"caCertPath":"only-cert.pem"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    // No listener was left behind.
+    assert_eq!(
+        c.get(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    admin.shutdown().await;
+}
+
+/// AC6: a bind failure (port already in use) is a 400 through the admin handler, not a 500 or a
+/// half-started listener.
+#[tokio::test]
+async fn start_on_occupied_port_is_bad_request() {
+    let (base, admin) = admin_without_intercept_flag().await;
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+    let port = occupied.local_addr().unwrap().port();
+    let c = reqwest::Client::new();
+    let resp = c
+        .post(format!("{base}/intercept"))
+        .body(format!(r#"{{"port":{port}}}"#))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400, "occupied port → 400");
+    // Nothing was installed.
+    assert_eq!(
+        c.get(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    admin.shutdown().await;
+}
+
+/// AC5: on a server started WITH `--intercept-port`, the lifecycle endpoints see and manage it, and
+/// shutdown afterwards is clean (no double-stop panic).
+#[tokio::test]
+async fn lifecycle_on_server_started_with_flag() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--intercept-port",
+        "0",
+    ]);
+    let server = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("server starts");
+    let admin = server.admin_addr();
+    let base = format!("http://{admin}");
+    let flag_port = server.intercept_addr().expect("flag listener bound").port();
+    let c = reqwest::Client::new();
+
+    // GET reports the flag-started listener (the shared slot's whole point).
+    let got = c.get(format!("{base}/intercept")).send().await.unwrap();
+    assert_eq!(got.status(), 200);
+    let got_body: serde_json::Value = got.json().await.unwrap();
+    assert_eq!(
+        got_body["interceptPort"].as_u64().unwrap() as u16,
+        flag_port
+    );
+
+    // POST → 409 (already running).
+    assert_eq!(
+        c.post(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        409
+    );
+
+    // DELETE stops it; GET → 404.
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+    assert_eq!(
+        c.get(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    // shutdown() must not double-stop the (already-stopped) listener.
+    server.shutdown().await;
+}
+
+/// AC7: with `--apikey`, all three lifecycle verbs reject a missing/wrong Authorization with 401.
+#[tokio::test]
+async fn lifecycle_endpoints_are_apikey_gated() {
+    let manager = Arc::new(ImposterManager::new());
+    let admin = AdminApiServer::new(
+        "127.0.0.1:0".parse().unwrap(),
+        manager,
+        Some("s3cret".to_string()),
+    )
+    .with_intercept(InterceptControl::default())
+    .bind()
+    .await
+    .expect("admin binds");
+    let base = format!("http://{}", admin.local_addr());
+    let c = reqwest::Client::new();
+
+    for (method, url) in [
+        ("POST", format!("{base}/intercept")),
+        ("GET", format!("{base}/intercept")),
+        ("DELETE", format!("{base}/intercept")),
+    ] {
+        let req = |auth: Option<&str>| {
+            let mut r = match method {
+                "POST" => c.post(&url),
+                "GET" => c.get(&url),
+                _ => c.delete(&url),
+            };
+            if let Some(a) = auth {
+                r = r.header("Authorization", a);
+            }
+            r
+        };
+        assert_eq!(
+            req(None).send().await.unwrap().status(),
+            401,
+            "{method} {url} without a key must be 401"
+        );
+        assert_eq!(
+            req(Some("wrong")).send().await.unwrap().status(),
+            401,
+            "{method} {url} with a wrong key must be 401"
+        );
+    }
+
+    // The correct key gets through (POST → 201, then a clean DELETE).
+    assert_eq!(
+        c.post(format!("{base}/intercept"))
+            .header("Authorization", "s3cret")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        201
+    );
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .header("Authorization", "s3cret")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+
+    admin.shutdown().await;
+}

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -67,6 +67,11 @@ Options:
 expansion), which is otherwise applied on load. `--formatter` and `--protofile` are accepted for
 Mountebank command-line compatibility but have no effect in Rift.
 
+`--intercept-port` eagerly starts the [intercept/TLS-MITM proxy]({{ site.baseurl }}/features/intercept-proxy/)
+at boot. It is no longer the only way to enable it: a server started without the flag still exposes
+the runtime lifecycle endpoints (`POST`/`GET`/`DELETE /intercept`), so intercept can be turned on at
+runtime over the admin API. The flag and the endpoints drive the same single listener.
+
 ### API-key authentication
 
 `--api-key` (or `MB_APIKEY`) requires every admin API request to carry the token in the

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -123,11 +123,12 @@ rift_free(result);
 
 Start the [intercept/TLS-MITM proxy]({{ site.baseurl }}/features/intercept-proxy/) on the handle and
 drive its whole control plane over C-ABI — no in-process admin HTTP needed. One intercept listener
-per handle; `rift_stop` shuts it down.
+per handle; `rift_stop_intercept` stops it, and `rift_stop` shuts it down with the handle.
 
 | Function | Signature | Returns |
 |---|---|---|
 | `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. |
+| `rift_stop_intercept` | `int rift_stop_intercept(RiftHandle* h)` | `0` on success (**including** the idempotent nothing-running case), `-1` only on a null handle / caught panic. Stops the listener, releases its port, and drops its rules + CA — RFC-003 parity with `DELETE /intercept`. A later `rift_start_intercept` without CA paths mints a fresh CA. |
 | `rift_intercept_add_rules` | `int rift_intercept_add_rules(RiftHandle* h, const char* rules_json)` | `0`/`-1`. One rule (object) or many (array), same shape as `/intercept/rules`. |
 | `rift_intercept_list_rules` | `char* rift_intercept_list_rules(RiftHandle* h)` | The current rules as a JSON array (**caller frees**), or `NULL` on error. |
 | `rift_intercept_clear_rules` | `int rift_intercept_clear_rules(RiftHandle* h)` | `0`/`-1`. |
@@ -139,6 +140,12 @@ truststore (all over FFI), then points a CA-trusting SUT's HTTPS proxy at `inter
 loopback HTTP. `Forward { port }` rules reach any imposter on that localhost port, including
 FFI-created ones. Errors set `rift_last_error`. A handle that never calls `rift_start_intercept` is
 unaffected.
+
+The intercept listener and the handle's embedded admin plane share one slot (#493): if you also call
+`rift_serve_admin`, its `/intercept*` routes operate on the **same** listener the C-ABI functions
+drive. `rift_start_intercept` then `GET /intercept` reports it; `POST /intercept` feeds
+`rift_intercept_add_rules`; and a double-start across the two surfaces conflicts consistently
+(`409` / `-1`). (Previously `rift_serve_admin` served no `/intercept` routes at all.)
 
 By default (no `caCertPath`/`caKeyPath`) `rift_start_intercept` generates a fresh ephemeral intercept
 CA, unchanged from earlier releases. As of v0.11.3 (#429), passing both `caCertPath` and `caKeyPath`

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -59,8 +59,10 @@ let listener = InterceptListener::bind("127.0.0.1:0".parse()?, resolver, rules.c
 // Point the SUT at `listener.local_addr()` as its HTTPS proxy, trusting `ca`.
 ```
 
-To expose rule configuration and CA export over the admin API, build the admin server
-`with_intercept(Arc::new(InterceptState { rules, ca }))`.
+To expose the `/intercept` routes over the admin API, build the admin server
+`with_intercept(control)` where `control: InterceptControl` is the shared lifecycle slot (see
+[Runtime lifecycle](#runtime-lifecycle-admin-api) below). The standalone `rift` binary always wires
+one in, so those routes are available on every server.
 
 ### Standalone binary
 
@@ -76,14 +78,58 @@ rift --intercept-port 8443 --intercept-ca-cert ca.pem --intercept-ca-key ca.key
 
 (Equivalently `RIFT_INTERCEPT_PORT` / `RIFT_INTERCEPT_CA_CERT` / `RIFT_INTERCEPT_CA_KEY`.)
 
+`--intercept-port` is just an *eager* start of the same listener the admin API can start at runtime
+— it is no longer the only way to enable intercept. A server started **without** the flag still
+serves the lifecycle endpoints below, so a client can turn intercept on later.
+
+### Runtime lifecycle (admin API)
+
+Start, inspect, and stop the intercept listener at runtime over the admin API — no restart, and no
+`--intercept-port` required (issue #493). This is what lets an SDK enable intercept against a server
+it merely *connected* to.
+
+```
+POST   /intercept   body (optional): { "host"?: "127.0.0.1", "port"?: 0,
+                                        "caCertPath"?: "...", "caKeyPath"?: "..." }
+                    → 201 { "interceptPort": N, "interceptUrl": "http://127.0.0.1:N" }
+                    → 409 if a listener is already running (flag, FFI, or a prior POST)
+GET    /intercept   → 200 { "interceptPort": N, "interceptUrl": "..." }  |  404 when not running
+DELETE /intercept   → 204 always (idempotent); stops the listener and drops its rules + CA
+```
+
+- The body is optional: absent, empty, or `{}` all mean defaults (`127.0.0.1:0`, a fresh in-memory
+  CA). Port `0` is OS-assigned; read the real port back from the response.
+- The default bind host is `127.0.0.1` — **not** the admin server's host. A containerized,
+  connect-transport caller that needs the proxy reachable off-box must pass `"host": "0.0.0.0"`
+  explicitly.
+- CA paths are both-or-neither. A half-supplied pair, an unknown field, a bad CA file, or an
+  occupied port is a `400` with the standard error envelope; the private key is never echoed.
+- `DELETE` discards the CA along with the listener, so a later `POST` without CA paths mints a
+  **fresh** CA — re-export `/intercept/ca.pem` (below) after any restart.
+- All three verbs are gated by `--apikey` like every other admin route.
+
+```bash
+# Enable intercept on an already-running server, then read back the proxy port:
+curl -sX POST http://localhost:2525/intercept
+# {"interceptPort":49711,"interceptUrl":"http://127.0.0.1:49711"}
+
+# ...configure rules / export the CA (see below), point the SUT at the proxy...
+
+# Tear it down when done (safe to call unconditionally):
+curl -sX DELETE http://localhost:2525/intercept
+```
+
 ### Embedding over the C-ABI (non-Rust)
 
 > A non-Rust host (JVM, Node, Go, Python, …) can start and drive the intercept listener with **no
 > loopback HTTP and no Rust code** — see [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/#intercept-proxy-over-ffi).
-> `rift_start_intercept` starts the listener, and the `rift_intercept_*` control-plane functions —
-> `rift_intercept_add_rules`, `rift_intercept_list_rules`, `rift_intercept_clear_rules`,
-> `rift_intercept_export_truststore`, and `rift_intercept_ca_pem` — add rules, list them, export a
-> truststore, and fetch the CA PEM, all over C-ABI.
+> `rift_start_intercept` starts the listener, `rift_stop_intercept` stops it, and the
+> `rift_intercept_*` control-plane functions — `rift_intercept_add_rules`,
+> `rift_intercept_list_rules`, `rift_intercept_clear_rules`, `rift_intercept_export_truststore`, and
+> `rift_intercept_ca_pem` — add rules, list them, export a truststore, and fetch the CA PEM, all
+> over C-ABI. The listener started this way is the *same* one `rift_serve_admin`'s `/intercept`
+> routes see: `rift_start_intercept` then `GET /intercept` reports it, and a double-start across the
+> two surfaces conflicts consistently (409 / `-1`).
 
 ---
 
@@ -177,5 +223,7 @@ private keys**, and it works identically for the container and embedded adapters
 - **Request bodies are read only when `Content-Length`-framed** — chunked / streamed request bodies
   are not decoded and are treated as empty for matching and forwarding (logged at `warn`).
 - **Forward-proxy (`CONNECT`) only** — transparent interception is not implemented.
-- The listener is started either by an **embedder** (or the zio-bdd adapter) or from the standalone
-  `rift` binary via `--intercept-port` (see [Standalone binary](#standalone-binary)).
+- The listener is started by an **embedder** (or the zio-bdd adapter), from the standalone `rift`
+  binary via `--intercept-port` (see [Standalone binary](#standalone-binary)), or at runtime over
+  the admin API (see [Runtime lifecycle](#runtime-lifecycle-admin-api)) — one listener at a time
+  either way.


### PR DESCRIPTION
Adds runtime intercept lifecycle endpoints over the admin API, backed by a shared InterceptControl slot used by the CLI, admin handlers, and FFI. Adds rift_stop_intercept and makes rift_serve_admin share the handle's intercept slot for SDK connect/spawn transport parity. Docs and CHANGELOG updated.

Closes #493

Part of: language-SDK program (#458, RFC-003).