### PR TITLE
test(conformance): scripting corpus fixtures carry no _verify, so the engine gate proves only that they load, not that they behave

### DIFF
--- a/sdk-conformance/corpus/imposters/02-predicates.json
+++ b/sdk-conformance/corpus/imposters/02-predicates.json
@@ -12,42 +12,82 @@
     {
       "name": "equals — exact path + method",
       "predicates": [{ "equals": { "method": "GET", "path": "/eq" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/eq" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"equals\"" } }
+        ]
+      }
     },
     {
       "name": "equals caseSensitive=false — /CaSe matches /case",
       "predicates": [{ "equals": { "path": "/case" }, "caseSensitive": false }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals-caseInsensitive" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "equals-caseInsensitive" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/CaSe" }, "expect": { "status": 200, "bodyContains": "equals-caseInsensitive" } }
+        ]
+      }
     },
     {
       "name": "deepEquals — query must be EXACTLY {a:1}",
       "predicates": [{ "deepEquals": { "query": { "a": "1" } }, "caseSensitive": true }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "deepEquals" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "deepEquals" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/anything?a=1" }, "expect": { "status": 200, "bodyContains": "deepEquals" } }
+        ]
+      }
     },
     {
       "name": "contains — body contains 'needle'",
       "predicates": [{ "contains": { "body": "needle" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "contains" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "contains" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "method": "POST", "path": "/whatever", "body": "hasneedleinside" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"contains\"" } }
+        ]
+      }
     },
     {
       "name": "startsWith — path starts with /start",
       "predicates": [{ "startsWith": { "path": "/start" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "startsWith" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "startsWith" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/start/foo" }, "expect": { "status": 200, "bodyContains": "startsWith" } }
+        ]
+      }
     },
     {
       "name": "endsWith — path ends with /end",
       "predicates": [{ "endsWith": { "path": "/end" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "endsWith" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "endsWith" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/foo/end" }, "expect": { "status": 200, "bodyContains": "endsWith" } }
+        ]
+      }
     },
     {
       "name": "matches — regex path /id/<digits>",
       "predicates": [{ "matches": { "path": "^/id/[0-9]+$" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "matches" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "matches" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/id/123" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"matches\"" } }
+        ]
+      }
     },
     {
       "name": "exists — Authorization header present",
       "predicates": [{ "exists": { "headers": { "Authorization": true } } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "exists-header" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "exists-header" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/anyroute", "headers": { "Authorization": "Bearer x" } }, "expect": { "status": 200, "bodyContains": "exists-header" } }
+        ]
+      }
     },
     {
       "name": "or — path is /red OR /blue",
@@ -57,7 +97,13 @@
           { "equals": { "path": "/blue" } }
         ]
       }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "or" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "or" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/red" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"or\"" } },
+          { "request": { "path": "/blue" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"or\"" } }
+        ]
+      }
     },
     {
       "name": "not — path is /open and has NO Authorization header",
@@ -67,7 +113,12 @@
           { "not": { "exists": { "headers": { "Authorization": true } } } }
         ]
       }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "not" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "not" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/open" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"not\"" } }
+        ]
+      }
     },
     {
       "name": "jsonpath — JSON body where $.type == 'order'",
@@ -75,7 +126,12 @@
         "equals": { "body": "order" },
         "jsonpath": { "selector": "$.type" }
       }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "jsonpath" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "jsonpath" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "method": "POST", "path": "/jsonthing", "body": "{\"type\":\"order\"}" }, "expect": { "status": 200, "bodyContains": "jsonpath" } }
+        ]
+      }
     },
     {
       "name": "xpath — XML body where //user/@role == 'admin'",
@@ -83,7 +139,12 @@
         "equals": { "body": "admin" },
         "xpath": { "selector": "string(//user/@role)" }
       }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "xpath" } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "matched": "xpath" } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "method": "POST", "path": "/xmlthing", "body": "<user role=\"admin\"/>" }, "expect": { "status": 200, "bodyContains": "\"matched\":\"xpath\"" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/03-behaviors.json
+++ b/sdk-conformance/corpus/imposters/03-behaviors.json
@@ -10,7 +10,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": { "note": "delayed 1.5s" } },
         "_behaviors": { "wait": 1500 }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/slow" }, "expect": { "status": 200, "bodyContains": "delayed 1.5s" } }
+        ]
+      }
     },
     {
       "name": "wait — random delay between 200ms and 1200ms",
@@ -18,7 +23,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": { "note": "delayed 200-1200ms" } },
         "_behaviors": { "wait": { "min": 200, "max": 1200 } }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/slow-range" }, "expect": { "status": 200, "bodyContains": "delayed 200-1200ms" } }
+        ]
+      }
     },
     {
       "name": "repeat — fail 503 twice, then 200 (sequence cycles)",
@@ -29,7 +39,15 @@
           "_behaviors": { "repeat": 2 }
         },
         { "is": { "statusCode": 200, "body": { "ok": true } } }
-      ]
+      ],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/retry-me" }, "expect": { "status": 503, "bodyContains": "try again" } },
+          { "request": { "path": "/retry-me" }, "expect": { "status": 503, "bodyContains": "try again" } },
+          { "request": { "path": "/retry-me" }, "expect": { "status": 200, "bodyContains": "\"ok\":true" } },
+          { "request": { "path": "/retry-me" }, "expect": { "status": 503, "bodyContains": "try again" } }
+        ]
+      }
     },
     {
       "name": "decorate — JS post-processes the response (adds a header) [needs --allow-injection]",
@@ -43,7 +61,12 @@
         "_behaviors": {
           "decorate": "function (request, response) { response.headers['X-Decorated-By'] = 'rift'; response.body = response.body.replace('false', 'true'); }"
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/decorated" }, "expect": { "status": 200, "bodyContains": "\"decorated\":true" } }
+        ]
+      }
     },
     {
       "name": "copy — pull the numeric id out of the path into the body",
@@ -61,7 +84,12 @@
             "using": { "method": "regex", "selector": "/orders/(\\d+)" }
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/orders/42" }, "expect": { "status": 200, "bodyContains": "\"orderId\":\"42\"" } }
+        ]
+      }
     },
     {
       "name": "copy — pull a query parameter (?user=) into the response",
@@ -79,7 +107,12 @@
             "using": { "method": "regex", "selector": "(.*)" }
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/greet?user=Bob" }, "expect": { "status": 200, "bodyContains": "hello Bob" } }
+        ]
+      }
     },
     {
       "name": "lookup — enrich the response from data/products.csv by id in the path",
@@ -102,7 +135,12 @@
             "into": "${row}"
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/catalog/123" }, "expect": { "status": 200, "bodyContains": "\"name\":\"Widget\"" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/05-scripting-engines.json
+++ b/sdk-conformance/corpus/imposters/05-scripting-engines.json
@@ -17,21 +17,38 @@
             "code": "fn respond(ctx) { let count = ctx.state.incr_by(\"count\", 1); http(200, #{engine: \"rhai\", count: count}) }"
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/rhai/counter" }, "expect": { "status": 200, "bodyContains": "\"count\":1" } },
+          { "request": { "path": "/rhai/counter" }, "expect": { "status": 200, "bodyContains": "\"count\":2" } }
+        ]
+      }
     },
     {
       "name": "JavaScript inject — counter [needs --allow-injection]",
       "predicates": [{ "equals": { "method": "GET", "path": "/js/counter" } }],
       "responses": [{
         "inject": "function (config, state) { state.count = (state.count || 0) + 1; return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ engine: 'javascript', count: state.count }) }; }"
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/js/counter" }, "expect": { "status": 200, "bodyContains": "\"count\":1" } },
+          { "request": { "path": "/js/counter" }, "expect": { "status": 200, "bodyContains": "\"count\":2" } }
+        ]
+      }
     },
     {
       "name": "JavaScript inject — echo the request [needs --allow-injection]",
       "predicates": [{ "equals": { "method": "POST", "path": "/js/echo" } }],
       "responses": [{
         "inject": "function (config, state) { var req = config.request || config; return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ engine: 'javascript', method: req.method, path: req.path, body: req.body }) }; }"
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "method": "POST", "path": "/js/echo", "body": "{\"hello\":\"world\"}" }, "expect": { "status": 200, "bodyContains": "\"body\":\"{\\\"hello\\\":\\\"world\\\"}\"" } }
+        ]
+      }
     },
     {
       "name": "Health — lists the engines this imposter exercises",
@@ -42,7 +59,12 @@
           "headers": { "Content-Type": "application/json" },
           "body": { "status": "ok", "engines": ["rhai", "javascript"] }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/health" }, "expect": { "status": 200, "bodyContains": "\"engines\":[\"rhai\",\"javascript\"]" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/06-stateful-retry.json
+++ b/sdk-conformance/corpus/imposters/06-stateful-retry.json
@@ -17,7 +17,15 @@
             "code": "fn respond(ctx) { let attempts = ctx.state.incr_by(\"attempts\", 1); if attempts <= 2 { http(503, #{error: \"service unavailable\", attempt: attempts}).header(\"Retry-After\", \"1\").header(\"X-Attempt\", `${attempts}`) } else { http(200, #{ok: true, succeededOnAttempt: attempts}).header(\"X-Attempt\", `${attempts}`) } }"
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-resource" } }, "expect": { "status": 503, "bodyContains": "\"attempt\":1" } },
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-resource" } }, "expect": { "status": 503, "bodyContains": "\"attempt\":2" } },
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-resource" } }, "expect": { "status": 200, "bodyContains": "\"succeededOnAttempt\":3" } },
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-resource" } }, "expect": { "status": 200, "bodyContains": "\"succeededOnAttempt\":4" } }
+        ]
+      }
     },
     {
       "name": "Inspect the current attempt count for a flow",
@@ -29,7 +37,14 @@
             "code": "fn respond(ctx) { let flow_id = ctx.request.header(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; let attempts = ctx.state.get_or(\"attempts\", 0); http(200, #{flowId: flow_id, attempts: attempts}) }"
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-attempts" } }, "expect": { "status": 503 } },
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-attempts" } }, "expect": { "status": 503 } },
+          { "request": { "path": "/api/attempts", "headers": { "X-Flow-Id": "verify-attempts" } }, "expect": { "status": 200, "bodyContains": "\"attempts\":2" } }
+        ]
+      }
     },
     {
       "name": "Reset the attempt counter for a flow",
@@ -41,7 +56,14 @@
             "code": "fn respond(ctx) { let flow_id = ctx.request.header(\"x-flow-id\"); if flow_id == () { flow_id = \"default\"; }; ctx.state.delete(\"attempts\"); http(200, #{message: \"reset\", flowId: flow_id}) }"
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/api/resource", "headers": { "X-Flow-Id": "verify-reset" } }, "expect": { "status": 503 } },
+          { "request": { "method": "DELETE", "path": "/api/reset", "headers": { "X-Flow-Id": "verify-reset" } }, "expect": { "status": 200, "bodyContains": "\"message\":\"reset\"" } },
+          { "request": { "path": "/api/attempts", "headers": { "X-Flow-Id": "verify-reset" } }, "expect": { "status": 200, "bodyContains": "\"attempts\":0" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/07-proxy-record.json
+++ b/sdk-conformance/corpus/imposters/07-proxy-record.json
@@ -13,7 +13,13 @@
           "mode": "proxyOnce",
           "predicateGenerators": [{ "matches": { "method": true, "path": true } }]
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/api/products" }, "expect": { "status": 200, "bodyContains": "\"name\":\"Widget\"" } },
+          { "request": { "path": "/api/products" }, "expect": { "status": 200, "bodyContains": "\"name\":\"Widget\"" } }
+        ]
+      }
     },
     {
       "name": "Local info route (not proxied)",
@@ -28,7 +34,12 @@
             "tip": "After a few calls, GET http://localhost:2525/imposters/4507 to see the auto-generated stubs."
           }
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/info" }, "expect": { "status": 200, "bodyContains": "auto-generated stubs" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/10-correlated-isolation.json
+++ b/sdk-conformance/corpus/imposters/10-correlated-isolation.json
@@ -15,18 +15,33 @@
       "name": "space=alice — only matches requests with X-Mock-Space: alice",
       "space": "alice",
       "predicates": [{ "equals": { "path": "/data" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice", "items": [1, 2] } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "alice", "items": [1, 2] } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/data", "headers": { "X-Mock-Space": "alice" } }, "expect": { "status": 200, "bodyContains": "\"owner\":\"alice\"" } }
+        ]
+      }
     },
     {
       "name": "space=bob — isolated from alice",
       "space": "bob",
       "predicates": [{ "equals": { "path": "/data" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "bob", "items": [9] } } }]
+      "responses": [{ "is": { "statusCode": 200, "body": { "owner": "bob", "items": [9] } } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/data", "headers": { "X-Mock-Space": "bob" } }, "expect": { "status": 200, "bodyContains": "\"owner\":\"bob\"" } }
+        ]
+      }
     },
     {
       "name": "global (no space) — matches any caller",
       "predicates": [{ "equals": { "path": "/health" } }],
-      "responses": [{ "is": { "statusCode": 200, "body": "OK" } }]
+      "responses": [{ "is": { "statusCode": 200, "body": "OK" } }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/health" }, "expect": { "status": 200, "bodyEquals": "OK" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/11-headers-and-templates.json
+++ b/sdk-conformance/corpus/imposters/11-headers-and-templates.json
@@ -14,7 +14,12 @@
           "headers": { "Set-Cookie": ["sessionId=abc", "theme=dark"], "X-Single": "one" },
           "body": "two cookies set"
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/cookies" }, "expect": { "status": 200, "bodyContains": "two cookies set" } }
+        ]
+      }
     },
     {
       "name": "serve-time date templates — {{DAYS+N}}/{{MONTHS+N}}/{{NOW}} (#195)",
@@ -25,7 +30,12 @@
           "headers": { "Content-Type": "application/json" },
           "body": "{\"issued\":\"{{NOW}}\",\"expires\":\"{{DAYS+30}}\",\"renewal\":\"{{MONTHS+12}}\"}"
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/token" }, "expect": { "status": 200, "bodyContains": "\"expires\":\"" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/13-js-config-decorate.json
+++ b/sdk-conformance/corpus/imposters/13-js-config-decorate.json
@@ -11,7 +11,12 @@
         "_behaviors": {
           "decorate": "config => { config.response.headers['X-Decorated-By'] = 'config-arrow'; config.response.statusCode = 202; }"
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/js-arrow" }, "expect": { "status": 202, "bodyContains": "\"v\":1" } }
+        ]
+      }
     },
     {
       "name": "Mountebank JS function(config) form — reads config.request",
@@ -21,7 +26,12 @@
         "_behaviors": {
           "decorate": "function(config) { config.response.body = 'method-was-' + config.request.method; }"
         }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/js-fn" }, "expect": { "status": 200, "bodyContains": "method-was-GET" } }
+        ]
+      }
     },
     {
       "name": "Rhai decorate (Rift-native) — unchanged",
@@ -29,7 +39,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": "orig" },
         "_behaviors": { "decorate": "response.body = \"rhai-\" + request.path;" }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/rhai" }, "expect": { "status": 200, "bodyContains": "rhai-/rhai" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/corpus/imposters/16-behaviors-advanced.json
+++ b/sdk-conformance/corpus/imposters/16-behaviors-advanced.json
@@ -10,7 +10,12 @@
       "responses": [{
         "is": { "statusCode": 200, "headers": { "Content-Type": "application/json" }, "body": { "requestId": "${rid}" } },
         "_behaviors": { "copy": { "from": { "headers": "X-Request-Id" }, "into": "${rid}", "using": { "method": "regex", "selector": ".*" } } }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/from-header", "headers": { "X-Request-Id": "abc-123" } }, "expect": { "status": 200, "bodyContains": "\"requestId\":\"abc-123\"" } }
+        ]
+      }
     },
     {
       "name": "copy — extract a JSON field from the body via jsonpath",
@@ -18,7 +23,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": "who=${who}" },
         "_behaviors": { "copy": { "from": "body", "into": "${who}", "using": { "method": "jsonpath", "selector": "$.user.name" } } }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "method": "POST", "path": "/from-json", "body": "{\"user\":{\"name\":\"Alice\"}}" }, "expect": { "status": 200, "bodyContains": "who=Alice" } }
+        ]
+      }
     },
     {
       "name": "lookup — enrich the response from products.csv by id",
@@ -26,7 +36,12 @@
       "responses": [{
         "is": { "statusCode": 200, "headers": { "Content-Type": "application/json" }, "body": { "name": "${row}[name]", "price": "${row}[price]" } },
         "_behaviors": { "lookup": { "key": { "from": "path", "using": { "method": "regex", "selector": "/catalog/([0-9]+)" } }, "fromDataSource": { "csv": { "path": "data/products.csv", "keyColumn": "id" } }, "into": "${row}" } }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/catalog/456" }, "expect": { "status": 200, "bodyContains": "\"name\":\"Gadget\"" } }
+        ]
+      }
     },
     {
       "name": "wait — JS function returning a fixed delay",
@@ -34,7 +49,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": "waited" },
         "_behaviors": { "wait": "function(){ return 400; }" }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/slow-fn" }, "expect": { "status": 200, "bodyContains": "waited" } }
+        ]
+      }
     },
     {
       "name": "decorate — Rhai native, mutate response body in place",
@@ -42,7 +62,12 @@
       "responses": [{
         "is": { "statusCode": 200, "body": "orig" },
         "_behaviors": { "decorate": "response.body = \"rhai-decorated\";" }
-      }]
+      }],
+      "_verify": {
+        "sequence": [
+          { "request": { "path": "/decorate-rhai" }, "expect": { "status": 200, "bodyContains": "rhai-decorated" } }
+        ]
+      }
     }
   ]
 }

--- a/sdk-conformance/manifest.json
+++ b/sdk-conformance/manifest.json
@@ -14,7 +14,7 @@
       "port": 4502,
       "name": "02 \u00b7 Predicate Showcase",
       "requires": [],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/03-behaviors.json",
@@ -23,7 +23,7 @@
       "requires": [
         "injection"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/04-fault-injection.json",
@@ -39,7 +39,7 @@
       "requires": [
         "injection"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/06-stateful-retry.json",
@@ -48,7 +48,7 @@
       "requires": [
         "injection"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/07-proxy-record.json",
@@ -57,21 +57,21 @@
       "requires": [
         "proxy"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/10-correlated-isolation.json",
       "port": 4510,
       "name": "10 \u00b7 Correlated isolation (one port, partitioned by a header)",
       "requires": [],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/11-headers-and-templates.json",
       "port": 4511,
       "name": "11 \u00b7 Multi-value headers, date templates, defaultResponse/defaultForward, CORS",
       "requires": [],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/13-js-config-decorate.json",
@@ -80,7 +80,7 @@
       "requires": [
         "injection"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/14-verify-annotations.json",
@@ -103,7 +103,7 @@
       "requires": [
         "injection"
       ],
-      "hasVerify": false
+      "hasVerify": true
     },
     {
       "file": "corpus/imposters/17-faults-and-binary.json",


### PR DESCRIPTION
Only 3 of the 15 SDK-conformance corpus fixtures carried `_verify`, so an SDK could prove **DSL-expressibility** on the other 12 (parse→rebuild→deep-equal) but not **replay-and-assert behavior**. This broadens the fix (per discussion on the issue) to make the SDK-relevant fixtures self-describing.

Adds empirically-derived `_verify.sequence` blocks — driven against the real engine, observed, then encoded — to: predicates (02), behaviors (03), scripting engines (05), stateful retry/FSM (06), proxy record-replay (07), correlated isolation (10), headers+templating (11), config-decorate (13), advanced behaviors (16). Stateful/cycling stubs get multi-step sequences asserting the state progression (e.g. 503→503→200). `manifest.json` `hasVerify` goes 3→12 of 15.

The engine-side gate `crates/rift-http-proxy/tests/corpus_replay.rs::corpus_serves_and_verify_holds` (which runs `rift-verify --skip-dynamic --verify-dynamic` over the whole corpus) validates every transcript, and `manifest_is_consistent` enforces `hasVerify ⇔ the fixture contains _verify`.

Out of scope (harness-only or engine-internal, not SDK DSL surface): admin ops, config reload, HTTPS, gateway/metrics, intercept/TLS.

Closes #517