### PR TITLE
fix(release): use portable sed -i.bak in build-job lockstep bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,14 @@ jobs:
           # path crate and `cargo build` fails. Bump the `version = "..."` that follows each internal
           # path dep so the requirement matches. (Mirrors the publish job — must run here too, else the
           # build fails before publish is ever reached.)
-          find crates -name Cargo.toml -exec sed -i -E \
+          #
+          # Use the attached-suffix `-i.bak` form: this job's matrix includes macOS runners whose BSD
+          # sed does not accept the GNU space-separated `-i -E` (no suffix) form — it would leave the
+          # files un-edited and trip the assertion below. `-i.bak` works on both GNU and BSD sed (the
+          # workspace-version line above relies on the same form). Clean up the backups afterward.
+          find crates -name Cargo.toml -exec sed -i.bak -E \
             's|(path = "\.\./rift-[a-z-]+", version = ")[^"]*|\1'"$VERSION"'|g' {} +
+          find crates -name 'Cargo.toml.bak' -delete
           # Verify the change
           grep 'version = ' Cargo.toml | head -1
           grep -R 'path = "\.\./rift-' crates/*/Cargo.toml || true


### PR DESCRIPTION
Follow-up to #526. The build matrix includes macOS runners whose **BSD sed** rejects the GNU space-separated `sed -i -E` (no-suffix) form, so the internal path-dep lockstep bump left the versions un-bumped and the new stale-version assertion aborted the `*-apple-darwin` legs (fail-fast then cancelled the rest).

Switch to the attached-suffix `sed -i.bak -E` form — accepted by both GNU and BSD sed (the same form the workspace-version line already uses) — and `find … -delete` the `.bak` files. Verified against BSD sed on macOS: all internal deps bump to the release version, no backups left.

The publish job runs on ubuntu, so it is unaffected.

Surfaced cutting v0.13.0 (Linux legs green, darwin legs failed at the version-stamp assertion).