### PR TITLE
chore(release): prepare 0.13.1 — rift-core → rift-mock-core rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ record.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-11
+
+### Changed
+
+- Renamed the `rift-core` crate to **`rift-mock-core`** to resolve a crates.io name collision — the
+  `rift-core` name is owned by an unrelated project, which blocked publishing and had also frozen
+  `rift-http-proxy` on crates.io at 0.4.0. This is purely a packaging change: the binary, FFI
+  cdylib, Docker image, and npm package are functionally identical to 0.13.0. Rust code depending on
+  the engine library from crates.io should switch the dependency name to `rift-mock-core`; the
+  FFI / Docker / binary / npm distribution (what the language SDKs consume) is unaffected.
+
 ## [0.13.0] - 2026-07-10
 
 This release lands the engine-side surface the official language SDKs build on — server-side
@@ -341,7 +352,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/EtaCassiopeia/rift/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/EtaCassiopeia/rift/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/EtaCassiopeia/rift/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/EtaCassiopeia/rift/compare/v0.11.2...v0.11.3


### PR DESCRIPTION
Adds the `[0.13.1]` CHANGELOG entry for the crate rename shipped in #528.

Tagging `v0.13.1` after merge republishes the artifacts (identical binary/FFI/Docker/npm to 0.13.0) and, critically, lets the crates.io job publish **`rift-mock-core`** and the previously-frozen **`rift-http-proxy`** under our ownership.

Milestone: n/a (packaging patch).