### PR TITLE
feat(fault): probabilistic TCP faults — _rift.fault.tcp accepts {probability, type} alongside the bare string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **Probabilistic TCP faults** (`_rift.fault.tcp`): the fault now accepts an object form
+  `{ "probability": 0.1, "type": "CONNECTION_RESET_BY_PEER" }` alongside the existing bare string,
+  so a connection reset can be made to fire only some of the time (e.g. "reset 10% of requests").
+  The bare string form is unchanged and equivalent to `probability: 1.0`; each form round-trips
+  unchanged through `GET /imposters`. `rift-lint` validates the object form (`probability` required
+  and in `[0, 1]`, unknown fault types warned).
+
 ## [0.13.1] - 2026-07-11
 
 ### Changed

--- a/crates/rift-http-proxy/src/bin/verify.rs
+++ b/crates/rift-http-proxy/src/bin/verify.rs
@@ -1083,14 +1083,17 @@ fn check_if_dynamic(responses: &[serde_json::Value]) -> (bool, Option<String>) {
 }
 
 /// True when the stub's first response injects a connection-level TCP fault
-/// (`_rift.fault.tcp`, issue #239), for which a transport error is the expected outcome.
+/// (`_rift.fault.tcp`, issue #239) that is *certain* to fire, for which a transport error is the
+/// expected outcome. The probabilistic object form (`{ probability < 1.0, type }`, issue #531) is
+/// non-deterministic — its reset can't be asserted — so it does not expect a transport error.
+/// A bare-string `tcp` is certain (`is_certain` treats an absent `probability` as always-fires).
 fn expects_tcp_fault(responses: &[serde_json::Value]) -> bool {
     responses
         .first()
         .and_then(|r| r.get("_rift"))
         .and_then(|r| r.get("fault"))
         .and_then(|f| f.get("tcp"))
-        .is_some()
+        .is_some_and(dynamic::is_certain)
 }
 
 /// Render an error together with its full `source()` chain. reqwest's top-level `Display` is only
@@ -2661,6 +2664,18 @@ mod verify_tests {
         assert!(!expects_tcp_fault(&[
             json!({ "_rift": { "fault": { "latency": 50 } } })
         ]));
+    }
+
+    // Issue #531: the certain object form (p >= 1.0) still expects a transport error, but the
+    // probabilistic form (p < 1.0) is non-deterministic and must not be asserted as a reset.
+    #[test]
+    fn expects_tcp_fault_certainty() {
+        assert!(expects_tcp_fault(&[json!({
+            "_rift": { "fault": { "tcp": { "probability": 1.0, "type": "reset" } } }
+        })]));
+        assert!(!expects_tcp_fault(&[json!({
+            "_rift": { "fault": { "tcp": { "probability": 0.1, "type": "reset" } } }
+        })]));
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/bin/verify/dynamic.rs
+++ b/crates/rift-http-proxy/src/bin/verify/dynamic.rs
@@ -184,11 +184,12 @@ pub enum FaultExpectation {
 
 /// Derive the deterministic fault expectation from a stub response's `_rift.fault` block, or
 /// `None` when there is no fault or it is probabilistic (`probability < 1.0`, non-asserted by
-/// design). `tcp` is always deterministic (it has no probability).
+/// design). `tcp` is deterministic in its bare string form and its object form with
+/// `probability >= 1.0`; a probabilistic `tcp` object (issue #531) is non-asserted like the others.
 pub fn fault_expectation(response: &serde_json::Value) -> Option<FaultExpectation> {
     let fault = response.get("_rift")?.get("fault")?;
-    if fault.get("tcp").is_some() {
-        return Some(FaultExpectation::TransportReset);
+    if let Some(tcp) = fault.get("tcp") {
+        return is_certain(tcp).then_some(FaultExpectation::TransportReset);
     }
     if let Some(latency) = fault.get("latency")
         && is_certain(latency)
@@ -206,8 +207,9 @@ pub fn fault_expectation(response: &serde_json::Value) -> Option<FaultExpectatio
 }
 
 /// A fault sub-config is asserted only when it is certain to fire: `probability` absent (treated
-/// as always) or `>= 1.0`.
-fn is_certain(fault_part: &serde_json::Value) -> bool {
+/// as always) or `>= 1.0`. Also used by `expects_tcp_fault` in the parent module for the `tcp`
+/// fault (a bare string has no `probability`, so it reads as certain).
+pub fn is_certain(fault_part: &serde_json::Value) -> bool {
     match fault_part.get("probability") {
         None => true,
         Some(p) => p.as_f64().map(|p| p >= 1.0).unwrap_or(false),
@@ -717,6 +719,21 @@ mod tests {
             fault_expectation(&r),
             Some(FaultExpectation::TransportReset)
         );
+    }
+
+    // Issue #531: the object tcp form asserts a reset only when it is certain (p >= 1.0); a
+    // probabilistic object (p < 1.0) is non-deterministic and yields no expectation.
+    #[test]
+    fn fault_expectation_tcp_object_form() {
+        let certain =
+            json!({ "_rift": { "fault": { "tcp": { "probability": 1.0, "type": "reset" } } } });
+        assert_eq!(
+            fault_expectation(&certain),
+            Some(FaultExpectation::TransportReset)
+        );
+        let probabilistic =
+            json!({ "_rift": { "fault": { "tcp": { "probability": 0.1, "type": "reset" } } } });
+        assert_eq!(fault_expectation(&probabilistic), None);
     }
 
     #[test]

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -141,6 +141,88 @@ fn check_script_syntax(
     }
 }
 
+/// The `_rift.fault.tcp` fault kinds Rift accepts, canonical names plus short aliases — mirrors
+/// `TcpFaultKind::parse` (rift-mock-core `imposter/fault_io.rs`). Kept in sync by hand because
+/// rift-lint does not depend on rift-mock-core.
+const TCP_FAULT_KINDS: &[&str] = &[
+    "reset",
+    "CONNECTION_RESET_BY_PEER",
+    "empty",
+    "EMPTY_RESPONSE",
+    "garbage",
+    "random",
+    "RANDOM_DATA_THEN_CLOSE",
+    "malformed",
+    "MALFORMED_RESPONSE_CHUNK",
+];
+
+/// Validate a `_rift.fault.tcp` value (issue #531). Accepts the bare kind string and the
+/// probabilistic object form `{ probability, type }`. The object form must carry a numeric
+/// `probability` in `[0, 1]` (E041) — it exists solely to express that probability. An unknown
+/// fault type is a warning (W011), mirroring the serve-time `warn!` rather than failing the config.
+fn validate_tcp_fault(file: &Path, tcp: &Value, location: &str, result: &mut LintResult) {
+    let warn_unknown_kind = |result: &mut LintResult, kind: &str| {
+        if !TCP_FAULT_KINDS.contains(&kind) {
+            result.add_issue(
+                LintIssue::warning(
+                    "W011",
+                    format!("Unknown TCP fault type '{kind}' — the fault will not fire at runtime"),
+                    file.to_path_buf(),
+                )
+                .with_location(location.to_string())
+                .with_suggestion(format!("Use one of: {}", TCP_FAULT_KINDS.join(", "))),
+            );
+        }
+    };
+
+    match tcp {
+        Value::String(kind) => warn_unknown_kind(result, kind),
+        Value::Object(_) => {
+            match tcp.get("probability").and_then(Value::as_f64) {
+                Some(p) if (0.0..=1.0).contains(&p) => {}
+                Some(_) => result.add_issue(
+                    LintIssue::error(
+                        "E041",
+                        "_rift.fault.tcp 'probability' must be between 0.0 and 1.0",
+                        file.to_path_buf(),
+                    )
+                    .with_location(location.to_string()),
+                ),
+                None => result.add_issue(
+                    LintIssue::error(
+                        "E041",
+                        "_rift.fault.tcp object form requires a numeric 'probability' (use the bare string form for an always-firing fault)",
+                        file.to_path_buf(),
+                    )
+                    .with_location(location.to_string())
+                    .with_suggestion(
+                        "Add \"probability\": <0.0-1.0>, or replace the object with the bare fault-type string",
+                    ),
+                ),
+            }
+            match tcp.get("type").and_then(Value::as_str) {
+                Some(kind) => warn_unknown_kind(result, kind),
+                None => result.add_issue(
+                    LintIssue::error(
+                        "E041",
+                        "_rift.fault.tcp object form requires a string 'type'",
+                        file.to_path_buf(),
+                    )
+                    .with_location(location.to_string()),
+                ),
+            }
+        }
+        _ => result.add_issue(
+            LintIssue::error(
+                "E041",
+                "_rift.fault.tcp must be a fault-type string or an object { probability, type }",
+                file.to_path_buf(),
+            )
+            .with_location(location.to_string()),
+        ),
+    }
+}
+
 /// Validate one `_rift.script`-shaped object: `{ engine?, code?, file?, ref? }` (issue #356).
 /// Exactly one of `code`/`file`/`ref` must be present (E036). A `file:` is read relative to
 /// `config_file`'s own directory (E038 if unreadable); a `ref:` is resolved against `registry`
@@ -685,6 +767,16 @@ pub fn validate_response(
             result,
             registry,
         );
+    }
+
+    // `_rift.fault.tcp` accepts both the bare kind string and the probabilistic object form
+    // (issue #531). Validate the object form's `probability` and warn on an unknown fault type.
+    if let Some(tcp) = response
+        .get("_rift")
+        .and_then(|rift| rift.get("fault"))
+        .and_then(|fault| fault.get("tcp"))
+    {
+        validate_tcp_fault(file, tcp, &format!("{location}._rift.fault.tcp"), result);
     }
 
     let response_types = [has_is, has_proxy, has_inject, has_fault, has_rift];
@@ -1414,5 +1506,76 @@ mod header_value_tests {
     fn string_header_is_valid() {
         let result = lint(json!({ "Content-Type": "text/plain" }));
         assert_eq!(result.errors, 0);
+    }
+}
+
+// Issue #531: `_rift.fault.tcp` accepts the bare kind string and the probabilistic object form.
+#[cfg(test)]
+mod tcp_fault_tests {
+    use super::validate_tcp_fault;
+    use crate::types::LintResult;
+    use serde_json::{Value, json};
+    use std::path::Path;
+
+    fn lint(tcp: Value) -> LintResult {
+        let mut result = LintResult::new();
+        validate_tcp_fault(Path::new("test.json"), &tcp, "loc", &mut result);
+        result
+    }
+
+    fn has_code(result: &LintResult, code: &str) -> bool {
+        result.issues.iter().any(|i| i.code == code)
+    }
+
+    #[test]
+    fn bare_string_known_kind_is_clean() {
+        let result = lint(json!("CONNECTION_RESET_BY_PEER"));
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn object_form_with_valid_probability_is_clean() {
+        let result = lint(json!({ "probability": 0.1, "type": "reset" }));
+        assert_eq!(result.errors, 0);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn object_form_missing_probability_errors() {
+        let result = lint(json!({ "type": "CONNECTION_RESET_BY_PEER" }));
+        assert!(has_code(&result, "E041"));
+    }
+
+    #[test]
+    fn object_form_probability_out_of_range_errors() {
+        assert!(has_code(
+            &lint(json!({ "probability": 1.5, "type": "reset" })),
+            "E041"
+        ));
+        assert!(has_code(
+            &lint(json!({ "probability": -0.1, "type": "reset" })),
+            "E041"
+        ));
+    }
+
+    #[test]
+    fn object_form_missing_type_errors() {
+        let result = lint(json!({ "probability": 0.5 }));
+        assert!(has_code(&result, "E041"));
+    }
+
+    #[test]
+    fn unknown_kind_warns_both_forms() {
+        assert!(has_code(&lint(json!("NONSENSE")), "W011"));
+        assert!(has_code(
+            &lint(json!({ "probability": 0.5, "type": "NONSENSE" })),
+            "W011"
+        ));
+    }
+
+    #[test]
+    fn non_string_non_object_errors() {
+        assert!(has_code(&lint(json!(42)), "E041"));
     }
 }

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -417,7 +417,7 @@ impl Imposter {
             rift.fault
                 .as_ref()
                 .and_then(|f| f.tcp.as_ref())
-                .is_some_and(|t| TcpFaultKind::parse(t).is_some())
+                .is_some_and(|t| TcpFaultKind::parse(t.kind()).is_some())
         };
         self.stubs
             .load()

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -1431,6 +1431,18 @@ async fn apply_rift_fault(
         }
     };
 
+    // A `tcp` fault fires with its own probability (issue #531): the bare string form is always
+    // 1.0; the object form carries a chosen probability. When the roll fails the fault is treated
+    // as absent for this request, falling through to the `error` fault and normal response — the
+    // same semantics `latency`/`error` already use.
+    let apply_tcp = {
+        let mut rng = rand::thread_rng();
+        fault_config
+            .tcp
+            .as_ref()
+            .is_some_and(|tcp| rng.r#gen::<f64>() < tcp.probability())
+    };
+
     // Apply latency fault (this is async)
     if apply_latency && latency_delay_ms > 0 {
         debug!("Applying _rift.fault latency: {}ms", latency_delay_ms);
@@ -1441,8 +1453,8 @@ async fn apply_rift_fault(
     // the connection is reset before any HTTP response can be written, so it must win over an
     // `error` fault — otherwise a configured `tcp` is silently dropped whenever `error` also fires
     // (issue #271). Latency above still applies first, keeping delay-then-drop coherent.
-    if let Some(ref tcp_fault) = fault_config.tcp {
-        if let Some(kind) = super::fault_io::TcpFaultKind::parse(tcp_fault) {
+    if apply_tcp && let Some(ref tcp_fault) = fault_config.tcp {
+        if let Some(kind) = super::fault_io::TcpFaultKind::parse(tcp_fault.kind()) {
             debug!("Applying _rift.fault.tcp: {:?}", kind);
             if apply_error {
                 debug!("_rift.fault.error preempted by tcp fault (connection reset)");
@@ -1452,13 +1464,13 @@ async fn apply_rift_fault(
             // (issue #239) — the status/body here are never observed by the client.
             let mut response = build_response_with_headers(
                 StatusCode::BAD_GATEWAY,
-                [("x-rift-fault", tcp_fault.as_str())],
+                [("x-rift-fault", tcp_fault.kind())],
                 Bytes::new(),
             );
             response.extensions_mut().insert(kind);
             return Some(response);
         }
-        warn!("Unknown TCP fault type: {}", tcp_fault);
+        warn!("Unknown TCP fault type: {}", tcp_fault.kind());
     }
 
     // Apply error fault
@@ -1573,7 +1585,7 @@ mod matcher_error_response_tests {
 #[cfg(test)]
 mod fault_precedence_tests {
     use super::super::fault_io::TcpFaultKind;
-    use super::super::types::{RiftErrorFault, RiftFaultConfig, RiftLatencyFault};
+    use super::super::types::{RiftErrorFault, RiftFaultConfig, RiftLatencyFault, RiftTcpFault};
     use super::{Bytes, Full, Response, apply_rift_fault, handle_fault_response};
     use std::time::Instant;
 
@@ -1647,7 +1659,7 @@ mod fault_precedence_tests {
         let config = RiftFaultConfig {
             latency: Some(latency_fault(0)),
             error: Some(error_fault(503)),
-            tcp: Some("CONNECTION_RESET_BY_PEER".to_string()),
+            tcp: Some(RiftTcpFault::Kind("CONNECTION_RESET_BY_PEER".to_string())),
         };
         let response = apply(&config).await;
 
@@ -1689,7 +1701,7 @@ mod fault_precedence_tests {
         let config = RiftFaultConfig {
             latency: None,
             error: Some(error_fault(503)),
-            tcp: Some("NONSENSE".to_string()),
+            tcp: Some(RiftTcpFault::Kind("NONSENSE".to_string())),
         };
         let response = apply(&config).await;
 
@@ -1704,7 +1716,7 @@ mod fault_precedence_tests {
         let config = RiftFaultConfig {
             latency: None,
             error: None,
-            tcp: Some("CONNECTION_RESET_BY_PEER".to_string()),
+            tcp: Some(RiftTcpFault::Kind("CONNECTION_RESET_BY_PEER".to_string())),
         };
         let response = apply(&config).await;
 
@@ -1720,7 +1732,7 @@ mod fault_precedence_tests {
         let config = RiftFaultConfig {
             latency: Some(latency_fault(60)),
             error: Some(error_fault(503)),
-            tcp: Some("CONNECTION_RESET_BY_PEER".to_string()),
+            tcp: Some(RiftTcpFault::Kind("CONNECTION_RESET_BY_PEER".to_string())),
         };
         let start = Instant::now();
         let response = apply(&config).await;
@@ -1732,6 +1744,97 @@ mod fault_precedence_tests {
         assert_eq!(
             response.extensions().get::<TcpFaultKind>().copied(),
             Some(TcpFaultKind::Reset)
+        );
+    }
+
+    /// Issue #531: a `tcp` fault with `probability: 0.0` must never reset — with no other fault it
+    /// falls through to the normal response (no fault response at all).
+    #[tokio::test]
+    async fn tcp_object_probability_zero_never_resets() {
+        let config = RiftFaultConfig {
+            latency: None,
+            error: None,
+            tcp: Some(RiftTcpFault::Probabilistic {
+                probability: 0.0,
+                kind: "CONNECTION_RESET_BY_PEER".to_string(),
+            }),
+        };
+        let (mut status, mut body) = (200, String::new());
+        for _ in 0..200 {
+            let response = apply_rift_fault(&config, &mut status, &mut body).await;
+            assert!(
+                response.is_none(),
+                "probability 0.0 tcp fault must never fire"
+            );
+        }
+    }
+
+    /// A `probability: 0.0` tcp fault falls through to a certain `error` fault (treated as absent).
+    #[tokio::test]
+    async fn tcp_object_probability_zero_falls_through_to_error() {
+        let config = RiftFaultConfig {
+            latency: None,
+            error: Some(error_fault(503)),
+            tcp: Some(RiftTcpFault::Probabilistic {
+                probability: 0.0,
+                kind: "CONNECTION_RESET_BY_PEER".to_string(),
+            }),
+        };
+        let response = apply(&config).await;
+        assert_eq!(response.status(), 503);
+        assert!(response.extensions().get::<TcpFaultKind>().is_none());
+    }
+
+    /// The object form with `probability: 1.0` behaves exactly like the bare string.
+    #[tokio::test]
+    async fn tcp_object_probability_one_matches_bare_string() {
+        let config = RiftFaultConfig {
+            latency: None,
+            error: Some(error_fault(503)),
+            tcp: Some(RiftTcpFault::Probabilistic {
+                probability: 1.0,
+                kind: "CONNECTION_RESET_BY_PEER".to_string(),
+            }),
+        };
+        let response = apply(&config).await;
+        assert_eq!(
+            response.extensions().get::<TcpFaultKind>().copied(),
+            Some(TcpFaultKind::Reset)
+        );
+        assert_ne!(response.status(), 503);
+        assert_eq!(
+            response.headers().get("x-rift-fault").unwrap(),
+            "CONNECTION_RESET_BY_PEER"
+        );
+    }
+
+    /// Statistical gate: a `probability: 0.3` tcp fault fires at roughly the configured rate.
+    #[tokio::test]
+    async fn tcp_object_fires_at_configured_probability() {
+        let config = RiftFaultConfig {
+            latency: None,
+            error: None,
+            tcp: Some(RiftTcpFault::Probabilistic {
+                probability: 0.3,
+                kind: "CONNECTION_RESET_BY_PEER".to_string(),
+            }),
+        };
+        let iterations = 4000;
+        let mut resets = 0;
+        let (mut status, mut body) = (200, String::new());
+        for _ in 0..iterations {
+            if apply_rift_fault(&config, &mut status, &mut body)
+                .await
+                .and_then(|r| r.extensions().get::<TcpFaultKind>().copied())
+                .is_some()
+            {
+                resets += 1;
+            }
+        }
+        let observed = f64::from(resets) / f64::from(iterations);
+        assert!(
+            (observed - 0.3).abs() < 0.05,
+            "expected ~0.3 reset rate, got {observed}"
         );
     }
 }

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -37,8 +37,8 @@ pub use types::{
     PredicateOperation, PredicateParameters, PredicateSelector, ProxyResponse, RecordedRequest,
     ResponseMode, RiftConfig, RiftConnectionPoolConfig, RiftErrorFault, RiftFaultConfig,
     RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig, RiftRedisConfig,
-    RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig, RiftUpstreamConfig, Stub,
-    StubResponse,
+    RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig, RiftTcpFault,
+    RiftUpstreamConfig, Stub, StubResponse,
 };
 
 // Re-export script `file:`/`ref:` resolution (issue #356)

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -1055,7 +1055,97 @@ pub struct RiftFaultConfig {
     pub error: Option<RiftErrorFault>,
     /// TCP-level fault
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tcp: Option<String>,
+    pub tcp: Option<RiftTcpFault>,
+}
+
+/// A `_rift.fault.tcp` fault (issue #531). Either the bare kind string — always fires, the
+/// canonical Mountebank-compatible form — or the probabilistic object form, a Rift extension that
+/// carries a firing probability. Serialized back in exactly the form it was parsed from (string
+/// stays string, object stays object) so `GET /imposters` round-trips, which is what the SDK
+/// parse-fidelity gate enforces.
+///
+/// Deserialization is hand-written (rather than `#[serde(untagged)]`) so a malformed object form
+/// gets an actionable error at the `POST /imposters` boundary — an untagged enum only ever reports
+/// the opaque "data did not match any variant" — mirroring the diagnostics `rift-lint` emits.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum RiftTcpFault {
+    /// Bare form: `"CONNECTION_RESET_BY_PEER"` — always fires (probability 1.0).
+    Kind(String),
+    /// Probabilistic form: fires with the given probability. `probability` is required (no serde
+    /// default): the object form exists solely to carry it, so `{ "type": X }` alone would be a
+    /// second spelling of the bare form and break parse-fidelity round-trips.
+    Probabilistic {
+        probability: f64,
+        #[serde(rename = "type")]
+        kind: String,
+    },
+}
+
+impl<'de> Deserialize<'de> for RiftTcpFault {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+        match serde_json::Value::deserialize(deserializer)? {
+            serde_json::Value::String(kind) => Ok(RiftTcpFault::Kind(kind)),
+            serde_json::Value::Object(map) => {
+                let probability = match map.get("probability") {
+                    None => {
+                        return Err(D::Error::custom(
+                            "_rift.fault.tcp object form requires a numeric 'probability' (use the bare fault-type string for an always-firing fault)",
+                        ));
+                    }
+                    Some(v) => v.as_f64().ok_or_else(|| {
+                        D::Error::custom(
+                            "_rift.fault.tcp 'probability' must be a number between 0.0 and 1.0",
+                        )
+                    })?,
+                };
+                if !(0.0..=1.0).contains(&probability) {
+                    return Err(D::Error::custom(
+                        "_rift.fault.tcp 'probability' must be between 0.0 and 1.0",
+                    ));
+                }
+                let kind = match map.get("type") {
+                    None => {
+                        return Err(D::Error::custom(
+                            "_rift.fault.tcp object form requires a string 'type'",
+                        ));
+                    }
+                    Some(v) => v
+                        .as_str()
+                        .ok_or_else(|| D::Error::custom("_rift.fault.tcp 'type' must be a string"))?
+                        .to_string(),
+                };
+                Ok(RiftTcpFault::Probabilistic { probability, kind })
+            }
+            _ => Err(D::Error::custom(
+                "_rift.fault.tcp must be a fault-type string or an object { probability, type }",
+            )),
+        }
+    }
+}
+
+impl RiftTcpFault {
+    /// The TCP fault kind string, fed to `TcpFaultKind::parse`.
+    #[must_use]
+    pub fn kind(&self) -> &str {
+        match self {
+            Self::Kind(kind) => kind,
+            Self::Probabilistic { kind, .. } => kind,
+        }
+    }
+
+    /// Probability the fault fires: `1.0` for the bare form.
+    #[must_use]
+    pub fn probability(&self) -> f64 {
+        match self {
+            Self::Kind(_) => 1.0,
+            Self::Probabilistic { probability, .. } => *probability,
+        }
+    }
 }
 
 /// Latency fault configuration
@@ -1557,5 +1647,91 @@ mod tests {
         assert_eq!(stub.recorded_from.as_deref(), Some("http://upstream:8080"));
         let serialized = serde_json::to_value(&stub).unwrap();
         assert_eq!(serialized["recordedFrom"], json!("http://upstream:8080"));
+    }
+
+    // Issue #531: `_rift.fault.tcp` accepts both the bare kind string and the probabilistic object
+    // form, and must round-trip in exactly the parsed shape (string↔string, object↔object) — the
+    // untagged enum must not normalize one into the other, or the SDK parse-fidelity gate breaks.
+    #[test]
+    fn rift_tcp_fault_roundtrips_both_forms() {
+        let bare = json!("CONNECTION_RESET_BY_PEER");
+        let parsed: RiftTcpFault = serde_json::from_value(bare.clone()).unwrap();
+        assert!(matches!(parsed, RiftTcpFault::Kind(_)));
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), bare);
+
+        let object = json!({ "probability": 0.1, "type": "CONNECTION_RESET_BY_PEER" });
+        let parsed: RiftTcpFault = serde_json::from_value(object.clone()).unwrap();
+        assert!(matches!(parsed, RiftTcpFault::Probabilistic { .. }));
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), object);
+    }
+
+    // The object form exists solely to carry `probability`; `{ "type": X }` alone would be a second
+    // spelling of the bare form, so it must be rejected rather than silently defaulted.
+    #[test]
+    fn rift_tcp_fault_object_requires_probability() {
+        let missing = json!({ "type": "CONNECTION_RESET_BY_PEER" });
+        assert!(serde_json::from_value::<RiftTcpFault>(missing).is_err());
+    }
+
+    // The object form must carry both fields: neither `probability` nor `type` alone is a valid
+    // object (an object without `type` is not a second spelling of the bare string either).
+    #[test]
+    fn rift_tcp_fault_object_requires_type() {
+        let missing = json!({ "probability": 0.5 });
+        assert!(serde_json::from_value::<RiftTcpFault>(missing).is_err());
+    }
+
+    // The rejection message must be actionable at the API boundary (not the opaque untagged-enum
+    // "data did not match any variant") — it names the offending field.
+    #[test]
+    fn rift_tcp_fault_errors_are_actionable() {
+        let missing_prob = serde_json::from_value::<RiftTcpFault>(json!({ "type": "reset" }))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing_prob.contains("probability"),
+            "message should name 'probability': {missing_prob}"
+        );
+
+        let missing_type = serde_json::from_value::<RiftTcpFault>(json!({ "probability": 0.5 }))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing_type.contains("type"),
+            "message should name 'type': {missing_type}"
+        );
+    }
+
+    // An out-of-range probability is rejected at parse time rather than silently degrading to
+    // always/never fires at request time.
+    #[test]
+    fn rift_tcp_fault_object_rejects_out_of_range_probability() {
+        for bad in [
+            json!({ "probability": 1.5, "type": "reset" }),
+            json!({ "probability": -0.1, "type": "reset" }),
+        ] {
+            assert!(serde_json::from_value::<RiftTcpFault>(bad).is_err());
+        }
+        // The boundary values 0.0 and 1.0 are valid.
+        assert!(
+            serde_json::from_value::<RiftTcpFault>(json!({ "probability": 0.0, "type": "reset" }))
+                .is_ok()
+        );
+        assert!(
+            serde_json::from_value::<RiftTcpFault>(json!({ "probability": 1.0, "type": "reset" }))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rift_tcp_fault_accessors() {
+        let bare: RiftTcpFault = serde_json::from_value(json!("EMPTY_RESPONSE")).unwrap();
+        assert_eq!(bare.kind(), "EMPTY_RESPONSE");
+        assert_eq!(bare.probability(), 1.0);
+
+        let object: RiftTcpFault =
+            serde_json::from_value(json!({ "probability": 0.25, "type": "reset" })).unwrap();
+        assert_eq!(object.kind(), "reset");
+        assert_eq!(object.probability(), 0.25);
     }
 }

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -183,6 +183,28 @@ TCP fault types (each accepts a WireMock-style canonical name or a short alias):
 | `RANDOM_DATA_THEN_CLOSE` | `random`, `garbage` | Write random bytes, then close |
 | `MALFORMED_RESPONSE_CHUNK` | `malformed` | Send a status line + a malformed chunked body, then close |
 
+#### Probabilistic TCP faults
+
+The bare string form above always fires. To reset only *some* of the time, use the object form,
+which carries a firing `probability` (0.0–1.0) alongside the fault `type`:
+
+```json
+{
+  "_rift": {
+    "fault": {
+      "tcp": { "probability": 0.1, "type": "CONNECTION_RESET_BY_PEER" }
+    }
+  }
+}
+```
+
+This resets the connection on ~10% of requests and serves the normal response the rest of the time,
+mirroring the `probability` roll `latency` and `error` already use. `probability` is **required** in
+the object form — `{ "type": ... }` with no probability is rejected; use the bare string form for an
+always-firing fault. The bare form is exactly equivalent to the object form with `probability: 1.0`,
+and each form round-trips unchanged through `GET /imposters` (a string stays a string, an object
+stays an object).
+
 These are real transport-level events applied beneath TLS, so HTTPS imposters get a genuine socket
 fault too. Because a connection-level fault aborts the whole socket, an imposter that uses any TCP
 fault is served over **HTTP/1 only** (HTTP/2 multiplexing is incompatible with mid-stream connection

--- a/sdk-conformance/corpus/imposters/04-fault-injection.json
+++ b/sdk-conformance/corpus/imposters/04-fault-injection.json
@@ -74,6 +74,18 @@
       }]
     },
     {
+      "name": "TCP — reset the connection 10% of the time (probabilistic object form)",
+      "predicates": [{ "equals": { "path": "/faults/tcp-flaky" } }],
+      "responses": [{
+        "is": {
+          "statusCode": 200,
+          "headers": { "Content-Type": "application/json" },
+          "body": { "endpoint": "/faults/tcp-flaky", "note": "10% chance of a connection reset" }
+        },
+        "_rift": { "fault": { "tcp": { "probability": 0.1, "type": "CONNECTION_RESET_BY_PEER" } } }
+      }]
+    },
+    {
       "name": "Baseline — no fault, for comparison",
       "predicates": [{ "equals": { "path": "/faults/healthy" } }],
       "responses": [{


### PR DESCRIPTION
Adds runtime support for probabilistic TCP connection resets, enabling fault injection scenarios where failures occur non-deterministically. The change accepts both a bare string (backward-compatible) and a structured {probability, type} form, with a probability roll at runtime similar to latency/error injection. Includes validation in rift-lint with actionable error messages.

Closes #531

Note: Follow-up #532 (datadir silent-skip) filed separately.