### PR TITLE
feat(flow-state): per-key ctx.state.ttl(key, seconds), fix Redis flow-level TTL divergence, flow invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ record.
 
 ### Added
 
+- **Per-key flow-state TTL and flow invalidation** (`ctx.state`): scripts can now set a single key's
+  TTL with `ctx.state.ttl(key, seconds)` (returns `true` if the key existed, `false` if absent;
+  `seconds <= 0` deletes it, matching Redis `EXPIRE`) alongside the existing flow-level
+  `ctx.state.ttl(seconds)`. New `ctx.state.clear()` removes every key in the flow, and a new admin
+  route `DELETE /admin/imposters/:port/flow-state/:flow_id` clears a whole flow (the test
+  arrange/teardown tool). Both rhai and JavaScript engines expose the same surface.
+
 - **Probabilistic TCP faults** (`_rift.fault.tcp`): the fault now accepts an object form
   `{ "probability": 0.1, "type": "CONNECTION_RESET_BY_PEER" }` alongside the existing bare string,
   so a connection reset can be made to fire only some of the time (e.g. "reset 10% of requests").
@@ -27,6 +34,12 @@ record.
   reported together in a single prominent startup error listing every skipped file and why, instead
   of a per-file warning that was easy to miss — so a typo'd fixture that vanishes from the running
   set is visible. One bad file also no longer aborts loading of the remaining valid imposters.
+- **Flow-level `ctx.state.ttl(seconds)` on the Redis backend** was a silent no-op — a script calling
+  `ttl(3600)` got `true` back while nothing changed. It now re-stamps every key in the flow via
+  `SCAN` + `EXPIRE`, matching the in-memory backend's behavior.
+- **Non-positive `flowState.ttlSeconds`** (`< 1`) is now rejected with `400 Bad Request` at imposter
+  creation instead of misbehaving later (in-memory: instant expiry of every write; Redis: a `SETEX`
+  error on the first write).
 
 ## [0.13.1] - 2026-07-11
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -189,6 +189,26 @@ pub async fn handle_put_flow_state(
     }
 }
 
+/// DELETE /admin/imposters/:port/flow-state/:flow_id — clear every key in a flow (issue #530).
+/// Idempotent: clearing an absent/empty flow still returns 200. 404 only when the imposter/port
+/// does not exist.
+pub async fn handle_clear_flow_state(
+    port: u16,
+    flow_id: &str,
+    manager: Arc<ImposterManager>,
+) -> Response<Full<Bytes>> {
+    match manager.get_imposter(port) {
+        Ok(imposter) => match imposter.flow_clear(flow_id) {
+            Ok(()) => json_response(
+                StatusCode::OK,
+                &serde_json::json!({ "flowId": flow_id, "cleared": true }),
+            ),
+            Err(e) => backend_error_response(&e),
+        },
+        Err(e) => e.into(),
+    }
+}
+
 /// DELETE /admin/imposters/:port/flow-state/:flow_id/:key
 pub async fn handle_delete_flow_state(
     port: u16,

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -231,7 +231,8 @@ async fn route_by_path(
     not_found()
 }
 
-/// Route `/admin/imposters/:port/flow-state/:flow_id/:key` (issue #190 StateInspection).
+/// Route `/admin/imposters/:port/flow-state/:flow_id[/:key]` — per-key inspection (issue #190
+/// StateInspection) and whole-flow invalidation (issue #530).
 async fn route_admin_flow_state(
     method: &Method,
     rest: &str,
@@ -240,6 +241,16 @@ async fn route_admin_flow_state(
 ) -> Response<Full<Bytes>> {
     let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
     match segments.as_slice() {
+        // Whole-flow invalidation (issue #530): DELETE /admin/imposters/:port/flow-state/:flow_id
+        [port_str, "flow-state", flow_id] => {
+            let Ok(port) = port_str.parse::<u16>() else {
+                return not_found();
+            };
+            match *method {
+                Method::DELETE => scenarios::handle_clear_flow_state(port, flow_id, manager).await,
+                _ => not_found(),
+            }
+        }
         [port_str, "flow-state", flow_id, key] => {
             let Ok(port) = port_str.parse::<u16>() else {
                 return not_found();

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -122,6 +122,99 @@ async fn scenario_admin_endpoints_arrange_inspect_reset() {
     let _ = manager.delete_imposter(19763).await;
 }
 
+// Issue #530: DELETE /admin/imposters/:port/flow-state/:flow_id clears every key in the flow.
+#[tokio::test]
+async fn delete_flow_state_clears_whole_flow() {
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    let config = serde_json::from_value(order_fsm(19780, None)).unwrap();
+    manager.create_imposter(config).await.expect("create");
+
+    let admin_addr = "127.0.0.1:12602".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12602";
+    let key_url = |k: &str| format!("{admin}/admin/imposters/19780/flow-state/flowX/{k}");
+
+    // Arrange two keys under flow "flowX".
+    for (k, v) in [("a", "1"), ("b", "2")] {
+        let r = c
+            .put(key_url(k))
+            .header("content-type", "application/json")
+            .body(format!(r#"{{"value":{v}}}"#))
+            .send()
+            .await
+            .expect("put");
+        assert_eq!(r.status(), 200);
+    }
+
+    // Clear the whole flow.
+    let r = c
+        .delete(format!("{admin}/admin/imposters/19780/flow-state/flowX"))
+        .send()
+        .await
+        .expect("clear");
+    assert_eq!(r.status(), 200);
+    assert_eq!(
+        r.json::<serde_json::Value>().await.unwrap()["cleared"],
+        true
+    );
+
+    // Both keys are gone.
+    assert_eq!(c.get(key_url("a")).send().await.unwrap().status(), 404);
+    assert_eq!(c.get(key_url("b")).send().await.unwrap().status(), 404);
+
+    // Idempotent: clearing again still succeeds; an unknown port is 404.
+    assert_eq!(
+        c.delete(format!("{admin}/admin/imposters/19780/flow-state/flowX"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    assert_eq!(
+        c.delete(format!("{admin}/admin/imposters/29999/flow-state/flowX"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    let _ = manager.delete_imposter(19780).await;
+}
+
+// Issue #530: creating an imposter with flowState.ttlSeconds < 1 is rejected with 400.
+#[tokio::test]
+async fn create_imposter_rejects_non_positive_ttl_seconds() {
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    let admin_addr = "127.0.0.1:12603".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12603";
+    let r = c
+        .post(format!("{admin}/imposters"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "port": 19781, "protocol": "http", "stubs": [],
+                "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 0 } }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(r.status(), 400, "ttlSeconds:0 must be rejected at creation");
+    assert!(r.text().await.unwrap().contains("ttlSeconds"));
+}
+
 #[tokio::test]
 async fn scenario_admin_reset_is_per_flow_with_explicit_flow_id() {
     let manager = std::sync::Arc::new(ImposterManager::new());

--- a/crates/rift-http-proxy/tests/redis_backend.rs
+++ b/crates/rift-http-proxy/tests/redis_backend.rs
@@ -229,4 +229,163 @@ mod tests {
 
         store.delete("casf2", "state").unwrap();
     }
+
+    // ===== per-key ttl, flow-level ttl fix, clear_flow (issue #530) =====
+
+    // Regression for finding 2: flow-level set_ttl was a silent no-op on Redis. It must now actually
+    // extend every key's TTL via SCAN + EXPIRE. With a 2s store default, extending to 100s must keep
+    // the keys alive past a 3s wait (before the fix they'd expire at 2s and be gone).
+    #[tokio::test]
+    async fn test_redis_set_ttl_extends_all_keys() {
+        let Some((_container, store)) = setup(2).await else {
+            return;
+        };
+        store.set("extendf", "a", json!(1)).unwrap();
+        store.set("extendf", "b", json!(2)).unwrap();
+        // A sibling flow that is NOT extended must keep its short default TTL and expire.
+        store.set("extendsibling", "k", json!(1)).unwrap();
+
+        store.set_ttl("extendf", 100).unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        assert!(
+            store.exists("extendf", "a").unwrap(),
+            "set_ttl must extend key a"
+        );
+        assert!(
+            store.exists("extendf", "b").unwrap(),
+            "set_ttl must extend key b"
+        );
+        assert!(
+            !store.exists("extendsibling", "k").unwrap(),
+            "set_ttl must extend only the target flow; the sibling keeps its TTL and expires"
+        );
+
+        store.clear_flow("extendf").unwrap();
+        store.clear_flow("extendsibling").unwrap();
+    }
+
+    // Flow-level ttl(<=0) expires every current key (Redis EXPIRE semantics), matching in-memory.
+    #[tokio::test]
+    async fn test_redis_set_ttl_zero_expires_flow() {
+        let Some((_container, store)) = setup(300).await else {
+            return;
+        };
+        store.set("zerof", "a", json!(1)).unwrap();
+        store.set("zerof", "b", json!(2)).unwrap();
+
+        store.set_ttl("zerof", 0).unwrap();
+        assert!(!store.exists("zerof", "a").unwrap());
+        assert!(!store.exists("zerof", "b").unwrap());
+    }
+
+    // Per-key ttl mirrors Redis EXPIRE: true when the key exists, false when absent; <=0 deletes.
+    #[tokio::test]
+    async fn test_redis_set_key_ttl() {
+        let Some((_container, store)) = setup(300).await else {
+            return;
+        };
+        store.set("keyttl", "k", json!("v")).unwrap();
+
+        assert!(
+            store.set_key_ttl("keyttl", "k", 100).unwrap(),
+            "existing key -> true"
+        );
+        assert!(
+            !store.set_key_ttl("keyttl", "absent", 100).unwrap(),
+            "absent key -> false"
+        );
+
+        // <=0 deletes the key.
+        assert!(
+            store.set_key_ttl("keyttl", "k", 0).unwrap(),
+            "delete existing -> true"
+        );
+        assert!(
+            !store.exists("keyttl", "k").unwrap(),
+            "key deleted by ttl<=0"
+        );
+        assert!(
+            !store.set_key_ttl("keyttl", "k", -1).unwrap(),
+            "delete absent -> false"
+        );
+    }
+
+    // clear_flow removes only the target flow's keys.
+    #[tokio::test]
+    async fn test_redis_clear_flow() {
+        let Some((_container, store)) = setup(300).await else {
+            return;
+        };
+        store.set("clearf", "k1", json!(1)).unwrap();
+        store.set("clearf", "k2", json!(2)).unwrap();
+        store.set("keepf", "k", json!(3)).unwrap();
+
+        store.clear_flow("clearf").unwrap();
+
+        assert!(
+            !store.exists("clearf", "k1").unwrap(),
+            "target flow cleared"
+        );
+        assert!(
+            !store.exists("clearf", "k2").unwrap(),
+            "target flow cleared"
+        );
+        assert!(
+            store.exists("keepf", "k").unwrap(),
+            "sibling flow untouched"
+        );
+
+        // Idempotent on an absent flow.
+        store.clear_flow("no-such-flow").unwrap();
+        store.clear_flow("keepf").unwrap();
+    }
+
+    // Issue #530 (review finding): a flow_id containing a Redis glob metacharacter must be treated
+    // literally by clear_flow's SCAN MATCH — it must NOT wipe sibling flows whose ids the glob would
+    // otherwise match. Here clear_flow("a*") must clear only the literal flow "a*", leaving "abc".
+    #[tokio::test]
+    async fn test_redis_clear_flow_does_not_glob_across_flows() {
+        let Some((_container, store)) = setup(300).await else {
+            return;
+        };
+        store.set("a*", "k", json!("literal-star-flow")).unwrap();
+        store.set("abc", "k", json!("sibling")).unwrap();
+
+        store.clear_flow("a*").unwrap();
+
+        assert!(
+            !store.exists("a*", "k").unwrap(),
+            "the literal 'a*' flow must be cleared"
+        );
+        assert!(
+            store.exists("abc", "k").unwrap(),
+            "a glob in the flow_id must not clear sibling flows ('abc')"
+        );
+
+        // Same guarantee for the destructive flow-level set_ttl(<=0).
+        store.set("a*", "k", json!("again")).unwrap();
+        store.set_ttl("a*", 0).unwrap();
+        assert!(!store.exists("a*", "k").unwrap(), "literal 'a*' expired");
+        assert!(
+            store.exists("abc", "k").unwrap(),
+            "set_ttl(<=0) must not expire sibling flows"
+        );
+
+        store.clear_flow("abc").unwrap();
+    }
+
+    // Per-key ttl on an already-expired key reports false (the key is absent), on Redis too.
+    #[tokio::test]
+    async fn test_redis_set_key_ttl_on_expired_key_is_false() {
+        let Some((_container, store)) = setup(2).await else {
+            return;
+        };
+        store.set("expttl", "k", json!("v")).unwrap();
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        assert!(
+            !store.set_key_ttl("expttl", "k", 100).unwrap(),
+            "an expired key is absent, so per-key ttl returns false"
+        );
+    }
 }

--- a/crates/rift-mock-core/src/backends/inmemory.rs
+++ b/crates/rift-mock-core/src/backends/inmemory.rs
@@ -180,10 +180,17 @@ impl FlowStore for InMemoryFlowStore {
     }
 
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()> {
-        let new_expiry =
-            SystemTime::now() + Duration::from_secs(u64::try_from(ttl_seconds).unwrap_or(0));
         let mut data = self.data.write();
 
+        // Flow-level "expire now" (issue #530): a non-positive TTL drops every current key (and the
+        // flow map), matching per-key `set_key_ttl(<=0)` and Redis `EXPIRE`.
+        if ttl_seconds <= 0 {
+            data.remove(flow_id);
+            return Ok(());
+        }
+
+        let new_expiry =
+            SystemTime::now() + Duration::from_secs(u64::try_from(ttl_seconds).unwrap_or(0));
         // Nested keying (issue #483): touch only this flow's entries, not the whole store.
         if let Some(flow) = data.get_mut(flow_id) {
             for (_, expiry) in flow.values_mut() {
@@ -191,6 +198,41 @@ impl FlowStore for InMemoryFlowStore {
             }
         }
 
+        Ok(())
+    }
+
+    fn set_key_ttl(&self, flow_id: &str, key: &str, ttl_seconds: i64) -> Result<bool> {
+        let mut data = self.data.write();
+        let Some(flow) = data.get_mut(flow_id) else {
+            return Ok(false);
+        };
+        // An already-expired entry counts as absent: clean it up and report false.
+        Self::remove_if_expired(flow, key);
+
+        // Non-positive TTL deletes the key immediately (Redis `EXPIRE` semantics), returning whether
+        // it existed. Drop the flow map if that was its last key (issue #483's growth vector).
+        if ttl_seconds <= 0 {
+            let existed = flow.remove(key).is_some();
+            if flow.is_empty() {
+                data.remove(flow_id);
+            }
+            return Ok(existed);
+        }
+
+        let new_expiry =
+            SystemTime::now() + Duration::from_secs(u64::try_from(ttl_seconds).unwrap_or(0));
+        match flow.get_mut(key) {
+            Some((_, expiry)) => {
+                *expiry = Some(new_expiry);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn clear_flow(&self, flow_id: &str) -> Result<()> {
+        // Drop the whole flow map in one step (nested keying, issue #483); absent flow → no-op.
+        self.data.write().remove(flow_id);
         Ok(())
     }
 
@@ -639,5 +681,97 @@ mod tests {
             !store.exists("drop", "k").unwrap(),
             "a sibling flow must keep its original (now expired) TTL"
         );
+    }
+
+    // ===== per-key ttl + clear_flow (issue #530) =====
+
+    // set_key_ttl extends only the target key: a short-lived sibling key in the same flow expires
+    // while the extended key survives.
+    #[test]
+    fn set_key_ttl_extends_only_the_target_key() {
+        let store = InMemoryFlowStore::new(1); // 1s default TTL
+        store.set("f", "keep", json!("v")).unwrap();
+        store.set("f", "drop", json!("v")).unwrap();
+
+        assert!(
+            store.set_key_ttl("f", "keep", 100).unwrap(),
+            "extending an existing key returns true"
+        );
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        assert!(store.exists("f", "keep").unwrap(), "target key extended");
+        assert!(
+            !store.exists("f", "drop").unwrap(),
+            "sibling key keeps its original (now expired) TTL"
+        );
+    }
+
+    #[test]
+    fn set_key_ttl_absent_key_returns_false() {
+        let store = InMemoryFlowStore::new(300);
+        assert!(!store.set_key_ttl("f", "nope", 60).unwrap());
+        // A flow that exists but lacks the key also returns false, and must not create the key.
+        store.set("f", "other", json!(1)).unwrap();
+        assert!(!store.set_key_ttl("f", "nope", 60).unwrap());
+        assert!(!store.exists("f", "nope").unwrap());
+    }
+
+    #[test]
+    fn set_key_ttl_non_positive_deletes_the_key() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f", "k", json!("v")).unwrap();
+        assert!(
+            store.set_key_ttl("f", "k", 0).unwrap(),
+            "deleting an existing key returns true"
+        );
+        assert!(!store.exists("f", "k").unwrap(), "key deleted by ttl<=0");
+        // Deleting the flow's last key drops the flow map (no empty-map leak, issue #483).
+        assert_eq!(store.stored_flow_count(), 0);
+        // Deleting an absent key returns false.
+        assert!(!store.set_key_ttl("f", "k", -5).unwrap());
+    }
+
+    #[test]
+    fn set_key_ttl_on_expired_key_returns_false() {
+        let store = InMemoryFlowStore::new(1);
+        store.set("f", "k", json!("v")).unwrap();
+        std::thread::sleep(Duration::from_secs(2));
+        assert!(
+            !store.set_key_ttl("f", "k", 100).unwrap(),
+            "an already-expired key is absent, so per-key ttl returns false"
+        );
+    }
+
+    // Flow-level ttl(<=0) expires every current key (issue #530), matching per-key semantics.
+    #[test]
+    fn set_ttl_non_positive_expires_whole_flow() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f", "a", json!(1)).unwrap();
+        store.set("f", "b", json!(2)).unwrap();
+        store.set_ttl("f", 0).unwrap();
+        assert!(!store.exists("f", "a").unwrap());
+        assert!(!store.exists("f", "b").unwrap());
+        assert_eq!(store.stored_flow_count(), 0, "flow map dropped");
+    }
+
+    #[test]
+    fn clear_flow_drops_only_the_target_flow() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("keep", "k", json!(1)).unwrap();
+        store.set("drop", "k1", json!(1)).unwrap();
+        store.set("drop", "k2", json!(2)).unwrap();
+
+        store.clear_flow("drop").unwrap();
+
+        assert!(
+            store.keys_for_flow("drop").is_empty(),
+            "target flow emptied"
+        );
+        assert!(store.exists("keep", "k").unwrap(), "sibling flow untouched");
+        // No empty flow-map left behind for the cleared flow (issue #483 growth vector).
+        assert_eq!(store.stored_flow_count(), 1);
+        // Clearing an absent flow is an idempotent no-op success.
+        assert!(store.clear_flow("no-such-flow").is_ok());
     }
 }

--- a/crates/rift-mock-core/src/backends/redis.rs
+++ b/crates/rift-mock-core/src/backends/redis.rs
@@ -99,6 +99,32 @@ impl RedisFlowStore {
     fn make_key(&self, flow_id: &str, key: &str) -> String {
         format!("{}flow:{}:{}", self.key_prefix, flow_id, key)
     }
+
+    /// `SCAN MATCH` glob for every key under a flow (issue #530). Mirrors [`Self::make_key`] with a
+    /// trailing `*` for the key part, so `set_ttl` and `clear_flow` operate on exactly the flow's own
+    /// namespace.
+    ///
+    /// `flow_id` is glob-**escaped** before interpolation: it is request-derived (a path/header/body
+    /// capture, or the admin `DELETE .../flow-state/:flow_id` path segment), so a raw `*`/`?`/`[` in
+    /// it would otherwise make these destructive ops match — and wipe/expire — *sibling* flows' keys.
+    /// Escaping keeps the match literal, matching the in-memory backend's exact-string keying.
+    fn flow_scan_pattern(&self, flow_id: &str) -> String {
+        format!("{}flow:{}:*", self.key_prefix, escape_glob(flow_id))
+    }
+}
+
+/// Escape the Redis glob metacharacters (`*`, `?`, `[`, `]`, `\`) in `s` so it matches literally
+/// inside a `SCAN`/`KEYS` `MATCH` pattern (issue #530). Redis pattern matching treats `\x` as a
+/// literal `x`, so a backslash prefix neutralizes each metacharacter.
+fn escape_glob(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '*' | '?' | '[' | ']' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }
 
 /// Wrap a Redis op failure so response boundaries map it to a structured 503 (issue
@@ -287,18 +313,113 @@ end
     }
 
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()> {
-        // For now, just log a debug message - individual keys get TTL via set() and increment()
-        // To fully implement this, we'd need to SCAN for all keys matching the pattern
-        // and EXPIRE each one, which is expensive
-        tracing::debug!(
-            "set_ttl called for flow_id={} with ttl={}s - individual operations already set TTL",
-            flow_id,
-            ttl_seconds
-        );
-
-        // Return success since individual operations already handle TTL
+        // Issue #530: re-stamp the TTL of every key currently in the flow via SCAN + EXPIRE. This
+        // replaces the former silent no-op — a script calling `ctx.state.ttl(3600)` on Redis now
+        // actually extends its keys, matching the in-memory backend. A non-positive TTL drops every
+        // key (Redis `EXPIRE` semantics). O(keys-in-flow), but this is an explicit script call, not
+        // on the per-request hot path.
+        let pattern = self.flow_scan_pattern(flow_id);
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| backend_err("flowStore.pool", e))?;
+        let mut guard = conn.lock().unwrap();
+        let mut cursor: u64 = 0;
+        loop {
+            let (next, keys) = scan_batch(&mut guard, cursor, &pattern, "flowStore.setTtl")?;
+            for k in &keys {
+                if ttl_seconds <= 0 {
+                    let _: i64 = redis::cmd("DEL")
+                        .arg(k)
+                        .query(&mut *guard)
+                        .map_err(|e| backend_err("flowStore.setTtl", e))?;
+                } else {
+                    let _: i64 = redis::cmd("EXPIRE")
+                        .arg(k)
+                        .arg(ttl_seconds)
+                        .query(&mut *guard)
+                        .map_err(|e| backend_err("flowStore.setTtl", e))?;
+                }
+            }
+            if next == 0 {
+                break;
+            }
+            cursor = next;
+        }
         Ok(())
     }
+
+    fn set_key_ttl(&self, flow_id: &str, key: &str, ttl_seconds: i64) -> Result<bool> {
+        let key_str = self.make_key(flow_id, key);
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| backend_err("flowStore.pool", e))?;
+        let mut guard = conn.lock().unwrap();
+        if ttl_seconds <= 0 {
+            // Redis `EXPIRE key <=0` deletes the key; use DEL explicitly and report whether it
+            // existed (issue #530).
+            let deleted: i64 = redis::cmd("DEL")
+                .arg(&key_str)
+                .query(&mut *guard)
+                .map_err(|e| backend_err("flowStore.setKeyTtl", e))?;
+            Ok(deleted > 0)
+        } else {
+            // EXPIRE returns 1 if the timeout was set, 0 if the key does not exist — exactly the
+            // "existed?" bool this method promises.
+            let applied: i64 = redis::cmd("EXPIRE")
+                .arg(&key_str)
+                .arg(ttl_seconds)
+                .query(&mut *guard)
+                .map_err(|e| backend_err("flowStore.setKeyTtl", e))?;
+            Ok(applied == 1)
+        }
+    }
+
+    fn clear_flow(&self, flow_id: &str) -> Result<()> {
+        // SCAN + batched DEL over the flow's key namespace (issue #530). SCAN never blocks the
+        // server and tolerates concurrent mutation; DEL of a batch is one round trip.
+        let pattern = self.flow_scan_pattern(flow_id);
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| backend_err("flowStore.pool", e))?;
+        let mut guard = conn.lock().unwrap();
+        let mut cursor: u64 = 0;
+        loop {
+            let (next, keys) = scan_batch(&mut guard, cursor, &pattern, "flowStore.clearFlow")?;
+            if !keys.is_empty() {
+                let _: i64 = redis::cmd("DEL")
+                    .arg(&keys)
+                    .query(&mut *guard)
+                    .map_err(|e| backend_err("flowStore.clearFlow", e))?;
+            }
+            if next == 0 {
+                break;
+            }
+            cursor = next;
+        }
+        Ok(())
+    }
+}
+
+/// One `SCAN cursor MATCH pattern COUNT 100` round trip, returning the next cursor and the batch of
+/// matched keys. Callers loop until the returned cursor is 0. Extracted so `set_ttl` and
+/// `clear_flow` share the identical scan shape (issue #530).
+fn scan_batch(
+    conn: &mut Connection,
+    cursor: u64,
+    pattern: &str,
+    op: &'static str,
+) -> Result<(u64, Vec<String>)> {
+    redis::cmd("SCAN")
+        .arg(cursor)
+        .arg("MATCH")
+        .arg(pattern)
+        .arg("COUNT")
+        .arg(100)
+        .query::<(u64, Vec<String>)>(conn)
+        .map_err(|e| backend_err(op, e))
 }
 
 /// Health check for Redis connection
@@ -331,5 +452,17 @@ mod tests {
         assert_eq!(unavailable.feature, "flowState");
         assert!(unavailable.detail.contains("flowStore.get"));
         assert!(unavailable.detail.contains("connection refused"));
+    }
+
+    // Issue #530: a flow_id carrying glob metacharacters must be escaped so a SCAN MATCH pattern
+    // matches ONLY the literal flow — otherwise clear_flow/set_ttl would destructively match
+    // sibling flows. A plain id is passed through unchanged.
+    #[test]
+    fn escape_glob_neutralizes_scan_metacharacters() {
+        assert_eq!(escape_glob("plain"), "plain");
+        assert_eq!(escape_glob("a*b"), r"a\*b");
+        assert_eq!(escape_glob("a?b"), r"a\?b");
+        assert_eq!(escape_glob("a[bc]d"), r"a\[bc\]d");
+        assert_eq!(escape_glob(r"a\b"), r"a\\b");
     }
 }

--- a/crates/rift-mock-core/src/extensions/flow_state.rs
+++ b/crates/rift-mock-core/src/extensions/flow_state.rs
@@ -61,8 +61,32 @@ pub trait FlowStore: Send + Sync {
         Ok(new_value)
     }
 
-    /// Set TTL for all keys under a flow_id
+    /// Set TTL for all keys under a flow_id. `ttl_seconds <= 0` expires (drops) every current key
+    /// immediately (issue #530), mirroring the per-key `set_key_ttl` and Redis `EXPIRE` semantics.
     fn set_ttl(&self, flow_id: &str, ttl_seconds: i64) -> Result<()>;
+
+    /// Set the TTL of a single `key` under `flow_id` (issue #530). Returns `true` if the key existed
+    /// and the TTL was applied, `false` if it was absent — mirroring Redis `EXPIRE`. A
+    /// `ttl_seconds <= 0` deletes the key immediately (Redis `EXPIRE` semantics), returning whether
+    /// it existed.
+    ///
+    /// The default is a fail-loud `Err` so third-party `FlowStore` impls keep compiling but can't
+    /// silently pretend a per-key TTL was applied when it wasn't (precedent: the #311/#358 defaults).
+    fn set_key_ttl(&self, flow_id: &str, key: &str, ttl_seconds: i64) -> Result<bool> {
+        let _ = (flow_id, key, ttl_seconds);
+        Err(anyhow!("set_key_ttl not supported by this store"))
+    }
+
+    /// Remove every key under `flow_id` (issue #530) — the whole-flow invalidation primitive behind
+    /// `ctx.state.clear()` and `DELETE /admin/imposters/:port/flow-state/:flow_id`. Clearing an
+    /// absent flow is a no-op success (idempotent).
+    ///
+    /// The default is a fail-loud `Err` so third-party impls keep compiling but can't silently
+    /// claim a flow was cleared when it wasn't.
+    fn clear_flow(&self, flow_id: &str) -> Result<()> {
+        let _ = flow_id;
+        Err(anyhow!("clear_flow not supported by this store"))
+    }
 
     /// Atomically set `key` to `new` iff its current value equals `expected`
     /// (`None` = "not present"). Returns the winning current value on conflict.
@@ -136,6 +160,15 @@ impl FlowStore for NoOpFlowStore {
     }
 
     fn set_ttl(&self, _flow_id: &str, _ttl_seconds: i64) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_key_ttl(&self, _flow_id: &str, _key: &str, _ttl_seconds: i64) -> Result<bool> {
+        // No state is tracked, so no key can exist to expire.
+        Ok(false)
+    }
+
+    fn clear_flow(&self, _flow_id: &str) -> Result<()> {
         Ok(())
     }
 }
@@ -253,6 +286,47 @@ mod tests {
         assert!(store.set_ttl("flow-1", 3600).is_ok());
         assert!(store.set_ttl("flow-1", 0).is_ok());
         assert!(store.set_ttl("flow-1", -1).is_ok());
+    }
+
+    // Issue #530: NoOp has no state, so per-key ttl reports "absent" (false) and clear is a no-op.
+    #[test]
+    fn test_noop_flow_store_set_key_ttl_and_clear() {
+        let store = NoOpFlowStore;
+        assert!(!store.set_key_ttl("flow-1", "k", 60).unwrap());
+        assert!(!store.set_key_ttl("flow-1", "k", 0).unwrap());
+        assert!(store.clear_flow("flow-1").is_ok());
+    }
+
+    // Issue #530: a third-party store that does NOT override the new methods must keep compiling and
+    // fail loud (never silently claim success) — the trait defaults enforce that.
+    #[test]
+    fn test_default_set_key_ttl_and_clear_are_fail_loud() {
+        use std::sync::Mutex;
+        struct Bare(Mutex<()>);
+        impl FlowStore for Bare {
+            fn get(&self, _: &str, _: &str) -> Result<Option<Value>> {
+                let _g = self.0.lock();
+                Ok(None)
+            }
+            fn set(&self, _: &str, _: &str, _: Value) -> Result<()> {
+                Ok(())
+            }
+            fn exists(&self, _: &str, _: &str) -> Result<bool> {
+                Ok(false)
+            }
+            fn delete(&self, _: &str, _: &str) -> Result<()> {
+                Ok(())
+            }
+            fn increment(&self, _: &str, _: &str) -> Result<i64> {
+                Ok(1)
+            }
+            fn set_ttl(&self, _: &str, _: i64) -> Result<()> {
+                Ok(())
+            }
+        }
+        let store = Bare(Mutex::new(()));
+        assert!(store.set_key_ttl("f", "k", 60).is_err());
+        assert!(store.clear_flow("f").is_err());
     }
 
     #[test]
@@ -521,6 +595,12 @@ impl FlowStore for FailingFlowStore {
     }
     fn set_ttl(&self, flow_id: &str, _ttl_seconds: i64) -> Result<()> {
         self.fail("flowStore.setTtl", flow_id, "")
+    }
+    fn set_key_ttl(&self, flow_id: &str, key: &str, _ttl_seconds: i64) -> Result<bool> {
+        self.fail("flowStore.setKeyTtl", flow_id, key)
+    }
+    fn clear_flow(&self, flow_id: &str) -> Result<()> {
+        self.fail("flowStore.clearFlow", flow_id, "")
     }
 }
 

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -437,6 +437,12 @@ impl Imposter {
         self.flow_store.delete(flow_id, key)
     }
 
+    /// Clear every key under a flow (issue #530) — backs `DELETE /admin/imposters/:port/flow-state/
+    /// :flow_id`. Idempotent: clearing an absent flow succeeds.
+    pub fn flow_clear(&self, flow_id: &str) -> anyhow::Result<()> {
+        self.flow_store.clear_flow(flow_id)
+    }
+
     /// Distinct scenario names declared by this imposter's stubs (sorted).
     pub fn scenario_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -322,6 +322,16 @@ impl Imposter {
             return Ok(store);
         }
         if let Some(flow_state_config) = config.rift.as_ref().and_then(|r| r.flow_state.as_ref()) {
+            // Fail-loud config validation (issue #530): a non-positive default TTL misbehaves late
+            // and inconsistently (in-memory → instant expiry of every write; Redis → SETEX error on
+            // the first write), so reject it at construction. This surfaces as a 400 via
+            // ImposterError::FlowStoreConfig, matching the unrecognized-backend rule (#377).
+            if flow_state_config.ttl_seconds < 1 {
+                anyhow::bail!(
+                    "flowState.ttlSeconds must be >= 1 (got {}); a non-positive TTL would expire every write immediately",
+                    flow_state_config.ttl_seconds
+                );
+            }
             return match flow_state_config.backend.as_str() {
                 "inmemory" => {
                     info!(
@@ -787,6 +797,38 @@ mod tests {
             Imposter::new_with_hooks_and_journal(cfg, None, None, None).is_err(),
             "an unrecognized flowState.backend must fail construction, not fall back to NoOp"
         );
+    }
+
+    // Issue #530: a non-positive flowState.ttlSeconds misbehaves late (instant expiry / SETEX
+    // error), so it must fail construction up front — surfacing as a 400 at imposter creation.
+    #[test]
+    fn non_positive_ttl_seconds_fails_construction() {
+        for ttl in [0, -1] {
+            let cfg = serde_json::from_value(json!({
+                "port": 0, "protocol": "http", "stubs": [],
+                "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": ttl } }
+            }))
+            .expect("valid imposter config");
+            let msg = match Imposter::new_with_hooks_and_journal(cfg, None, None, None) {
+                Ok(_) => panic!("ttlSeconds = {ttl} must fail construction"),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                msg.contains("ttlSeconds"),
+                "error must name the offending field, got: {msg}"
+            );
+        }
+    }
+
+    // A ttlSeconds of exactly 1 (the boundary) is accepted.
+    #[test]
+    fn ttl_seconds_one_is_accepted() {
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http", "stubs": [],
+            "_rift": { "flowState": { "backend": "inmemory", "ttlSeconds": 1 } }
+        }))
+        .expect("valid imposter config");
+        assert!(Imposter::new_with_hooks_and_journal(cfg, None, None, None).is_ok());
     }
 
     /// Serve the state's next response body, advancing the shared cycler.

--- a/crates/rift-mock-core/src/scripting/js_engine.rs
+++ b/crates/rift-mock-core/src/scripting/js_engine.rs
@@ -1124,20 +1124,57 @@ fn state_cas(
     }
 }
 
-/// Per-flow TTL override in seconds (issue #358). Always fail-loud.
+/// TTL override, dispatched on the first argument's type (issue #358, per-key added by #530):
+/// `ttl(seconds)` re-stamps every current key of the flow; `ttl(key, seconds)` sets a single key's
+/// TTL (returning `true` if it existed, `false` if absent) and `seconds <= 0` deletes it. Always
+/// fail-loud. The error names both signatures so the #530 "TypeError on `ttl("k", 1)`" can't recur.
 fn state_ttl(
     _this: &JsValue,
     args: &[JsValue],
     flow_id: &StateCaptures,
     _ctx: &mut Context,
 ) -> JsResult<JsValue> {
-    let ttl_seconds = args
+    // Per-key form: first arg is a string key, second is the TTL.
+    if let Some(key) = args
         .first()
-        .and_then(|v| v.as_number())
-        .map(|n| n as i64)
-        .ok_or_else(|| JsNativeError::typ().with_message("seconds must be a number"))?;
+        .and_then(|v| v.as_string())
+        .map(|s| s.to_std_string_escaped())
+    {
+        let ttl_seconds = args
+            .get(1)
+            .and_then(|v| v.as_number())
+            .map(|n| n as i64)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("ttl(key, seconds): seconds must be a number")
+            })?;
+        let outcome = with_current_flow_store(|store| {
+            flow_result("keyTtl", store.set_key_ttl(flow_id, &key, ttl_seconds))
+        });
+        return js_flow_outcome_strict(outcome);
+    }
+    // Flow-level form: first arg is the TTL number.
+    if let Some(ttl_seconds) = args.first().and_then(|v| v.as_number()).map(|n| n as i64) {
+        let outcome = with_current_flow_store(|store| {
+            flow_result("ttl", store.set_ttl(flow_id, ttl_seconds).map(|()| true))
+        });
+        return js_flow_outcome_strict(outcome);
+    }
+    Err(JsNativeError::typ()
+        .with_message(
+            "expected ttl(seconds) or ttl(key, seconds): a number, or a string key and a number",
+        )
+        .into())
+}
+
+/// Remove every key in the flow (issue #530): `ctx.state.clear()`. Always fail-loud.
+fn state_clear(
+    _this: &JsValue,
+    _args: &[JsValue],
+    flow_id: &StateCaptures,
+    _ctx: &mut Context,
+) -> JsResult<JsValue> {
     let outcome = with_current_flow_store(|store| {
-        flow_result("ttl", store.set_ttl(flow_id, ttl_seconds).map(|()| true))
+        flow_result("clear", store.clear_flow(flow_id).map(|()| true))
     });
     js_flow_outcome_strict(outcome)
 }
@@ -1148,7 +1185,7 @@ type StateMethodFn = fn(&JsValue, &[JsValue], &StateCaptures, &mut Context) -> J
 
 fn create_state_object(context: &mut Context, flow_id: String) -> Result<JsValue> {
     let obj = create_js_object(context);
-    let methods: [(&str, StateMethodFn); 9] = [
+    let methods: [(&str, StateMethodFn); 10] = [
         ("get", state_get),
         ("set", state_set),
         ("incr", state_incr),
@@ -1158,6 +1195,7 @@ fn create_state_object(context: &mut Context, flow_id: String) -> Result<JsValue
         ("incrBy", state_incr_by),
         ("cas", state_cas),
         ("ttl", state_ttl),
+        ("clear", state_clear),
     ];
     for (name, func) in methods {
         let native_fn = NativeFunction::from_copy_closure_with_captures(func, flow_id.clone())
@@ -4114,6 +4152,100 @@ function respond(ctx) {
             engine.should_inject(request, store())
         }
 
+        /// Run a `respond` script returning `http(200, ...)` and yield the JSON body string.
+        fn run_body(script: &str) -> String {
+            match run_respond(script, &req(HashMap::new(), None)).unwrap() {
+                FaultDecision::Error { body, .. } => body,
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        // --- ctx.state.ttl(key, seconds) + clear() (issue #530) ---
+
+        // Regression for the original #530 report: `ttl("k", 1)` used to throw
+        // `TypeError: seconds must be a number`. It now dispatches to the per-key form.
+        #[test]
+        fn per_key_ttl_no_longer_type_errors_and_returns_true() {
+            let body = run_body(
+                r#"function respond(ctx) {
+                    ctx.state.set("k", "v");
+                    return http(200, { ok: ctx.state.ttl("k", 100) });
+                }"#,
+            );
+            assert!(
+                body.contains("true"),
+                "per-key ttl on existing key -> true, got {body}"
+            );
+        }
+
+        #[test]
+        fn per_key_ttl_absent_key_returns_false() {
+            let body = run_body(
+                r#"function respond(ctx) { return http(200, { ok: ctx.state.ttl("absent", 60) }); }"#,
+            );
+            assert!(
+                body.contains("false"),
+                "per-key ttl on absent key -> false, got {body}"
+            );
+        }
+
+        #[test]
+        fn per_key_ttl_zero_deletes_the_key() {
+            let body = run_body(
+                r#"function respond(ctx) {
+                    ctx.state.set("k", "v");
+                    ctx.state.ttl("k", 0);
+                    return http(200, { present: ctx.state.exists("k") });
+                }"#,
+            );
+            assert!(
+                body.contains("false"),
+                "ttl(key, 0) deletes the key, got {body}"
+            );
+        }
+
+        #[test]
+        fn flow_level_ttl_still_dispatches() {
+            let body = run_body(
+                r#"function respond(ctx) { return http(200, { ok: ctx.state.ttl(60) }); }"#,
+            );
+            assert!(
+                body.contains("true"),
+                "flow-level ttl(seconds) still works, got {body}"
+            );
+        }
+
+        #[test]
+        fn clear_empties_the_flow() {
+            let body = run_body(
+                r#"function respond(ctx) {
+                    ctx.state.set("a", 1);
+                    ctx.state.set("b", 2);
+                    ctx.state.clear();
+                    return http(200, { a: ctx.state.exists("a"), b: ctx.state.exists("b") });
+                }"#,
+            );
+            assert!(
+                !body.contains("true"),
+                "clear() removes every key, got {body}"
+            );
+        }
+
+        // The bad-arg error names BOTH signatures so the #530 confusion can't recur.
+        #[test]
+        fn ttl_bad_arg_error_names_both_signatures() {
+            let err = run_respond(
+                r#"function respond(ctx) { return http(200, { v: ctx.state.ttl(true) }); }"#,
+                &req(HashMap::new(), None),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                err.contains("ttl(seconds)") && err.contains("ttl(key, seconds)"),
+                "error must name both signatures, got: {err}"
+            );
+        }
+
         #[test]
         fn respond_named_wrapper() {
             let script = r#"
@@ -4453,6 +4585,14 @@ function respond(ctx) {
                 (
                     "ttl",
                     r#"function respond(ctx) { return http(200, { v: ctx.state.ttl(60) }); }"#,
+                ),
+                (
+                    "ttl_key",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.ttl("k", 60) }); }"#,
+                ),
+                (
+                    "clear",
+                    r#"function respond(ctx) { return http(200, { v: ctx.state.clear() }); }"#,
                 ),
             ] {
                 let result = JsEngine::new(script, "fail")

--- a/crates/rift-mock-core/src/scripting/mod.rs
+++ b/crates/rift-mock-core/src/scripting/mod.rs
@@ -578,6 +578,29 @@ impl ScriptFlowStore {
         )
         .map_err(Into::into)
     }
+
+    /// Set a per-key TTL override (issue #530). Returns `true` if the key existed, `false` if
+    /// absent; `ttl_seconds <= 0` deletes the key. Always fail-loud.
+    pub fn key_ttl(
+        &mut self,
+        flow_id: String,
+        key: String,
+        ttl_seconds: i64,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        flow_result(
+            "keyTtl",
+            self.store.set_key_ttl(&flow_id, &key, ttl_seconds),
+        )
+        .map_err(Into::into)
+    }
+
+    /// Remove every key in a flow (issue #530). Returns `true`. Always fail-loud.
+    pub fn clear(
+        &mut self,
+        flow_id: String,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        flow_result("clear", self.store.clear_flow(&flow_id).map(|()| true)).map_err(Into::into)
+    }
 }
 
 #[cfg(test)]
@@ -606,6 +629,12 @@ mod tests {
             Err(anyhow!("boom"))
         }
         fn set_ttl(&self, _: &str, _: i64) -> Result<()> {
+            Err(anyhow!("boom"))
+        }
+        fn set_key_ttl(&self, _: &str, _: &str, _: i64) -> Result<bool> {
+            Err(anyhow!("boom"))
+        }
+        fn clear_flow(&self, _: &str) -> Result<()> {
             Err(anyhow!("boom"))
         }
     }
@@ -657,6 +686,19 @@ mod tests {
             "set_ttl must raise on a backend failure"
         );
         assert!(take_last_flow_error().is_some_and(|e| e.contains("setTtl")));
+
+        // Issue #530: the per-key ttl and clear ops are fail-loud too.
+        assert!(
+            s.key_ttl("f".into(), "k".into(), 60).is_err(),
+            "key_ttl must raise on a backend failure"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("keyTtl")));
+
+        assert!(
+            s.clear("f".into()).is_err(),
+            "clear must raise on a backend failure"
+        );
+        assert!(take_last_flow_error().is_some_and(|e| e.contains("clear")));
     }
 
     // AC2 (issue #322): the Rhai flow_store.last_error() accessor surfaces the last recorded

--- a/crates/rift-mock-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-mock-core/src/scripting/rhai_engine.rs
@@ -52,7 +52,9 @@ fn is_leap_year(year: u64) -> bool {
 /// - `ctx.state.get_or(key, default)` - Get a value, or `default` if absent
 /// - `ctx.state.incr_by(key, by)` - Atomic increment by `by`, starting at 0 when absent
 /// - `ctx.state.cas(key, expected, new)` - Atomic compare-and-set
-/// - `ctx.state.ttl(seconds)` - Set flow expiration
+/// - `ctx.state.ttl(seconds)` - Set flow expiration (re-stamps every current key)
+/// - `ctx.state.ttl(key, seconds)` - Set a single key's TTL (returns bool; `seconds <= 0` deletes)
+/// - `ctx.state.clear()` - Remove every key in the flow
 ///
 /// `ctx.store.flow(flow_id)` returns the same handle scoped to an arbitrary (not necessarily the
 /// request's own) flow id.
@@ -253,7 +255,9 @@ fn register_v2_api(engine: &mut Engine) {
         .register_fn("get_or", RhaiStateHandle::get_or)
         .register_fn("incr_by", RhaiStateHandle::incr_by)
         .register_fn("cas", RhaiStateHandle::cas)
-        .register_fn("ttl", RhaiStateHandle::ttl);
+        .register_fn("ttl", RhaiStateHandle::ttl)
+        .register_fn("ttl", RhaiStateHandle::ttl_key)
+        .register_fn("clear", RhaiStateHandle::clear);
 
     engine
         .register_type::<RhaiStoreHandle>()
@@ -394,6 +398,22 @@ impl RhaiStateHandle {
     /// Per-flow TTL override in seconds (issue #358). Always fail-loud.
     pub fn ttl(&mut self, seconds: i64) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
         self.inner.ttl(self.flow_id.clone(), seconds)
+    }
+
+    /// Per-key TTL override (issue #530): `ttl(key, seconds)`. Returns `true` if the key existed,
+    /// `false` if absent; `seconds <= 0` deletes it. Registered as an overload of `ttl` — Rhai
+    /// dispatches `ttl(number)` to the flow-level form and `ttl(string, number)` here. Fail-loud.
+    pub fn ttl_key(
+        &mut self,
+        key: String,
+        seconds: i64,
+    ) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.key_ttl(self.flow_id.clone(), key, seconds)
+    }
+
+    /// Remove every key in this flow (issue #530): `clear()`. Returns `true`. Always fail-loud.
+    pub fn clear(&mut self) -> std::result::Result<bool, Box<rhai::EvalAltResult>> {
+        self.inner.clear(self.flow_id.clone())
     }
 }
 
@@ -1117,6 +1137,95 @@ mod tests {
         fn run_respond(script: &str, request: &ScriptRequest) -> Result<FaultDecision> {
             let engine = RhaiEngine::new(script, "v2-rule").unwrap();
             engine.should_inject_fault(request, store())
+        }
+
+        /// Run a `respond` script that returns `http(200, ...)` and yield the JSON body string.
+        fn run_body(script: &str) -> String {
+            match run_respond(script, &req(HashMap::new(), None)).unwrap() {
+                FaultDecision::Error { body, .. } => body,
+                other => panic!("expected Error(200) carrier, got {other:?}"),
+            }
+        }
+
+        // --- ctx.state.ttl(key, seconds) + clear() (issue #530) ---
+
+        // Regression for the original #530 report: `ttl("k", 1)` used to throw a TypeError because
+        // only the one-arg flow-level overload existed. It now resolves the per-key overload and
+        // returns true for an existing key.
+        #[test]
+        fn per_key_ttl_no_longer_type_errors_and_returns_true() {
+            let body = run_body(
+                r#"fn respond(ctx) {
+                    ctx.state.set("k", "v");
+                    http(200, #{ ok: ctx.state.ttl("k", 100) })
+                }"#,
+            );
+            assert!(
+                body.contains("true"),
+                "per-key ttl on existing key -> true, got {body}"
+            );
+        }
+
+        #[test]
+        fn per_key_ttl_absent_key_returns_false() {
+            let body =
+                run_body(r#"fn respond(ctx) { http(200, #{ ok: ctx.state.ttl("absent", 60) }) }"#);
+            assert!(
+                body.contains("false"),
+                "per-key ttl on absent key -> false, got {body}"
+            );
+        }
+
+        #[test]
+        fn per_key_ttl_zero_deletes_the_key() {
+            let body = run_body(
+                r#"fn respond(ctx) {
+                    ctx.state.set("k", "v");
+                    ctx.state.ttl("k", 0);
+                    http(200, #{ present: ctx.state.exists("k") })
+                }"#,
+            );
+            assert!(
+                body.contains("false"),
+                "ttl(key, 0) deletes the key, got {body}"
+            );
+        }
+
+        // The one-arg flow-level overload still dispatches (arity/type overloading).
+        #[test]
+        fn flow_level_ttl_still_dispatches() {
+            let body = run_body(r#"fn respond(ctx) { http(200, #{ ok: ctx.state.ttl(60) }) }"#);
+            assert!(
+                body.contains("true"),
+                "flow-level ttl(seconds) still works, got {body}"
+            );
+        }
+
+        #[test]
+        fn clear_empties_the_flow() {
+            let body = run_body(
+                r#"fn respond(ctx) {
+                    ctx.state.set("a", 1);
+                    ctx.state.set("b", 2);
+                    ctx.state.clear();
+                    http(200, #{ a: ctx.state.exists("a"), b: ctx.state.exists("b") })
+                }"#,
+            );
+            assert!(
+                !body.contains("true"),
+                "clear() removes every key, got {body}"
+            );
+        }
+
+        // A `ttl` call matching neither overload (e.g. a bool arg) must raise, not silently pass —
+        // parity with the JS engine's bad-arg guard.
+        #[test]
+        fn ttl_bad_arg_raises() {
+            let result = run_respond(
+                r#"fn respond(ctx) { http(200, #{ v: ctx.state.ttl(true) }) }"#,
+                &req(HashMap::new(), None),
+            );
+            assert!(result.is_err(), "ttl(<bool>) must raise, got {result:?}");
         }
 
         // --- ctx.request ---

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -30,7 +30,7 @@ is resolved exactly as for [Spaces]({{ site.baseurl }}/features/spaces/).
 | Field | Default | Notes |
 |:------|:--------|:------|
 | `backend` | `inmemory` | `inmemory` or `redis`. |
-| `ttlSeconds` | `300` | Default entry TTL. |
+| `ttlSeconds` | `300` | Default entry TTL, in seconds. Must be `>= 1` (see [TTL semantics](#ttl-semantics)). |
 | `flowIdSource` | `imposter_port` | How the flow id is derived (`imposter_port` or `header:<Name>`). |
 
 With `backend: "redis"` you may also set `url`, `poolSize` (default 10), and `keyPrefix`
@@ -45,6 +45,9 @@ An explicit `flowState` block that can't be honored now **fails imposter creatio
   construction.
 - A **`redis` backend that can't be created** — no redis config block, a connection/pool failure, or
   a binary built without the `redis-backend` feature — fails creation too.
+- A **non-positive `ttlSeconds`** (`< 1`) is rejected: a zero/negative default TTL would expire every
+  write the instant it lands (and errors on the first Redis `SETEX`), so it's caught up front rather
+  than misbehaving later.
 
 Only imposters with genuinely **no state surface** stay on the silent no-op store: no `flowState`
 block, no scenario stubs, and no `_rift.script` stub. Such an imposter never touches the store, so
@@ -77,12 +80,33 @@ for the full surface:
 | `ctx.state.delete(key)` | remove a key |
 | `ctx.state.incr(key)` / `incr_by(key, n)` | atomic increment, returns the new number |
 | `ctx.state.cas(key, expected, new)` | atomic compare-and-set — `{ applied: … }` |
-| `ctx.state.ttl(seconds)` | override the TTL for this flow |
+| `ctx.state.ttl(seconds)` | re-stamp the TTL of **every** key currently in this flow |
+| `ctx.state.ttl(key, seconds)` | set **one** key's TTL — `true` if it existed, `false` if absent; `seconds <= 0` deletes it |
+| `ctx.state.clear()` | remove **every** key in this flow |
 | `ctx.store.flow(id)` | a handle scoped to a **different** flow id (cross-flow access) |
 
 Every `ctx.state` call is **fail-loud**: a backend error (e.g. Redis dropping mid-request) raises a
 script error and is logged — it is never silently swallowed into a default. In JavaScript the
-method names are camelCase (`getOr`/`incrBy`); `cas`/`ttl` are spelled the same in both engines.
+method names are camelCase (`getOr`/`incrBy`); `cas`/`ttl`/`clear` are spelled the same in both
+engines.
+
+### TTL semantics
+
+TTL is a **per-key** attribute, and every backend applies the same rules:
+
+- **Every write stamps the default TTL.** A `set`/`incr`/`incr_by`/applied-`cas` (re)stamps the key's
+  expiry to `now + ttlSeconds`.
+- **Writes reset the TTL.** `ttl(key, s)` overrides a key's expiry, but a *subsequent* write to that
+  key re-stamps it back to the default `ttlSeconds` — TTLs are set by the last write (this is exactly
+  what Redis `SETEX` does; there is no sticky/`KEEPTTL` mode).
+- **`seconds <= 0` expires immediately.** `ttl(key, 0)` (or negative) deletes the key now; flow-level
+  `ttl(0)` expires every current key in the flow. This mirrors Redis `EXPIRE`, giving scripts both
+  "shrink the lifetime" (`ttl(key, 5)`) and "kill now" (`ttl(key, 0)`) with one primitive.
+- **Flow-level `ttl(seconds)` is a convenience** over the per-key primitive: it re-stamps every key
+  *currently* in the flow. On Redis it does an O(keys-in-flow) `SCAN` + `EXPIRE`; on both backends the
+  observable result is identical.
+- There is deliberately **no "no expiry" mode** — an unexpirable store is a memory leak by
+  construction — so `ttlSeconds` is mandatory and must be `>= 1`.
 
 ---
 
@@ -135,6 +159,10 @@ curl -X PUT http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts \
 
 # Delete a key
 curl -X DELETE http://localhost:2525/admin/imposters/4506/flow-state/t1/attempts
+
+# Clear an entire flow (all keys) — the test-arrange/teardown tool for resetting a flow
+# between scenario runs. Idempotent: clearing an absent/empty flow still returns 200.
+curl -X DELETE http://localhost:2525/admin/imposters/4506/flow-state/t1
 ```
 
 Note: an imposter gets a real store when `_rift.flowState` is configured, or it declares scenario

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -174,8 +174,14 @@ if ctx.state.exists("key") {
 // Delete value
 ctx.state.delete("key");
 
-// Set TTL for the flow (seconds)
+// Set TTL for every key in the flow (seconds)
 ctx.state.ttl(300);
+
+// Set one key's TTL — returns true if it existed, false if absent; <= 0 deletes it
+ctx.state.ttl("counter", 60);
+
+// Remove every key in the flow
+ctx.state.clear();
 ```
 
 ### Return Values
@@ -408,7 +414,9 @@ Atomic ops and ergonomic getters:
 let n = ctx.state.get_or("attempts", 0);   // value, or the default if absent — kills
                                             // the `if v == () { v = 0; }` idiom
 let n = ctx.state.incr_by("attempts", 5);  // atomic +5, starts at 0 when absent
-ctx.state.ttl(60);                         // per-flow TTL override, in seconds
+ctx.state.ttl(60);                         // re-stamp every key in the flow (seconds)
+ctx.state.ttl("attempts", 60);             // set one key's TTL (bool); <= 0 deletes it
+ctx.state.clear();                         // remove every key in the flow
 
 let outcome = ctx.state.cas("status", "pending", "paid");
 if outcome.applied {


### PR DESCRIPTION
Adds per-key `ctx.state.ttl(key, seconds)` (rhai + JS; returns whether the key existed, `<= 0` deletes it), fixes the Redis flow-level `ctx.state.ttl(seconds)` silent no-op (now SCAN + EXPIRE, with the flow_id glob-escaped so it can't match sibling flows), and adds whole-flow invalidation via `ctx.state.clear()` and `DELETE /admin/imposters/:port/flow-state/:flow_id`. Rejects `ttlSeconds < 1` at imposter creation (400). Docs + CHANGELOG updated.

Closes #530

Milestone: none (standalone agent-found issue; base master)