### PR TITLE
chore(release): prepare 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ record.
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-11
+
 ### Added
 
 - **Per-key flow-state TTL and flow invalidation** (`ctx.state`): scripts can now set a single key's
@@ -382,7 +384,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/EtaCassiopeia/rift/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/EtaCassiopeia/rift/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/EtaCassiopeia/rift/compare/v0.11.3...v0.12.0


### PR DESCRIPTION
Release-prep for **0.13.2**: rolls the Unreleased CHANGELOG entries into a dated `[0.13.2]` section and updates the compare links.

Shipping in 0.13.2:
- Per-key flow-state TTL + Redis flow-level TTL fix + flow invalidation (#535)
- Probabilistic TCP faults (#533)
- `--datadir` malformed-file surfacing fix (#534)

Merging this, then pushing the `v0.13.2` tag, triggers the release workflow (which bumps the workspace/internal versions from the tag and publishes).