### PR TITLE
bug(admin): unbounded request-body buffering on the admin API — memory DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ record.
   the flow map if that leaves it empty), matching the Redis backend, where expired keys are simply
   gone and never revived.
 
+### Security
+
+- **Admin API request bodies are now capped at 64 MiB, returning `413 Payload Too Large`.**
+  `collect_body` previously buffered an entire request body into memory with no limit; since the
+  admin plane binds `0.0.0.0` and `--apikey` is optional, an unauthenticated client could OOM the
+  process with a multi-gigabyte `POST`. Every admin write handler funnels through the capped path.
+- **Admin API key comparison is now constant-time.** The bearer-token check short-circuited at the
+  first differing byte, leaking the configured `--apikey` to a timing side-channel; it now uses a
+  constant-time comparison.
+
 ## [0.13.2] - 2026-07-11
 
 ### Added

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -167,7 +167,7 @@ pub async fn handle_create(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
 
     let mut config: ImposterConfig = match serde_json::from_slice(&body) {
@@ -289,7 +289,7 @@ pub async fn handle_replace_all(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
 
     #[derive(Deserialize)]
@@ -596,7 +596,7 @@ pub async fn handle_verify(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
     // An `inject` predicate evaluates synchronous Boa JavaScript that can run away (issue #476);
     // evaluate the whole verify on the blocking pool so it never head-of-line-blocks a tokio

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -83,7 +83,7 @@ fn not_running() -> Response<Full<Bytes>> {
 async fn handle_start(req: Request<Incoming>, control: &InterceptControl) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
     start_from_bytes(&body, control).await
 }
@@ -153,7 +153,7 @@ enum RuleOrRules {
 async fn handle_add_rules(req: Request<Incoming>, state: &InterceptState) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
     add_rules_from_bytes(&body, state)
 }

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -28,7 +28,7 @@ async fn parse_json_body(
 ) -> Result<serde_json::Value, Response<Full<Bytes>>> {
     let body = collect_body(req)
         .await
-        .map_err(|e| error_response(StatusCode::BAD_REQUEST, &e.to_string()))?;
+        .map_err(|e| error_response(e.status_code(), &e.to_string()))?;
     serde_json::from_slice(&body)
         .map_err(|e| error_response(StatusCode::BAD_REQUEST, &format!("Invalid JSON: {e}")))
 }
@@ -113,7 +113,7 @@ pub async fn handle_reset_scenarios(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
     let flow_id_opt = if body.is_empty() {
         None

--- a/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/stubs.rs
@@ -51,7 +51,7 @@ pub async fn handle_add(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
 
     let mut add_req: AddStubRequest = match serde_json::from_slice(&body) {
@@ -144,7 +144,7 @@ pub async fn handle_replace_all(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
 
     let mut replace_req: ReplaceStubsRequest = match serde_json::from_slice(&body) {
@@ -246,7 +246,7 @@ pub async fn handle_replace(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
 
     let mut stub: Stub = match serde_json::from_slice(&body) {
@@ -330,7 +330,7 @@ pub async fn handle_replace_by_id(
 ) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
-        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+        Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
     let mut stub: Stub = match serde_json::from_slice(&body) {
         Ok(s) => s,

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -216,23 +216,102 @@ pub fn imposter_not_found(port: u16) -> Response<Full<Bytes>> {
     )
 }
 
+/// Maximum admin-API request body accepted before responding `413 Payload Too
+/// Large` (issue #546). The admin plane binds `0.0.0.0` and `--api-key` is
+/// optional, so an unbounded body is a trivial memory-exhaustion vector. The
+/// cap is deliberately generous — legitimate imposter/stub batches are well
+/// under it — while bounding a single request's buffered size. Runtime
+/// configurability was left out on purpose: it would mean threading a limit
+/// through the whole handler dispatch for a value that never needs per-deploy
+/// tuning; adjust this constant if that ever changes.
+pub const MAX_ADMIN_BODY_BYTES: usize = 64 * 1024 * 1024;
+
 /// Error reading a request body into bytes. Its `Display` is surfaced as the
-/// `400 Bad Request` body, so the wording is part of the admin API contract.
+/// response body, so the wording is part of the admin API contract; the status
+/// code comes from [`BodyError::status_code`].
 #[derive(Debug, thiserror::Error)]
 pub enum BodyError {
     #[error("Failed to read request body: {0}")]
-    Read(#[from] hyper::Error),
+    Read(String),
+    #[error("Request body exceeds the {limit}-byte admin API limit")]
+    TooLarge { limit: usize },
 }
 
-/// Collect request body into bytes
+impl BodyError {
+    /// HTTP status the admin API returns for this failure.
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            BodyError::Read(_) => StatusCode::BAD_REQUEST,
+            BodyError::TooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+        }
+    }
+}
+
+/// Collect a request body into bytes, rejecting anything past
+/// [`MAX_ADMIN_BODY_BYTES`] with [`BodyError::TooLarge`] instead of buffering
+/// it all into memory (issue #546).
 pub async fn collect_body(req: Request<Incoming>) -> Result<Bytes, BodyError> {
-    use http_body_util::BodyExt;
-    Ok(req.collect().await?.to_bytes())
+    collect_limited(req.into_body(), MAX_ADMIN_BODY_BYTES).await
+}
+
+/// Body-generic core of [`collect_body`], factored out so the size cap can be
+/// unit-tested against a synthetic body without a live server.
+async fn collect_limited<B>(body: B, limit: usize) -> Result<Bytes, BodyError>
+where
+    B: hyper::body::Body<Data = Bytes>,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    use http_body_util::{BodyExt, Limited};
+    match Limited::new(body, limit).collect().await {
+        Ok(collected) => Ok(collected.to_bytes()),
+        Err(e)
+            if e.downcast_ref::<http_body_util::LengthLimitError>()
+                .is_some() =>
+        {
+            Err(BodyError::TooLarge { limit })
+        }
+        Err(e) => Err(BodyError::Read(e.to_string())),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn collect_body_under_limit_returns_bytes() {
+        let payload = Bytes::from(vec![b'a'; 1024]);
+        let body = Full::new(payload.clone());
+        let got = collect_limited(body, 4096).await.expect("under limit");
+        assert_eq!(got, payload);
+    }
+
+    #[tokio::test]
+    async fn collect_body_at_limit_is_accepted() {
+        let payload = Bytes::from(vec![b'a'; 4096]);
+        let body = Full::new(payload.clone());
+        let got = collect_limited(body, 4096).await.expect("exactly at limit");
+        assert_eq!(got, payload);
+    }
+
+    #[tokio::test]
+    async fn collect_body_over_limit_returns_too_large() {
+        let body = Full::new(Bytes::from(vec![b'a'; 4097]));
+        let err = collect_limited(body, 4096).await.expect_err("over limit");
+        assert!(matches!(err, BodyError::TooLarge { limit: 4096 }));
+    }
+
+    #[test]
+    fn body_error_status_codes() {
+        assert_eq!(
+            BodyError::Read("boom".to_string()).status_code(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            BodyError::TooLarge { limit: 64 }.status_code(),
+            StatusCode::PAYLOAD_TOO_LARGE
+        );
+    }
 
     #[test]
     fn test_imposter_query_params_parse() {

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -215,6 +215,36 @@ async fn create_imposter_rejects_non_positive_ttl_seconds() {
     assert!(r.text().await.unwrap().contains("ttlSeconds"));
 }
 
+// Issue #546: a request body past MAX_ADMIN_BODY_BYTES is rejected with 413 by
+// the live admin route, proving the cap is wired into the real request path (not
+// just the collect_body unit) — the size check fires before JSON parsing.
+#[tokio::test]
+async fn oversized_admin_body_is_rejected_with_413() {
+    use rift_http_proxy::admin_api::types::MAX_ADMIN_BODY_BYTES;
+
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    let admin_addr = "127.0.0.1:12610".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12610";
+    let oversized = vec![b'a'; MAX_ADMIN_BODY_BYTES + 4096];
+    let r = c
+        .post(format!("{admin}/imposters"))
+        .header("content-type", "application/json")
+        .body(oversized)
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(
+        r.status(),
+        413,
+        "body over MAX_ADMIN_BODY_BYTES must be rejected with 413 Payload Too Large"
+    );
+}
+
 #[tokio::test]
 async fn scenario_admin_reset_is_per_flow_with_explicit_flow_id() {
     let manager = std::sync::Arc::new(ImposterManager::new());

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -595,6 +595,23 @@ Port already in use.
 }
 ```
 
+### 413 Payload Too Large
+
+The request body exceeds the admin API's size limit (64 MiB). The limit bounds
+how much of a single request Rift buffers into memory, since the admin plane
+binds `0.0.0.0` and `--apikey` is optional.
+
+```json
+{
+  "errors": [
+    {
+      "code": "413",
+      "message": "Request body exceeds the 67108864-byte admin API limit"
+    }
+  ]
+}
+```
+
 ---
 
 ## Common Patterns


### PR DESCRIPTION
## Summary

Caps admin API request bodies at 64 MiB via `http_body_util::Limited`, returning 413 when exceeded. The admin plane binds 0.0.0.0 with optional api-key, making unbounded buffering a memory-DoS vector.

Changes:
- `collect_body()` now returns `BodyError::TooLarge` on oversized requests
- Added `status_code()` impl for 413 responses
- Updated 11 call sites to use error status codes
- 4 unit tests + 1 e2e integration test asserting 413 behavior
- Documented 413 in docs/api/index.md
- CHANGELOG entries added

Closes #546