### PR TITLE
fix(tui): byte-index string slicing panics on multibyte UTF-8, tearing down the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ record.
 
 ### Fixed
 
+- **The TUI no longer panics on imposter names or paths containing multibyte UTF-8.** Several
+  truncation sites guarded on byte length but sliced at a byte index, so a name/scenario/recorded
+  path with multibyte characters (e.g. `日本語サービス` from imported JSON or proxy recordings)
+  panicked with "byte index is not a char boundary" inside the render loop, tearing down the
+  terminal (often leaving it in raw mode). Truncation is now char-based via a single shared helper.
 - **`rift lint` no longer executes JavaScript while syntax-checking it.** The `javascript`-feature
   validator ran scripts via the JS engine, so an inject/decorate body containing a loop (e.g.
   `while (true) {}`) hung the linter, and any engine error whose message lacked `SyntaxError`/

--- a/crates/rift-tui/src/ui/imposter_detail.rs
+++ b/crates/rift-tui/src/ui/imposter_detail.rs
@@ -1,5 +1,6 @@
 //! Imposter detail view
 
+use super::truncate;
 use crate::app::{App, FocusArea};
 use ratatui::{
     Frame,
@@ -155,11 +156,7 @@ fn build_stub_summary(stubs: &[crate::api::Stub], max_width: usize) -> String {
         }
     }
 
-    if summary.len() > max_width {
-        format!("{}…", &summary[..max_width.saturating_sub(1)])
-    } else {
-        summary
-    }
+    truncate(&summary, max_width)
 }
 
 /// Draw the stubs panel
@@ -211,11 +208,7 @@ fn draw_stubs_panel(frame: &mut Frame, app: &App, area: Rect) {
 
             // Truncate stub name to fit panel width
             let max_name_len = area.width.saturating_sub(15) as usize;
-            let display_name = if stub_name.len() > max_name_len {
-                format!("{}…", &stub_name[..max_name_len.saturating_sub(1)])
-            } else {
-                stub_name
-            };
+            let display_name = truncate(&stub_name, max_name_len);
 
             let fg_color = if dim { app.theme.muted } else { app.theme.fg };
 
@@ -572,14 +565,5 @@ fn method_color(method: &str, app: &App) -> ratatui::style::Color {
         "PUT" | "PATCH" => ratatui::style::Color::Cyan,
         "DELETE" => app.theme.error,
         _ => app.theme.fg,
-    }
-}
-
-/// Truncate string with ellipsis
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max - 1])
     }
 }

--- a/crates/rift-tui/src/ui/imposters.rs
+++ b/crates/rift-tui/src/ui/imposters.rs
@@ -1,5 +1,6 @@
 //! Imposter list view
 
+use super::truncate;
 use crate::app::App;
 use ratatui::{
     Frame,
@@ -121,14 +122,5 @@ pub fn draw_list(frame: &mut Frame, app: &App, area: Rect) {
         };
 
         frame.render_widget(paragraph, centered);
-    }
-}
-
-/// Truncate a string to max length with ellipsis
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max - 1])
     }
 }

--- a/crates/rift-tui/src/ui/mod.rs
+++ b/crates/rift-tui/src/ui/mod.rs
@@ -367,11 +367,58 @@ pub fn format_uptime(duration: std::time::Duration) -> String {
     }
 }
 
+/// Truncate a string to at most `max` characters, appending an ellipsis when
+/// shortened. Operates on chars, not bytes, so it never slices mid-codepoint.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app::tests::{make_imposter, make_test_app};
     use ratatui::{Terminal, backend::TestBackend};
+
+    // ─── truncate ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_multibyte_no_panic() {
+        // Multibyte codepoints (from imported JSON / proxy recordings) must never
+        // land mid-codepoint and panic — regression for #542.
+        let s = "日本語サービス";
+        for max in 0..=s.chars().count() + 2 {
+            let out = truncate(s, max);
+            assert!(out.chars().count() <= max.max(1));
+        }
+    }
+
+    #[test]
+    fn truncate_char_count() {
+        // Shortened result is at most `max` chars, ending in the ellipsis.
+        let out = truncate("日本語サービス", 4);
+        assert_eq!(out, "日本語…");
+        assert_eq!(out.chars().count(), 4);
+    }
+
+    #[test]
+    fn truncate_ascii() {
+        assert_eq!(truncate("hello", 10), "hello"); // fits → unchanged
+        assert_eq!(truncate("hello", 5), "hello"); // exact → unchanged
+        assert_eq!(truncate("hello world", 5), "hell…"); // long → keep 4 + …
+    }
+
+    #[test]
+    fn truncate_edges() {
+        assert_eq!(truncate("", 0), ""); // empty passthrough
+        assert_eq!(truncate("abc", 0), "…"); // max 0 → no underflow
+        assert_eq!(truncate("abc", 1), "…"); // max 1 → just ellipsis
+    }
 
     // ─── format_number ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Truncation in the TUI guarded on byte length but sliced at a byte index, causing panics when imposter names or paths contained multibyte UTF-8 characters (e.g., Japanese characters from imported JSON or proxy recordings). The panic tore down the terminal, often leaving it in raw mode. 

Truncation now operates on chars, not bytes, via a single shared helper function to prevent mid-codepoint slices.

Closes #542