### PR TITLE
bug(imposter): create-path persistence is fire-and-forget — a datadir write failure silently loses the imposter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ record.
   path with multibyte characters (e.g. `日本語サービス` from imported JSON or proxy recordings)
   panicked with "byte index is not a char boundary" inside the render loop, tearing down the
   terminal (often leaving it in raw mode). Truncation is now char-based via a single shared helper.
+- **Creating an imposter no longer silently succeeds when it can't be persisted to `--datadir`.** The
+  create path wrote the config in a fire-and-forget task that only logged failures, so a datadir
+  write error returned `201 Created` to the caller and the imposter then vanished on restart. Create
+  now persists synchronously and, on failure, rolls back the in-memory imposter and returns a
+  `503` (`ImposterError::PersistError`) — matching the durability contract already used by stub
+  mutations (#173).
 - **`rift lint` no longer executes JavaScript while syntax-checking it.** The `javascript`-feature
   validator ran scripts via the JS engine, so an inject/decorate body containing a loop (e.g.
   `while (true) {}`) hung the linter, and any engine error whose message lacked `SyntaxError`/

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -468,7 +468,18 @@ impl ImposterManager {
             imposters.insert(port, Arc::clone(&imposter));
         }
 
-        self.persist_imposter(&imposter);
+        // Persist synchronously and surface the result: a create that can't be durably recorded
+        // must fail loudly rather than return a success that vanishes on restart (issue #563).
+        // On failure roll back the insert and stop the listener so `Err` keeps meaning "not
+        // running" for every caller (create_for_apply / replace_imposter rely on that).
+        if let Err(e) = self.persist_imposter_checked(&imposter).await {
+            self.imposters.write().remove(&port);
+            // A write that failed partway (e.g. ENOSPC) can leave a truncated {port}.json; drop it
+            // so a later restart doesn't try to load a corrupt file for a create that never took.
+            self.remove_persisted_imposter(port);
+            let _ = shutdown_tx.send(());
+            return Err(e);
+        }
 
         Ok(port)
     }
@@ -923,35 +934,6 @@ impl ImposterManager {
         })
     }
 
-    /// Persist an imposter's current config to datadir (if configured).
-    /// Fire-and-forget: write failures are logged but not propagated.
-    /// Used by create_imposter where the imposter is already running and
-    /// a persistence failure should not roll back the in-memory state.
-    fn persist_imposter(&self, imposter: &Imposter) {
-        let Some(ref datadir) = self.datadir else {
-            return;
-        };
-        let Some(port) = imposter.config.port else {
-            return;
-        };
-        let mut snapshot = imposter.config.clone();
-        snapshot.stubs = imposter.get_stubs();
-        let path = datadir.join(format!("{port}.json"));
-        tokio::spawn(async move {
-            match serde_json::to_string_pretty(&snapshot) {
-                Ok(json) => {
-                    if let Err(e) = tokio::fs::write(&path, json).await {
-                        error!("Failed to persist imposter {} to {:?}: {}", port, path, e);
-                    }
-                }
-                Err(e) => error!(
-                    "Failed to serialize imposter {} for persistence: {}",
-                    port, e
-                ),
-            }
-        });
-    }
-
     /// Remove an imposter's file from datadir (if configured).
     fn remove_persisted_imposter(&self, port: u16) {
         let Some(ref datadir) = self.datadir else {
@@ -1104,13 +1086,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_stub_returns_persist_error_on_write_failure() {
-        // Point the datadir at a path that cannot be written (a file, not a dir).
-        // The write will fail, and add_stub must propagate ImposterError::PersistError.
+        // Create must succeed first (issue #563 made create persist synchronously), so use a
+        // writable datadir, then remove it so the *subsequent* add_stub write fails and must
+        // propagate ImposterError::PersistError.
         let fake_dir = tempfile::tempdir().expect("tempdir");
-        // Use a datadir sub-path that was never created, so fs::write fails.
-        let nonexistent_datadir = fake_dir.path().join("does_not_exist_subdir");
+        let datadir = fake_dir.path().join("datadir");
+        std::fs::create_dir(&datadir).expect("mk datadir");
 
-        let manager = ImposterManager::with_datadir(Some(nonexistent_datadir));
+        let manager = ImposterManager::with_datadir(Some(datadir.clone()));
         let config: ImposterConfig = serde_json::from_value(serde_json::json!({
             "protocol": "http",
             "port": 19600,
@@ -1121,7 +1104,9 @@ mod tests {
         manager
             .create_imposter(config)
             .await
-            .expect("create should succeed in memory");
+            .expect("create should succeed with a writable datadir");
+
+        std::fs::remove_dir_all(&datadir).expect("break the datadir");
 
         let stub: Stub = serde_json::from_value(serde_json::json!({
             "predicates": [],
@@ -1136,6 +1121,55 @@ mod tests {
         );
 
         manager.delete_imposter(19600).await.unwrap();
+    }
+
+    // Issue #563: create-time persistence must surface as an error and roll back the imposter,
+    // not silently succeed and vanish on restart (the fire-and-forget bug).
+    #[tokio::test]
+    async fn create_returns_persist_error_on_unwritable_datadir() {
+        let fake_dir = tempfile::tempdir().expect("tempdir");
+        let nonexistent_datadir = fake_dir.path().join("does_not_exist_subdir");
+        let manager = ImposterManager::with_datadir(Some(nonexistent_datadir));
+
+        let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "port": 19611,
+            "stubs": []
+        }))
+        .unwrap();
+
+        let result = manager.create_imposter(config).await;
+        assert!(
+            matches!(result, Err(ImposterError::PersistError(_))),
+            "create must surface PersistError when the datadir is not writable, got: {result:?}"
+        );
+        // Rolled back: the imposter must not linger in the map, and its port must be free again.
+        assert!(
+            manager.get_imposter(19611).is_err(),
+            "a create that failed to persist must not leave a running imposter"
+        );
+        assert_eq!(manager.count(), 0, "the failed create must be rolled back");
+    }
+
+    #[tokio::test]
+    async fn create_persists_file_synchronously() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = ImposterManager::with_datadir(Some(dir.path().to_path_buf()));
+        let config: ImposterConfig = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "port": 19612,
+            "stubs": []
+        }))
+        .unwrap();
+
+        manager.create_imposter(config).await.expect("create");
+        // No sleep: create now awaits the persist, so the file exists the moment create returns.
+        assert!(
+            dir.path().join("19612.json").exists(),
+            "create must have written the imposter file before returning"
+        );
+
+        manager.delete_imposter(19612).await.unwrap();
     }
 
     // =========================================================================
@@ -1585,6 +1619,33 @@ mod tests {
         manager.delete_all().await;
     }
 
+    // A create-time persist failure during apply_config lands in `failed` with no phantom entry in
+    // `created` — the create rollback (issue #563) keeps create_for_apply honest under the new
+    // synchronous-persist contract.
+    #[tokio::test]
+    async fn apply_config_create_persist_failure_reports_failed_not_created() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let datadir = dir.path().join("datadir");
+        std::fs::create_dir(&datadir).expect("mk datadir");
+        let manager = ImposterManager::with_datadir(Some(datadir.clone()));
+        std::fs::remove_dir_all(&datadir).expect("break the datadir");
+
+        let cfg = imposter_cfg(json!({"protocol": "http", "port": 19454, "stubs": []}));
+        let report = manager.apply_config(vec![cfg]).await.expect("apply");
+        assert!(
+            report.created.is_empty(),
+            "a create that failed to persist must not appear as created: {:?}",
+            report.created
+        );
+        assert!(
+            matches!(report.failed[0], (19454, ImposterError::PersistError(_))),
+            "got: {:?}",
+            report.failed
+        );
+        assert!(manager.get_imposter(19454).is_err(), "must be rolled back");
+        assert_eq!(manager.count(), 0);
+    }
+
     // A replace whose recreate fails after teardown is honestly reported: the port lands in
     // both `deleted` and `failed`, and a Deleted event fires so listeners don't track a
     // phantom imposter.
@@ -1642,14 +1703,19 @@ mod tests {
     #[tokio::test]
     async fn apply_config_patch_persist_failure_lands_in_failed() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let manager = ImposterManager::with_datadir(Some(dir.path().join("does_not_exist_subdir")));
+        let datadir = dir.path().join("datadir");
+        std::fs::create_dir(&datadir).expect("mk datadir");
+        let manager = ImposterManager::with_datadir(Some(datadir.clone()));
         manager
             .create_imposter(imposter_cfg(json!({
                 "protocol": "http", "port": 19453,
                 "stubs": [stub_json("a"), stub_json("b"), stub_json("c")]
             })))
             .await
-            .expect("create succeeds in memory");
+            .expect("create succeeds with a writable datadir");
+        // Break the datadir so the apply_config patch's persist fails (issue #173), while the
+        // in-memory patch still stands.
+        std::fs::remove_dir_all(&datadir).expect("break the datadir");
 
         let patched = imposter_cfg(json!({
             "protocol": "http", "port": 19453,


### PR DESCRIPTION
Create used fire-and-forget persistence, so a datadir write failure returned 201 Created and the imposter vanished on restart. Now create awaits persist_imposter_checked, rolls back on failure, and returns 503 (PersistError), matching the durability contract from #173.

Closes #563