### PR TITLE
bug(tui): imposter refresh does N+1 sequential HTTP round-trips and swallows per-imposter errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ record.
   whose body reports what failed and what did apply. (Behavior note: an imposter whose config is
   unchanged now keeps its runtime state — recorded requests, response cycling — instead of being
   torn down and recreated; `DELETE /imposters` first if a full reset is wanted.)
+- **The TUI imposter list refreshes with one request instead of N+1, and no longer mis-renders a
+  transiently-failing imposter as "Disabled / 0 stubs".** Every ~1s refresh listed the imposters and
+  then fetched each one's detail sequentially just to fill in its stub count — 51 serial round-trips
+  per tick with 50 imposters — silently dropping any per-imposter failure. `GET /imposters` now
+  carries `stubCount` per entry (alongside the existing `enabled`), and the TUI renders the list
+  straight from that single response.
 - **Script-pool `queue_depth` / `active_tasks` metrics no longer leak on a timed-out script.** Both
   gauges were incremented per request but only decremented on the success path, so every script that
   hit its execution timeout (the exact case the pool bounds) permanently inflated them — the metrics

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -266,6 +266,7 @@ pub async fn handle_list(
                     port,
                     name: i.config.name.clone(),
                     number_of_requests: i.get_request_count(),
+                    stub_count: i.stub_count(),
                     enabled: i.is_enabled(),
                     links: make_imposter_links(base_url, port),
                 })
@@ -1519,6 +1520,58 @@ mod replace_all_tests {
             "a rejected set must leave the running imposters untouched"
         );
         assert!(manager.get_imposter(19765).is_err());
+        manager.delete_all().await;
+    }
+}
+
+#[cfg(test)]
+mod list_tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    // Issue #558: the default list response carries per-imposter stubCount (and enabled) so
+    // clients like the TUI can render the list from ONE request instead of an N+1 detail loop
+    // whose per-imposter failures were silently dropped.
+    #[tokio::test]
+    async fn list_response_includes_stub_count_and_enabled() {
+        let manager = Arc::new(ImposterManager::new());
+        let config = serde_json::from_value(serde_json::json!({
+            "port": 19770, "protocol": "http",
+            "stubs": [
+                {"predicates": [], "responses": [{"is": {"statusCode": 200}}]},
+                {"predicates": [], "responses": [{"is": {"statusCode": 201}}]}
+            ]
+        }))
+        .expect("config");
+        manager.create_imposter(config).await.expect("create");
+
+        let resp = handle_list(Arc::clone(&manager), None, "http://localhost:2525").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let entry = &json["imposters"][0];
+        assert_eq!(
+            entry["stubCount"], 2,
+            "the list payload must carry the stub count: {entry}"
+        );
+        assert_eq!(entry["enabled"], true);
+
+        // Boundary: a stubless imposter reports 0, not a missing field.
+        let empty = serde_json::from_value(serde_json::json!({
+            "port": 19771, "protocol": "http", "stubs": []
+        }))
+        .expect("config");
+        manager.create_imposter(empty).await.expect("create");
+        let resp = handle_list(Arc::clone(&manager), None, "http://localhost:2525").await;
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let stubless = json["imposters"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|i| i["port"] == 19771)
+            .expect("stubless imposter listed");
+        assert_eq!(stubless["stubCount"], 0);
         manager.delete_all().await;
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -38,6 +38,7 @@ pub struct ImposterSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub number_of_requests: u64,
+    pub stub_count: usize,
     pub enabled: bool,
     #[serde(rename = "_links")]
     pub links: ImposterLinks,

--- a/crates/rift-mock-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-mock-core/src/imposter/core/lifecycle.rs
@@ -126,6 +126,11 @@ impl Imposter {
             .collect()
     }
 
+    /// Number of stubs, without cloning them (list/summary endpoints poll this on a tick).
+    pub fn stub_count(&self) -> usize {
+        self.stubs.load().len()
+    }
+
     /// Get a specific stub by index
     pub fn get_stub(&self, index: usize) -> Option<Stub> {
         let stubs = self.stubs.load();

--- a/crates/rift-tui/src/api.rs
+++ b/crates/rift-tui/src/api.rs
@@ -244,18 +244,11 @@ impl ApiClient {
             return self.handle_error(resp).await;
         }
 
+        // The list payload carries stubCount/enabled directly (issue #558) — no per-imposter
+        // detail fetches, so refresh is one request per tick and a transient per-imposter failure
+        // can no longer be silently rendered as "Disabled / 0 stubs".
         let body: ImpostersResponse = resp.json().await?;
-
-        // Enrich with stub counts by fetching each imposter
-        let mut imposters = body.imposters;
-        for imp in &mut imposters {
-            if let Ok(detail) = self.get_imposter(imp.port).await {
-                imp.stub_count = detail.stubs.len();
-                imp.enabled = detail.enabled;
-            }
-        }
-
-        Ok(imposters)
+        Ok(body.imposters)
     }
 
     /// Get details for a specific imposter
@@ -582,6 +575,18 @@ mod tests {
     fn test_api_client_no_trailing_slash() {
         let client = ApiClient::new("http://localhost:2525");
         assert_eq!(client.base_url(), "http://localhost:2525");
+    }
+
+    #[test]
+    fn imposter_summary_parses_list_payload_fields() {
+        // Issue #558 contract: the list response carries stubCount/enabled, so the list view
+        // renders from one request — these fields must deserialize straight from the payload.
+        let json = r#"{"imposters":[{"port":4545,"protocol":"http","numberOfRequests":7,"stubCount":3,"enabled":true}]}"#;
+        let body: ImpostersResponse = serde_json::from_str(json).unwrap();
+        let imp = &body.imposters[0];
+        assert_eq!(imp.stub_count, 3);
+        assert!(imp.enabled);
+        assert_eq!(imp.number_of_requests, 7);
     }
 
     #[test]

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -67,13 +67,17 @@ List all imposters.
       "port": 4545,
       "protocol": "http",
       "name": "User Service",
-      "numberOfRequests": 42
+      "numberOfRequests": 42,
+      "stubCount": 3,
+      "enabled": true
     },
     {
       "port": 4546,
       "protocol": "https",
       "name": "Payment Service",
-      "numberOfRequests": 15
+      "numberOfRequests": 15,
+      "stubCount": 1,
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

The TUI's imposter list refresh was fetching list details with N+1 sequential HTTP calls per tick just to populate stub counts, and silently dropping any per-imposter failures. This change adds `stubCount` to the list-get payload, allowing the TUI to render counts from a single request. The enrichment loop that did the detail fetches is now deleted entirely.

Closes #558