### PR TITLE
bug(tui): imposter recording indicator always false, never reflects recordRequests state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ record.
 
 ### Fixed
 
+- **`GET /imposters` list summaries now report `recordRequests`.** The abbreviated summary omitted
+  the field entirely, so any client that reads it — including the TUI's per-imposter recording
+  indicator — always saw `false` regardless of the imposter's actual `recordRequests` config. The
+  summary now carries `recordRequests` (from `config.record_requests`), so the indicator reflects
+  the real recording state.
 - **`PUT /imposters` no longer loses imposters on a partial failure.** The handler deleted every
   running imposter and then recreated the payload's set, merely logging any create failure — so a
   single bad imposter (or a transiently-held port) returned `200` with a silently smaller set, the

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -267,6 +267,7 @@ pub async fn handle_list(
                     name: i.config.name.clone(),
                     number_of_requests: i.get_request_count(),
                     enabled: i.is_enabled(),
+                    record_requests: i.config.record_requests,
                     links: make_imposter_links(base_url, port),
                 })
             })
@@ -1363,6 +1364,55 @@ mod verify_tests {
         let m = Arc::new(ImposterManager::new());
         let resp = verify_response(19755, br#"{"predicates":[]}"#, &m, false);
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}
+
+#[cfg(test)]
+mod list_summary_tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    async fn manager_with(port: u16, record_requests: bool) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new());
+        let cfg = serde_json::json!({
+            "port": port, "protocol": "http", "recordRequests": record_requests, "stubs": []
+        });
+        let config = serde_json::from_value(cfg).expect("config");
+        manager.create_imposter(config).await.expect("create");
+        manager
+    }
+
+    async fn summaries(resp: Response<Full<Bytes>>) -> serde_json::Value {
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    /// The default `GET /imposters` summary must expose `recordRequests` so the TUI
+    /// recording indicator reflects each imposter's configured state (issue #584).
+    #[tokio::test]
+    async fn handle_list_summary_includes_record_requests() {
+        let recording = manager_with(19771, true).await;
+        let resp = handle_list(recording.clone(), None, "http://localhost:2525").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = summaries(resp).await;
+        let entry = &json["imposters"][0];
+        assert_eq!(
+            entry["recordRequests"],
+            serde_json::Value::Bool(true),
+            "recording imposter must report recordRequests=true in the list summary"
+        );
+        let _ = recording.delete_imposter(19771).await;
+
+        let not_recording = manager_with(19772, false).await;
+        let resp = handle_list(not_recording.clone(), None, "http://localhost:2525").await;
+        let json = summaries(resp).await;
+        let entry = &json["imposters"][0];
+        assert_eq!(
+            entry["recordRequests"],
+            serde_json::Value::Bool(false),
+            "non-recording imposter must report recordRequests=false in the list summary"
+        );
+        let _ = not_recording.delete_imposter(19772).await;
     }
 }
 

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -39,6 +39,7 @@ pub struct ImposterSummary {
     pub name: Option<String>,
     pub number_of_requests: u64,
     pub enabled: bool,
+    pub record_requests: bool,
     #[serde(rename = "_links")]
     pub links: ImposterLinks,
 }

--- a/docs/mountebank/imposters.md
+++ b/docs/mountebank/imposters.md
@@ -243,11 +243,14 @@ curl http://localhost:2525/imposters
 # Response:
 {
   "imposters": [
-    { "port": 4545, "protocol": "http", "name": "User Service" },
-    { "port": 4546, "protocol": "https", "name": "Payment Service" }
+    { "port": 4545, "protocol": "http", "name": "User Service", "recordRequests": true },
+    { "port": 4546, "protocol": "https", "name": "Payment Service", "recordRequests": false }
   ]
 }
 ```
+
+Each summary carries `recordRequests` (alongside `numberOfRequests` and `enabled`), so tooling can
+show whether an imposter is recording without fetching its full detail.
 
 ### Get Imposter Details
 


### PR DESCRIPTION
Add recordRequests field to ImposterSummary in GET /imposters response so TUI recording indicator reflects actual state.

Closes #584