### PR TITLE
fault(repeat): response-cycle counter commits after the response — zero-latency next request can see stale state (embedded/loaded ubuntu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ record.
 
 ### Fixed
 
+- **Response cycling (`repeat`) no longer serves a stale branch to a zero-latency next request.**
+  The per-imposter response cursor advanced with `Relaxed` atomic ordering, so a strictly-sequential
+  client that issued its next request with near-zero latency — reached via a different worker thread
+  on a loaded in-process (embedded) runtime — could observe the pre-advance cursor and be served the
+  previous response (e.g. a third `503` where a `repeat: 2` stub should have crossed to `200`). The
+  cursor now advances with `SeqCst`, matching the ordering the sibling per-imposter cross-request
+  state already uses, so the advance is published before the response is returned.
 - **`PUT /imposters` no longer loses imposters on a partial failure.** The handler deleted every
   running imposter and then recreated the payload's set, merely logging any create failure — so a
   single bad imposter (or a transiently-held port) returned `200` with a silently smaller set, the

--- a/crates/rift-mock-core/src/behaviors/cycler.rs
+++ b/crates/rift-mock-core/src/behaviors/cycler.rs
@@ -41,13 +41,13 @@ impl RuleCycler {
 
     #[must_use]
     pub fn peek_response_index(&self, response_count: u32) -> u32 {
-        let value = self.0.load(Ordering::Relaxed);
+        let value = self.0.load(Ordering::SeqCst);
         let (resp_idx, _repeat_idx) = split(value);
         resp_idx.min(response_count.saturating_sub(1))
     }
 
     pub fn reset(&self) {
-        self.0.store(0, Ordering::Relaxed);
+        self.0.store(0, Ordering::SeqCst);
     }
 
     /// Get current response index for a rule, handling repeat behavior
@@ -58,9 +58,15 @@ impl RuleCycler {
         response_count: u32,
         mut repeat_for_response: impl FnMut(u32) -> Option<u32>,
     ) -> u32 {
+        // SeqCst (not Relaxed): the advanced cursor must be *published* so a strictly-sequential
+        // zero-latency next request — reached via a different tokio worker thread after the client
+        // handoff — observes it, rather than serving a stale repeat branch (issue #565). Matches the
+        // ordering the sibling per-imposter cross-request state already uses (`enabled`, journal
+        // counts). The window is invisible under load-free / spawn transports but real on the
+        // in-process embedded runtime on loaded runners.
         let old_value = self
             .0
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
                 let (mut resp_idx, repeat_idx) = split(v);
                 if resp_idx >= response_count {
                     resp_idx = response_count.saturating_sub(1);
@@ -80,7 +86,7 @@ impl RuleCycler {
 
 impl fmt::Debug for RuleCycler {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (response_idx, repeat_idx) = split(self.0.load(Ordering::Relaxed));
+        let (response_idx, repeat_idx) = split(self.0.load(Ordering::SeqCst));
         f.debug_struct("RuleCycler")
             .field("response_idx", &response_idx)
             .field("repeat_idx", &repeat_idx)
@@ -228,6 +234,93 @@ impl ResponseCycler {
 /// Trait for types that can have a repeat behavior
 pub trait HasRepeatBehavior {
     fn get_repeat(&self) -> Option<u32>;
+}
+
+#[cfg(test)]
+mod rule_cycler_ordering_tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+
+    /// AC1 — durable regression tripwire. A pure memory-visibility fix can't be caught by a
+    /// deterministic runtime test on a strong memory model, so gate the source instead: the cursor's
+    /// atomic ops must stay on a published ordering (`SeqCst`) and never regress to the relaxed
+    /// ordering that let a zero-latency next request observe a stale cursor (issue #565). The needle
+    /// is assembled at runtime so this assertion never matches its own source.
+    #[test]
+    fn rule_cycler_stays_on_published_ordering() {
+        let src = include_str!("cycler.rs");
+        let regressed = format!("Ordering::{}", "Relaxed");
+        assert!(
+            !src.contains(&regressed),
+            "RuleCycler atomic ops must use SeqCst (a published ordering), not the relaxed ordering — issue #565"
+        );
+    }
+
+    /// AC2 — the exact cycling the flaky `/retry` fixture asserts: two responses where the first
+    /// repeats twice and the second once, i.e. index sequence 0,0,1 then wrap (503,503,200,...).
+    #[test]
+    fn cycler_matches_retry_fixture_pattern() {
+        let cycler = RuleCycler::new();
+        let repeats = [2u32, 1u32];
+        let repeat_for = |i: u32| repeats.get(i as usize).copied();
+        let got: Vec<u32> = (0..6)
+            .map(|_| cycler.get_response_index_advance(2, repeat_for))
+            .collect();
+        assert_eq!(
+            got,
+            vec![0, 0, 1, 0, 0, 1],
+            "repeat:[2,1] must cycle 503,503,200 and wrap"
+        );
+    }
+
+    /// AC3 — a strictly-sequential client hands the cursor from one worker thread to the next; the
+    /// request that crosses a repeat boundary must observe the prior request's advance. Emulates
+    /// the conformance replay (pull exactly one index, hand off, pull the next) with the pulls
+    /// landing on alternating threads, and asserts the concatenated sequence is the exact
+    /// deterministic cycling — no skipped or duplicated index across the hand-off.
+    #[test]
+    fn concurrent_strict_handoff_preserves_cycling() {
+        // Two responses, first repeats twice: expected 0,0,1,0,0,1,... (the /retry shape).
+        const ROUNDS: usize = 2_000;
+        let cycler = Arc::new(RuleCycler::new());
+        let (to_b, from_a) = mpsc::channel::<()>();
+        let (to_a, from_b) = mpsc::channel::<u32>();
+
+        let cycler_b = Arc::clone(&cycler);
+        let handle = std::thread::spawn(move || {
+            let repeats = [2u32, 1u32];
+            let repeat_for = |i: u32| repeats.get(i as usize).copied();
+            while from_a.recv().is_ok() {
+                let idx = cycler_b.get_response_index_advance(2, repeat_for);
+                if to_a.send(idx).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let repeats = [2u32, 1u32];
+        let repeat_for = |i: u32| repeats.get(i as usize).copied();
+        let mut seq = Vec::with_capacity(ROUNDS);
+        for round in 0..ROUNDS {
+            // Even rounds pulled on this (main) thread, odd rounds on the worker — so consecutive
+            // pulls alternate threads, exercising the cross-thread hand-off on every boundary.
+            if round % 2 == 0 {
+                seq.push(cycler.get_response_index_advance(2, repeat_for));
+            } else {
+                to_b.send(()).expect("worker alive");
+                seq.push(from_b.recv().expect("worker replied"));
+            }
+        }
+        drop(to_b);
+        handle.join().expect("worker joined");
+
+        let expected: Vec<u32> = (0..ROUNDS).map(|i| [0, 0, 1][i % 3]).collect();
+        assert_eq!(
+            seq, expected,
+            "cross-thread strict hand-off must observe every prior advance (no stale cursor)"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
RuleCycler's atomic counter used Relaxed ordering, allowing zero-latency requests on other threads to observe stale cursor state and be served the wrong repeat branch. Changed all 4 atomic ops to SeqCst for consistent synchronization with sibling per-imposter state. Includes 2 gate tests (source-scan tripwire + cross-thread semantics) and CHANGELOG entry.

Closes #565