### PR TITLE
bug(tui): imposter recording indicator always false, never reflects recordRequests state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ record.
 
 ### Fixed
 
+- **The TUI imposter-list recording indicator now reflects real state.** The default
+  `GET /imposters` list summary omitted `recordRequests`, so the TUI (which deserializes a missing
+  field to `false`) always drew the indicator as not-recording regardless of the imposter's actual
+  configuration. The list summary now carries `recordRequests`, sourced from each imposter's config,
+  alongside the existing `stubCount`/`enabled` fields.
 - **Response cycling (`repeat`) no longer serves a stale branch to a zero-latency next request.**
   The per-imposter response cursor advanced with `Relaxed` atomic ordering, so a strictly-sequential
   client that issued its next request with near-zero latency — reached via a different worker thread

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -268,6 +268,7 @@ pub async fn handle_list(
                     number_of_requests: i.get_request_count(),
                     stub_count: i.stub_count(),
                     enabled: i.is_enabled(),
+                    record_requests: i.config.record_requests,
                     links: make_imposter_links(base_url, port),
                 })
             })
@@ -1572,6 +1573,48 @@ mod list_tests {
             .find(|i| i["port"] == 19771)
             .expect("stubless imposter listed");
         assert_eq!(stubless["stubCount"], 0);
+        manager.delete_all().await;
+    }
+
+    // Issue #584: the list summary must carry recordRequests so the TUI's recording indicator
+    // reflects real state instead of always deserializing a missing field to false.
+    #[tokio::test]
+    async fn list_response_includes_record_requests() {
+        let manager = Arc::new(ImposterManager::new());
+        let recording = serde_json::from_value(serde_json::json!({
+            "port": 19772, "protocol": "http", "recordRequests": true, "stubs": []
+        }))
+        .expect("config");
+        manager.create_imposter(recording).await.expect("create");
+        let plain = serde_json::from_value(serde_json::json!({
+            "port": 19773, "protocol": "http", "stubs": []
+        }))
+        .expect("config");
+        manager.create_imposter(plain).await.expect("create");
+
+        let resp = handle_list(Arc::clone(&manager), None, "http://localhost:2525").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let by_port = |port: u64| {
+            json["imposters"]
+                .as_array()
+                .expect("array")
+                .iter()
+                .find(|i| i["port"] == port)
+                .unwrap_or_else(|| panic!("imposter {port} listed"))
+                .clone()
+        };
+        assert_eq!(
+            by_port(19772)["recordRequests"],
+            true,
+            "a recording imposter must report recordRequests: true in the list"
+        );
+        assert_eq!(
+            by_port(19773)["recordRequests"],
+            false,
+            "a non-recording imposter must report recordRequests: false, not a missing field"
+        );
         manager.delete_all().await;
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -40,6 +40,7 @@ pub struct ImposterSummary {
     pub number_of_requests: u64,
     pub stub_count: usize,
     pub enabled: bool,
+    pub record_requests: bool,
     #[serde(rename = "_links")]
     pub links: ImposterLinks,
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -69,7 +69,8 @@ List all imposters.
       "name": "User Service",
       "numberOfRequests": 42,
       "stubCount": 3,
-      "enabled": true
+      "enabled": true,
+      "recordRequests": false
     },
     {
       "port": 4546,
@@ -77,7 +78,8 @@ List all imposters.
       "name": "Payment Service",
       "numberOfRequests": 15,
       "stubCount": 1,
-      "enabled": true
+      "enabled": true,
+      "recordRequests": true
     }
   ]
 }


### PR DESCRIPTION
The TUI's recording indicator always showed false because the GET /imposters list summary omitted the recordRequests field. When deserialized with a missing field, it defaults to false. Now the list summary carries recordRequests from each imposter's configuration.

Closes #584