### PR TITLE
chore(release): prepare 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ record.
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-07-12
+
 ### Fixed
 
 - **The TUI imposter-list recording indicator now reflects real state.** The default
@@ -500,7 +502,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.2...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.3...HEAD
+[0.13.3]: https://github.com/EtaCassiopeia/rift/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/EtaCassiopeia/rift/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/EtaCassiopeia/rift/compare/v0.12.0...v0.13.0


### PR DESCRIPTION
Prepare the 0.13.3 release: roll the fixes merged since 0.13.2 into a dated `## [0.13.3]` CHANGELOG section and update the compare links.

Included since 0.13.2:
- `GET /imposters` list summary carries `recordRequests` — TUI recording indicator now reflects real state (#588, closes #584)
- Response cycler advances with `SeqCst` (#586)
- `PUT /imposters` reconciles instead of delete-all-then-recreate (#582)
- Imposter-list refresh is a single request via `stubCount` (#583)
- Flaky `shared_store_is_used_and_cleared_on_delete` fixed via OS-assigned test ports (#589, closes #587)

Merging this and pushing tag `v0.13.3` triggers the release workflow (which bumps the crate version from the tag).