### PR TITLE
intercept: accept inline CA (caCertPem/caKeyPem) in POST /intercept + a generate-and-return-CA mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ record.
 
 ### Added
 
+- **Intercept CA: inline PEM input and a generate-and-return bootstrap mode.** `POST /intercept`
+  (and the FFI `rift_start_intercept`) now accept the CA as inline PEM bytes — `caCertPem` /
+  `caKeyPem` — in addition to the existing `caCertPath` / `caKeyPath` file pair, so an SDK can hand a
+  containerized engine its CA over the admin API without a filesystem mount. The two source pairs are
+  each both-or-neither and mutually exclusive. Setting `"returnCaKey": true` (valid only when no CA
+  source is supplied) has Rift mint a fresh CA and return **both** its cert and key once in the `201`
+  response, so a caller can persist and redistribute a shareable trust anchor instead of pre-making
+  one with `openssl`. The CLI/env gains inline `RIFT_INTERCEPT_CA_CERT_PEM` / `RIFT_INTERCEPT_CA_KEY_PEM`
+  (mutually exclusive with the file flags). **Security:** the returned `caKeyPem` is CA private-key
+  material — it is returned once (never by `GET /intercept`), only when Rift generated the CA
+  (combining `returnCaKey` with a supplied CA is a `400`, closing a filesystem-exfiltration path),
+  and should be transported over the `--apikey`-gated admin plane and treated as a secret. Additive
+  and feature-detectable (an older engine's `deny_unknown_fields` rejects the new fields with a
+  `400`); the C-ABI contract version is unchanged.
 - **`rift_abi_version()` — a queryable C-ABI contract version for SDK compatibility gating.** The
   new FFI symbol returns the C-ABI contract version (`uint32_t`, currently `2`), bumped only on a
   breaking ABI change and never on additive or bugfix releases. SDKs can now gate on the ABI

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -301,20 +301,30 @@ char *rift_space_recorded(RiftHandle *h, uint16_t port, const char *flow_id);
 
 /**
  * Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime. The intercept CA
- * is loaded from `caCertPath`/`caKeyPath` when both are supplied (letting independent instances
- * share a committed trust anchor), and generated fresh otherwise. Returns JSON
+ * is loaded from `caCertPath`/`caKeyPath` (files) or `caCertPem`/`caKeyPem` (inline PEM bytes,
+ * issue #593) when a pair is supplied — letting independent instances share a committed trust
+ * anchor — and generated fresh otherwise. The two source pairs are each both-or-neither and are
+ * mutually exclusive. Returns JSON
  * `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}` the caller frees with
- * [`rift_free`], or null on error (bad JSON, half-configured CA pair, CA load failure, bind
- * failure, or already started — one listener per handle). `interceptUrl` reflects the bound
- * address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
+ * [`rift_free`], or null on error (bad JSON, half-configured CA pair, both pairs supplied, CA load
+ * failure, bind failure, or already started — one listener per handle). `interceptUrl` reflects the
+ * bound address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
  * dial a concrete interface). `options_json`:
  * `{"host":"127.0.0.1","port":0,"caCertPath":"ca.pem","caKeyPath":"ca.key"}` (port 0 =
  * OS-assigned; CA paths optional, both-or-neither); pass null or `{}` for defaults.
  *
+ * Set `"returnCaKey":true` (only valid when NO CA source is supplied — otherwise `null`/error) to
+ * have the engine mint a fresh CA and return its material once in the response, so a caller can
+ * persist and redistribute a shareable anchor:
+ * `{"interceptPort":…,"interceptUrl":…,"caCertPem":"<cert>","caKeyPem":"<key>"}`. The `caKeyPem`
+ * is the CA private key — treat the response as secret material. Absent `returnCaKey`, the response
+ * carries no CA fields (byte-compatible with pre-#593).
+ *
  * # Safety
  * `h` must be a live handle (or null); `options_json` must be null or a valid C string.
  */
-char *rift_start_intercept(RiftHandle *h, const char *options_json);
+char *rift_start_intercept(RiftHandle *h,
+                           const char *options_json);
 
 /**
  * Stop the intercept listener started by [`rift_start_intercept`] (or over the embedded admin

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1371,15 +1371,24 @@ enum RuleOrRules {
 }
 
 /// Start the intercept/TLS-MITM forward-proxy listener on this handle's runtime. The intercept CA
-/// is loaded from `caCertPath`/`caKeyPath` when both are supplied (letting independent instances
-/// share a committed trust anchor), and generated fresh otherwise. Returns JSON
+/// is loaded from `caCertPath`/`caKeyPath` (files) or `caCertPem`/`caKeyPem` (inline PEM bytes,
+/// issue #593) when a pair is supplied — letting independent instances share a committed trust
+/// anchor — and generated fresh otherwise. The two source pairs are each both-or-neither and are
+/// mutually exclusive. Returns JSON
 /// `{"interceptPort":<u16>,"interceptUrl":"http://<bind-host>:<port>"}` the caller frees with
-/// [`rift_free`], or null on error (bad JSON, half-configured CA pair, CA load failure, bind
-/// failure, or already started — one listener per handle). `interceptUrl` reflects the bound
-/// address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
+/// [`rift_free`], or null on error (bad JSON, half-configured CA pair, both pairs supplied, CA load
+/// failure, bind failure, or already started — one listener per handle). `interceptUrl` reflects the
+/// bound address (the configured `host`, loopback by default; a `0.0.0.0` bind surfaces verbatim, so
 /// dial a concrete interface). `options_json`:
 /// `{"host":"127.0.0.1","port":0,"caCertPath":"ca.pem","caKeyPath":"ca.key"}` (port 0 =
 /// OS-assigned; CA paths optional, both-or-neither); pass null or `{}` for defaults.
+///
+/// Set `"returnCaKey":true` (only valid when NO CA source is supplied — otherwise `null`/error) to
+/// have the engine mint a fresh CA and return its material once in the response, so a caller can
+/// persist and redistribute a shareable anchor:
+/// `{"interceptPort":…,"interceptUrl":…,"caCertPem":"<cert>","caKeyPem":"<key>"}`. The `caKeyPem`
+/// is the CA private key — treat the response as secret material. Absent `returnCaKey`, the response
+/// carries no CA fields (byte-compatible with pre-#593).
 ///
 /// # Safety
 /// `h` must be a live handle (or null); `options_json` must be null or a valid C string.
@@ -1415,7 +1424,7 @@ pub unsafe extern "C" fn rift_start_intercept(
         // The shared control serializes concurrent starts and handles CA load + bind; map its
         // typed errors back to the exact `last_error` strings the SDKs match on.
         match handle.runtime.block_on(handle.intercept.start(opts)) {
-            Ok(addr) => match serde_json::to_string(&InterceptStatus::from_addr(addr)) {
+            Ok(started) => match serde_json::to_string(&InterceptStatus::from_started(started)) {
                 Ok(json) => into_c_string(json),
                 Err(e) => {
                     set_last_error(format!("rift_start_intercept: encode failed: {e}"));

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -1260,6 +1260,52 @@ fn ffi_intercept_serve_and_forward() {
     }
 }
 
+/// Issue #593: over FFI, `rift_start_intercept` with `returnCaKey` hands back a generated CA pair,
+/// and that pair, supplied inline on a later start, reconstructs the same trust anchor.
+#[test]
+fn ffi_intercept_return_ca_key_round_trip() {
+    unsafe {
+        let h = rift_start();
+
+        // Generate-and-return the CA.
+        let started: serde_json::Value = serde_json::from_str(&take_json(rift_start_intercept(
+            h,
+            cstr(r#"{"returnCaKey":true}"#).as_ptr(),
+        )))
+        .unwrap();
+        let ca_cert = started["caCertPem"]
+            .as_str()
+            .expect("caCertPem")
+            .to_string();
+        let ca_key = started["caKeyPem"].as_str().expect("caKeyPem").to_string();
+        assert!(ca_cert.contains("BEGIN CERTIFICATE") && ca_key.contains("PRIVATE KEY"));
+
+        // Stop, then restart with the persisted pair supplied inline.
+        assert_eq!(rift_stop_intercept(h), 0);
+        let opts = serde_json::json!({"caCertPem": ca_cert, "caKeyPem": ca_key}).to_string();
+        let restarted = take_json(rift_start_intercept(h, cstr(&opts).as_ptr()));
+        assert!(!restarted.is_empty(), "restart with inline PEM succeeds");
+
+        // The listener now serves the SAME anchor we bootstrapped.
+        let served_ca = take_json(rift_intercept_ca_pem(h));
+        assert_eq!(
+            served_ca, ca_cert,
+            "restarted listener uses the supplied CA"
+        );
+
+        // returnCaKey combined with a supplied source is rejected (null + last_error).
+        let bad = rift_stop_intercept(h);
+        assert_eq!(bad, 0);
+        let rejected = rift_start_intercept(
+            h,
+            cstr(r#"{"returnCaKey":true,"caCertPath":"x","caKeyPath":"y"}"#).as_ptr(),
+        );
+        assert!(rejected.is_null(), "returnCaKey with a CA source must fail");
+
+        rift_stop(h);
+    }
+}
+
 /// Export a truststore over FFI to a temp path, assert success, and return the written bytes.
 unsafe fn export_truststore_bytes(
     h: *mut RiftHandle,

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -105,7 +105,7 @@ async fn start_from_bytes(body: &[u8], control: &InterceptControl) -> Response<F
         }
     };
     match control.start(opts).await {
-        Ok(addr) => json_response(StatusCode::CREATED, &InterceptStatus::from_addr(addr)),
+        Ok(started) => json_response(StatusCode::CREATED, &InterceptStatus::from_started(started)),
         Err(e) => {
             let status = match e {
                 InterceptStartError::AlreadyRunning => StatusCode::CONFLICT,
@@ -546,6 +546,69 @@ mod tests {
         assert!(json.contains("interceptPort"));
         assert!(json.contains("interceptUrl"));
         control.stop().await;
+    }
+
+    // Issue #593 AC4: a start without returnCaKey omits the CA fields entirely (byte-compat), and
+    // GET /intercept never carries them either.
+    #[tokio::test]
+    async fn start_without_return_ca_key_omits_ca_fields() {
+        let control = InterceptControl::default();
+        let json = read_body(start_from_bytes(b"{}", &control).await).await;
+        assert!(!json.contains("caCertPem"), "no CA cert unless requested");
+        assert!(!json.contains("caKeyPem"), "no CA key unless requested");
+        let status_json = read_body(handle_status(&control)).await;
+        assert!(
+            !status_json.contains("caKeyPem") && !status_json.contains("caCertPem"),
+            "GET /intercept never carries CA material"
+        );
+        control.stop().await;
+    }
+
+    // Issue #593 AC2: POST {"returnCaKey":true} → 201 carrying the generated CA cert+key.
+    #[tokio::test]
+    async fn start_returns_ca_pair_when_requested() {
+        let control = InterceptControl::default();
+        let resp = start_from_bytes(br#"{"returnCaKey":true}"#, &control).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let v: serde_json::Value = serde_json::from_str(&read_body(resp).await).unwrap();
+        let cert = v["caCertPem"].as_str().expect("caCertPem present");
+        let key = v["caKeyPem"].as_str().expect("caKeyPem present");
+        assert!(cert.contains("BEGIN CERTIFICATE") && key.contains("PRIVATE KEY"));
+        // The running listener uses exactly the returned CA.
+        assert_eq!(control.state().unwrap().ca.ca_cert_pem(), cert);
+        control.stop().await;
+    }
+
+    // Issue #593 AC3: returnCaKey combined with a supplied CA source is a 400 that starts nothing.
+    #[tokio::test]
+    async fn start_return_ca_key_with_supplied_ca_is_400() {
+        let control = InterceptControl::default();
+        let body = br#"{"returnCaKey":true,"caCertPath":"c.pem","caKeyPath":"k.pem"}"#;
+        assert_eq!(
+            start_from_bytes(body, &control).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert!(control.status().is_none(), "no listener left behind");
+    }
+
+    // Issue #593 AC1/AC3: inline PEM loads a CA; a half PEM pair is a 400.
+    #[tokio::test]
+    async fn start_inline_pem_loads_ca_and_half_pair_is_400() {
+        let ca = CertificateAuthority::generate().expect("ca");
+        let cert_pem = ca.ca_cert_pem();
+        let key_pem = ca.ca_key_pem();
+        let control = InterceptControl::default();
+        let body = serde_json::json!({"caCertPem": cert_pem, "caKeyPem": key_pem}).to_string();
+        let resp = start_from_bytes(body.as_bytes(), &control).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(control.state().unwrap().ca.ca_cert_pem(), cert_pem);
+        control.stop().await;
+
+        let half = serde_json::json!({"caCertPem": cert_pem}).to_string();
+        assert_eq!(
+            start_from_bytes(half.as_bytes(), &control).await.status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     fn body_bytes(resp: Response<Full<Bytes>>) -> Vec<u8> {

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -9,12 +9,12 @@
 //! CLI flag or FFI call started.
 
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::intercept::InterceptListener;
 use crate::intercept_rules::{InterceptRules, InterceptState};
-use rift_mock_core::proxy::intercept_ca::{CertificateAuthority, SniCertResolver};
+use rift_mock_core::proxy::intercept_ca::{CaSource, CertificateAuthority, SniCertResolver};
 use serde::Serialize;
 
 /// A running intercept plane: the listener plus the control-plane [`InterceptState`] (rule store +
@@ -33,8 +33,10 @@ pub struct InterceptControl(Arc<Mutex<Option<InterceptPlane>>>);
 /// Start options — the exact shape (and serde attributes) of the FFI's former `InterceptOptions`,
 /// so the admin `POST /intercept` body and `rift_start_intercept` parse identically.
 /// `deny_unknown_fields` so a misspelled `caCertpath` is a hard error, not a silent fresh-CA
-/// fallback that would defeat the caller's intended CA reuse.
-#[derive(serde::Deserialize, Default, Debug)]
+/// fallback that would defeat the caller's intended CA reuse. A pre-#593 engine's
+/// `deny_unknown_fields` also gives SDKs deterministic feature detection: an unknown `caCertPem`
+/// or `returnCaKey` is a hard 400 naming the field, not a silent ignore.
+#[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InterceptStartOptions {
     /// Bind host, default `127.0.0.1`.
@@ -44,25 +46,90 @@ pub struct InterceptStartOptions {
     pub ca_cert_path: Option<String>,
     /// Both-or-neither with `ca_cert_path`.
     pub ca_key_path: Option<String>,
+    /// Inline CA certificate PEM (issue #593) — both-or-neither with `ca_key_pem`, mutually
+    /// exclusive with the path pair. Lets a containerized engine be handed a CA over the admin
+    /// API without a filesystem mount.
+    pub ca_cert_pem: Option<String>,
+    /// Inline CA private-key PEM (issue #593). Secret material — never logged (see the `Debug` impl).
+    pub ca_key_pem: Option<String>,
+    /// Generate a fresh CA and return its cert **and** key in the start response (issue #593).
+    /// Only valid when no CA source is supplied — combining it with a path/PEM pair is a `400`.
+    pub return_ca_key: Option<bool>,
+}
+
+impl std::fmt::Debug for InterceptStartOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact the inline key PEM — it is secret material (issue #593). Paths and the cert are safe.
+        f.debug_struct("InterceptStartOptions")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("ca_cert_path", &self.ca_cert_path)
+            .field("ca_key_path", &self.ca_key_path)
+            .field("ca_cert_pem", &self.ca_cert_pem.as_ref().map(|_| "<pem>"))
+            .field(
+                "ca_key_pem",
+                &self.ca_key_pem.as_ref().map(|_| "<redacted>"),
+            )
+            .field("return_ca_key", &self.return_ca_key)
+            .finish()
+    }
+}
+
+/// Outcome of a successful [`InterceptControl::start`]: the bound address plus, when the caller set
+/// `return_ca_key` on a generated CA, the CA's `(cert_pem, key_pem)` to hand back exactly once.
+pub struct StartedIntercept {
+    pub(crate) addr: SocketAddr,
+    pub(crate) ca_export: Option<(String, String)>,
+}
+
+impl std::fmt::Debug for StartedIntercept {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Show only whether a CA was exported, never the key material (issue #593).
+        f.debug_struct("StartedIntercept")
+            .field("addr", &self.addr)
+            .field(
+                "ca_export",
+                &self.ca_export.as_ref().map(|_| "<ca cert+key>"),
+            )
+            .finish()
+    }
 }
 
 /// The running-listener status shared by `POST`/`GET /intercept` and `rift_start_intercept` — the
-/// same field names and derivation so every surface returns a byte-compatible body.
+/// same field names and derivation so every surface returns a byte-compatible body. The `caCertPem`
+/// /`caKeyPem` fields are populated **only** by `POST /intercept` with `returnCaKey` (issue #593);
+/// `GET /intercept` never carries key material.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InterceptStatus {
     pub intercept_port: u16,
     pub intercept_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ca_cert_pem: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ca_key_pem: Option<String>,
 }
 
 impl InterceptStatus {
-    /// Derive both fields from the *real* bound address (OS-assigned port resolved). A `0.0.0.0`
-    /// bind surfaces verbatim — dial a concrete interface.
+    /// Derive the address fields from the *real* bound address (OS-assigned port resolved), with no
+    /// CA export. A `0.0.0.0` bind surfaces verbatim — dial a concrete interface.
     pub fn from_addr(addr: SocketAddr) -> Self {
         Self {
             intercept_port: addr.port(),
             intercept_url: format!("http://{addr}"),
+            ca_cert_pem: None,
+            ca_key_pem: None,
         }
+    }
+
+    /// Build the start-response status, attaching the CA export when the start produced one.
+    pub fn from_started(started: StartedIntercept) -> Self {
+        let mut status = Self::from_addr(started.addr);
+        if let Some((cert, key)) = started.ca_export {
+            status.ca_cert_pem = Some(cert);
+            status.ca_key_pem = Some(key);
+        }
+        status
     }
 }
 
@@ -113,7 +180,7 @@ impl InterceptControl {
     pub async fn start(
         &self,
         opts: InterceptStartOptions,
-    ) -> Result<SocketAddr, InterceptStartError> {
+    ) -> Result<StartedIntercept, InterceptStartError> {
         if self.is_occupied() {
             return Err(InterceptStartError::AlreadyRunning);
         }
@@ -122,18 +189,38 @@ impl InterceptControl {
         let addr: SocketAddr = format!("{host}:{}", opts.port.unwrap_or(0))
             .parse()
             .map_err(|e| InterceptStartError::InvalidAddr(format!("{e}")))?;
-        // Log CA/bind failures here so every surface (FFI, admin `POST /intercept`, CLI flag) gets a
-        // server-side trail — not just the FFI, which used to `warn!` these on its own.
-        let ca = Arc::new(
-            CertificateAuthority::load_or_generate(
-                opts.ca_cert_path.as_deref().map(Path::new),
-                opts.ca_key_path.as_deref().map(Path::new),
-            )
-            .map_err(|e| {
-                tracing::warn!(error = %e, "intercept start: CA setup failed");
-                InterceptStartError::Ca(e)
-            })?,
-        );
+
+        // Resolve the single CA source (validating both-or-neither + pair exclusion) before binding.
+        // Log CA/option failures here so every surface (FFI, admin `POST /intercept`, CLI flag) gets
+        // a server-side trail — not just the FFI, which used to `warn!` these on its own. The map to
+        // `Ca` keeps these validation failures on the existing 400 path.
+        let source = CaSource::resolve(
+            opts.ca_cert_path.map(PathBuf::from),
+            opts.ca_key_path.map(PathBuf::from),
+            opts.ca_cert_pem,
+            opts.ca_key_pem,
+        )
+        .map_err(|e| {
+            tracing::warn!(error = %e, "intercept start: invalid CA options");
+            InterceptStartError::Ca(e)
+        })?;
+
+        // `returnCaKey` hands the CA private key back to the caller, so it is only allowed against a
+        // CA this call generates (issue #593, D4). Allowing it with a supplied path/PEM source would
+        // turn the admin API into a file-exfiltration primitive (echo back any keypair on disk).
+        let return_ca_key = opts.return_ca_key.unwrap_or(false);
+        if return_ca_key && !source.is_generate() {
+            return Err(InterceptStartError::Ca(anyhow::anyhow!(
+                "returnCaKey requires the CA to be generated by this call (omit caCert*/caKey*)"
+            )));
+        }
+
+        let ca = Arc::new(CertificateAuthority::from_source(&source).map_err(|e| {
+            tracing::warn!(error = %e, "intercept start: CA setup failed");
+            InterceptStartError::Ca(e)
+        })?);
+        let ca_export = return_ca_key.then(|| (ca.ca_cert_pem().to_string(), ca.ca_key_pem()));
+
         let rules = InterceptRules::new();
         let resolver = Arc::new(SniCertResolver::new(ca.clone()));
         let listener = InterceptListener::bind(addr, resolver, rules.clone())
@@ -148,7 +235,10 @@ impl InterceptControl {
             listener,
             state: InterceptState { rules, ca },
         }) {
-            Ok(()) => Ok(bound),
+            Ok(()) => Ok(StartedIntercept {
+                addr: bound,
+                ca_export,
+            }),
             Err(listener) => {
                 listener.shutdown().await;
                 Err(InterceptStartError::AlreadyRunning)
@@ -196,9 +286,13 @@ mod tests {
         assert!(control.status().is_none());
         assert!(control.state().is_none());
 
-        let addr = control.start(defaults()).await.expect("start");
-        assert_eq!(control.status(), Some(addr));
-        assert!(addr.port() > 0, "OS assigned a real port");
+        let started = control.start(defaults()).await.expect("start");
+        assert_eq!(control.status(), Some(started.addr));
+        assert!(started.addr.port() > 0, "OS assigned a real port");
+        assert!(
+            started.ca_export.is_none(),
+            "no CA export unless returnCaKey was requested"
+        );
         assert!(control.state().is_some());
 
         assert!(control.stop().await, "stop reports it was running");
@@ -283,7 +377,139 @@ mod tests {
         // The winner's port is the one installed; the loser's listener was shut down, not leaked.
         let installed = control.status().expect("a listener is installed");
         let won = a.or(b).expect("the Ok addr");
-        assert_eq!(installed, won, "the installed listener is the winner's");
+        assert_eq!(
+            installed, won.addr,
+            "the installed listener is the winner's"
+        );
         control.stop().await;
+    }
+
+    // Issue #593: the manual Debug impls must never render CA key material — guard against a future
+    // field being added without updating the redaction.
+    #[test]
+    fn debug_impls_redact_ca_key_material() {
+        let secret = "supersecret-key-bytes";
+        let opts = InterceptStartOptions {
+            ca_cert_pem: Some("cert".to_string()),
+            ca_key_pem: Some(secret.to_string()),
+            ..Default::default()
+        };
+        assert!(
+            !format!("{opts:?}").contains(secret),
+            "InterceptStartOptions Debug must redact the inline key PEM"
+        );
+        let started = StartedIntercept {
+            addr: "127.0.0.1:0".parse().unwrap(),
+            ca_export: Some(("cert".to_string(), secret.to_string())),
+        };
+        assert!(
+            !format!("{started:?}").contains(secret),
+            "StartedIntercept Debug must redact the exported CA key"
+        );
+    }
+
+    // Issue #593: a CA pair for inline-PEM tests, minted out of band.
+    fn ca_pem_pair() -> (String, String) {
+        let ca = CertificateAuthority::generate().expect("generate CA out of band");
+        (ca.ca_cert_pem().to_string(), ca.ca_key_pem())
+    }
+
+    #[tokio::test]
+    async fn start_with_inline_pem_loads_ca() {
+        let (cert_pem, key_pem) = ca_pem_pair();
+        let control = InterceptControl::default();
+        let opts = InterceptStartOptions {
+            ca_cert_pem: Some(cert_pem.clone()),
+            ca_key_pem: Some(key_pem),
+            ..Default::default()
+        };
+        control.start(opts).await.expect("start with inline PEM");
+        let state = control.state().expect("running");
+        assert_eq!(
+            state.ca.ca_cert_pem(),
+            cert_pem,
+            "the running listener uses the supplied CA as its trust anchor"
+        );
+        control.stop().await;
+    }
+
+    #[tokio::test]
+    async fn return_ca_key_exports_generated_pair() {
+        let control = InterceptControl::default();
+        let opts = InterceptStartOptions {
+            return_ca_key: Some(true),
+            ..Default::default()
+        };
+        let started = control.start(opts).await.expect("start with returnCaKey");
+        let (cert, key) = started.ca_export.expect("CA pair returned");
+        assert!(cert.contains("CERTIFICATE") && key.contains("PRIVATE KEY"));
+        // The returned pair reconstructs the same running CA.
+        assert_eq!(control.state().unwrap().ca.ca_cert_pem(), cert);
+        let reloaded = CertificateAuthority::load_pem(&cert, &key).expect("reload returned pair");
+        assert_eq!(
+            reloaded.ca_cert_pem(),
+            cert,
+            "returned pair is a usable anchor"
+        );
+        control.stop().await;
+    }
+
+    #[tokio::test]
+    async fn return_ca_key_with_supplied_source_is_error() {
+        // With inline PEM.
+        let (cert_pem, key_pem) = ca_pem_pair();
+        let control = InterceptControl::default();
+        let err = control
+            .start(InterceptStartOptions {
+                ca_cert_pem: Some(cert_pem),
+                ca_key_pem: Some(key_pem),
+                return_ca_key: Some(true),
+                ..Default::default()
+            })
+            .await
+            .expect_err("returnCaKey with a supplied CA must be rejected");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+        assert!(control.status().is_none(), "no listener left behind");
+
+        // With CA paths.
+        let err = control
+            .start(InterceptStartOptions {
+                ca_cert_path: Some("cert.pem".to_string()),
+                ca_key_path: Some("key.pem".to_string()),
+                return_ca_key: Some(true),
+                ..Default::default()
+            })
+            .await
+            .expect_err("returnCaKey with CA paths must be rejected");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+    }
+
+    #[tokio::test]
+    async fn inline_pem_half_pair_and_mutual_exclusion_are_errors() {
+        let control = InterceptControl::default();
+        // Half a PEM pair.
+        let err = control
+            .start(InterceptStartOptions {
+                ca_cert_pem: Some("cert".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("half PEM pair");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+
+        // PEM pair AND path pair.
+        let (cert_pem, key_pem) = ca_pem_pair();
+        let err = control
+            .start(InterceptStartOptions {
+                ca_cert_path: Some("cert.pem".to_string()),
+                ca_key_path: Some("key.pem".to_string()),
+                ca_cert_pem: Some(cert_pem),
+                ca_key_pem: Some(key_pem),
+                ..Default::default()
+            })
+            .await
+            .expect_err("path and PEM are mutually exclusive");
+        assert!(matches!(err, InterceptStartError::Ca(_)));
+        assert!(control.status().is_none());
     }
 }

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -152,6 +152,29 @@ pub struct Cli {
     /// PEM CA private key for interception. Required together with `--intercept-ca-cert`.
     #[arg(long, value_name = "FILE", env = "RIFT_INTERCEPT_CA_KEY")]
     pub intercept_ca_key: Option<PathBuf>,
+
+    /// Inline CA certificate PEM for interception (issue #593) — the PEM text itself, not a path.
+    /// Used with `--intercept-ca-key-pem`; conflicts with the `--intercept-ca-cert`/`-key` file
+    /// pair. Env is the intended vehicle (`RIFT_INTERCEPT_CA_CERT_PEM`).
+    #[arg(
+        long,
+        value_name = "PEM",
+        env = "RIFT_INTERCEPT_CA_CERT_PEM",
+        conflicts_with = "intercept_ca_cert",
+        conflicts_with = "intercept_ca_key"
+    )]
+    pub intercept_ca_cert_pem: Option<String>,
+
+    /// Inline CA private-key PEM for interception (issue #593). Required together with
+    /// `--intercept-ca-cert-pem`; conflicts with the CA file pair.
+    #[arg(
+        long,
+        value_name = "PEM",
+        env = "RIFT_INTERCEPT_CA_KEY_PEM",
+        conflicts_with = "intercept_ca_cert",
+        conflicts_with = "intercept_ca_key"
+    )]
+    pub intercept_ca_key_pem: Option<String>,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -394,6 +417,10 @@ impl ServerBuilder {
                         .intercept_ca_key
                         .as_deref()
                         .map(|p| p.to_string_lossy().into_owned()),
+                    ca_cert_pem: cli.intercept_ca_cert_pem.clone(),
+                    ca_key_pem: cli.intercept_ca_key_pem.clone(),
+                    // Cloned (not moved) because `cli` is borrowed for the rest of startup.
+                    ..Default::default()
                 })
                 .await
                 .map_err(|e| anyhow::anyhow!("intercept: {e}"))?;
@@ -903,6 +930,34 @@ mod tests {
         assert_eq!(cli.intercept_port, Some(9000));
         let none = Cli::try_parse_from(["rift"]).expect("parse");
         assert_eq!(none.intercept_port, None);
+    }
+
+    // Issue #593 AC5: inline CA PEM flags parse, and conflict with the CA file flags at parse time.
+    #[test]
+    fn intercept_ca_pem_flags_parse_and_conflict_with_paths() {
+        let cli = Cli::try_parse_from([
+            "rift",
+            "--intercept-ca-cert-pem",
+            "CERT",
+            "--intercept-ca-key-pem",
+            "KEY",
+        ])
+        .expect("inline PEM flags parse");
+        assert_eq!(cli.intercept_ca_cert_pem.as_deref(), Some("CERT"));
+        assert_eq!(cli.intercept_ca_key_pem.as_deref(), Some("KEY"));
+
+        // A PEM flag alongside a CA file flag is a hard parse error (D6 conflicts_with).
+        assert!(
+            Cli::try_parse_from([
+                "rift",
+                "--intercept-ca-cert",
+                "ca.pem",
+                "--intercept-ca-cert-pem",
+                "CERT",
+            ])
+            .is_err(),
+            "path and inline-PEM CA flags must conflict at parse"
+        );
     }
 
     // Issue #356: `--scripts-dir` is the admin-API `file:` script resolution root.

--- a/crates/rift-http-proxy/tests/intercept_runtime_lifecycle.rs
+++ b/crates/rift-http-proxy/tests/intercept_runtime_lifecycle.rs
@@ -369,3 +369,87 @@ async fn lifecycle_endpoints_are_apikey_gated() {
 
     admin.shutdown().await;
 }
+
+/// Issue #593 AC2: the full CA-bootstrap round-trip over the admin API — generate-and-return a CA,
+/// tear down, restart with the returned pair supplied inline, and confirm the same trust anchor is
+/// live (and actually terminates a proxied TLS handshake).
+#[tokio::test]
+async fn ca_bootstrap_round_trip_over_admin_api() {
+    let (base, admin) = admin_without_intercept_flag().await;
+    let c = reqwest::Client::new();
+
+    // 1. Generate and return the CA pair.
+    let started: serde_json::Value = c
+        .post(format!("{base}/intercept"))
+        .body(r#"{"returnCaKey":true}"#)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let ca_cert = started["caCertPem"]
+        .as_str()
+        .expect("caCertPem")
+        .to_string();
+    let ca_key = started["caKeyPem"].as_str().expect("caKeyPem").to_string();
+    assert!(ca_cert.contains("BEGIN CERTIFICATE") && ca_key.contains("PRIVATE KEY"));
+
+    // 2. Tear the listener down (drops the ephemeral CA from the slot).
+    assert_eq!(
+        c.delete(format!("{base}/intercept"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+
+    // 3. Restart with the persisted pair supplied INLINE — no filesystem mount.
+    let restarted = c
+        .post(format!("{base}/intercept"))
+        .json(&serde_json::json!({"caCertPem": ca_cert, "caKeyPem": ca_key}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(restarted.status(), 201);
+    let intercept_url = restarted.json::<serde_json::Value>().await.unwrap()["interceptUrl"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // 4. GET /intercept/ca.pem returns the SAME anchor we bootstrapped.
+    let served_ca = c
+        .get(format!("{base}/intercept/ca.pem"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(
+        served_ca, ca_cert,
+        "the restarted listener uses the supplied CA"
+    );
+
+    // 5. The bootstrapped CA actually terminates a proxied TLS handshake: add a serve rule and
+    //    dial an HTTPS host through the intercept proxy, trusting only the returned cert.
+    assert_eq!(
+        c.post(format!("{base}/intercept/rules"))
+            .body(r#"{"host":"svc.internal","action":{"serve":{"statusCode":204}}}"#)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        201
+    );
+    let proxied = trusting_client(&intercept_url, &ca_cert);
+    let resp = proxied
+        .get("https://svc.internal/")
+        .send()
+        .await
+        .expect("handshake terminates with the bootstrapped CA");
+    assert_eq!(resp.status(), 204);
+
+    admin.shutdown().await;
+}

--- a/crates/rift-mock-core/src/proxy/intercept_ca.rs
+++ b/crates/rift-mock-core/src/proxy/intercept_ca.rs
@@ -9,7 +9,7 @@
 //! `rift-http-proxy` crate.
 
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use lru::LruCache;
@@ -42,6 +42,75 @@ impl std::fmt::Debug for CertificateAuthority {
         f.debug_struct("CertificateAuthority")
             .field("cert_pem", &self.cert_pem)
             .finish_non_exhaustive()
+    }
+}
+
+/// Where a [`CertificateAuthority`] comes from, resolved once from the three mutually-exclusive
+/// input pairs an intercept start accepts (issue #593). Building it via [`CaSource::resolve`] keeps
+/// the "both-or-neither per pair, at most one pair" validation in a single place shared by the
+/// admin API, the FFI, and the CLI/env launch path.
+pub enum CaSource {
+    /// Mint a fresh in-memory CA (the default when no CA input is supplied).
+    Generate,
+    /// Load the CA from PEM files on the engine's filesystem.
+    Paths { cert: PathBuf, key: PathBuf },
+    /// Load the CA from inline PEM bytes carried in the request/env.
+    Pem { cert: String, key: String },
+}
+
+impl std::fmt::Debug for CaSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render inline PEM — the `Pem` key is secret material. Paths are safe to show.
+        match self {
+            CaSource::Generate => f.write_str("Generate"),
+            CaSource::Paths { cert, key } => f
+                .debug_struct("Paths")
+                .field("cert", cert)
+                .field("key", key)
+                .finish(),
+            CaSource::Pem { .. } => f.write_str("Pem { .. }"),
+        }
+    }
+}
+
+impl CaSource {
+    /// Reduce the three optional pairs to a single source, rejecting a half-supplied pair or more
+    /// than one pair. Both path fields empty and both PEM fields empty → [`CaSource::Generate`].
+    /// Error messages never include PEM contents.
+    pub fn resolve(
+        cert_path: Option<PathBuf>,
+        key_path: Option<PathBuf>,
+        cert_pem: Option<String>,
+        key_pem: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let paths = match (cert_path, key_path) {
+            (Some(cert), Some(key)) => Some((cert, key)),
+            (None, None) => None,
+            _ => anyhow::bail!(
+                "intercept CA cert and key paths must be provided together (or both omitted)"
+            ),
+        };
+        let pem = match (cert_pem, key_pem) {
+            (Some(cert), Some(key)) => Some((cert, key)),
+            (None, None) => None,
+            _ => anyhow::bail!(
+                "intercept CA cert and key PEM must be provided together (or both omitted)"
+            ),
+        };
+        match (paths, pem) {
+            (Some((cert, key)), None) => Ok(CaSource::Paths { cert, key }),
+            (None, Some((cert, key))) => Ok(CaSource::Pem { cert, key }),
+            (None, None) => Ok(CaSource::Generate),
+            (Some(_), Some(_)) => anyhow::bail!(
+                "intercept CA path and inline PEM are mutually exclusive — supply only one"
+            ),
+        }
+    }
+
+    /// True when this source mints a fresh CA (nothing was supplied). `returnCaKey` is only valid
+    /// against a generated CA, so callers gate the key-return on this (issue #593, D4).
+    pub fn is_generate(&self) -> bool {
+        matches!(self, CaSource::Generate)
     }
 }
 
@@ -96,33 +165,49 @@ impl CertificateAuthority {
         })
     }
 
-    /// Load the CA from PEM files when both paths are supplied, generate a fresh one when neither
-    /// is, and reject a half-configured pair (both-or-neither). This is the single implementation
-    /// shared by the container adapter (`--intercept-ca-cert`/`--intercept-ca-key`) and the
-    /// embedded FFI (`caCertPath`/`caKeyPath`), so both surfaces agree on load-or-generate
-    /// semantics and error.
-    pub fn load_or_generate(
-        cert_path: Option<&Path>,
-        key_path: Option<&Path>,
-    ) -> anyhow::Result<Self> {
-        match (cert_path, key_path) {
-            (Some(cert), Some(key)) => {
+    /// Load or generate the CA per a resolved [`CaSource`] — the single implementation shared by
+    /// the admin `POST /intercept`, the FFI `rift_start_intercept`, and the CLI/env launch path
+    /// (issue #593), so every surface agrees on load-or-generate semantics and error. Errors never
+    /// include PEM contents.
+    pub fn from_source(source: &CaSource) -> anyhow::Result<Self> {
+        match source {
+            CaSource::Generate => Self::generate(),
+            CaSource::Paths { cert, key } => {
                 let cert_pem = std::fs::read_to_string(cert)
                     .with_context(|| format!("reading intercept CA cert {}", cert.display()))?;
                 let key_pem = std::fs::read_to_string(key)
                     .with_context(|| format!("reading intercept CA key {}", key.display()))?;
                 Self::load_pem(&cert_pem, &key_pem)
             }
-            (None, None) => Self::generate(),
-            _ => anyhow::bail!(
-                "intercept CA cert and key must be provided together (or both omitted to generate a CA)"
-            ),
+            CaSource::Pem { cert, key } => Self::load_pem(cert, key),
         }
+    }
+
+    /// Load the CA from PEM files when both paths are supplied, generate a fresh one when neither
+    /// is, and reject a half-configured pair (both-or-neither). Thin compat shim over
+    /// [`CaSource::resolve`] + [`from_source`](Self::from_source) for existing path-only callers.
+    pub fn load_or_generate(
+        cert_path: Option<&Path>,
+        key_path: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        let source = CaSource::resolve(
+            cert_path.map(Path::to_path_buf),
+            key_path.map(Path::to_path_buf),
+            None,
+            None,
+        )?;
+        Self::from_source(&source)
     }
 
     /// The CA certificate as PEM.
     pub fn ca_cert_pem(&self) -> &str {
         &self.cert_pem
+    }
+
+    /// The CA private key as PKCS#8 PEM. Secret material — only returned when a caller explicitly
+    /// asks to bootstrap a fresh CA (issue #593); never logged and never exposed by `GET /intercept`.
+    pub fn ca_key_pem(&self) -> String {
+        self.key.serialize_pem()
     }
 
     /// The CA certificate in DER form (the trust anchor).
@@ -400,6 +485,84 @@ mod tests {
             CertificateAuthority::load_pem("not a pem", "also not a pem").is_err(),
             "malformed PEM input must be a typed error, not a panic or silent success"
         );
+    }
+
+    // Issue #593: CaSource::resolve encodes the whole validation matrix in one place.
+    #[test]
+    fn ca_source_resolve_matrix() {
+        use std::path::PathBuf;
+        let p = || Some(PathBuf::from("x"));
+        let s = || Some("pem".to_string());
+
+        assert!(matches!(
+            CaSource::resolve(None, None, None, None).unwrap(),
+            CaSource::Generate
+        ));
+        assert!(matches!(
+            CaSource::resolve(p(), p(), None, None).unwrap(),
+            CaSource::Paths { .. }
+        ));
+        assert!(matches!(
+            CaSource::resolve(None, None, s(), s()).unwrap(),
+            CaSource::Pem { .. }
+        ));
+        // Half a path pair, half a PEM pair, and both pairs together are all rejected.
+        assert!(
+            CaSource::resolve(p(), None, None, None).is_err(),
+            "half path pair"
+        );
+        assert!(
+            CaSource::resolve(None, None, s(), None).is_err(),
+            "half PEM pair"
+        );
+        assert!(
+            CaSource::resolve(p(), p(), s(), s()).is_err(),
+            "path and PEM are mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn ca_source_debug_never_prints_inline_pem() {
+        let src = CaSource::Pem {
+            cert: "-----BEGIN CERTIFICATE-----secret".to_string(),
+            key: "-----BEGIN PRIVATE KEY-----supersecret".to_string(),
+        };
+        let rendered = format!("{src:?}");
+        assert!(
+            !rendered.contains("secret"),
+            "inline PEM must never appear in Debug output"
+        );
+    }
+
+    #[test]
+    fn from_source_pem_round_trips() {
+        // Generate a CA, export its PEM pair, and reload it through CaSource::Pem — the loaded CA
+        // must expose the same trust anchor and mint leaves that chain to it.
+        let original = CertificateAuthority::generate().expect("generate CA");
+        let cert_pem = original.ca_cert_pem().to_string();
+        let key_pem = original.ca_key_pem();
+
+        let source = CaSource::resolve(None, None, Some(cert_pem.clone()), Some(key_pem))
+            .expect("resolve inline PEM");
+        let loaded = CertificateAuthority::from_source(&source).expect("load from inline PEM");
+        assert_eq!(loaded.ca_cert_pem(), cert_pem, "same trust anchor");
+        let ck = loaded
+            .mint_leaf("svc.internal")
+            .expect("mint via loaded CA");
+        assert_chains_to_ca(&loaded, &ck.cert[0], &[], "svc.internal");
+    }
+
+    #[test]
+    fn ca_key_pem_is_loadable_pkcs8() {
+        let ca = CertificateAuthority::generate().expect("generate CA");
+        let key_pem = ca.ca_key_pem();
+        assert!(
+            key_pem.contains("PRIVATE KEY"),
+            "serialized as PEM private key"
+        );
+        // The exported key must reload as the same CA (cert PEM equality).
+        let reloaded = CertificateAuthority::load_pem(ca.ca_cert_pem(), &key_pem).expect("reload");
+        assert_eq!(reloaded.ca_cert_pem(), ca.ca_cert_pem());
     }
 
     #[test]

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -140,8 +140,10 @@ Environment variables override CLI defaults:
 | `RIFT_DEFAULT_TLS_KEY` | Default TLS private key (PEM) | |
 | `RIFT_NO_SELF_SIGNED_TLS` | Disable self-signed TLS fallback (`true`/`false`) | `false` |
 | `RIFT_INTERCEPT_PORT` | Start the intercept/TLS-MITM proxy on this port (epic #394) | |
-| `RIFT_INTERCEPT_CA_CERT` | PEM CA certificate for interception (with `RIFT_INTERCEPT_CA_KEY`) | |
-| `RIFT_INTERCEPT_CA_KEY` | PEM CA private key for interception | |
+| `RIFT_INTERCEPT_CA_CERT` | PEM CA certificate **file** for interception (with `RIFT_INTERCEPT_CA_KEY`) | |
+| `RIFT_INTERCEPT_CA_KEY` | PEM CA private key **file** for interception | |
+| `RIFT_INTERCEPT_CA_CERT_PEM` | Inline PEM CA certificate (the bytes, not a path; with `RIFT_INTERCEPT_CA_KEY_PEM`) — mutually exclusive with the `_CA_CERT`/`_CA_KEY` file pair | |
+| `RIFT_INTERCEPT_CA_KEY_PEM` | Inline PEM CA private key for interception | |
 | `RIFT_DISABLE_HTTP2` | Force HTTP/1-only listeners, disabling HTTP/2 & h2c auto-negotiation (truthy: `1`/`true`/`yes`/`on`) | off |
 | `RIFT_TCP_BACKLOG` | Listen backlog for the accept loop (positive integer) | `1024` |
 | `RIFT_TCP_NODELAY` | `TCP_NODELAY` on accepted sockets; set `false`/`0`/`off` to disable | on |

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -56,6 +56,8 @@ Options:
       --intercept-port <PORT>      Start the TLS-MITM intercept/redirect proxy on this port (epic #394); off when unset
       --intercept-ca-cert <FILE>   PEM CA certificate for interception (with --intercept-ca-key); a CA is generated if omitted
       --intercept-ca-key <FILE>    PEM CA private key for interception (required with --intercept-ca-cert)
+      --intercept-ca-cert-pem <PEM>  Inline PEM CA certificate for interception (with --intercept-ca-key-pem); mutually exclusive with file paths
+      --intercept-ca-key-pem <PEM>   Inline PEM CA private key for interception (required with --intercept-ca-cert-pem)
       --no-parse                   Disable EJS preprocessing of --configfile (alias: --noParse)
       --formatter <NAME>           Custom config formatter module (no-op; Rift auto-detects JSON/YAML)
       --protofile <FILE>           Custom protocol definitions file (no-op; custom protocols unsupported)

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -127,7 +127,7 @@ per handle; `rift_stop_intercept` stops it, and `rift_stop` shuts it down with t
 
 | Function | Signature | Returns |
 |---|---|---|
-| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. |
+| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, both CA pairs supplied, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null,"caCertPem":null,"caKeyPem":null,"returnCaKey":false}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. Supply the CA as files (`caCertPath`/`caKeyPath`) **or** inline PEM bytes (`caCertPem`/`caKeyPem`, issue #593 — each pair both-or-neither, mutually exclusive). `"returnCaKey":true` (only with no CA source) mints a fresh CA and adds `"caCertPem"`/`"caKeyPem"` to the response once — CA private-key material, treat as secret. |
 | `rift_stop_intercept` | `int rift_stop_intercept(RiftHandle* h)` | `0` on success (**including** the idempotent nothing-running case), `-1` only on a null handle / caught panic. Stops the listener, releases its port, and drops its rules + CA — RFC-003 parity with `DELETE /intercept`. A later `rift_start_intercept` without CA paths mints a fresh CA. |
 | `rift_intercept_add_rules` | `int rift_intercept_add_rules(RiftHandle* h, const char* rules_json)` | `0`/`-1`. One rule (object) or many (array), same shape as `/intercept/rules`. |
 | `rift_intercept_list_rules` | `char* rift_intercept_list_rules(RiftHandle* h)` | The current rules as a JSON array (**caller frees**), or `NULL` on error. |
@@ -147,11 +147,20 @@ drive. `rift_start_intercept` then `GET /intercept` reports it; `POST /intercept
 `rift_intercept_add_rules`; and a double-start across the two surfaces conflicts consistently
 (`409` / `-1`). (Previously `rift_serve_admin` served no `/intercept` routes at all.)
 
-By default (no `caCertPath`/`caKeyPath`) `rift_start_intercept` generates a fresh ephemeral intercept
-CA, unchanged from earlier releases. As of v0.11.3 (#429), passing both `caCertPath` and `caKeyPath`
-(PEM file paths) loads that committed CA instead — letting independent embedded instances share one
-trust anchor rather than each minting its own. Passing only one of the pair is a hard error (both or
+By default (no CA source) `rift_start_intercept` generates a fresh ephemeral intercept CA, unchanged
+from earlier releases. As of v0.11.3 (#429), passing both `caCertPath` and `caKeyPath` (PEM file
+paths) loads that committed CA instead — letting independent embedded instances share one trust
+anchor rather than each minting its own. Passing only one of the pair is a hard error (both or
 neither).
+
+Since issue #593 the CA may instead be supplied **inline** as `caCertPem`/`caKeyPem` (the PEM bytes,
+not paths) — the same both-or-neither rule, and mutually exclusive with the path pair — so a remote
+or containerized engine can be handed a CA over the C-ABI without staging a file. And
+`"returnCaKey":true` (valid only when no CA source is given) has the engine mint a fresh CA and
+return its cert **and** key once in the response (`caCertPem`/`caKeyPem`), for a bootstrap flow:
+start with `returnCaKey`, persist the pair, then supply it back via `caCertPem`/`caKeyPem` on later
+starts. The returned `caKeyPem` is CA private-key material — treat it as secret. Combining
+`returnCaKey` with any supplied CA source is a hard error.
 
 `interceptUrl`/`interceptPort` in the response are derived from the listener's **actual bound
 address** (v0.11.2, #425/#426) — not hardcoded to `127.0.0.1`. A loopback `host` (the default)

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -72,11 +72,17 @@ CA are automatically shared with the admin API, so the `/intercept/*` routes bel
 ```bash
 # Generate a CA in-memory:
 rift --intercept-port 8443
-# Or load an existing CA:
+# Or load an existing CA from files:
 rift --intercept-port 8443 --intercept-ca-cert ca.pem --intercept-ca-key ca.key
+# Or pass the CA inline as PEM (issue #593) — env is the intended vehicle:
+RIFT_INTERCEPT_CA_CERT_PEM="$(cat ca.pem)" RIFT_INTERCEPT_CA_KEY_PEM="$(cat ca.key)" \
+  rift --intercept-port 8443
 ```
 
-(Equivalently `RIFT_INTERCEPT_PORT` / `RIFT_INTERCEPT_CA_CERT` / `RIFT_INTERCEPT_CA_KEY`.)
+(Equivalently `RIFT_INTERCEPT_PORT` / `RIFT_INTERCEPT_CA_CERT` / `RIFT_INTERCEPT_CA_KEY`, or the
+inline `RIFT_INTERCEPT_CA_CERT_PEM` / `RIFT_INTERCEPT_CA_KEY_PEM`. The file pair and the PEM pair are
+mutually exclusive — passing both is a startup error. There is no `returnCaKey` at launch; bootstrap
+a CA over the admin API instead, so the key is never printed to logs.)
 
 `--intercept-port` is just an *eager* start of the same listener the admin API can start at runtime
 — it is no longer the only way to enable intercept. A server started **without** the flag still
@@ -90,7 +96,9 @@ it merely *connected* to.
 
 ```
 POST   /intercept   body (optional): { "host"?: "127.0.0.1", "port"?: 0,
-                                        "caCertPath"?: "...", "caKeyPath"?: "..." }
+                                        "caCertPath"?: "...",  "caKeyPath"?: "...",
+                                        "caCertPem"?: "...",   "caKeyPem"?: "...",
+                                        "returnCaKey"?: false }
                     → 201 { "interceptPort": N, "interceptUrl": "http://127.0.0.1:N" }
                     → 409 if a listener is already running (flag, FFI, or a prior POST)
 GET    /intercept   → 200 { "interceptPort": N, "interceptUrl": "..." }  |  404 when not running
@@ -102,10 +110,29 @@ DELETE /intercept   → 204 always (idempotent); stops the listener and drops it
 - The default bind host is `127.0.0.1` — **not** the admin server's host. A containerized,
   connect-transport caller that needs the proxy reachable off-box must pass `"host": "0.0.0.0"`
   explicitly.
-- CA paths are both-or-neither. A half-supplied pair, an unknown field, a bad CA file, or an
-  occupied port is a `400` with the standard error envelope; the private key is never echoed.
-- `DELETE` discards the CA along with the listener, so a later `POST` without CA paths mints a
-  **fresh** CA — re-export `/intercept/ca.pem` (below) after any restart.
+- **Supplying a CA.** Three mutually-exclusive options: none (a fresh CA is generated),
+  `caCertPath`/`caKeyPath` (PEM **files** on the engine's filesystem), or `caCertPem`/`caKeyPem`
+  (inline PEM **bytes** in the request body — issue #593). Inline PEM lets an SDK hand a
+  containerized engine its CA over the admin API with no volume mount. Each pair is
+  both-or-neither, and the path pair and PEM pair cannot be combined. A half-supplied pair, both
+  pairs together, an unknown field, a bad CA, or an occupied port is a `400` with the standard error
+  envelope; a supplied private key is never echoed back.
+- **Bootstrapping a CA (`returnCaKey`).** Set `"returnCaKey": true` (only when **no** CA source is
+  supplied) to have Rift mint a fresh CA and return **both** its cert and key in the `201` response,
+  so you can persist and redistribute a shareable anchor instead of pre-making one with `openssl`:
+  ```json
+  { "interceptPort": N, "interceptUrl": "...", "caCertPem": "-----BEGIN CERTIFICATE-----…",
+    "caKeyPem": "-----BEGIN PRIVATE KEY-----…" }
+  ```
+  The key is returned **once**, in this response only — `GET /intercept` never carries it. Combining
+  `returnCaKey` with any supplied `caCert*`/`caKey*` is a `400` (it would otherwise let a caller echo
+  back an arbitrary keypair from the engine's filesystem). Absent `returnCaKey`, the response carries
+  no CA fields, exactly as before. **Security:** `caKeyPem` is CA private-key material — treat the
+  response as a secret, transport it over the `--apikey`-gated admin plane only, and prefer a
+  pre-provisioned CA where policy requires the key never transit the API.
+- `DELETE` discards the CA along with the listener, so a later `POST` without a CA source mints a
+  **fresh** CA — re-export `/intercept/ca.pem` (below), or bootstrap with `returnCaKey` and supply
+  the pair back via `caCertPem`/`caKeyPem`, after any restart.
 - All three verbs are gated by `--apikey` like every other admin route.
 
 ```bash


### PR DESCRIPTION
## Summary

Adds inline CA PEM input (`caCertPem`/`caKeyPem`) and a `returnCaKey` generate-and-return-CA mode to `POST /intercept`, enabling SDKs reaching a containerized Rift engine over the admin API to either supply their own CA or have Rift mint and return a shareable CA once, across the admin API, C-ABI, and CLI/env.

The `returnCaKey` mode is restricted to generated CAs only, preventing accidental keypair leakage from the engine's filesystem.

Closes #593

## Scope

- Docs updated: `docs/features/intercept-proxy.md`, `docs/configuration/cli.md`, `docs/embedding/ffi.md`
- CHANGELOG updated
- Security: `returnCaKey` restricted to generated CAs; keypair returned once and never by GET
- Consumer: rift-java#111