### PR TITLE
chore(release): prepare 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ record.
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-07-12
+
 ### Added
 
 - **Intercept CA: inline PEM input and a generate-and-return bootstrap mode.** `POST /intercept`
@@ -526,7 +528,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.3...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.4...HEAD
+[0.13.4]: https://github.com/EtaCassiopeia/rift/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/EtaCassiopeia/rift/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/EtaCassiopeia/rift/compare/v0.13.0...v0.13.1


### PR DESCRIPTION
Stamp the `0.13.4` CHANGELOG section and roll the compare links ahead of tagging `v0.13.4`.

Bundles the two features merged since 0.13.3:
- **#593** — intercept: inline CA (`caCertPem`/`caKeyPem`) + generate-and-return-CA mode (#594)
- **#592** — `rift_abi_version()` for SDK ABI-contract gating

No code changes; CHANGELOG only. Tagging `v0.13.4` on the merge commit triggers the Release workflow.