### PR TITLE
chore(release): prepare 0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ record.
 
 ## [Unreleased]
 
+## [0.13.5] - 2026-07-12
+
 ### Fixed
 
 - **Deleting an imposter now fully tears it down before the call returns.** `DELETE /imposters[/{port}]`
@@ -541,7 +543,8 @@ Initial release-candidate series establishing the Mountebank-compatible core: im
 predicates, responses, behaviors, proxy/record, and the `_rift` extension namespace (fault
 injection, multi-engine scripting, flow state).
 
-[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.4...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/rift/compare/v0.13.5...HEAD
+[0.13.5]: https://github.com/EtaCassiopeia/rift/compare/v0.13.4...v0.13.5
 [0.13.4]: https://github.com/EtaCassiopeia/rift/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/EtaCassiopeia/rift/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/EtaCassiopeia/rift/compare/v0.13.1...v0.13.2


### PR DESCRIPTION
Stamp the `0.13.5` CHANGELOG section and roll the compare links ahead of tagging `v0.13.5`.

Contains the one fix merged since 0.13.4:
- **#596** — imposter `delete` now awaits full teardown so a deleted imposter can't serve after delete returns (#597); unblocks rift-java#79.

No code changes; CHANGELOG only.