### PR TITLE
fix(lint): resolve ~6 clippy warnings in rift-mock-core with --no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,11 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+      # The minimal-feature cdylib (docs/embedding/ffi.md) is a shipped configuration, so lint it
+      # too — otherwise warnings can silently accumulate in feature-gated paths (issue #599).
+      - name: Run clippy (no default features)
+        run: cargo clippy -p rift-mock-core -p rift-ffi --all-targets --no-default-features -- -D warnings
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/crates/rift-mock-core/src/extensions/flow_state.rs
+++ b/crates/rift-mock-core/src/extensions/flow_state.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -197,6 +197,11 @@ pub fn create_flow_store(config: &crate::config::FlowStateConfig) -> Result<Arc<
             Ok(Arc::new(InMemoryFlowStore::new(config.ttl_seconds as u64)))
         }
         "redis" => {
+            // Validate config presence in *all* builds so the "no redis config" error is returned
+            // even without the backend feature (a test locks this in); the value is only *consumed*
+            // when the backend is compiled in, hence the unused-var allow for the minimal build.
+            // `Context` is likewise only used inside the feature block, so it's imported there (#599).
+            #[cfg_attr(not(feature = "redis-backend"), allow(unused_variables))]
             let redis_config = config
                 .redis
                 .as_ref()
@@ -204,6 +209,8 @@ pub fn create_flow_store(config: &crate::config::FlowStateConfig) -> Result<Arc<
 
             #[cfg(feature = "redis-backend")]
             {
+                use anyhow::Context;
+
                 use crate::backends::RedisFlowStore;
 
                 let store = RedisFlowStore::new(

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -168,6 +168,10 @@ pub fn predicate_matches(
 ///
 /// See [`stub_matches`] for the `Err` contract (issue #440).
 #[allow(clippy::too_many_arguments)]
+// `imposter_port` is consumed by the `inject` predicate evaluator, which is `javascript`-gated
+// (issue #599); without that feature the arm doesn't use it, so it's only threaded through the
+// recursive And/Or descent — a false positive for this build only.
+#[cfg_attr(not(feature = "javascript"), allow(clippy::only_used_in_recursion))]
 pub(crate) fn predicate_matches_inner(
     predicate: &Predicate,
     method: &str,

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -402,12 +402,12 @@ pub fn apply_js_or_rhai_decorate(
         #[cfg(not(feature = "javascript"))]
         {
             // Fallback to Rhai conversion when JavaScript feature is disabled
-            if let Some(start) = script.find('{') {
-                if let Some(end) = script.rfind('}') {
-                    let js_body = script[start + 1..end].trim();
-                    let rhai_script = js_body.replace('\'', "\"");
-                    return apply_decorate(&rhai_script, request, body, status, headers);
-                }
+            if let Some(start) = script.find('{')
+                && let Some(end) = script.rfind('}')
+            {
+                let js_body = script[start + 1..end].trim();
+                let rhai_script = js_body.replace('\'', "\"");
+                return apply_decorate(&rhai_script, request, body, status, headers);
             }
             Err(DecorateError::JsParseFailure)
         }

--- a/crates/rift-mock-core/src/scripting/script_pool.rs
+++ b/crates/rift-mock-core/src/scripting/script_pool.rs
@@ -566,6 +566,9 @@ mod tests {
             rule_id: "test-rule".to_string(),
         };
 
+        // `CompiledScript` has a second (`Js`) variant only under the `javascript` feature, so this
+        // pattern is refutable there but irrefutable without it (issue #599).
+        #[cfg_attr(not(feature = "javascript"), allow(irrefutable_let_patterns))]
         if let CompiledScript::Rhai { rule_id, .. } = compiled {
             assert_eq!(rule_id, "test-rule");
         }
@@ -584,6 +587,7 @@ mod tests {
         };
 
         let cloned = compiled.clone();
+        #[cfg_attr(not(feature = "javascript"), allow(irrefutable_let_patterns))]
         if let CompiledScript::Rhai { rule_id, .. } = cloned {
             assert_eq!(rule_id, "clone-test");
         }


### PR DESCRIPTION
Fixes ~6 clippy warnings in rift-mock-core that only surface under the minimal
--no-default-features build (a shipped FFI configuration). Each warning is fixed
feature-aware to preserve the default/all-features build cleanness.

Adds a --no-default-features clippy CI lane so this configuration can't silently accumulate warnings again.

Closes #599