### PR TITLE
docs(readme): add Used By section and drop removed Lua scripting engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ await server.close();
 
 ### Features
 - [Fault Injection](https://etacassiopeia.github.io/rift/features/fault-injection) - Chaos engineering
-- [Scripting](https://etacassiopeia.github.io/rift/features/scripting) - Rhai, Lua, JavaScript
+- [Scripting](https://etacassiopeia.github.io/rift/features/scripting) - Rhai, JavaScript
 - [TLS/HTTPS](https://etacassiopeia.github.io/rift/features/tls) - Secure connections
 - [Metrics](https://etacassiopeia.github.io/rift/features/metrics) - Prometheus integration
 - [TUI](https://etacassiopeia.github.io/rift/features/tui) - Interactive terminal interface
@@ -301,6 +301,17 @@ cd tests/benchmark && python3 scripts/bench_direct.py --run-all \
   --rift-bin ../../target/release/rift-http-proxy \
   --mb-bin ~/bench-mb/node_modules/mountebank/bin/mb
 ```
+
+---
+
+## Used By
+
+Rift powers HTTP mocking in the following projects:
+
+- **[zio-bdd](https://github.com/EtaCassiopeia/zio-bdd)** — a Gherkin-style BDD testing framework for ZIO
+- **[zio-openfeature](https://github.com/EtaCassiopeia/zio-openfeature)** — a ZIO-native wrapper around the OpenFeature Java SDK
+
+Using Rift somewhere? Open a PR to add it here.
 
 ---
 


### PR DESCRIPTION
Adds a **Used By** section to the README listing two real consumers of Rift — [zio-bdd](https://github.com/EtaCassiopeia/zio-bdd) and [zio-openfeature](https://github.com/EtaCassiopeia/zio-openfeature) — to signal active adoption, plus an invite for others to add themselves.

Also fixes a stale reference: the scripting line listed Lua, which was removed (`deac0b9`) when scripting consolidated on Rhai + JavaScript.

Docs-only; no code or behavior change.