### PR TITLE
fix(lint): reuse parsed imposter values

### DIFF
--- a/crates/rift-lint/src/main.rs
+++ b/crates/rift-lint/src/main.rs
@@ -7,7 +7,7 @@
 //!   rift-lint <directory_or_file> [OPTIONS]
 
 use clap::Parser;
-use rift_lint::{LintIssue, LintOptions, LintResult, Severity, lint_file};
+use rift_lint::{LintIssue, LintOptions, LintResult, Severity, lint_value};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io::IsTerminal;
@@ -179,9 +179,9 @@ fn main() {
     // Check for port conflicts
     check_port_conflicts(&port_map, &mut result);
 
-    // Second pass: Validate each imposter using the library
-    for (file, _) in &imposters {
-        let file_result = lint_file(file, &options);
+    // Second pass: Validate each parsed imposter using the library
+    for (file, value) in &imposters {
+        let file_result = lint_value(value, &file.to_string_lossy(), &options);
         // Merge without double-counting files_checked (we already counted)
         result.issues.extend(file_result.issues);
         result.errors += file_result.errors;

--- a/crates/rift-lint/tests/cli_output.rs
+++ b/crates/rift-lint/tests/cli_output.rs
@@ -72,6 +72,65 @@ fn lint_json_empty_dir_still_emits_json() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+#[test]
+fn lint_json_directory_attributes_parse_and_validation_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let valid_json = dir.path().join("valid-json.json");
+    let invalid_json = dir.path().join("invalid-json.json");
+    // Valid JSON that intentionally reaches pass-two validation with one missing field.
+    std::fs::write(&valid_json, r#"{"protocol":"http","stubs":[]}"#).expect("write valid JSON");
+    std::fs::write(&invalid_json, r#"{"port":8001"#).expect("write invalid JSON");
+
+    let out = Command::new(BIN)
+        .args([dir.path().to_str().unwrap(), "-o", "json"])
+        .output()
+        .expect("run rift-lint");
+    assert!(
+        !out.status.success(),
+        "lint errors must produce a failure exit"
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout parses as JSON");
+    let issues = report["issues"].as_array().expect("issues is an array");
+    assert_eq!(report["files_checked"].as_u64(), Some(2));
+    assert_eq!(report["errors"].as_u64(), Some(2));
+    assert_eq!(issues.len(), 2, "expected one issue per file: {issues:?}");
+
+    let parse_errors: Vec<_> = issues
+        .iter()
+        .filter(|issue| {
+            issue["code"] == "E001"
+                && issue["message"]
+                    .as_str()
+                    .is_some_and(|message| message.starts_with("Failed to parse JSON:"))
+        })
+        .collect();
+    assert_eq!(
+        parse_errors.len(),
+        1,
+        "expected one parse error: {issues:?}"
+    );
+    assert_eq!(
+        parse_errors[0]["file"],
+        invalid_json.to_string_lossy().as_ref()
+    );
+
+    let validation_issues: Vec<_> = issues
+        .iter()
+        .filter(|issue| issue["code"] == "E003")
+        .collect();
+    assert_eq!(
+        validation_issues.len(),
+        1,
+        "valid JSON should produce one validation issue: {issues:?}"
+    );
+    assert_eq!(
+        validation_issues[0]["file"],
+        valid_json.to_string_lossy().as_ref()
+    );
+}
+
 // AC1: NO_COLOR is honored regardless of TTY.
 #[test]
 fn lint_no_color_env_disables_ansi() {


### PR DESCRIPTION
## What changed

- Reuse the parsed `serde_json::Value` in rift-lint's validation pass via the existing `lint_value` API.
- Add a CLI regression test covering one valid JSON validation issue and one JSON parse error, including file attribution and counts.

## Why

The first pass already parses each file for port-conflict detection and stores the resulting value. The second pass discarded that value and called `lint_file`, which reread and reparsed the same path. Reusing the value removes duplicate I/O/parsing and prevents validation from observing different file contents after a concurrent change.

## Validation

- `cargo fmt --all`
- `cargo check -p rift-lint --tests --offline` (passes with Rust 1.92.0)
- `cargo clippy -p rift-lint --tests --offline -- -D warnings` (passes)
- `cargo test -p rift-lint` was attempted; this Windows runner lacks MSVC SDK import libraries and GNU binutils, so linking is environment-blocked. The source and test targets type-check cleanly; upstream CI will run the executable tests.

Fixes #556