### PR TITLE
feat(admin): savedRequests cursor (?since=<index>) via per-port monotonic journal indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **`savedRequests` cursor — tail an imposter's recorded requests without re-fetching the journal.**
+  `GET /imposters/{port}/savedRequests?since=<index>` now serves only the requests newer than a
+  cursor, so an SDK request-tail costs O(new entries) per poll instead of O(journal) with
+  client-side dedupe. Every recorded request gets a stable, 1-based, per-port index; the cursor
+  rides in the `x-rift-next-index` response header (pass it back verbatim as the next `since`), and
+  the response body stays the same bare JSON array, so existing clients and Mountebank compatibility
+  are unaffected. `since` composes with the existing `match=` filters, and the cursor always
+  advances past entries a filter rejected — a filtered tail never re-scans. Indices survive
+  `DELETE savedRequests` and scoped clears (later entries simply get larger indices), so a cursor
+  held across a clear stays valid. `x-rift-truncated: true` appears only when the 10k retention cap
+  evicted entries you had not seen yet — the signal to re-baseline. Absence of `x-rift-next-index`
+  is the capability probe: older engines and custom `RequestJournal` backends without stable indices
+  serve the full list and are polled exactly as before. The `RequestJournal` trait gains
+  `read_since`/`record_indexed` as default methods returning "unsupported", so existing embedder
+  implementations compile and behave unchanged.
+
 ## [0.13.5] - 2026-07-12
 
 ### Fixed

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1,20 +1,17 @@
 //! Imposter CRUD handlers.
 
-use crate::admin_api::request_filter::{parse_match_clauses, request_matches};
+use crate::admin_api::request_filter::{parse_match_clauses, parse_since, request_matches};
 use crate::admin_api::types::{
     ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
     RiftImposterExtensions, StubWithLinks, build_response_with_headers, collect_body,
     error_response, json_response, make_imposter_links, make_stub_links,
 };
 use crate::extensions::decorate::backend_error_response;
+use crate::imposter::RecordedRequest;
 use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
     ScriptBaseDir, Stub, StubResponse, VerifyOptions, resolve_scripts,
 };
-// `RecordedRequest` is only named in tests now that the `/requests` handler filters before
-// cloning via `get_recorded_requests_filtered` (issue #485).
-#[cfg(test)]
-use crate::imposter::RecordedRequest;
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
 use http_body_util::Full;
@@ -580,8 +577,13 @@ fn flow_id_source(imposter: &Imposter) -> String {
         .unwrap_or_else(|| "imposter_port".to_string())
 }
 
-/// GET /imposters/:port/requests[?match=...] - recorded requests, optionally
-/// filtered by `header:<Name>=<Value>` / `flow_id=<Value>` clauses (AND'd).
+/// GET /imposters/:port/requests[?match=...][?since=<index>] - recorded requests, optionally
+/// filtered by `header:<Name>=<Value>` / `flow_id=<Value>` clauses (AND'd) and cut to entries
+/// newer than a cursor.
+///
+/// The body is always the historical bare array; cursor metadata rides in `x-rift-next-index`
+/// (and `x-rift-truncated` when retention outran the caller). Backends without stable indices
+/// emit neither, which is exactly how an SDK probes for cursor support (issue #603).
 pub async fn handle_get_requests(
     port: u16,
     query: Option<&str>,
@@ -591,17 +593,64 @@ pub async fn handle_get_requests(
         Ok(c) => c,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
     };
+    let since = match parse_since(query) {
+        Ok(s) => s,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string()),
+    };
     match manager.get_imposter(port) {
         Ok(imposter) => {
             let source = flow_id_source(&imposter);
             // Filter over references before cloning so an unmatched journal entry is never
-            // deep-cloned (issue #485).
-            let filtered = imposter
-                .get_recorded_requests_filtered(|r| request_matches(r, &clauses, &source, port));
-            json_response(StatusCode::OK, &filtered)
+            // deep-cloned (issue #485) — on both the cursor and the fallback path.
+            let keep = |r: &RecordedRequest| request_matches(r, &clauses, &source, port);
+            match imposter.read_recorded_requests_since(since, keep) {
+                Some(read) => {
+                    let entries: Vec<RecordedRequest> =
+                        read.entries.into_iter().map(|e| e.request).collect();
+                    if read.complete {
+                        cursor_response(&entries, read.next, read.truncated)
+                    } else {
+                        // A degraded read reached only part of its storage, so `next` spans
+                        // entries that were never served. Withholding the cursor is what stops
+                        // a client from advancing past them and losing them for good; it
+                        // re-polls instead, exactly as against a backend with no cursor at all.
+                        json_response(StatusCode::OK, &entries)
+                    }
+                }
+                None => {
+                    let filtered = imposter.get_recorded_requests_filtered(keep);
+                    json_response(StatusCode::OK, &filtered)
+                }
+            }
         }
         Err(e) => e.into(),
     }
+}
+
+/// The savedRequests array plus its cursor headers. `truncated` is emitted only when true —
+/// an SDK tests for the header's presence, never parses a `false`.
+fn cursor_response(
+    entries: &[RecordedRequest],
+    next: u64,
+    truncated: bool,
+) -> Response<Full<Bytes>> {
+    let json = match serde_json::to_string_pretty(entries) {
+        Ok(j) => j,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("failed to serialize recorded requests: {e}"),
+            );
+        }
+    };
+    let mut headers = vec![
+        ("Content-Type".to_string(), "application/json".to_string()),
+        ("x-rift-next-index".to_string(), next.to_string()),
+    ];
+    if truncated {
+        headers.push(("x-rift-truncated".to_string(), "true".to_string()));
+    }
+    build_response_with_headers(StatusCode::OK, headers, json)
 }
 
 /// DELETE /imposters/:port/savedRequests - Clear recorded requests.
@@ -1272,6 +1321,382 @@ mod requests_filter_tests {
             "malformed DELETE must not clear anything"
         );
         let _ = m.delete_imposter(19741).await;
+    }
+
+    // ---- #603: savedRequests cursor ----------------------------------------------------
+
+    fn header<'a>(resp: &'a Response<Full<Bytes>>, name: &str) -> Option<&'a str> {
+        resp.headers().get(name).and_then(|v| v.to_str().ok())
+    }
+
+    fn next_index(resp: &Response<Full<Bytes>>) -> Option<&str> {
+        header(resp, "x-rift-next-index")
+    }
+
+    fn rec_at(path: &str, space: &str) -> RecordedRequest {
+        let mut r = rec(space, None);
+        r.path = path.to_string();
+        r
+    }
+
+    // AC7 (#603): `?since=` serves only entries newer than the cursor, and reports the new
+    // cursor in the response header. The body stays the historical bare array.
+    #[tokio::test]
+    async fn get_requests_since_returns_newer_with_cursor_header() {
+        let m = manager_with(
+            19750,
+            None,
+            &[rec_at("/a", "A"), rec_at("/b", "A"), rec_at("/c", "A")],
+        )
+        .await;
+
+        let resp = handle_get_requests(19750, Some("since=1"), m.clone()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(next_index(&resp), Some("3"));
+        let got = requests(resp).await;
+        assert_eq!(
+            got.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            vec!["/b", "/c"],
+            "index 1 was already seen"
+        );
+
+        // Caught up: empty body, cursor unchanged.
+        let resp = handle_get_requests(19750, Some("since=3"), m.clone()).await;
+        assert_eq!(next_index(&resp), Some("3"));
+        assert!(requests(resp).await.is_empty());
+
+        let _ = m.delete_imposter(19750).await;
+    }
+
+    // AC8 (#603): `since` and `match` compose — cursor cut first, filter after — and a window
+    // that matches nothing still advances the cursor.
+    #[tokio::test]
+    async fn get_requests_since_composes_with_match() {
+        let m = manager_with(
+            19751,
+            None,
+            &[
+                rec_at("/1", "A"),
+                rec_at("/2", "B"),
+                rec_at("/3", "A"),
+                rec_at("/4", "B"),
+            ],
+        )
+        .await;
+
+        let resp = handle_get_requests(
+            19751,
+            Some("since=1&match=header:X-Mock-Space=A"),
+            m.clone(),
+        )
+        .await;
+        assert_eq!(next_index(&resp), Some("4"), "cursor spans scanned entries");
+        let got = requests(resp).await;
+        assert_eq!(
+            got.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            vec!["/3"],
+            "cut at 1, then keep only space A"
+        );
+
+        // A filtered tail whose window matches nothing must still advance, or it re-scans forever.
+        let resp = handle_get_requests(
+            19751,
+            Some("since=1&match=header:X-Mock-Space=ZZZ"),
+            m.clone(),
+        )
+        .await;
+        assert_eq!(next_index(&resp), Some("4"));
+        assert!(requests(resp).await.is_empty());
+
+        let _ = m.delete_imposter(19751).await;
+    }
+
+    // AC9 (#603): a malformed cursor is rejected before any journal work.
+    #[tokio::test]
+    async fn get_requests_rejects_non_numeric_since() {
+        let m = manager_with(19752, None, &[rec_at("/a", "A")]).await;
+        for bad in ["since=abc", "since=-1", "since=", "since=1.5"] {
+            let resp = handle_get_requests(19752, Some(bad), m.clone()).await;
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "'{bad}' must be rejected"
+            );
+            assert!(next_index(&resp).is_none(), "no cursor header on a 400");
+        }
+        let _ = m.delete_imposter(19752).await;
+    }
+
+    // A journal with no stable indices: it records and reads normally but never overrides the
+    // cursor methods, so it inherits the honest `None` defaults (the out-of-tree embedder case).
+    #[derive(Default)]
+    struct CursorlessJournal(crate::imposter::LocalJournal);
+    impl crate::imposter::RequestJournal for CursorlessJournal {
+        fn note_request(&self, port: u16) {
+            self.0.note_request(port);
+        }
+        fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+            self.0.record(port, flow_id, req);
+        }
+        fn read(&self, port: u16) -> crate::imposter::JournalRead {
+            self.0.read(port)
+        }
+        fn clear(&self, port: u16) -> anyhow::Result<()> {
+            self.0.clear(port)
+        }
+        fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+            self.0.retain(port, keep);
+        }
+        fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
+            self.0.clear_flow(port, flow_id)
+        }
+        fn count(&self, port: u16) -> u64 {
+            self.0.count(port)
+        }
+    }
+
+    async fn manager_with_journal(
+        port: u16,
+        journal: Arc<dyn crate::imposter::RequestJournal>,
+        recorded: &[RecordedRequest],
+    ) -> Arc<ImposterManager> {
+        let manager = Arc::new(ImposterManager::new().with_request_journal(journal));
+        let cfg = serde_json::from_value(serde_json::json!({
+            "port": port, "protocol": "http", "recordRequests": true, "stubs": []
+        }))
+        .expect("config");
+        manager.create_imposter(cfg).await.expect("create");
+        let imposter = manager.get_imposter(port).expect("imposter");
+        for r in recorded {
+            imposter.record_request(r);
+        }
+        manager
+    }
+
+    // AC10 (#603): against a backend without stable indices the endpoint behaves exactly as it
+    // does today — full list, no cursor headers. That absence IS the SDK capability probe, so
+    // it must hold even when the client asks for a cursor.
+    #[tokio::test]
+    async fn get_requests_omits_cursor_headers_without_support() {
+        let m = manager_with_journal(
+            19753,
+            Arc::new(CursorlessJournal::default()),
+            &[rec_at("/a", "A"), rec_at("/b", "A")],
+        )
+        .await;
+
+        for query in [None, Some("since=1")] {
+            let resp = handle_get_requests(19753, query, m.clone()).await;
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert!(
+                next_index(&resp).is_none(),
+                "no cursor support => no cursor header (the probe)"
+            );
+            assert!(header(&resp, "x-rift-truncated").is_none());
+            assert_eq!(
+                requests(resp).await.len(),
+                2,
+                "an unsupported `since` is ignored, not an error — the full list is served"
+            );
+        }
+        let _ = m.delete_imposter(19753).await;
+    }
+
+    // AC11 (#603): the baseline poll (no `since`) is unchanged in body but carries the cursor
+    // the SDK loop starts from — including on an empty journal.
+    #[tokio::test]
+    async fn get_requests_baseline_reports_next_index() {
+        let empty = manager_with(19754, None, &[]).await;
+        let resp = handle_get_requests(19754, None, empty.clone()).await;
+        assert_eq!(next_index(&resp), Some("0"), "0 == 'seen nothing yet'");
+        assert!(header(&resp, "x-rift-truncated").is_none());
+        assert!(requests(resp).await.is_empty());
+        let _ = empty.delete_imposter(19754).await;
+
+        let m = manager_with(19755, None, &[rec_at("/a", "A"), rec_at("/b", "A")]).await;
+        let resp = handle_get_requests(19755, None, m.clone()).await;
+        assert_eq!(next_index(&resp), Some("2"));
+        assert!(
+            header(&resp, "x-rift-truncated").is_none(),
+            "a baseline read is never truncated"
+        );
+        assert_eq!(requests(resp).await.len(), 2);
+        let _ = m.delete_imposter(19755).await;
+    }
+
+    // A journal reporting a cursor whose unseen entries were lost to retention pressure.
+    // Eviction semantics themselves are proven in journal.rs; this pins the handler's plumbing
+    // of the flag onto the wire.
+    #[derive(Default)]
+    struct TruncatingJournal(crate::imposter::LocalJournal);
+    impl crate::imposter::RequestJournal for TruncatingJournal {
+        fn note_request(&self, port: u16) {
+            self.0.note_request(port);
+        }
+        fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+            self.0.record(port, flow_id, req);
+        }
+        fn record_indexed(&self, port: u16, flow_id: &str, req: RecordedRequest) -> Option<u64> {
+            self.0.record_indexed(port, flow_id, req)
+        }
+        fn read(&self, port: u16) -> crate::imposter::JournalRead {
+            self.0.read(port)
+        }
+        fn read_since(
+            &self,
+            port: u16,
+            since: Option<u64>,
+            keep: &dyn Fn(&RecordedRequest) -> bool,
+        ) -> Option<crate::imposter::JournalReadSince> {
+            self.0.read_since(port, since, keep).map(|mut r| {
+                r.truncated = since.is_some();
+                r
+            })
+        }
+        fn clear(&self, port: u16) -> anyhow::Result<()> {
+            self.0.clear(port)
+        }
+        fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+            self.0.retain(port, keep);
+        }
+        fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
+            self.0.clear_flow(port, flow_id)
+        }
+        fn count(&self, port: u16) -> u64 {
+            self.0.count(port)
+        }
+    }
+
+    // AC12 (#603): `truncated` reaches the wire only when the backend reports a hole, and is
+    // absent otherwise — SDKs treat its presence as "your baseline is stale, re-poll".
+    #[tokio::test]
+    async fn get_requests_flags_truncated_after_eviction() {
+        let m = manager_with_journal(
+            19756,
+            Arc::new(TruncatingJournal::default()),
+            &[rec_at("/a", "A"), rec_at("/b", "A")],
+        )
+        .await;
+
+        let resp = handle_get_requests(19756, Some("since=1"), m.clone()).await;
+        assert_eq!(
+            header(&resp, "x-rift-truncated"),
+            Some("true"),
+            "the backend reported a hole; the client must be told"
+        );
+        assert_eq!(next_index(&resp), Some("2"), "cursor still advances");
+
+        let resp = handle_get_requests(19756, None, m.clone()).await;
+        assert!(
+            header(&resp, "x-rift-truncated").is_none(),
+            "not truncated => header absent entirely, never 'false'"
+        );
+
+        let _ = m.delete_imposter(19756).await;
+    }
+
+    // AC12 (#603), end to end: drive the real 10k cap through the real recording path and
+    // confirm a stale cursor is told it lost data. The double above pins the plumbing; this
+    // pins that genuine retention pressure actually reaches the wire.
+    #[tokio::test]
+    async fn get_requests_truncated_by_real_cap_eviction() {
+        let m = manager_with(19757, None, &[]).await;
+        let imposter = m.get_imposter(19757).expect("imposter");
+        for i in 0..(crate::imposter::MAX_RECORDED_REQUESTS + 5) {
+            imposter.record_request(&rec_at(&format!("/{i}"), "A"));
+        }
+
+        // Indices 1..=5 were evicted; a cursor at 2 never received 3..=5.
+        let resp = handle_get_requests(19757, Some("since=2"), m.clone()).await;
+        assert_eq!(header(&resp, "x-rift-truncated"), Some("true"));
+        assert_eq!(
+            next_index(&resp),
+            Some((crate::imposter::MAX_RECORDED_REQUESTS + 5).to_string()).as_deref()
+        );
+
+        // A cursor past the eviction watermark lost nothing.
+        let resp = handle_get_requests(19757, Some("since=5"), m.clone()).await;
+        assert!(
+            header(&resp, "x-rift-truncated").is_none(),
+            "cursor at the watermark saw everything eviction removed"
+        );
+
+        let _ = m.delete_imposter(19757).await;
+    }
+
+    // A journal that reached only part of its storage (issue #314's degraded-read contract),
+    // now on the cursor path: it returns fewer entries than it counted, but `next` still spans
+    // the range it scanned.
+    #[derive(Default)]
+    struct DegradedJournal(crate::imposter::LocalJournal);
+    impl crate::imposter::RequestJournal for DegradedJournal {
+        fn note_request(&self, port: u16) {
+            self.0.note_request(port);
+        }
+        fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+            self.0.record(port, flow_id, req);
+        }
+        fn record_indexed(&self, port: u16, flow_id: &str, req: RecordedRequest) -> Option<u64> {
+            self.0.record_indexed(port, flow_id, req)
+        }
+        fn read(&self, port: u16) -> crate::imposter::JournalRead {
+            self.0.read(port)
+        }
+        fn read_since(
+            &self,
+            port: u16,
+            since: Option<u64>,
+            keep: &dyn Fn(&RecordedRequest) -> bool,
+        ) -> Option<crate::imposter::JournalReadSince> {
+            self.0.read_since(port, since, keep).map(|mut r| {
+                r.entries.truncate(1);
+                r.complete = false;
+                r
+            })
+        }
+        fn clear(&self, port: u16) -> anyhow::Result<()> {
+            self.0.clear(port)
+        }
+        fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+            self.0.retain(port, keep);
+        }
+        fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
+            self.0.clear_flow(port, flow_id)
+        }
+        fn count(&self, port: u16) -> u64 {
+            self.0.count(port)
+        }
+    }
+
+    // A degraded read must not hand out a cursor: `next` spans entries the backend could not
+    // serve, so advancing on it would skip them permanently and silently. Withholding the
+    // header makes the client re-poll instead — partial data is served, but never at the cost
+    // of losing the rest.
+    #[tokio::test]
+    async fn get_requests_withholds_cursor_on_degraded_read() {
+        let m = manager_with_journal(
+            19758,
+            Arc::new(DegradedJournal::default()),
+            &[rec_at("/a", "A"), rec_at("/b", "A"), rec_at("/c", "A")],
+        )
+        .await;
+
+        for query in [None, Some("since=1")] {
+            let resp = handle_get_requests(19758, query, m.clone()).await;
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert!(
+                next_index(&resp).is_none(),
+                "an incomplete read must not advertise a cursor to advance from"
+            );
+            assert!(header(&resp, "x-rift-truncated").is_none());
+            assert_eq!(
+                requests(resp).await.len(),
+                1,
+                "the partial results the backend did reach are still served"
+            );
+        }
+
+        let _ = m.delete_imposter(19758).await;
     }
 }
 

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -35,22 +35,46 @@ pub(crate) fn parse_match_clauses(
     query: Option<&str>,
 ) -> Result<Vec<MatchClause>, MatchClauseError> {
     let mut clauses = Vec::new();
-    let Some(q) = query else {
-        return Ok(clauses);
-    };
-    for pair in q.split('&') {
-        let Some((key, raw_value)) = pair.split_once('=') else {
-            continue;
-        };
-        if key != "match" {
-            continue;
+    for (key, value) in query_pairs(query) {
+        if key == "match" {
+            clauses.push(parse_one(&value)?);
         }
-        let value = urlencoding::decode(raw_value)
-            .map(|v| v.into_owned())
-            .unwrap_or_else(|_| raw_value.to_string());
-        clauses.push(parse_one(&value)?);
     }
     Ok(clauses)
+}
+
+/// Decoded `key=value` pairs of a query string. Pairs without `=` are skipped, and a value that
+/// is not valid percent-encoding is passed through raw so it fails the caller's own validation
+/// rather than the decoder's.
+fn query_pairs(query: Option<&str>) -> impl Iterator<Item = (&str, String)> {
+    query
+        .into_iter()
+        .flat_map(|q| q.split('&'))
+        .filter_map(|pair| {
+            let (key, raw_value) = pair.split_once('=')?;
+            let value = urlencoding::decode(raw_value)
+                .map(|v| v.into_owned())
+                .unwrap_or_else(|_| raw_value.to_string());
+            Some((key, value))
+        })
+}
+
+/// Rejected `?since=` cursor. Like [`MatchClauseError`], the message is served verbatim in a
+/// `400 Bad Request` body and is therefore part of the admin API contract.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid since cursor '{0}' (expected a non-negative integer)")]
+pub(crate) struct SinceError(String);
+
+/// Parse the `?since=<u64>` cursor (issue #603). `None` = no cursor requested, i.e. a baseline
+/// read of everything retained. Unknown keys are skipped, so `since` composes with `match`.
+pub(crate) fn parse_since(query: Option<&str>) -> Result<Option<u64>, SinceError> {
+    let mut since = None;
+    for (key, value) in query_pairs(query) {
+        if key == "since" {
+            since = Some(value.parse::<u64>().map_err(move |_| SinceError(value))?);
+        }
+    }
+    Ok(since)
 }
 
 fn parse_one(value: &str) -> Result<MatchClause, MatchClauseError> {

--- a/crates/rift-mock-core/src/imposter/core/recording.rs
+++ b/crates/rift-mock-core/src/imposter/core/recording.rs
@@ -4,7 +4,7 @@
 //! signatures are unchanged so the admin API and embedders are untouched.
 
 use super::*;
-use crate::imposter::journal::JournalRead;
+use crate::imposter::journal::{JournalRead, JournalReadSince};
 
 impl Imposter {
     pub(super) fn journal_port(&self) -> u16 {
@@ -12,12 +12,16 @@ impl Imposter {
     }
 
     /// Record a request (when body recording is enabled), tagged with its resolved flow id.
-    pub fn record_request(&self, req: &RecordedRequest) {
-        if self.config.record_requests {
-            let flow_id = self.resolve_flow_id_recorded(&req.headers);
-            self.journal
-                .record(self.journal_port(), &flow_id, req.clone());
+    ///
+    /// Returns the journal index assigned to the entry, or `None` when nothing was recorded
+    /// (recording is off) or the backend has no stable indices (issue #603).
+    pub fn record_request(&self, req: &RecordedRequest) -> Option<u64> {
+        if !self.config.record_requests {
+            return None;
         }
+        let flow_id = self.resolve_flow_id_recorded(&req.headers);
+        self.journal
+            .record_indexed(self.journal_port(), &flow_id, req.clone())
     }
 
     /// Read recorded requests with the backend's completeness flag intact, so embedders
@@ -26,18 +30,22 @@ impl Imposter {
         self.journal.read(self.journal_port())
     }
 
+    fn warn_if_incomplete(&self, complete: bool, entries_served: usize) {
+        if !complete {
+            tracing::warn!(
+                port = self.journal_port(),
+                entries_served,
+                "request journal returned an incomplete read; serving partial results"
+            );
+        }
+    }
+
     /// Get recorded requests. An incomplete read (backend partially unreachable) serves
     /// the partial entries and surfaces the degradation in the log; callers that need to
     /// react to it programmatically use [`Self::read_recorded_requests`].
     pub fn get_recorded_requests(&self) -> Vec<RecordedRequest> {
         let read = self.read_recorded_requests();
-        if !read.complete {
-            tracing::warn!(
-                port = self.journal_port(),
-                entries_served = read.entries.len(),
-                "request journal returned an incomplete read; serving partial results"
-            );
-        }
+        self.warn_if_incomplete(read.complete, read.entries.len());
         read.entries
     }
 
@@ -48,14 +56,24 @@ impl Imposter {
         keep: F,
     ) -> Vec<RecordedRequest> {
         let read = self.journal.read_filtered(self.journal_port(), &keep);
-        if !read.complete {
-            tracing::warn!(
-                port = self.journal_port(),
-                entries_served = read.entries.len(),
-                "request journal returned an incomplete read; serving partial results"
-            );
-        }
+        self.warn_if_incomplete(read.complete, read.entries.len());
         read.entries
+    }
+
+    /// Recorded requests newer than `since` (all retained when `None`), matching `keep`.
+    /// `None` means the backend has no stable indices — callers fall back to
+    /// [`Self::get_recorded_requests_filtered`] and omit cursor metadata (issue #603).
+    ///
+    /// A returned read with `complete: false` has a `next` spanning entries it could not
+    /// serve: callers must withhold the cursor rather than let it advance past them.
+    pub fn read_recorded_requests_since<F: Fn(&RecordedRequest) -> bool>(
+        &self,
+        since: Option<u64>,
+        keep: F,
+    ) -> Option<JournalReadSince> {
+        let read = self.journal.read_since(self.journal_port(), since, &keep)?;
+        self.warn_if_incomplete(read.complete, read.entries.len());
+        Some(read)
     }
 
     /// Clear recorded requests. Also resets the request count to match Mountebank behavior.

--- a/crates/rift-mock-core/src/imposter/journal.rs
+++ b/crates/rift-mock-core/src/imposter/journal.rs
@@ -26,6 +26,39 @@ pub struct JournalRead {
     pub complete: bool,
 }
 
+/// A recorded request paired with its stable per-port index (issue #603).
+#[derive(Debug, Clone)]
+pub struct JournalEntry {
+    pub index: u64,
+    pub request: RecordedRequest,
+}
+
+/// Result of a cursor read ([`RequestJournal::read_since`], issue #603).
+#[derive(Debug, Clone)]
+pub struct JournalReadSince {
+    pub entries: Vec<JournalEntry>,
+    /// Last index assigned for this port; `0` means nothing was ever recorded. Callers pass
+    /// this back verbatim as the next `since`.
+    ///
+    /// This is the last *assigned* index, not the largest one still retained: it must not
+    /// regress when entries leave the journal (a clear would otherwise hand out a cursor that
+    /// moves backwards), and it must advance past entries the caller's filter rejected (a
+    /// filtered tail would otherwise re-scan the same range forever).
+    pub next: u64,
+    /// Cap eviction discarded entries at or below the requested cursor, so the caller's view
+    /// has a hole. Only retention pressure sets this — `clear`/`clear_flow`/`retain` are
+    /// deliberate, caller-visible deletions and never do.
+    ///
+    /// A baseline read (`since: None`) is never truncated: it asks for whatever is retained
+    /// and receives exactly that. `since: Some(0)` is a different question — "replay from the
+    /// beginning" — and *is* truncated once anything has been evicted, because entries the
+    /// caller asked for are gone. The two return identical entries but disagree here, and that
+    /// is the intended distinction between snapshotting and resuming.
+    pub truncated: bool,
+    /// Same degraded-read semantics as [`JournalRead::complete`].
+    pub complete: bool,
+}
+
 /// Pluggable recorded-request backend, keyed by imposter port.
 pub trait RequestJournal: Send + Sync {
     /// Called for EVERY request (even when body recording is off) — backs
@@ -60,15 +93,58 @@ pub trait RequestJournal: Send + Sync {
     /// [`Self::clear`]: a failed delete must surface, not be reported as success.
     fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()>;
     fn count(&self, port: u16) -> u64;
+
+    /// Entries with `index > since` (all retained entries when `None`), keeping only those
+    /// matching `keep` — applied *after* the cursor cut, over references before cloning so a
+    /// `?match=` query does not deep-clone rejected entries (#485).
+    ///
+    /// `None` means this backend has no stable indices: callers fall back to
+    /// [`Self::read_filtered`] and omit cursor metadata from responses, which is what lets an
+    /// SDK probe for cursor support. Defaulting to `None` — rather than synthesizing indices
+    /// from array offsets — is deliberate: offsets shift under eviction and scoped clears, so
+    /// a synthetic cursor would silently skip or replay entries (issue #603).
+    ///
+    /// A cursor read that sets `complete: false` must not have its `next` trusted: callers
+    /// withhold the cursor entirely rather than let a caller advance past entries a degraded
+    /// backend could not serve.
+    fn read_since(
+        &self,
+        port: u16,
+        since: Option<u64>,
+        keep: &dyn Fn(&RecordedRequest) -> bool,
+    ) -> Option<JournalReadSince> {
+        let _ = (port, since, keep);
+        None
+    }
+
+    /// Like [`record`](Self::record), returning the index assigned to the entry; `None` when
+    /// the backend does not support stable indices (issue #603).
+    ///
+    /// Override this and [`record`](Self::record) **both or neither**: the default delegates to
+    /// `record`, so a backend that overrides only `record` and points it back here recurses
+    /// forever. [`LocalJournal`] overrides both.
+    fn record_indexed(&self, port: u16, flow_id: &str, req: RecordedRequest) -> Option<u64> {
+        self.record(port, flow_id, req);
+        None
+    }
 }
 
 #[derive(Default)]
 struct PortSlot {
-    /// Entries paired with the flow id resolved at record time (issue #314: scoped clears
-    /// must not re-derive flows from stored headers). A `VecDeque` so the oldest-first cap
-    /// eviction is O(1) `pop_front` instead of an O(n) `Vec::remove(0)` shift (issue #289).
-    entries: RwLock<VecDeque<(String, RecordedRequest)>>,
+    /// Entries carrying their stable index (issue #603) and the flow id resolved at record
+    /// time (issue #314: scoped clears must not re-derive flows from stored headers). A
+    /// `VecDeque` so the oldest-first cap eviction is O(1) `pop_front` instead of an O(n)
+    /// `Vec::remove(0)` shift (issue #289).
+    entries: RwLock<VecDeque<(u64, String, RecordedRequest)>>,
     count: AtomicU64,
+    /// Last index handed out for this port; 1-based, so 0 reads as "nothing recorded yet".
+    /// Assigned under the `entries` write lock so index order always matches deque order.
+    /// Never reset — not by eviction, not by `clear`/`clear_flow`/`retain` — which is what
+    /// keeps a cursor held across any of them valid (issue #603).
+    last_index: AtomicU64,
+    /// Highest index dropped by *cap eviction*. Deliberate deletions never touch it: losing
+    /// entries you asked to delete is not a hole in your view of the journal.
+    evicted_through: AtomicU64,
 }
 
 /// Reference journal with the exact semantics of the storage it replaced.
@@ -92,6 +168,10 @@ impl RequestJournal for LocalJournal {
     }
 
     fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+        self.record_indexed(port, flow_id, req);
+    }
+
+    fn record_indexed(&self, port: u16, flow_id: &str, req: RecordedRequest) -> Option<u64> {
         let slot = self.slot(port);
         let mut entries = slot.entries.write();
         if entries.len() >= MAX_RECORDED_REQUESTS {
@@ -100,9 +180,15 @@ impl RequestJournal for LocalJournal {
                 max = MAX_RECORDED_REQUESTS,
                 "Recorded requests cap reached; oldest entry evicted"
             );
-            entries.pop_front();
+            if let Some((evicted, _, _)) = entries.pop_front() {
+                slot.evicted_through.store(evicted, Ordering::SeqCst);
+            }
         }
-        entries.push_back((flow_id.to_string(), req));
+        // Assigned under the write lock: a fetch_add outside it could interleave with a
+        // concurrent recorder and push entries in a different order than their indices.
+        let index = slot.last_index.fetch_add(1, Ordering::SeqCst) + 1;
+        entries.push_back((index, flow_id.to_string(), req));
+        Some(index)
     }
 
     fn read(&self, port: u16) -> JournalRead {
@@ -112,7 +198,7 @@ impl RequestJournal for LocalJournal {
                 .entries
                 .read()
                 .iter()
-                .map(|(_, req)| req.clone())
+                .map(|(_, _, req)| req.clone())
                 .collect(),
             complete: true,
         }
@@ -126,11 +212,38 @@ impl RequestJournal for LocalJournal {
                 .entries
                 .read()
                 .iter()
-                .filter(|(_, req)| keep(req))
-                .map(|(_, req)| req.clone())
+                .filter(|(_, _, req)| keep(req))
+                .map(|(_, _, req)| req.clone())
                 .collect(),
             complete: true,
         }
+    }
+
+    fn read_since(
+        &self,
+        port: u16,
+        since: Option<u64>,
+        keep: &dyn Fn(&RecordedRequest) -> bool,
+    ) -> Option<JournalReadSince> {
+        let slot = self.slot(port);
+        let entries = slot.entries.read();
+        // 0 admits every entry, since indices are 1-based — a baseline read needs no special case.
+        let cut = since.unwrap_or(0);
+        Some(JournalReadSince {
+            entries: entries
+                .iter()
+                .filter(|(index, _, _)| *index > cut)
+                .filter(|(_, _, req)| keep(req))
+                .map(|(index, _, req)| JournalEntry {
+                    index: *index,
+                    request: req.clone(),
+                })
+                .collect(),
+            next: slot.last_index.load(Ordering::SeqCst),
+            // A baseline read sees everything retained, so it cannot have a hole.
+            truncated: since.is_some_and(|s| slot.evicted_through.load(Ordering::SeqCst) > s),
+            complete: true,
+        })
     }
 
     fn clear(&self, port: u16) -> anyhow::Result<()> {
@@ -141,14 +254,17 @@ impl RequestJournal for LocalJournal {
     }
 
     fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
-        self.slot(port).entries.write().retain(|(_, req)| keep(req));
+        self.slot(port)
+            .entries
+            .write()
+            .retain(|(_, _, req)| keep(req));
     }
 
     fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
         self.slot(port)
             .entries
             .write()
-            .retain(|(flow, _)| flow != flow_id);
+            .retain(|(_, flow, _)| flow != flow_id);
         Ok(())
     }
 
@@ -271,6 +387,307 @@ mod tests {
         j.record(1, "flow-a", req("/a"));
         assert!(j.clear_flow(1, "flow-a").is_ok());
         assert!(j.clear(1).is_ok());
+    }
+
+    fn cursor(j: &LocalJournal, port: u16, since: Option<u64>) -> JournalReadSince {
+        j.read_since(port, since, &|_| true)
+            .expect("LocalJournal supports cursors")
+    }
+
+    fn indices(read: &JournalReadSince) -> Vec<u64> {
+        read.entries.iter().map(|e| e.index).collect()
+    }
+
+    fn paths(read: &JournalReadSince) -> Vec<&str> {
+        read.entries
+            .iter()
+            .map(|e| e.request.path.as_str())
+            .collect()
+    }
+
+    // AC1 (#603): indices are 1-based and sequential; a baseline read returns every retained
+    // entry with its index, and `next` is the last index assigned.
+    #[test]
+    fn cursor_assigns_1based_indices_and_reports_next() {
+        let j = LocalJournal::default();
+        assert_eq!(
+            cursor(&j, 1, None).next,
+            0,
+            "an empty journal has assigned nothing; 0 is the 'seen nothing' cursor"
+        );
+
+        assert_eq!(j.record_indexed(1, "f", req("/a")), Some(1), "1-based");
+        assert_eq!(j.record_indexed(1, "f", req("/b")), Some(2));
+        assert_eq!(j.record_indexed(1, "f", req("/c")), Some(3));
+
+        let read = cursor(&j, 1, None);
+        assert_eq!(indices(&read), vec![1, 2, 3]);
+        assert_eq!(paths(&read), vec!["/a", "/b", "/c"]);
+        assert_eq!(read.next, 3, "next is the last assigned index");
+        assert!(!read.truncated, "a baseline read can never be truncated");
+        assert!(read.complete);
+
+        // `record` shares the same counter — an unindexed write still advances the cursor.
+        j.record(1, "f", req("/d"));
+        assert_eq!(cursor(&j, 1, None).next, 4);
+
+        // Indices are per-port, not global.
+        assert_eq!(j.record_indexed(2, "f", req("/x")), Some(1));
+    }
+
+    // AC2 (#603): `since` is exclusive — strictly newer entries only; a cursor at or beyond the
+    // last assigned index yields nothing but still reports the unchanged high-water mark.
+    #[test]
+    fn cursor_since_returns_strictly_newer() {
+        let j = LocalJournal::default();
+        for p in ["/a", "/b", "/c"] {
+            j.record_indexed(1, "f", req(p));
+        }
+
+        let read = cursor(&j, 1, Some(1));
+        assert_eq!(indices(&read), vec![2, 3], "index 1 was already seen");
+
+        assert_eq!(indices(&cursor(&j, 1, Some(2))), vec![3]);
+
+        let caught_up = cursor(&j, 1, Some(3));
+        assert!(caught_up.entries.is_empty(), "nothing newer than the tip");
+        assert_eq!(caught_up.next, 3, "next still reports the tip");
+
+        let beyond = cursor(&j, 1, Some(99));
+        assert!(
+            beyond.entries.is_empty(),
+            "a cursor beyond the tip is unambiguous — indices never reset"
+        );
+        assert_eq!(beyond.next, 3);
+    }
+
+    // AC3 (#603): `keep` is applied after the cursor cut, and composes with it.
+    #[test]
+    fn cursor_keep_composes_after_cut() {
+        let j = LocalJournal::default();
+        j.record_indexed(1, "f", req("/keep/1")); // 1
+        j.record_indexed(1, "f", req("/drop/1")); // 2
+        j.record_indexed(1, "f", req("/keep/2")); // 3
+        j.record_indexed(1, "f", req("/drop/2")); // 4
+
+        let keep_only = |r: &RecordedRequest| r.path.starts_with("/keep");
+
+        let all = j.read_since(1, None, &keep_only).expect("cursor support");
+        assert_eq!(indices(&all), vec![1, 3], "filtered, indices preserved");
+        assert_eq!(all.next, 4, "next spans scanned entries, not returned ones");
+
+        let after = j
+            .read_since(1, Some(1), &keep_only)
+            .expect("cursor support");
+        assert_eq!(indices(&after), vec![3], "cut first, then filter");
+        assert_eq!(after.next, 4);
+
+        // A window whose entries all fail the filter must still advance the cursor, or a
+        // filtered tail would re-scan the same range forever.
+        let empty = j
+            .read_since(1, Some(3), &|r| r.path == "/nothing")
+            .expect("cursor support");
+        assert!(empty.entries.is_empty());
+        assert_eq!(empty.next, 4, "an all-rejected window still advances");
+    }
+
+    // AC4 (#603): a cursor held across a clear stays valid — indices continue, `next` does not
+    // regress, and a deliberate clear is never reported as truncation.
+    #[test]
+    fn cursor_survives_clear_without_truncation() {
+        let j = LocalJournal::default();
+        j.record_indexed(1, "f", req("/a"));
+        j.record_indexed(1, "f", req("/b"));
+        j.clear(1).expect("local clear is infallible");
+
+        let after_clear = cursor(&j, 1, Some(2));
+        assert!(after_clear.entries.is_empty());
+        assert_eq!(after_clear.next, 2, "next never regresses over a clear");
+        assert!(
+            !after_clear.truncated,
+            "a clear is a deliberate deletion, not retention pressure"
+        );
+
+        j.record_indexed(1, "f", req("/c"));
+        let resumed = cursor(&j, 1, Some(2));
+        assert_eq!(
+            indices(&resumed),
+            vec![3],
+            "post-clear entries keep counting up"
+        );
+        assert_eq!(paths(&resumed), vec!["/c"]);
+        assert!(!resumed.truncated);
+
+        // clear_flow and retain are deliberate too.
+        j.record_indexed(1, "flow-x", req("/x"));
+        j.clear_flow(1, "flow-x").expect("infallible");
+        assert!(!cursor(&j, 1, Some(1)).truncated);
+        j.retain(1, &|_| false);
+        assert!(!cursor(&j, 1, Some(1)).truncated);
+    }
+
+    // AC5 (#603): `truncated` fires exactly when cap eviction discarded entries the cursor had
+    // not yet seen.
+    #[test]
+    fn cursor_truncated_only_on_eviction_past_cursor() {
+        let j = LocalJournal::default();
+        for i in 0..(MAX_RECORDED_REQUESTS + 10) {
+            j.record_indexed(1, "f", req(&format!("/{i}")));
+        }
+        // Indices 1..=10 were evicted; the oldest retained is 11.
+        let read = cursor(&j, 1, None);
+        assert_eq!(read.entries.len(), MAX_RECORDED_REQUESTS);
+        assert_eq!(indices(&read)[0], 11, "oldest surviving index");
+        assert_eq!(read.next, (MAX_RECORDED_REQUESTS + 10) as u64);
+
+        assert!(
+            cursor(&j, 1, Some(5)).truncated,
+            "a cursor at 5 lost entries 6..=10 to the cap"
+        );
+        // The boundary sits exactly at the watermark: `since` is what the caller has already
+        // seen, so a caller at 9 lost entry 10, while one at 10 lost nothing — everything it
+        // asked for (11 onward) is still retained.
+        assert!(
+            cursor(&j, 1, Some(9)).truncated,
+            "a cursor at 9 never received entry 10 before the cap took it"
+        );
+        assert!(
+            !cursor(&j, 1, Some(10)).truncated,
+            "a cursor at the watermark has seen everything eviction removed"
+        );
+        assert!(
+            !cursor(&j, 1, Some(50)).truncated,
+            "well ahead of the watermark"
+        );
+        assert!(
+            !cursor(&j, 1, None).truncated,
+            "a baseline read reads everything retained — no hole by definition"
+        );
+    }
+
+    // AC5 (#603): `since: Some(0)` means "replay from the beginning" and reports the hole that
+    // a baseline read — asking only for what is retained — cannot have. Same entries, different
+    // question, and the difference is the whole point of the flag.
+    #[test]
+    fn cursor_since_zero_differs_from_baseline_only_in_truncation() {
+        let j = LocalJournal::default();
+        for i in 0..(MAX_RECORDED_REQUESTS + 3) {
+            j.record_indexed(1, "f", req(&format!("/{i}")));
+        }
+
+        let baseline = cursor(&j, 1, None);
+        let from_zero = cursor(&j, 1, Some(0));
+        assert_eq!(
+            indices(&baseline),
+            indices(&from_zero),
+            "identical entries: index > 0 admits everything retained"
+        );
+        assert_eq!(baseline.next, from_zero.next);
+        assert!(!baseline.truncated, "a snapshot cannot have a hole");
+        assert!(
+            from_zero.truncated,
+            "a replay from the beginning lost entries 1..=3 to the cap"
+        );
+
+        // Before any eviction the two agree completely.
+        let fresh = LocalJournal::default();
+        fresh.record_indexed(1, "f", req("/a"));
+        assert!(!cursor(&fresh, 1, None).truncated);
+        assert!(!cursor(&fresh, 1, Some(0)).truncated);
+    }
+
+    // AC1 (#603): indices are assigned under the entries write lock, so concurrent recorders can
+    // never publish entries in a different order than their indices. Without that coupling a
+    // reader could see the deque out of index order and `read_since`'s `index > cut` cut would
+    // silently skip entries.
+    #[test]
+    fn cursor_indices_stay_ordered_under_concurrent_recorders() {
+        use std::sync::Barrier;
+
+        const RECORDERS: usize = 8;
+        const PER_RECORDER: usize = 64;
+
+        let j = Arc::new(LocalJournal::default());
+        let barrier = Arc::new(Barrier::new(RECORDERS));
+        let mut handles = Vec::new();
+        for r in 0..RECORDERS {
+            let j = Arc::clone(&j);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                (0..PER_RECORDER)
+                    .filter_map(|i| j.record_indexed(1, "f", req(&format!("/{r}-{i}"))))
+                    .collect::<Vec<_>>()
+            }));
+        }
+        let mut assigned: Vec<u64> = handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("recorder thread"))
+            .collect();
+
+        let total = (RECORDERS * PER_RECORDER) as u64;
+        assigned.sort_unstable();
+        assert_eq!(
+            assigned,
+            (1..=total).collect::<Vec<_>>(),
+            "every index handed out exactly once, with no gaps"
+        );
+
+        let read = cursor(&j, 1, None);
+        let seen = indices(&read);
+        assert_eq!(seen.len(), total as usize);
+        assert!(
+            seen.windows(2).all(|w| w[0] < w[1]),
+            "deque order must match index order, or the cursor cut skips entries"
+        );
+        assert_eq!(read.next, total);
+    }
+
+    // AC6 (#603): the trait defaults keep the extension non-breaking — a backend that does not
+    // override them still records, and honestly reports that it has no cursor.
+    #[test]
+    fn default_journal_reports_no_cursor_support() {
+        #[derive(Default)]
+        struct DefaultJournal(LocalJournal);
+        impl RequestJournal for DefaultJournal {
+            fn note_request(&self, port: u16) {
+                self.0.note_request(port);
+            }
+            fn record(&self, port: u16, flow_id: &str, req: RecordedRequest) {
+                self.0.record(port, flow_id, req);
+            }
+            fn read(&self, port: u16) -> JournalRead {
+                self.0.read(port)
+            }
+            fn clear(&self, port: u16) -> anyhow::Result<()> {
+                self.0.clear(port)
+            }
+            fn retain(&self, port: u16, keep: &dyn Fn(&RecordedRequest) -> bool) {
+                self.0.retain(port, keep);
+            }
+            fn clear_flow(&self, port: u16, flow_id: &str) -> anyhow::Result<()> {
+                self.0.clear_flow(port, flow_id)
+            }
+            fn count(&self, port: u16) -> u64 {
+                self.0.count(port)
+            }
+        }
+
+        let j = DefaultJournal::default();
+        assert_eq!(
+            j.record_indexed(1, "f", req("/a")),
+            None,
+            "no index to report"
+        );
+        assert_eq!(
+            j.read(1).entries.len(),
+            1,
+            "but the request was still recorded"
+        );
+        assert!(
+            j.read_since(1, None, &|_| true).is_none(),
+            "absence of a cursor is reported honestly, not faked from offsets"
+        );
     }
 
     // Ports are isolated slices of the journal.

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -49,7 +49,10 @@ pub use script_resolve::{
 // Re-export core imposter
 #[allow(unused_imports)]
 pub mod journal;
-pub use journal::{JournalRead, LocalJournal, RequestJournal};
+pub use journal::{
+    JournalEntry, JournalRead, JournalReadSince, LocalJournal, MAX_RECORDED_REQUESTS,
+    RequestJournal,
+};
 
 pub use core::Imposter;
 pub use core::{ClosestMatch, FailedPredicate, VerifyOptions, VerifyOutcome};

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -364,8 +364,9 @@ Get recorded requests (if `recordRequests: true`). Also available under the alia
 **Query Parameters:**
 - `match=header:<Name>=<Value>` — keep only requests carrying a matching header
 - `match=flow_id=<Value>` — keep only requests whose resolved flow id matches
+- `since=<index>` — keep only requests newer than a cursor (see [Tailing with a cursor](#tailing-with-a-cursor))
 
-Multiple `match` clauses are AND-ed together.
+Multiple `match` clauses are AND-ed together. `since` is applied first, then the `match` clauses.
 
 **Response:** a JSON array of recorded requests. Each element carries `request_from` (the client
 `ip:port`); `body` is present only when the request had one.
@@ -384,6 +385,52 @@ Multiple `match` clauses are AND-ed together.
   }
 ]
 ```
+
+#### Tailing with a cursor
+
+Polling this endpoint without a cursor re-sends the whole journal every time. `since=<index>`
+makes a poll cost only what is new. Every recorded request is assigned a **stable, 1-based,
+per-port index**; the cursor rides in response headers so the body above is unchanged.
+
+**Response headers:**
+
+| Header | Meaning |
+|---|---|
+| `x-rift-next-index` | The cursor to pass as the next `since`. `0` means nothing has been recorded yet. |
+| `x-rift-truncated` | Present (`true`) only when retention discarded entries you had not seen — your view has a hole. Absent otherwise; it is never `false`. |
+
+```bash
+# Baseline: everything retained, plus the cursor to resume from.
+curl -i localhost:2525/imposters/3000/savedRequests
+# x-rift-next-index: 12
+
+# Only what arrived since — composes with match=.
+curl -i "localhost:2525/imposters/3000/savedRequests?since=12&match=flow_id=tenant-a"
+```
+
+**Contract:**
+
+- **`since` is exclusive** — you receive entries strictly newer than the index you pass. Pass
+  back `x-rift-next-index` verbatim; a cursor at or beyond the tip returns an empty array.
+- **`x-rift-next-index` always advances past everything scanned**, including entries your
+  `match=` clauses rejected. A filtered tail therefore never re-scans the same range.
+- **Indices survive deletion.** `DELETE savedRequests` and scoped clears do not reset them:
+  entries recorded afterwards simply get larger indices, so a cursor held across a clear stays
+  valid and is *not* reported as truncated. Deleting data you asked to delete is not a hole.
+- **`x-rift-truncated` means one thing:** the 10,000-entry cap evicted entries you had not seen.
+  Re-poll without `since` to rebuild a baseline. Note that `since=0` ("replay everything") does
+  report truncation once anything has been evicted, while omitting `since` ("snapshot what is
+  retained") never does — the two return the same entries but ask different questions.
+- **No `x-rift-next-index` means do not advance.** Keep your existing cursor and poll again.
+  Its absence covers three cases, all handled the same way: an older engine (which ignores the
+  unknown parameter), a custom `RequestJournal` backend without stable indices, and a backend
+  that served a *degraded* partial read. In the degraded case the entries returned are real but
+  incomplete, so the cursor is deliberately withheld — advancing on it would skip the entries the
+  backend could not reach. A synthetic index is never returned, because offsets shift under
+  eviction and would silently skip or replay entries.
+
+**Canonical SDK tail:** baseline poll → keep `x-rift-next-index` → poll `?since=<cursor>` on an
+interval, updating the cursor each time → on `x-rift-truncated`, re-baseline.
 
 ---
 


### PR DESCRIPTION
Adds GET /imposters/{port}/savedRequests?since=<index>, giving SDK request-tails an O(new entries) poll instead of O(journal) with client-side dedupe. Recorded requests get stable 1-based per-port indices; the cursor is carried in the x-rift-next-index response header so the body stays the historical bare array (Mountebank compat and existing clients unaffected — header absence is the capability probe).

since composes with the existing match= filters and always advances past filter-rejected entries, so a correlated tail never re-scans. Indices survive clears; x-rift-truncated marks only cap-eviction holes; a degraded partial read withholds the cursor rather than risk silent data loss. RequestJournal's two new methods are defaulted, so existing embedder implementations are unaffected.

Design resolution: https://github.com/EtaCassiopeia/rift/issues/603#issuecomment-4970193024

Closes #603