### PR TITLE
fix(admin): json_response silently serves 200 OK with an empty body when serialization fails

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -4,7 +4,7 @@ use crate::admin_api::request_filter::{parse_match_clauses, parse_since, request
 use crate::admin_api::types::{
     ImposterDetail, ImposterListEntry, ImposterQueryParams, ImposterSummary, ListImpostersResponse,
     RiftImposterExtensions, StubWithLinks, build_response_with_headers, collect_body,
-    error_response, json_response, make_imposter_links, make_stub_links,
+    error_response, json_response, make_imposter_links, make_stub_links, serialize_or_500,
 };
 use crate::extensions::decorate::backend_error_response;
 use crate::imposter::RecordedRequest;
@@ -634,14 +634,23 @@ fn cursor_response(
     next: u64,
     truncated: bool,
 ) -> Response<Full<Bytes>> {
-    let json = match serde_json::to_string_pretty(entries) {
+    build_cursor_response(serialize_or_500(&entries), next, truncated)
+}
+
+/// Attach the cursor headers to an already-serialized body, or serve the serialization failure
+/// verbatim.
+///
+/// Split from [`cursor_response`] so the ordering is enforced by types rather than by discipline:
+/// the headers cannot be built before serialization has succeeded, because this function never
+/// sees the payload. A 500 therefore can never advertise a cursor for a body that was not sent.
+fn build_cursor_response(
+    json: Result<String, Box<Response<Full<Bytes>>>>,
+    next: u64,
+    truncated: bool,
+) -> Response<Full<Bytes>> {
+    let json = match json {
         Ok(j) => j,
-        Err(e) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("failed to serialize recorded requests: {e}"),
-            );
-        }
+        Err(resp) => return *resp,
     };
     let mut headers = vec![
         ("Content-Type".to_string(), "application/json".to_string()),
@@ -1327,6 +1336,35 @@ mod requests_filter_tests {
 
     fn header<'a>(resp: &'a Response<Full<Bytes>>, name: &str) -> Option<&'a str> {
         resp.headers().get(name).and_then(|v| v.to_str().ok())
+    }
+
+    // AC3 (#606): a serialization failure must never be dressed with cursor headers describing a
+    // payload that was never sent. Driving the real header-assembly path with a synthetic failure
+    // — asserting the error is passed through untouched, rather than asserting error_response's
+    // fixed shape, which would hold no matter what this function did.
+    #[tokio::test]
+    async fn build_cursor_response_passes_failures_through_without_cursor_headers() {
+        let failed: Box<Response<Full<Bytes>>> = Box::new(crate::admin_api::types::error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "boom",
+        ));
+        let resp = build_cursor_response(Err(failed), 12, true);
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(
+            header(&resp, "x-rift-next-index").is_none(),
+            "a 500 must not advertise a cursor to advance from"
+        );
+        assert!(
+            header(&resp, "x-rift-truncated").is_none(),
+            "nor a truncation flag, even though truncated=true was requested"
+        );
+
+        // The success path still attaches them, so the assertions above are about the failure
+        // branch and not a helper that never sets headers at all.
+        let ok = build_cursor_response(Ok("[]".to_string()), 12, true);
+        assert_eq!(header(&ok, "x-rift-next-index"), Some("12"));
+        assert_eq!(header(&ok, "x-rift-truncated"), Some("true"));
     }
 
     fn next_index(resp: &Response<Full<Bytes>>) -> Option<&str> {

--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -194,10 +194,34 @@ pub fn make_stub_links(base_url: &str, port: u16, index: usize) -> StubLinks {
 // Response helper functions
 // =============================================================================
 
+/// Pretty-print `body`, or give back the `500` to serve instead (issue #606).
+///
+/// A response body that cannot be rendered is a server fault, so the failure never inherits the
+/// caller's intended status — a `201` that can't serialize is a `500`, not a `201` with the wrong
+/// body. Callers that add headers should apply this first and return the error verbatim, so an
+/// error response never carries metadata describing a payload that was never sent.
+/// Boxed so the `Err` variant stays small (`clippy::result_large_err`); the allocation only ever
+/// happens on the failure path.
+pub(crate) fn serialize_or_500<T: Serialize>(
+    body: &T,
+) -> Result<String, Box<Response<Full<Bytes>>>> {
+    serde_json::to_string_pretty(body).map_err(|e| {
+        tracing::error!(error = %e, "failed to serialize admin API response body");
+        Box::new(error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to serialize response body: {e}"),
+        ))
+    })
+}
+
 /// Create a JSON response
 pub fn json_response<T: Serialize>(status: StatusCode, body: &T) -> Response<Full<Bytes>> {
-    let json = serde_json::to_string_pretty(body).unwrap_or_else(|_| "{}".to_string());
-    build_response_with_headers(status, [("Content-Type", "application/json")], json)
+    match serialize_or_500(body) {
+        Ok(json) => {
+            build_response_with_headers(status, [("Content-Type", "application/json")], json)
+        }
+        Err(resp) => *resp,
+    }
 }
 
 // The generic response builders moved to `rift_mock_core::util` (issue #203) so the engine can use
@@ -279,6 +303,88 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::BodyExt;
+
+    /// A payload whose `Serialize` always fails — the only way to drive serde's error path, since
+    /// every real admin payload is plain structs/Vecs of strings and numbers (issue #606).
+    struct Unserializable;
+    impl Serialize for Unserializable {
+        fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("nope"))
+        }
+    }
+
+    async fn body_string(resp: Response<Full<Bytes>>) -> String {
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
+    // AC1 (#606): a serialization failure is a server fault — 500 with the structured error
+    // envelope, never 200 with a shape-invalid `{}` body that fails in the client's decoder.
+    #[tokio::test]
+    async fn json_response_maps_serialization_failure_to_500() {
+        let resp = json_response(StatusCode::OK, &Unserializable);
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "the caller's OK is discarded: a body that cannot render is a server fault"
+        );
+
+        let body = body_string(resp).await;
+        assert_ne!(
+            body.trim(),
+            "{}",
+            "the silent empty-object body must be gone"
+        );
+        let json: serde_json::Value = serde_json::from_str(&body).expect("a structured envelope");
+        assert!(
+            json["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("serialize")),
+            "the envelope names the real cause, not the client's codec: {body}"
+        );
+    }
+
+    // AC2 (#606): the success path is untouched — status, content type, and the exact
+    // pretty-printed bytes SDK codecs and Mountebank compat already depend on.
+    #[tokio::test]
+    async fn json_response_success_path_unchanged() {
+        let payload = serde_json::json!({"a": 1, "b": ["x"]});
+        let resp = json_response(StatusCode::CREATED, &payload);
+        assert_eq!(resp.status(), StatusCode::CREATED, "given status preserved");
+        assert_eq!(
+            resp.headers()
+                .get("Content-Type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        assert_eq!(
+            body_string(resp).await,
+            serde_json::to_string_pretty(&payload).expect("pretty"),
+            "body stays byte-identical to the pretty-printed payload"
+        );
+    }
+
+    // The shared helper both `json_response` and `cursor_response` route through, so the two
+    // paths of the savedRequests handler cannot drift apart again. The header-ordering half of
+    // AC3 lives with `build_cursor_response` in handlers/imposters.rs — asserting it here would
+    // only restate that `error_response` has no cursor headers, which is true regardless of what
+    // the cursor path does.
+    #[tokio::test]
+    async fn serialize_or_500_yields_json_or_a_500_response() {
+        let ok = serialize_or_500(&serde_json::json!({"a": 1}));
+        assert_eq!(
+            ok.ok().as_deref(),
+            Some(
+                serde_json::to_string_pretty(&serde_json::json!({"a": 1}))
+                    .unwrap()
+                    .as_str()
+            )
+        );
+
+        let err = *serialize_or_500(&Unserializable).expect_err("must not serialize");
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 
     #[tokio::test]
     async fn collect_body_under_limit_returns_bytes() {


### PR DESCRIPTION
json_response swallowed serialization failures into `200 OK` + `{}` — shape-invalid for array-contract endpoints like `savedRequests`, so an SDK decoder failed far from the cause with no server log. #603's `cursor_response` already mapped the identical failure to a 500, so one handler held two philosophies.

Both now route through a single `serialize_or_500` helper that logs and returns a structured 500. `build_cursor_response` is split out of `cursor_response` so the serialize-before-headers ordering is enforced by types: the header builder never sees the payload, so a 500 can never carry `x-rift-next-index` for a body that wasn't sent. That ordering guard is mutation-verified — injecting the bug fails the test.

Success path is byte-identical (pinned by a test); no user-facing change, so no docs/CHANGELOG entry.

Design: https://github.com/EtaCassiopeia/rift/issues/606#issuecomment-4971473742

Closes #606