### PR TITLE
fix(behaviors): accept the documented {"inject": ...} wait and keep it behind --allowInjection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`"wait": {"inject": "function(){...}"}` now works — it was silently doing nothing.** The
+  object spelling of a function wait is what `docs/features/fault-injection.md`, the shipped
+  `examples/latency-testing.json`, and the SDKs all use, but the engine's `WaitBehavior` had no
+  variant for it. Worse than a load error: `_behaviors` is parsed once into a cache and the parse
+  failure was swallowed, so such a config started cleanly and served requests with the **entire
+  `_behaviors` block dropped** — no latency, no `repeat`, no error, no log. The shipped example's
+  `/random-latency` stub has been answering with no delay. Both spellings are now accepted and
+  execute identically (same sandbox, same 60s cap); Rift preserves whichever you wrote when you
+  read the imposter back. The bare string remains the Mountebank-compatible form; the object form
+  is a Rift superset like `{"min","max"}`. `rift-lint` accepts it too — it previously flagged
+  Rift's own example as an error. A `_behaviors` block that still fails to parse is now logged at
+  error level instead of vanishing.
+
+### Security
+
+- **A function `wait` requires `--allowInjection` in both spellings.** The `--allowInjection`
+  admission gate classified only the bare-string function wait as a scripting surface, so the
+  newly-accepted `{"inject": ...}` form would have executed JavaScript with injection disabled.
+  Both spellings are one capability and now gate identically. The gate also **fails closed**: a
+  `_behaviors` block it cannot parse is treated as scripted rather than admitted as
+  "no script surface" — previously its safety depended on the executor's parser failing in
+  lockstep, an unwritten coupling this release's new wait variant would have broken.
+
 ### Added
 
 - **Admin SSE stream — push request tails instead of polling.** `GET /events` (and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "tracing-test",
  "urlencoding",
  "uuid",
  "yasna",

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -81,12 +81,7 @@ fn response_has_script_surface(response: &StubResponse) -> bool {
         StubResponse::Is {
             behaviors, rift, ..
         } => {
-            let behavior_is_scripted = behaviors
-                .as_ref()
-                .and_then(|b| {
-                    serde_json::from_value::<crate::behaviors::ResponseBehaviors>(b.clone()).ok()
-                })
-                .is_some_and(|b| behaviors_contain_script_surface(&b));
+            let behavior_is_scripted = behaviors.as_ref().is_some_and(raw_behaviors_are_scripted);
             behavior_is_scripted || rift.as_ref().is_some_and(|r| r.script.is_some())
         }
         StubResponse::Proxy { proxy } => {
@@ -100,17 +95,44 @@ fn response_has_script_surface(response: &StubResponse) -> bool {
     }
 }
 
-/// True if the parsed `_behaviors` block carries a scripting surface: `decorate` (JS/Rhai),
-/// `shellTransform` (runs a host shell command — B1), or a `wait` expressed as a JS function
-/// (executed on Boa since issue #355 Item 6 — B2). A numeric `wait` (`Fixed`/`Range`) is NOT a
-/// scripting surface and stays allowed.
-fn behaviors_contain_script_surface(behaviors: &crate::behaviors::ResponseBehaviors) -> bool {
-    behaviors.decorate.is_some()
-        || !behaviors.shell_transform.is_empty()
-        || matches!(
-            behaviors.wait,
-            Some(crate::behaviors::WaitBehavior::Function(_))
-        )
+/// True if a raw `_behaviors` block carries a scripting surface: `decorate` (JS/Rhai),
+/// `shellTransform` (runs a host shell command — B1), or a `wait` that is not plainly numeric
+/// (executed on Boa since issue #355 Item 6 — B2).
+///
+/// Read from the raw JSON rather than a parsed [`ResponseBehaviors`](crate::behaviors::ResponseBehaviors)
+/// deliberately (issue #610). The gate's question is only "could this execute code?", which the
+/// script-relevant keys answer on their own — so a block the *executor's* parser rejects can still
+/// be classified, and the gate never has to agree with that parser to stay closed. Parsing first
+/// and treating a parse failure as safe was the fail-open bug; treating it as *scripted* fixed the
+/// hole but 400'd `{"repeat": 2.0}` as an injection error, which is neither true nor this gate's
+/// business.
+///
+/// Fail-closed lives in `wait_is_plainly_numeric`: a `wait` is waved through only when it is
+/// provably a delay, never merely because it failed to parse.
+fn raw_behaviors_are_scripted(behaviors: &serde_json::Value) -> bool {
+    let Some(obj) = behaviors.as_object() else {
+        // Not an object (e.g. an array) — no key this gate recognizes, so nothing it can
+        // classify as executable. Such a block does not parse into `ResponseBehaviors` either,
+        // so it is inert: dropped at construction, with `new_is` logging the drop.
+        return false;
+    };
+    let scripted_key_present = obj.contains_key("decorate") || obj.contains_key("shellTransform");
+    let wait_is_scripted = obj.get("wait").is_some_and(|w| !wait_is_plainly_numeric(w));
+    scripted_key_present || wait_is_scripted
+}
+
+/// True only for the two wait spellings that cannot execute code: a fixed millisecond number and
+/// the `{min, max}` range. Everything else — a bare JS string, `{"inject": ...}`, or a shape this
+/// gate does not recognize — is treated as executable (issue #610).
+fn wait_is_plainly_numeric(wait: &serde_json::Value) -> bool {
+    if wait.is_number() {
+        return true;
+    }
+    wait.as_object().is_some_and(|o| {
+        o.len() == 2
+            && o.get("min").is_some_and(|v| v.is_number())
+            && o.get("max").is_some_and(|v| v.is_number())
+    })
 }
 
 /// Reject a set of stubs carrying a Mountebank scripting surface when `--allowInjection` is off,
@@ -1037,6 +1059,105 @@ mod allow_injection_tests {
             reject_stubs_if_injection_disallowed(&clean.stubs, false).is_none(),
             "a non-script stub slice is always allowed"
         );
+    }
+
+    // ---- #610: the injection gate vs #608's second wait spelling -----------------------
+
+    fn wait_cfg(wait: serde_json::Value) -> ImposterConfig {
+        cfg(json!({
+            "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "is": { "statusCode": 200 },
+                    "_behaviors": { "wait": wait }
+                }]
+            }]
+        }))
+    }
+
+    // AC 610-1: pins today's B2 behaviour explicitly — a bare-string function wait is a script
+    // surface. Previously only implied by the classifier's source.
+    #[test]
+    fn bare_string_function_wait_is_gated() {
+        let config = wait_cfg(json!("function() { return 100; }"));
+        assert!(
+            reject_if_injection_disallowed(&config, false).is_some(),
+            "a JS-function wait must require --allowInjection"
+        );
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    // AC 610-2: THE BYPASS REGRESSION TEST. #608 makes `{"inject": ...}` parse and execute on Boa;
+    // if the classifier still only matches `Function`, that config is admitted with injection off
+    // and runs anyway. Both spellings are the same capability and must gate identically.
+    #[test]
+    fn object_form_inject_wait_is_gated_identically() {
+        let config = wait_cfg(json!({ "inject": "function() { return 100; }" }));
+        assert!(
+            reject_if_injection_disallowed(&config, false).is_some(),
+            "the object-form wait executes JS just like the bare string — it must not bypass the gate"
+        );
+        assert!(reject_if_injection_disallowed(&config, true).is_none());
+    }
+
+    // AC 610-3: fail closed. A `wait` the gate cannot prove is a plain delay must classify as
+    // scripted rather than slipping through as "no script surface". Previously this was safe only
+    // because the executor's parser failed in lockstep — an invariant nothing tested, and one
+    // #608's new variant is exactly the kind of change to break.
+    #[test]
+    fn unrecognized_wait_shapes_fail_closed() {
+        for wait in [
+            json!({ "bogus": true }),
+            json!({ "inject": 42 }),
+            json!({ "min": 1 }),
+            json!(true),
+        ] {
+            let config = wait_cfg(wait.clone());
+            assert!(
+                reject_if_injection_disallowed(&config, false).is_some(),
+                "a wait the gate cannot prove is a plain delay must be treated as executable: {wait}"
+            );
+        }
+    }
+
+    // Fail-closed must stay scoped to what the gate is actually for. A malformed block with NO
+    // script surface is not an injection problem: 400-ing `{"repeat": 2.0}` with "inject requires
+    // --allowInjection" diagnoses a float as a scripting attempt, and makes a config's validity
+    // depend on an unrelated security flag. Such blocks stay admitted (and are dropped loudly at
+    // construction, per #608) exactly as before this change.
+    #[test]
+    fn script_free_behaviors_are_not_an_injection_problem() {
+        let script_free = [
+            json!({ "repeat": 2.0 }),
+            json!({ "wait": 100.0 }),
+            json!({ "repeat": 3 }),
+            json!([{ "wait": 500 }]),
+        ];
+        for behaviors in script_free {
+            let config = cfg(json!({
+                "protocol": "http",
+                "stubs": [{
+                    "responses": [{ "is": { "statusCode": 200 }, "_behaviors": behaviors }]
+                }]
+            }));
+            assert!(
+                reject_if_injection_disallowed(&config, false).is_none(),
+                "{behaviors} carries no script surface — the injection gate must not reject it"
+            );
+        }
+    }
+
+    // AC 610-5: guard against over-closing — numeric waits carry no script surface and must stay
+    // admissible with injection off.
+    #[test]
+    fn numeric_waits_are_not_script_surfaces() {
+        for wait in [json!(500), json!({ "min": 1, "max": 9 })] {
+            let config = wait_cfg(wait.clone());
+            assert!(
+                reject_if_injection_disallowed(&config, false).is_none(),
+                "{wait} is not a scripting surface and must not require --allowInjection"
+            );
+        }
     }
 }
 

--- a/crates/rift-lint/src/validator.rs
+++ b/crates/rift-lint/src/validator.rs
@@ -1108,15 +1108,26 @@ pub fn validate_behavior(
             // fixed millisecond delay — valid
         } else if is_valid_wait_range(wait) {
             // {min, max} range object — valid Rift extension
+        } else if let Some(script) = wait_inject_script(wait) {
+            // {inject: "function(){...}"} — the object spelling of a function wait (issue #608);
+            // validate the inner script exactly as the bare-string form.
+            validate_javascript_behavior(
+                file,
+                script,
+                &format!("{location}.wait.inject"),
+                result,
+                options,
+                false,
+            );
         } else {
             result.add_issue(
                 LintIssue::error(
                     "E025",
-                    "Wait behavior must be a number, JavaScript function string, or {min, max} object",
+                    "Wait behavior must be a number, JavaScript function string, {min, max} object, or {inject: \"function(){...}\"}",
                     file.to_path_buf(),
                 )
                 .with_location(format!("{location}.wait"))
-                .with_suggestion("Use a millisecond number, a JS function string, or {\"min\": N, \"max\": M}"),
+                .with_suggestion("Use a millisecond number, a JS function string, {\"min\": N, \"max\": M}, or {\"inject\": \"function() { ... }\"}"),
             );
         }
     }
@@ -1252,6 +1263,12 @@ fn is_valid_wait_range(wait: &Value) -> bool {
     };
     obj.get("min").and_then(|v| v.as_u64()).is_some()
         && obj.get("max").and_then(|v| v.as_u64()).is_some()
+}
+
+/// The inner script of a `{"inject": "function(){...}"}` wait (issue #608), or `None` for any
+/// other object — so a malformed wait object still reaches E025 rather than being waved through.
+fn wait_inject_script(wait: &Value) -> Option<&str> {
+    wait.as_object()?.get("inject")?.as_str()
 }
 
 /// Validate copy behavior.

--- a/crates/rift-lint/tests/validator_tests.rs
+++ b/crates/rift-lint/tests/validator_tests.rs
@@ -571,6 +571,34 @@ fn e025_not_fired_for_js_function_wait() {
     assert!(!has_code(&r, "E025"), "unexpected E025: {:?}", codes(&r));
 }
 
+// AC 608-5 (#608): the object-form wait is valid — lint used to mirror the engine enum and so
+// flagged the repo's own shipped example (`examples/latency-testing.json`) as an error.
+#[test]
+fn e025_not_fired_for_inject_object_wait() {
+    let behavior = json!({ "wait": { "inject": "function() { return 100; }" } });
+    let mut r = LintResult::new();
+    validate_behavior(path(), &behavior, "loc", &mut r, &opts());
+    assert!(
+        !has_code(&r, "E025"),
+        "E025 must not fire for the documented {{inject}} wait object, got {:?}",
+        codes(&r)
+    );
+}
+
+// Accepting the object form must not make E025 a rubber stamp for any object.
+#[test]
+fn e025_still_fires_for_malformed_wait_objects() {
+    for bad in [
+        json!({ "wait": { "bogus": true } }),
+        json!({ "wait": { "inject": 42 } }),
+        json!({ "wait": { "min": 100 } }),
+    ] {
+        let mut r = LintResult::new();
+        validate_behavior(path(), &bad, "loc", &mut r, &opts());
+        assert!(has_code(&r, "E025"), "E025 must still fire for {bad}");
+    }
+}
+
 #[test]
 fn e035_repeat_zero_is_invalid() {
     let behavior = json!({ "repeat": 0 });

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -95,6 +95,7 @@ tempfile = "3.8"
 reqwest.workspace = true
 tokio-test = "0.4"
 serial_test = "3.0"
+tracing-test = "0.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/rift-mock-core/src/behaviors/wait.rs
+++ b/crates/rift-mock-core/src/behaviors/wait.rs
@@ -42,8 +42,14 @@ pub enum WaitBehavior {
         #[serde(rename = "max")]
         max_ms: u64,
     },
-    /// JavaScript function that returns delay
+    /// JavaScript function that returns delay — the Mountebank-compatible spelling.
     Function(String),
+    /// The same JavaScript function in Rift's object spelling (issue #608), as written by
+    /// `docs/features/fault-injection.md`, the shipped examples, and the SDKs. Executes
+    /// identically to [`Self::Function`]; kept as a distinct variant only so a config
+    /// round-trips to the spelling its author wrote. Not portable to Mountebank, which has no
+    /// object form — like [`Self::Range`], this is a documented Rift superset.
+    Inject { inject: String },
 }
 
 impl WaitBehavior {
@@ -55,7 +61,9 @@ impl WaitBehavior {
                 use rand::Rng;
                 rand::thread_rng().gen_range(*min_ms..=*max_ms)
             }
-            WaitBehavior::Function(js_func) => {
+            // Both spellings of a JS-function wait run the identical path (issue #608): same Boa
+            // execution, same cap, same loud fallback.
+            WaitBehavior::Function(js_func) | WaitBehavior::Inject { inject: js_func } => {
                 // Parse JavaScript function and execute
                 // Format: "function() { return Math.floor(Math.random() * 100) + 50; }"
                 // A failed/unusable wait function falls back to 100ms — but loudly, so it is
@@ -220,6 +228,78 @@ fn extract_function_body(js_func: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // AC 608-1: every documented wait spelling deserializes, and each round-trips to the JSON the
+    // author wrote — `GET /imposters?replayable=true` must not rewrite one spelling into another.
+    #[test]
+    fn wait_accepts_all_four_shapes_and_round_trips() {
+        for raw in [
+            r#"100"#,
+            r#"{"min":100,"max":200}"#,
+            r#""function() { return 42; }""#,
+            r#"{"inject":"function() { return 42; }"}"#,
+        ] {
+            let wait: WaitBehavior =
+                serde_json::from_str(raw).unwrap_or_else(|e| panic!("{raw} must parse: {e}"));
+            let back = serde_json::to_string(&wait).expect("serialize");
+            let (a, b): (serde_json::Value, serde_json::Value) = (
+                serde_json::from_str(raw).expect("raw json"),
+                serde_json::from_str(&back).expect("round-trip json"),
+            );
+            assert_eq!(a, b, "{raw} must round-trip unchanged, got {back}");
+        }
+    }
+
+    // AC 608-1: the object shapes are disjoint, so untagged resolution is unambiguous.
+    #[test]
+    fn wait_object_shapes_resolve_to_distinct_variants() {
+        let inject: WaitBehavior =
+            serde_json::from_str(r#"{"inject":"function() { return 1; }"}"#).expect("inject");
+        assert!(matches!(inject, WaitBehavior::Inject { .. }));
+
+        let range: WaitBehavior = serde_json::from_str(r#"{"min":1,"max":2}"#).expect("range");
+        assert!(matches!(range, WaitBehavior::Range { .. }));
+
+        // A wait object that is neither shape is still rejected — the new variant must not turn
+        // the enum into a catch-all that silently accepts nonsense.
+        assert!(serde_json::from_str::<WaitBehavior>(r#"{"bogus":true}"#).is_err());
+        assert!(serde_json::from_str::<WaitBehavior>(r#"{"inject":42}"#).is_err());
+    }
+
+    // AC 608-2: the object form is a spelling of the same JS-function wait — identical execution,
+    // not a second implementation. Holds on both the Boa path and the regex fallback, since the
+    // variants share `execute_js_wait_function`.
+    #[test]
+    fn wait_inject_executes_identically_to_bare_string() {
+        let js = "function() { return Math.floor(Math.random() * 0) + 250; }";
+        let bare = WaitBehavior::Function(js.to_string());
+        let object = WaitBehavior::Inject {
+            inject: js.to_string(),
+        };
+        assert_eq!(bare.get_duration_ms(), object.get_duration_ms());
+        assert_eq!(object.get_duration_ms(), 250);
+    }
+
+    // AC 608-2: the 60s cap and the loud fallback apply to the object form too (issues #355/#490).
+    #[test]
+    fn wait_inject_shares_cap_and_fallback() {
+        let huge = WaitBehavior::Inject {
+            inject: "function() { return 999999999; }".to_string(),
+        };
+        assert!(
+            huge.get_duration_ms() <= MAX_WAIT_MS,
+            "the object form must share the 60s cap"
+        );
+
+        let unusable = WaitBehavior::Inject {
+            inject: "not a function at all".to_string(),
+        };
+        assert_eq!(
+            unusable.get_duration_ms(),
+            100,
+            "an unusable object-form wait falls back to the same loud 100ms as the bare form"
+        );
+    }
 
     #[test]
     fn test_wait_behavior_fixed() {

--- a/crates/rift-mock-core/src/extensions/fault.rs
+++ b/crates/rift-mock-core/src/extensions/fault.rs
@@ -22,8 +22,12 @@ pub enum FaultDecision {
         body: String,
         rule_id: String,
         headers: HashMap<String, String>,
-        /// Optional behaviors for response modification (Mountebank-compatible)
-        behaviors: Option<ResponseBehaviors>,
+        /// Optional behaviors for response modification (Mountebank-compatible).
+        ///
+        /// Boxed so this variant doesn't set the size of every `FaultDecision` — the common
+        /// `None`/`Latency` outcomes would otherwise each carry a `ResponseBehaviors`' worth of
+        /// stack (`clippy::large_enum_variant`).
+        behaviors: Option<Box<ResponseBehaviors>>,
     },
     /// TCP-level fault (Mountebank-compatible)
     TcpFault {
@@ -52,7 +56,7 @@ pub fn decide_fault(fault_config: &FaultConfig, rule_id: &str) -> FaultDecision 
             body: error_fault.body.clone(),
             rule_id: rule_id.to_string(),
             headers: error_fault.headers.clone(),
-            behaviors: error_fault.behaviors.clone(),
+            behaviors: error_fault.behaviors.clone().map(Box::new),
         };
     }
 

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -387,10 +387,26 @@ impl StubResponse {
         behaviors: Option<serde_json::Value>,
         rift: Option<RiftResponseExtension>,
     ) -> StubResponse {
+        // A block that won't parse can't be cached, so it is dropped — but never silently
+        // (issue #608). Dropping it quietly meant a config using an unsupported shape started
+        // clean and served with its behaviors gone: no wait, no repeat, no signal anywhere.
         let behaviors_parsed = behaviors
             .as_ref()
             .and_then(|v| {
-                serde_json::from_value::<crate::behaviors::ResponseBehaviors>(v.clone()).ok()
+                match serde_json::from_value::<crate::behaviors::ResponseBehaviors>(v.clone()) {
+                    Ok(parsed) => Some(parsed),
+                    Err(e) => {
+                        // Deliberately does not claim the response will serve: construction runs
+                        // before the admin gate, so this config may still be rejected.
+                        tracing::error!(
+                            error = %e,
+                            behaviors = %v,
+                            "malformed `_behaviors` block could not be parsed and will be ignored \
+                             if this response is served"
+                        );
+                        None
+                    }
+                }
             })
             .map(std::sync::Arc::new);
         // Only a non-string body needs rendering; a string body is served as-is.
@@ -1277,6 +1293,60 @@ pub enum ImposterError {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // AC 608-4 (#608): a `_behaviors` block that fails to parse is still dropped — the parse-once
+    // cache has nowhere to put it — but it must never be dropped *silently*. Before this, a config
+    // using a documented-but-unsupported shape served with its behaviors gone and no signal at all.
+    #[test]
+    #[tracing_test::traced_test]
+    fn unparseable_behaviors_are_dropped_loudly() {
+        let resp: StubResponse = serde_json::from_value(json!({
+            "is": { "statusCode": 200 },
+            "_behaviors": { "wait": { "bogus": true } }
+        }))
+        .expect("the stub itself still constructs");
+
+        match &resp {
+            StubResponse::Is {
+                behaviors,
+                behaviors_parsed,
+                ..
+            } => {
+                assert!(behaviors.is_some(), "the raw block is retained");
+                assert!(behaviors_parsed.is_none(), "but it could not be parsed");
+            }
+            other => panic!("expected an Is response, got {other:?}"),
+        }
+
+        assert!(
+            logs_contain("_behaviors"),
+            "a dropped behaviors block must be visible in the log, not silent"
+        );
+    }
+
+    // A well-formed block must not log — the error line means something is wrong.
+    #[test]
+    #[tracing_test::traced_test]
+    fn well_formed_behaviors_do_not_log() {
+        let resp: StubResponse = serde_json::from_value(json!({
+            "is": { "statusCode": 200 },
+            "_behaviors": { "wait": { "inject": "function() { return 5; }" } }
+        }))
+        .expect("object-form wait parses");
+        match &resp {
+            StubResponse::Is {
+                behaviors_parsed, ..
+            } => assert!(
+                behaviors_parsed.is_some(),
+                "the documented object-form wait must reach the cache"
+            ),
+            other => panic!("expected an Is response, got {other:?}"),
+        }
+        assert!(
+            !logs_contain("_behaviors"),
+            "a valid block must not emit the dropped-behaviors error"
+        );
+    }
 
     // Issue #479: `_behaviors` are parsed and a non-string body is rendered ONCE at construction,
     // so the request hot path reads cached values instead of re-deserializing/re-serializing.

--- a/crates/rift-mock-core/tests/shipped_examples_load.rs
+++ b/crates/rift-mock-core/tests/shipped_examples_load.rs
@@ -1,0 +1,91 @@
+//! Issue #608: the shipped `examples/*.json` must actually work on the engine that ships them.
+//!
+//! `_behaviors` is stored as raw JSON and parsed once into a cache at stub construction. That
+//! parse used to be swallowed, so an example using a documented-but-unsupported shape started
+//! cleanly and served requests with its behaviors silently gone — no error, no log, no latency.
+//! Asserting the file *loads* is therefore not enough: these tests assert the behaviors survive
+//! construction, which is what "the example works" actually means.
+
+use rift_mock_core::imposter::{ImposterConfig, StubResponse};
+use std::path::PathBuf;
+
+fn examples_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR = crates/rift-mock-core
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples")
+        .canonicalize()
+        .expect("examples dir")
+}
+
+fn configs_in(file: &str) -> Vec<ImposterConfig> {
+    let raw = std::fs::read_to_string(examples_dir().join(file))
+        .unwrap_or_else(|e| panic!("read {file}: {e}"));
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("{file} is not valid JSON: {e}"));
+    let imposters = match v.get("imposters") {
+        Some(serde_json::Value::Array(a)) => a.clone(),
+        _ => vec![v],
+    };
+    imposters
+        .into_iter()
+        .map(|i| {
+            serde_json::from_value(i.clone())
+                .unwrap_or_else(|e| panic!("{file}: imposter does not deserialize: {e}"))
+        })
+        .collect()
+}
+
+/// Every `_behaviors` block present in raw JSON must survive into the parsed cache. A `None` cache
+/// beside a `Some` raw block is the silent drop.
+fn assert_behaviors_survive(file: &str) {
+    let mut checked = 0;
+    for config in configs_in(file) {
+        for (s, stub) in config.stubs.iter().enumerate() {
+            for (r, response) in stub.responses.iter().enumerate() {
+                if let StubResponse::Is {
+                    behaviors: Some(raw),
+                    behaviors_parsed,
+                    ..
+                } = response
+                {
+                    assert!(
+                        behaviors_parsed.is_some(),
+                        "{file} stub[{s}].responses[{r}]: _behaviors present in JSON but dropped \
+                         at construction — the engine cannot honour its own shipped example. raw: {raw}"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+    }
+    assert!(checked > 0, "{file} exercised no _behaviors block");
+}
+
+// AC 608-3: the example that motivated the issue — its `/random-latency` stub uses the documented
+// object-form wait, which was silently dropped before the `Inject` variant existed.
+#[test]
+fn latency_testing_example_behaviors_survive() {
+    assert_behaviors_survive("latency-testing.json");
+}
+
+// The same guarantee for every other shipped example that carries behaviors, so a future
+// documented-but-unsupported shape cannot slip in through a different file.
+#[test]
+fn all_shipped_examples_deserialize() {
+    let dir = examples_dir();
+    let mut seen = 0;
+    for entry in std::fs::read_dir(&dir).expect("read examples dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("utf8 filename");
+        // Panics on any imposter that fails to deserialize.
+        let _ = configs_in(name);
+        seen += 1;
+    }
+    assert!(seen >= 5, "expected the shipped examples, found {seen}");
+}

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -29,6 +29,9 @@ Rift enables fault injection for chaos engineering and resilience testing.
 
 ### Random Latency
 
+A `wait` can be a JavaScript function returning the delay in milliseconds. Two spellings are
+accepted, and both execute identically:
+
 ```json
 {
   "_behaviors": {
@@ -37,6 +40,29 @@ Rift enables fault injection for chaos engineering and resilience testing.
     }
   }
 }
+```
+
+```json
+{
+  "_behaviors": {
+    "wait": "function() { return Math.floor(Math.random() * 1000) + 500; }"
+  }
+}
+```
+
+The **bare string** is the Mountebank-compatible spelling — use it if the same config must also run
+on Mountebank. The **`{"inject": ...}` object** is Rift's spelling, used by the SDKs; like the
+`{"min": N, "max": M}` range below, it is a Rift extension with no Mountebank equivalent, so a
+config using it is not portable to Mountebank. Rift accepts either and preserves whichever you
+wrote when you read the imposter back.
+
+A function wait requires **`--allowInjection`** (either spelling), the same as Mountebank — without
+it, creating the imposter returns `400 invalid injection`.
+
+For a simple random range with no JavaScript, use the range form instead:
+
+```json
+{ "_behaviors": { "wait": { "min": 500, "max": 1500 } } }
 ```
 
 ### Error Responses

--- a/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
+++ b/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
@@ -129,7 +129,13 @@ Rift supports multiple JSON format variations to ensure compatibility with vario
 | Format Variation | Standard Format | Alternative Format | Status |
 |-----------------|-----------------|-------------------|--------|
 | **Fixed delay** | `"wait": 1000` | `"wait": 1000` | ✅ **Complete** |
-| **Inject object** | `"wait": {"inject": "..."}` | `"wait": "function() {...}"` | ✅ **Complete** |
+| **Function wait** | `"wait": "function() {...}"` | `"wait": {"inject": "..."}` | ✅ **Complete** |
+| **Range** | _(none — Rift extension)_ | `"wait": {"min": N, "max": M}` | ✅ **Rift-only** |
+
+The bare string is Mountebank's standard for a function wait; Mountebank has **no** object form.
+The `{"inject": ...}` spelling and `{"min","max"}` are Rift supersets — accepted here, not portable
+to Mountebank. A function wait requires `--allowInjection` in both engines, in either spelling
+(issues #608, #610).
 
 ### Auto-Port Assignment
 


### PR DESCRIPTION
{"wait": {"inject": "function(){...}"}} is what docs/features/fault-injection.md, the shipped examples/latency-testing.json, and rift-java's WaitSpec all use — and the engine had no variant for it.

The failure was worse than "cannot deserialize". _behaviors is stored as raw JSON and parsed once into a cache via .ok(), so a config using the documented shape started cleanly and served with the whole _behaviors block silently dropped — no wait, no repeat, no error, no log. The shipped example's /random-latency stub has been answering with no delay, and rift-lint rejected that same example as invalid. Same swallow family as #606.

Both spellings are now canonical (ruling: https://github.com/EtaCassiopeia/rift/issues/608#issuecomment-4972209720). The bare string stays the Mountebank-compatible form; the object form is a Rift superset like {"min","max"} and is not portable to Mountebank. Both run one execution path, so they cannot diverge. A block that still fails to parse is logged at error level rather than vanishing.

Security (#610): the --allowInjection classifier matched only the bare-string wait, so shipping the variant alone would have admitted and executed object-form wait functions with injection off — a real gate bypass, invisible to #608's own tests. Both spellings now gate identically, and the gate reads script-relevant keys from the raw JSON instead of requiring the executor's parser to succeed — so it stays closed on shapes it cannot parse without 400-ing a script-free {"repeat": 2.0} as an injection attempt. Both guards are mutation-verified: reverting either fails its test.

Docs, the compat matrix (whose Standard/Alternative labels were backwards — Mountebank has no object form), and the CHANGELOG are updated. New: an integration test asserting every shipped example's behaviors survive construction, which is what #608 originally asked for.

Closes #608
Closes #610