### PR TITLE
fix: sweep the silent-fallback (swallow) pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,42 @@ record.
   Rift's own example as an error. A `_behaviors` block that still fails to parse is now logged at
   error level instead of vanishing.
 
+- **A failed response build now answers `500`, not `200` with the words "Internal Server Error".**
+  The shared terminal fallback behind every serving-path response builder used `Response::new`,
+  which defaults to status **200** — so a builder failure (an invalid header name or value, e.g.
+  from a proxied upstream, an inject, or a script) served an error string under a success status,
+  and the client's decoder was the first thing to notice. The fallback now sets a real `500` and
+  logs at error level. Six previously-silent builder fallbacks on the serving path now log the
+  cause instead of swallowing it.
+
+- **Proxy error responses are valid JSON and carry a correct status.** The proxy's error helper
+  interpolated the message straight into a JSON string literal, so any message containing a quote
+  produced a body that failed in the client's parser; it also took an unvalidated `u16` status, and
+  a code HTTP cannot represent fell into a fallback that answered **200**. It now delegates to the
+  same Mountebank-shaped error builder the rest of Rift uses (`{"errors":[{"code","message"}]}`),
+  escaping the message properly, and an unrepresentable status is a logged `500`. Note the body
+  shape of proxy-generated errors (e.g. `Bad Gateway`) changes from `{"error": "..."}` to the
+  Mountebank envelope, matching Rift's other error responses. All proxy modes now emit that one
+  envelope; previously the streaming and recording paths hand-built their own.
+
+- **`proxyAlways` no longer records a duplicate stub when a predicate matches on several fields.**
+  Stub dedup compared *serialized* predicates, but a predicate's operands are maps that serialize
+  in iteration order, so two semantically identical predicate sets reliably produced different
+  JSON strings. A `predicateGenerators: [{"matches": {"method": true, "path": true, "query":
+  true}}]` therefore appended a new stub per recorded request instead of merging responses into
+  the existing one. Dedup now compares the predicates structurally.
+
+- **A query or form value that is not valid percent-encoding is passed through raw instead of
+  being blanked.** Five decode sites — the behaviors request context, both `parse_query_string`
+  helpers, and form-body parsing — turned an undecodable sequence into an **empty string**, so a
+  predicate matched against `""` rather than the text the client actually sent, and an undecodable
+  *key* collapsed distinct parameters into a single `""` entry that comma-joined unrelated values.
+  They now pass the raw value through, which is what every other decode site in Rift already did.
+
+- **Debug-mode responses report a serialization failure as `500`.** An `X-Rift-Debug: true`
+  request answered `200` carrying an error string if the debug payload failed to serialize, with
+  no log.
+
 ### Security
 
 - **A function `wait` requires `--allowInjection` in both spellings.** The `--allowInjection`

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1935,6 +1935,9 @@ pub extern "C" fn rift_build_info() -> *const c_char {
             "builtAt": option_env!("RIFT_BUILT_AT"),
             "features": features,
         });
+        // Terminal last-resort: `json!` output cannot contain an interior NUL, so this fallback is
+        // unreachable; and build info carries no status for the `{}` fallback to misreport
+        // (issue #611).
         CString::new(info.to_string()).unwrap_or_else(|_| CString::new("{}").expect("no NUL"))
     })
     .as_ptr()

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -133,6 +133,8 @@ async fn handle_stop(control: &InterceptControl) -> Response<Full<Bytes>> {
     Response::builder()
         .status(StatusCode::NO_CONTENT)
         .body(Full::new(Bytes::new()))
+        // Terminal last-resort: `error_response` keeps the correct 500 status and its payload is
+        // infallible by construction, so this cannot mask a failure as success (issue #611).
         .unwrap_or_else(|_| {
             error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -211,6 +213,8 @@ fn handle_ca_pem(state: &InterceptState) -> Response<Full<Bytes>> {
         .status(StatusCode::OK)
         .header("content-type", "application/x-pem-file")
         .body(Full::new(Bytes::from(pem)))
+        // Terminal last-resort: `error_response` keeps the correct 500 status and its payload is
+        // infallible by construction, so this cannot mask a failure as success (issue #611).
         .unwrap_or_else(|_| {
             error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -226,6 +230,8 @@ fn password_from_query(query: Option<&str>) -> String {
             q.split('&').find_map(|pair| {
                 let (k, v) = pair.split_once('=')?;
                 (k == "password").then(|| {
+                    // Domain-optional decode: an undecodable value passes through raw, the repo's
+                    // convention for percent-decoding query values (issue #611).
                     urlencoding::decode(v)
                         .map(|d| d.into_owned())
                         .unwrap_or_else(|_| v.to_string())
@@ -245,6 +251,8 @@ fn truststore_response(bytes: Vec<u8>, password: &str, filename: &str) -> Respon
         )
         .header("x-truststore-password", password)
         .body(Full::new(Bytes::from(bytes)))
+        // Terminal last-resort: `error_response` keeps the correct 500 status and its payload is
+        // infallible by construction, so this cannot mask a failure as success (issue #611).
         .unwrap_or_else(|_| {
             error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -38,6 +38,8 @@ fn flow_id_from_query(query: Option<&str>) -> Option<String> {
     query?.split('&').find_map(|pair| {
         let (k, v) = pair.split_once('=')?;
         (k == "flowId").then(|| {
+            // Domain-optional decode: an undecodable value passes through raw, the repo's
+            // convention for percent-decoding query values (issue #611).
             urlencoding::decode(v)
                 .map(|d| d.into_owned())
                 .unwrap_or_else(|_| v.to_string())

--- a/crates/rift-mock-core/src/behaviors/request.rs
+++ b/crates/rift-mock-core/src/behaviors/request.rs
@@ -43,7 +43,7 @@ impl RequestContext {
                     None => (pair, ""),
                 };
                 let decoded_key = key.to_string();
-                let decoded_value = urlencoding::decode(value).unwrap_or_default().to_string();
+                let decoded_value = crate::util::decode_or_raw(value);
                 query_map
                     .entry(decoded_key)
                     .and_modify(|existing: &mut String| {
@@ -76,6 +76,27 @@ impl RequestContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Issue #611: an undecodable percent-sequence used to blank the value (`unwrap_or_default`),
+    // silently destroying text a predicate matches on. Every sibling decode site in the repo
+    // (request_filter.rs, intercept.rs, scenarios.rs) passes the raw value through instead.
+    #[test]
+    fn from_request_passes_through_an_undecodable_query_value() {
+        let uri: hyper::Uri = "/p?k=%FF".parse().unwrap();
+        let ctx = RequestContext::from_request("GET", &uri, &hyper::HeaderMap::new(), None);
+        assert_eq!(
+            ctx.query.get("k").map(String::as_str),
+            Some("%FF"),
+            "an undecodable value must pass through raw, not become an empty string"
+        );
+    }
+
+    #[test]
+    fn from_request_still_decodes_a_valid_query_value() {
+        let uri: hyper::Uri = "/p?k=hello%20world".parse().unwrap();
+        let ctx = RequestContext::from_request("GET", &uri, &hyper::HeaderMap::new(), None);
+        assert_eq!(ctx.query.get("k").map(String::as_str), Some("hello world"));
+    }
 
     // Issue #480 — the request context is now built from `req.headers().clone()`, whose names are
     // hyper's lowercase form, instead of a HashMap that was pre-title-cased. `from_request` must

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -513,12 +513,10 @@ impl Imposter {
             for pair in body_str.split('&').filter(|s| !s.is_empty()) {
                 let mut parts = pair.splitn(2, '=');
                 if let Some(raw_key) = parts.next() {
-                    let key = urlencoding::decode(raw_key)
-                        .unwrap_or_default()
-                        .into_owned();
+                    let key = crate::util::decode_or_raw(raw_key);
                     let value = parts
                         .next()
-                        .map(|v| urlencoding::decode(v).unwrap_or_default().into_owned())
+                        .map(crate::util::decode_or_raw)
                         .unwrap_or_default();
                     map.entry(key)
                         .and_modify(|existing: &mut String| {
@@ -554,6 +552,37 @@ mod bounded_matching_tests {
 
     fn no_headers() -> HashMap<String, String> {
         HashMap::new()
+    }
+
+    // Issue #611: an undecodable percent-sequence in a form body must pass through raw rather than
+    // blank the key or value — the same decode convention the rest of the repo follows.
+    #[test]
+    fn parse_form_data_passes_through_undecodable_sequences() {
+        let headers = HashMap::from([(
+            "Content-Type".to_string(),
+            "application/x-www-form-urlencoded".to_string(),
+        )]);
+
+        let form = Imposter::parse_form_data(&headers, Some("k=%FF")).expect("form parsed");
+        assert_eq!(
+            form.get("k"),
+            Some(&"%FF".to_string()),
+            "an undecodable value must pass through raw, not become empty"
+        );
+
+        let form = Imposter::parse_form_data(&headers, Some("%FF=v")).expect("form parsed");
+        assert_eq!(
+            form.get("%FF"),
+            Some(&"v".to_string()),
+            "an undecodable key must pass through raw, not collapse to an empty key"
+        );
+
+        let form = Imposter::parse_form_data(&headers, Some("k=hello%20world")).expect("parsed");
+        assert_eq!(
+            form.get("k"),
+            Some(&"hello world".to_string()),
+            "valid sequences must still decode"
+        );
     }
 
     // Issue #475: run_flow_blocking must be transparent — on the default (non-blocking) backend it

--- a/crates/rift-mock-core/src/imposter/core/proxy.rs
+++ b/crates/rift-mock-core/src/imposter/core/proxy.rs
@@ -245,11 +245,11 @@ impl Imposter {
                     .enumerate()
                     .skip(proxy_stub_index + 1) // Only look after the proxy stub
                     .find(|(_, existing)| {
-                        // Compare predicates (JSON comparison)
-                        let existing_preds =
-                            serde_json::to_string(&existing.predicates).unwrap_or_default();
-                        let new_preds = serde_json::to_string(&stub.predicates).unwrap_or_default();
-                        existing_preds == new_preds && !existing.predicates.is_empty()
+                        // Structural comparison, not serialized JSON (issue #611): a predicate's
+                        // operands are `HashMap`s, which serialize in iteration order, so two
+                        // semantically equal multi-key predicate sets reliably produced different
+                        // strings and dedup appended a duplicate stub instead of merging into it.
+                        existing.predicates == stub.predicates && !existing.predicates.is_empty()
                     })
                     .map(|(idx, _)| idx);
 
@@ -592,5 +592,64 @@ impl Imposter {
             body_bytes.to_vec(),
             proxy_config.add_wait_behavior.then_some(latency_ms),
         ))
+    }
+}
+
+#[cfg(test)]
+mod proxy_dedup_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn imposter_with_proxy(to: &str) -> Imposter {
+        let cfg = serde_json::from_value(json!({
+            "port": 0,
+            "protocol": "http",
+            "stubs": [{ "responses": [{ "proxy": { "to": to, "mode": "proxyAlways" } }] }],
+        }))
+        .expect("valid imposter config");
+        Imposter::new(cfg).expect("test imposter")
+    }
+
+    /// A stub whose single predicate matches on several fields at once — the shape a Mountebank
+    /// `predicateGenerators: [{matches: {method, path, query}}]` produces.
+    fn multi_key_stub(body: &str) -> Stub {
+        serde_json::from_value(json!({
+            "predicates": [{ "equals": { "method": "GET", "path": "/x", "query": { "a": "1" } } }],
+            "responses": [{ "is": { "statusCode": 200, "body": body } }],
+        }))
+        .expect("valid stub")
+    }
+
+    // Issue #611: dedup compared *serialized* predicates, but a predicate's operands are `HashMap`s
+    // that serialize in iteration order — so two semantically equal multi-key predicate sets
+    // produced different strings and proxyAlways appended a duplicate stub instead of merging the
+    // recorded response into the existing one.
+    #[test]
+    fn proxy_always_merges_responses_for_equal_multi_key_predicates() {
+        let imposter = imposter_with_proxy("http://upstream");
+
+        imposter.insert_or_append_proxy_stub(
+            multi_key_stub("first"),
+            "http://upstream",
+            "proxyAlways",
+        );
+        imposter.insert_or_append_proxy_stub(
+            multi_key_stub("second"),
+            "http://upstream",
+            "proxyAlways",
+        );
+
+        let stubs = imposter.get_stubs();
+        assert_eq!(
+            stubs.len(),
+            2,
+            "equal predicate sets must merge into one recorded stub alongside the proxy stub, \
+             not append a duplicate"
+        );
+        assert_eq!(
+            stubs[1].responses.len(),
+            2,
+            "both recorded responses must land on the single matching stub"
+        );
     }
 }

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -449,7 +449,8 @@ async fn handle_request_inner(
 
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
-                        .unwrap_or_else(|_| {
+                        .unwrap_or_else(|e| {
+                            warn!("proxy response build failed (bad upstream header?): {e}");
                             build_response(
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 "Response build error",
@@ -502,7 +503,8 @@ async fn handle_request_inner(
 
                     return Ok(response
                         .body(Full::new(Bytes::from(inject_response.body)))
-                        .unwrap_or_else(|_| {
+                        .unwrap_or_else(|e| {
+                            warn!("inject response build failed (bad injected header?): {e}");
                             build_response(
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 "Response build error",
@@ -567,6 +569,8 @@ async fn handle_request_inner(
                     .iter()
                     .map(|(k, v)| (k.to_ascii_lowercase(), v.clone()))
                     .collect(),
+                // Domain-optional parse: a request body may legitimately not be JSON, and the
+                // script contract exposes that as `null` rather than an error (issue #611).
                 body: body_string
                     .as_ref()
                     .and_then(|s| serde_json::from_str(s).ok())
@@ -677,7 +681,8 @@ async fn handle_request_inner(
 
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
-                        .unwrap_or_else(|_| {
+                        .unwrap_or_else(|e| {
+                            warn!("script response build failed (bad script header?): {e}");
                             build_response(
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 "Response build error",
@@ -1130,7 +1135,8 @@ async fn handle_request_inner(
                 response = response.header("x-rift-binary-error", "true");
             }
 
-            return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|_| {
+            return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|e| {
+                warn!("stub response build failed (bad stub header?): {e}");
                 build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
             }));
         }
@@ -1197,6 +1203,8 @@ async fn handle_request_inner(
                 if b.is_string() {
                     b.as_str().unwrap_or("").to_string()
                 } else {
+                    // Serializing a `serde_json::Value` is infallible by construction (map keys
+                    // are strings, numbers are finite), so this never defaults (issue #611).
                     serde_json::to_string(b).unwrap_or_default()
                 }
             })
@@ -1228,7 +1236,8 @@ async fn handle_request_inner(
         response = response.header("x-rift-imposter", "true");
         response = response.header("x-rift-default-response", "true");
 
-        return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|_| {
+        return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|e| {
+            warn!("defaultResponse build failed (bad default header?): {e}");
             build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
         }));
     }
@@ -1336,17 +1345,32 @@ fn handle_debug_request(
         match_result,
     };
 
-    let json_body = serde_json::to_string_pretty(&debug_response)
-        .unwrap_or_else(|_| r#"{"error": "Failed to serialize debug response"}"#.to_string());
+    let (status, json_body) = debug_serialize_or_500(&debug_response);
 
     Ok(build_response_with_headers(
-        StatusCode::OK,
+        status,
         [
             ("Content-Type", "application/json"),
             ("X-Rift-Debug-Response", "true"),
         ],
         json_body,
     ))
+}
+
+/// Serialize a debug payload into the `(status, body)` the debug endpoint should answer with.
+/// Split out from `handle_debug_request` so the serde error path — unreachable with the real
+/// `DebugResponse` — can be pinned by a test (issue #611).
+fn debug_serialize_or_500<T: serde::Serialize>(payload: &T) -> (StatusCode, String) {
+    match serde_json::to_string_pretty(payload) {
+        Ok(body) => (StatusCode::OK, body),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to serialize debug response");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"error": "Failed to serialize debug response"}"#.to_string(),
+            )
+        }
+    }
 }
 
 /// Handle a top-level `fault` response type. A Mountebank `fault` is a transport-level event, so
@@ -1469,7 +1493,8 @@ async fn apply_rift_fault(
         return Some(
             response
                 .body(Full::new(Bytes::from(error_body)))
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
+                    warn!("error-fault response build failed (bad fault header?): {e}");
                     build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
                 }),
         );
@@ -1557,6 +1582,43 @@ mod matcher_error_response_tests {
             resp.headers().contains_key("x-rift-inject-error"),
             "a predicate-inject timeout keeps the inject-error marker"
         );
+    }
+}
+
+#[cfg(test)]
+mod debug_serialize_tests {
+    use super::debug_serialize_or_500;
+    use hyper::StatusCode;
+    use serde::{Serialize, Serializer};
+
+    /// A payload whose `Serialize` always fails — the only way to drive serde's error path, since
+    /// the real `DebugResponse` is plain structs of strings and JSON values (issue #611, mirroring
+    /// the #606 technique in `admin_api/types.rs`).
+    struct Unserializable;
+    impl Serialize for Unserializable {
+        fn serialize<S: Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("nope"))
+        }
+    }
+
+    // Issue #611: a serialize failure used to be answered as `200 OK` carrying an error string —
+    // the #606 shape one endpoint over. It is a server fault and must be a 500.
+    #[test]
+    fn debug_serialize_failure_maps_to_500() {
+        let (status, _body) = debug_serialize_or_500(&Unserializable);
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a serialize failure must be a 500, not a 200 carrying an error string"
+        );
+    }
+
+    #[test]
+    fn debug_serialize_success_keeps_200_and_the_payload() {
+        let (status, body) = debug_serialize_or_500(&serde_json::json!({"debug": true}));
+        assert_eq!(status, StatusCode::OK);
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(parsed["debug"], serde_json::json!(true));
     }
 }
 

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -498,8 +498,8 @@ pub fn parse_query_string(query: &str) -> HashMap<String, String> {
             Some((k, v)) => (k, v),
             None => (pair, ""),
         };
-        let decoded_key = urlencoding::decode(key).unwrap_or_default().into_owned();
-        let decoded_value = urlencoding::decode(value).unwrap_or_default().into_owned();
+        let decoded_key = crate::util::decode_or_raw(key);
+        let decoded_value = crate::util::decode_or_raw(value);
         map.entry(decoded_key)
             .and_modify(|existing: &mut String| {
                 existing.push(',');
@@ -1793,6 +1793,37 @@ mod tests {
     fn test_parse_query_string_empty() {
         let result = parse_query_string("");
         assert!(result.is_empty());
+    }
+
+    // Issue #611: an undecodable percent-sequence must pass through raw rather than blank the key
+    // or value. Blanking destroys matchable text and, on the key, collapses distinct params into a
+    // single "" entry that then comma-joins unrelated values.
+    #[test]
+    fn test_parse_query_string_passes_through_undecodable_sequences() {
+        let value = parse_query_string("k=%FF");
+        assert_eq!(
+            value.get("k"),
+            Some(&"%FF".to_string()),
+            "an undecodable value must pass through raw, not become empty"
+        );
+
+        let key = parse_query_string("%FF=v");
+        assert_eq!(
+            key.get("%FF"),
+            Some(&"v".to_string()),
+            "an undecodable key must pass through raw, not collapse to an empty key"
+        );
+
+        // The collision the fix exists to prevent: two *different* undecodable keys both blanked
+        // to "" used to comma-join their unrelated values into a single bogus entry.
+        let collision = parse_query_string("%FF=a&%FE=b");
+        assert_eq!(collision.get("%FF"), Some(&"a".to_string()));
+        assert_eq!(collision.get("%FE"), Some(&"b".to_string()));
+        assert_eq!(
+            collision.len(),
+            2,
+            "distinct undecodable keys must stay distinct, not collapse into one \"\" entry"
+        );
     }
 
     // Fix #104: JSON body key matching now respects keyCaseSensitive

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -53,6 +53,8 @@ pub fn create_response_preview(response: &StubResponse) -> DebugResponsePreview 
             let body_preview = is.body.as_ref().map(|b| match b {
                 serde_json::Value::String(s) => truncate_with_ellipsis(s, 500),
                 other => {
+                    // Serializing a `serde_json::Value` is infallible by construction, so this
+                    // never defaults; it is a debug preview either way (issue #611).
                     let json = serde_json::to_string(other).unwrap_or_default();
                     truncate_with_ellipsis(&json, 500)
                 }

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -409,7 +409,8 @@ impl StubResponse {
                 }
             })
             .map(std::sync::Arc::new);
-        // Only a non-string body needs rendering; a string body is served as-is.
+        // Only a non-string body needs rendering; a string body is served as-is. Serializing a
+        // `serde_json::Value` is infallible by construction, so this never defaults (issue #611).
         let rendered_body =
             is.body.as_ref().filter(|b| !b.is_string()).map(|b| {
                 std::sync::Arc::from(serde_json::to_string(b).unwrap_or_default().as_str())

--- a/crates/rift-mock-core/src/predicate/deep_equals.rs
+++ b/crates/rift-mock-core/src/predicate/deep_equals.rs
@@ -134,11 +134,7 @@ pub fn parse_query_string(query: Option<&str>) -> HashMap<String, String> {
     if let Some(q) = query {
         for pair in q.split('&') {
             if let Some((key, value)) = pair.split_once('=') {
-                // URL decode would go here for full compatibility
-                params.insert(
-                    key.to_string(),
-                    urlencoding::decode(value).unwrap_or_default().to_string(),
-                );
+                params.insert(key.to_string(), crate::util::decode_or_raw(value));
             } else if !pair.is_empty() {
                 params.insert(pair.to_string(), String::new());
             }
@@ -258,5 +254,17 @@ mod tests {
 
         let encoded = parse_query_string(Some("name=hello%20world"));
         assert_eq!(encoded.get("name"), Some(&"hello world".to_string()));
+    }
+
+    // Issue #611: an undecodable percent-sequence must pass through raw, matching the repo's
+    // decode convention, rather than blanking the value a predicate matches on.
+    #[test]
+    fn test_query_string_passes_through_undecodable_value() {
+        let params = parse_query_string(Some("k=%FF"));
+        assert_eq!(
+            params.get("k"),
+            Some(&"%FF".to_string()),
+            "an undecodable value must pass through raw, not become empty"
+        );
     }
 }

--- a/crates/rift-mock-core/src/proxy/forwarding.rs
+++ b/crates/rift-mock-core/src/proxy/forwarding.rs
@@ -9,7 +9,6 @@ use super::headers::{
 };
 use super::response_ext::ResponseExt;
 use crate::recording::{ProxyMode, RecordedResponse, RecordingStore, RequestSignature};
-use crate::response::builder::ErrorResponseBuilder;
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
@@ -19,13 +18,17 @@ use std::sync::Arc;
 use tracing::{debug, error};
 
 /// Helper function to create an error response.
+///
+/// Delegates to the crate's canonical Mountebank-shaped error builder (issue #611) rather than
+/// interpolating the message into a JSON string literal, which produced invalid JSON whenever the
+/// message contained a quote. A `status` hyper cannot represent is a server fault, not something
+/// to serve as-is, so it becomes a loud 500.
 pub fn error_response(status: u16, message: &str) -> Response<Full<Bytes>> {
-    let body = format!(r#"{{"error": "{message}"}}"#);
-    Response::builder()
-        .status(status)
-        .header("content-type", "application/json")
-        .body(Full::new(Bytes::from(body)))
-        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(r#"{"error": "internal"}"#))))
+    let status = StatusCode::from_u16(status).unwrap_or_else(|e| {
+        error!(status, error = %e, "invalid HTTP status for error response; serving 500");
+        StatusCode::INTERNAL_SERVER_ERROR
+    });
+    crate::response::error_response(status, message)
 }
 
 /// Build a `Request::Builder` pointing at the upstream, with headers copied
@@ -122,10 +125,9 @@ pub async fn forward_request_streaming(
         }
         Err(e) => {
             error!("Failed to forward request to upstream: {}", e);
-            ErrorResponseBuilder::new(StatusCode::BAD_GATEWAY)
-                .header("content-type", "application/json")
-                .body(r#"{"error": "Bad Gateway"}"#)
-                .build_boxed()
+            // Same helper as the buffered path (issue #611) so an upstream failure produces one
+            // error envelope regardless of which proxy mode happens to be serving.
+            error_response(502, "Bad Gateway").into_boxed()
         }
     }
 }
@@ -154,10 +156,7 @@ pub async fn forward_with_recording(
         Ok(collected) => collected.to_bytes(),
         Err(e) => {
             error!("Failed to collect request body for recording: {}", e);
-            return ErrorResponseBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
-                .header("content-type", "application/json")
-                .body(r#"{"error": "Failed to read request body"}"#)
-                .build_boxed();
+            return error_response(500, "Failed to read request body").into_boxed();
         }
     };
 
@@ -368,5 +367,57 @@ mod tests {
     fn test_error_response_503() {
         let response = error_response(503, "Service Unavailable");
         assert_eq!(response.status(), 503);
+    }
+
+    async fn body_string(response: Response<Full<Bytes>>) -> String {
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body")
+            .to_bytes();
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
+    // Issue #611: the body was built by string interpolation, so a message containing a quote
+    // produced invalid JSON that only fails in the client's decoder. It must always parse.
+    #[tokio::test]
+    async fn error_response_escapes_quotes_in_the_message() {
+        let response = error_response(502, r#"upstream said "no""#);
+        let body = body_string(response).await;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("error body must be valid JSON");
+        assert_eq!(
+            parsed["errors"][0]["message"],
+            serde_json::json!(r#"upstream said "no""#),
+            "the message must survive escaping intact"
+        );
+    }
+
+    // Issue #611: `status: u16` let a code the builder rejects fall into the terminal fallback,
+    // which answered 200. An unrepresentable code is a server fault → 500, never a masked 200.
+    #[tokio::test]
+    async fn error_response_maps_an_invalid_status_code_to_500() {
+        for bad in [0u16, 1000] {
+            let response = error_response(bad, "boom");
+            assert_eq!(
+                response.status(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "status {bad} is not a valid HTTP status; must fall back to 500"
+            );
+        }
+    }
+
+    // Pins the Mountebank error envelope the proxy now shares with the rest of the crate.
+    #[tokio::test]
+    async fn error_response_body_is_the_mountebank_error_envelope() {
+        let response = error_response(502, "Bad Gateway");
+        let body = body_string(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(parsed["errors"][0]["code"], serde_json::json!("502"));
+        assert_eq!(
+            parsed["errors"][0]["message"],
+            serde_json::json!("Bad Gateway")
+        );
     }
 }

--- a/crates/rift-mock-core/src/util.rs
+++ b/crates/rift-mock-core/src/util.rs
@@ -60,16 +60,40 @@ fn rift_debug_from(val: Option<&str>) -> bool {
         .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
 }
 
+/// Percent-decode a query/form component, passing the raw text through unchanged if it is not
+/// valid percent-encoding.
+///
+/// This is Rift's decode contract (issue #611): an undecodable sequence is the client's own text,
+/// not an error to erase. Blanking it — the `unwrap_or_default()` this replaced — silently
+/// destroys text a predicate matches on, and on a key it collapses distinct parameters into a
+/// single `""` entry that then comma-joins unrelated values.
+pub fn decode_or_raw(value: &str) -> String {
+    urlencoding::decode(value)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| value.to_string())
+}
+
+/// The terminal fallback for the builders below: a 500 assembled without the builder, so it cannot
+/// itself fail. `Response::new` defaults to **200**, so the status must be set explicitly —
+/// answering 200 with an error string is the failure-masking shape issue #611 sweeps out.
+fn internal_error_fallback(e: &hyper::http::Error) -> Response<Full<Bytes>> {
+    tracing::error!(error = %e, "response build failed; serving a 500");
+    let mut resp = Response::new(Full::new(Bytes::from("Internal Server Error")));
+    *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+    resp
+}
+
 /// Build an HTTP response with the given status and body. Falls back to a minimal 500 if the
 /// builder fails (which should not happen with a valid `StatusCode`).
 pub fn build_response(status: StatusCode, body: impl Into<Bytes>) -> Response<Full<Bytes>> {
     Response::builder()
         .status(status)
         .body(Full::new(body.into()))
-        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from("Internal Server Error"))))
+        .unwrap_or_else(|e| internal_error_fallback(&e))
 }
 
-/// Build an HTTP response with headers. Falls back to a minimal 500 if the builder fails.
+/// Build an HTTP response with headers. Falls back to a minimal 500 if the builder fails (e.g. a
+/// caller-supplied header name/value that hyper rejects).
 pub fn build_response_with_headers(
     status: StatusCode,
     headers: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
@@ -81,7 +105,7 @@ pub fn build_response_with_headers(
     }
     builder
         .body(Full::new(body.into()))
-        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from("Internal Server Error"))))
+        .unwrap_or_else(|e| internal_error_fallback(&e))
 }
 
 /// Merge a slice of `(key, value)` header pairs into a `HashMap`,
@@ -144,7 +168,34 @@ pub fn unix_timestamp() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{http2_disabled_from, rift_debug_from, strict_behaviors_from};
+    use super::{
+        build_response, build_response_with_headers, http2_disabled_from, rift_debug_from,
+        strict_behaviors_from,
+    };
+    use hyper::StatusCode;
+
+    // Issue #611: the terminal builder fallback must not answer 200. A response-builder failure is
+    // a server fault, and `Response::new` defaults to 200 — the same 200-masking shape #606 fixed
+    // one helper up. An invalid header name is the only way to drive the builder's error path.
+    #[test]
+    fn build_response_with_headers_falls_back_to_500_on_builder_failure() {
+        let resp = build_response_with_headers(StatusCode::OK, [("bad\nname", "v")], "x");
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a builder failure must surface as 500, not a 200 carrying an error string"
+        );
+    }
+
+    // `build_response` takes a valid `StatusCode` and no headers, so its builder cannot fail today;
+    // pin the success path so the fallback added for #611 can't silently change the happy status.
+    #[test]
+    fn build_response_preserves_the_requested_status() {
+        assert_eq!(
+            build_response(StatusCode::NOT_FOUND, "x").status(),
+            StatusCode::NOT_FOUND
+        );
+    }
 
     // Issue #375: RIFT_STRICT_BEHAVIORS parsing — truthy values force strict, everything else lenient.
     #[test]

--- a/crates/rift-tui/src/app/mod.rs
+++ b/crates/rift-tui/src/app/mod.rs
@@ -210,6 +210,10 @@ impl StubEditor {
     }
 
     /// Get the stub if valid
+    ///
+    /// Domain-optional parse: editor content that isn't yet a valid stub is a normal editing
+    /// state, not an error — `validate()` is the path that reports the parse error to the user
+    /// (issue #611).
     pub fn get_stub(&self) -> Option<crate::api::Stub> {
         let content = self.editor.lines().join("\n");
         serde_json::from_str(&content).ok()


### PR DESCRIPTION
Sweeps the silent-fallback (swallow) family so it is closed out rather than rediscovered one site at a time. Implements the per-site ruling in #611.

**Fixed**
- `util.rs` terminal builder fallback answered **200** (`Response::new` defaults to 200) → now a logged 500. Every serving-path builder fallback funnels through it.
- `proxy/forwarding.rs::error_response`: quote in the message produced invalid JSON; an unrepresentable `u16` status fell into a 200 fallback → now delegates to the canonical Mountebank error builder with status mapping + a logged 500.
- `handle_debug_request`: serialize failure answered 200 with an error string → now a logged 500.
- Six silent `build_response(500, ..)` fallbacks in `handler.rs` now log, matching the existing `defaultForward` shape.

**Scope notes for the reviewer**
- The ruling named **one** percent-decode site (`behaviors/request.rs`). The issue's own exit-criterion sweep found **four more with the identical shape**, all on live request paths (`deep_equals.rs`, `predicates/mod.rs` — key *and* value, `matching.rs` form parsing). Fixing one of five would have recreated this issue's complaint, so all five are fixed and collapsed onto a shared `util::decode_or_raw`.
- **Two extra fixes came out of review, both beyond the ruling:**
  - `proxy.rs` dedup: the ruling asked for a comment naming `serde_json::Value` infallibility here, but the fields are `Vec<Predicate>`, and the line had a *live* bug — predicate operands are `HashMap`s that serialize in iteration order (measured: 20/20 equal-content sets produced different strings), so `proxyAlways` appended a duplicate stub instead of merging responses. Fixed structurally and pinned with a regression test verified to fail on the old comparison.
  - Consolidating the streaming/recording proxy paths onto `error_response`, which otherwise would have emitted a *different error envelope per proxy mode*.
- **Behavior change:** proxy-generated error bodies move from `{"error": "..."}` to the Mountebank envelope `{"errors":[{"code","message"}]}`, matching the rest of Rift. Nothing pinned the old shape (the compat suite accepts either).
- Not swept: ~15 `serde_json::to_string(<Value>).unwrap_or_default()` sites in `scripting/` and `rift-tui/` lack a taxonomy comment. They were verified category-B (serializing a `Value` is infallible) and are outside the ruling's audit table, so they are left for a comment-only follow-up.
- Filed #614 from this work: the two `parse_query_string` helpers disagree on whether the query **key** is percent-decoded (`a%20b=1` → `"a b"` vs `"a%20b"`). Not a swallow, so deliberately out of scope here.

**Verification:** `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` 0; `cargo clippy -p rift-mock-core --no-default-features` 0; `cargo test --workspace` 1811 passed / 0 failed.

Closes #611