### PR TITLE
security(config): --configfile/--datadir imposter load bypasses the --allowInjection gate entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,23 @@ record.
   "no script surface" — previously its safety depended on the executor's parser failing in
   lockstep, an unwritten coupling this release's new wait variant would have broken.
 
+- **`--allowInjection` is now enforced on `--configfile`, `--datadir`, and `POST /admin/reload`.**
+  The gate only ever guarded the admin API, so the same document got two different security
+  answers depending on the door it came through: `examples/latency-testing.json` (a JS-function
+  `wait`) was correctly refused when POSTed without `--allowInjection`, and loaded and executed
+  when passed to `--configfile`. This mattered most for `--datadir`, which is **not**
+  operator-authored — its `{port}.json` files are persisted from admin-API writes, so running once
+  with `--allowInjection` and restarting without it kept executing the persisted scripts: the gate
+  failed open across restarts. `POST /admin/reload` was ungated and network-reachable. All doors
+  now ask the same classifier the admin API uses (`inject` response/predicate,
+  `predicateGenerators.inject`, `decorate`, `shellTransform`, a non-numeric `wait`,
+  `_rift.script`), with per-door semantics: `--configfile` **aborts startup**, naming the file and
+  every offending port at once; a gated `--datadir` file is **skipped** and named in the existing
+  startup skip summary, so one leftover file cannot brick the rest; `POST /admin/reload` returns
+  **`400 invalid injection`** before applying anything, leaving running imposters untouched.
+  Mountebank refuses injection in a config file too — see the divergence note in the compatibility
+  matrix: mb logs the failed load and stays up, Rift fails fast on `--configfile`.
+
 ### Added
 
 - **Admin SSE stream — push request tails instead of polling.** `GET /events` (and the

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -9,8 +9,8 @@ use crate::admin_api::types::{
 use crate::extensions::decorate::backend_error_response;
 use crate::imposter::RecordedRequest;
 use crate::imposter::{
-    Imposter, ImposterConfig, ImposterError, ImposterManager, Predicate, PredicateOperation,
-    ScriptBaseDir, Stub, StubResponse, VerifyOptions, resolve_scripts,
+    Imposter, ImposterConfig, ImposterError, ImposterManager, ScriptBaseDir, Stub, StubResponse,
+    VerifyOptions, resolve_scripts,
 };
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
@@ -47,94 +47,6 @@ pub(crate) fn imposter_script_registry(
         .unwrap_or_default()
 }
 
-/// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`
-/// (issue #355 Item 4): an inject response, a decorate behavior (`_behaviors.decorate` / a
-/// proxy's `addDecorateBehavior`), a `_behaviors.shellTransform` (runs a host shell command),
-/// a `wait` behavior expressed as a JS function (which this engine now executes on Boa), a
-/// predicate `inject`, a `predicateGenerators.inject`, or `_rift.script`. Mirrors Mountebank's
-/// `allowInjection` gate.
-fn stubs_contain_script_surface(stubs: &[Stub]) -> bool {
-    stubs.iter().any(|stub| {
-        stub.predicates.iter().any(predicate_has_inject)
-            || stub.responses.iter().any(response_has_script_surface)
-    })
-}
-
-/// True if `predicate` (or anything nested under a `not`/`or`/`and`) is an `inject` predicate.
-fn predicate_has_inject(predicate: &Predicate) -> bool {
-    match &predicate.operation {
-        PredicateOperation::Inject(_) => true,
-        PredicateOperation::Not(inner) => predicate_has_inject(inner),
-        PredicateOperation::Or(preds) | PredicateOperation::And(preds) => {
-            preds.iter().any(predicate_has_inject)
-        }
-        _ => false,
-    }
-}
-
-/// True if `response` uses any script surface: an inject response, a decorate behavior, a
-/// shellTransform behavior, a JS-function `wait` behavior, or `_rift.script`.
-fn response_has_script_surface(response: &StubResponse) -> bool {
-    match response {
-        StubResponse::Inject { .. } => true,
-        StubResponse::RiftScript { rift } => rift.script.is_some(),
-        StubResponse::Is {
-            behaviors, rift, ..
-        } => {
-            let behavior_is_scripted = behaviors.as_ref().is_some_and(raw_behaviors_are_scripted);
-            behavior_is_scripted || rift.as_ref().is_some_and(|r| r.script.is_some())
-        }
-        StubResponse::Proxy { proxy } => {
-            proxy.add_decorate_behavior.is_some()
-                || proxy
-                    .predicate_generators
-                    .iter()
-                    .any(|g| g.get("inject").and_then(|v| v.as_str()).is_some())
-        }
-        StubResponse::Fault { .. } => false,
-    }
-}
-
-/// True if a raw `_behaviors` block carries a scripting surface: `decorate` (JS/Rhai),
-/// `shellTransform` (runs a host shell command — B1), or a `wait` that is not plainly numeric
-/// (executed on Boa since issue #355 Item 6 — B2).
-///
-/// Read from the raw JSON rather than a parsed [`ResponseBehaviors`](crate::behaviors::ResponseBehaviors)
-/// deliberately (issue #610). The gate's question is only "could this execute code?", which the
-/// script-relevant keys answer on their own — so a block the *executor's* parser rejects can still
-/// be classified, and the gate never has to agree with that parser to stay closed. Parsing first
-/// and treating a parse failure as safe was the fail-open bug; treating it as *scripted* fixed the
-/// hole but 400'd `{"repeat": 2.0}` as an injection error, which is neither true nor this gate's
-/// business.
-///
-/// Fail-closed lives in `wait_is_plainly_numeric`: a `wait` is waved through only when it is
-/// provably a delay, never merely because it failed to parse.
-fn raw_behaviors_are_scripted(behaviors: &serde_json::Value) -> bool {
-    let Some(obj) = behaviors.as_object() else {
-        // Not an object (e.g. an array) — no key this gate recognizes, so nothing it can
-        // classify as executable. Such a block does not parse into `ResponseBehaviors` either,
-        // so it is inert: dropped at construction, with `new_is` logging the drop.
-        return false;
-    };
-    let scripted_key_present = obj.contains_key("decorate") || obj.contains_key("shellTransform");
-    let wait_is_scripted = obj.get("wait").is_some_and(|w| !wait_is_plainly_numeric(w));
-    scripted_key_present || wait_is_scripted
-}
-
-/// True only for the two wait spellings that cannot execute code: a fixed millisecond number and
-/// the `{min, max}` range. Everything else — a bare JS string, `{"inject": ...}`, or a shape this
-/// gate does not recognize — is treated as executable (issue #610).
-fn wait_is_plainly_numeric(wait: &serde_json::Value) -> bool {
-    if wait.is_number() {
-        return true;
-    }
-    wait.as_object().is_some_and(|o| {
-        o.len() == 2
-            && o.get("min").is_some_and(|v| v.is_number())
-            && o.get("max").is_some_and(|v| v.is_number())
-    })
-}
-
 /// Reject a set of stubs carrying a Mountebank scripting surface when `--allowInjection` is off,
 /// mirroring Mountebank's gate (issue #355 Item 4). `None` when the stubs are allowed through.
 /// Shared by the imposter CRUD handlers and the stub sub-resource handlers (B3) so the gate can't
@@ -143,7 +55,7 @@ pub(crate) fn reject_stubs_if_injection_disallowed(
     stubs: &[Stub],
     allow_injection: bool,
 ) -> Option<Response<Full<Bytes>>> {
-    if allow_injection || !stubs_contain_script_surface(stubs) {
+    if allow_injection || !crate::injection_gate::stubs_contain_script_surface(stubs) {
         return None;
     }
     Some(injection_disallowed_response())
@@ -151,7 +63,7 @@ pub(crate) fn reject_stubs_if_injection_disallowed(
 
 /// The Mountebank-compatible `400 invalid injection` response returned when a request carries a
 /// scripting surface (`inject`, decorate, …) but `--allowInjection` is off.
-fn injection_disallowed_response() -> Response<Full<Bytes>> {
+pub(crate) fn injection_disallowed_response() -> Response<Full<Bytes>> {
     let body = serde_json::json!({
         "errors": [{
             "code": "invalid injection",
@@ -762,7 +674,12 @@ fn verify_response(
     // An `inject` predicate evaluates Boa JavaScript — a scripting surface gated by
     // `--allowInjection` for untrusted admin clients (issue #355), the same gate the stub
     // endpoints apply before accepting an inject predicate.
-    if !allow_injection && opts.predicates.iter().any(predicate_has_inject) {
+    if !allow_injection
+        && opts
+            .predicates
+            .iter()
+            .any(crate::injection_gate::predicate_has_inject)
+    {
         return injection_disallowed_response();
     }
     match manager.get_imposter(port) {

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -120,6 +120,15 @@ pub fn handle_logs(query: Option<&str>) -> Response<Full<Bytes>> {
     json_response(StatusCode::OK, &logs)
 }
 
+/// True when a reload's configs carry a scripting surface that `--allowInjection` has not
+/// enabled (issue #612) — the same classifier every other imposter door uses.
+fn reload_is_gated(configs: &[crate::imposter::ImposterConfig], allow_injection: bool) -> bool {
+    !allow_injection
+        && configs
+            .iter()
+            .any(crate::injection_gate::config_uses_script_surface)
+}
+
 /// POST /admin/reload - re-read the startup config source and reconcile the running imposters
 /// toward it incrementally (issues #197/#316, Rift extension). No-op (200) when no
 /// `--configfile`/`--datadir` was given. The new set is validated before the running imposters
@@ -129,6 +138,7 @@ pub fn handle_logs(query: Option<&str>) -> Response<Full<Bytes>> {
 pub async fn handle_reload(
     manager: Arc<ImposterManager>,
     config_source: Option<Arc<crate::config_loader::ConfigSource>>,
+    allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let Some(source) = config_source else {
         return json_response(
@@ -147,6 +157,12 @@ pub async fn handle_reload(
             );
         }
     };
+
+    // Validate-before-touch: refuse a gated config before anything mutates, so a refused reload
+    // leaves the running imposters exactly as they were (issue #612).
+    if reload_is_gated(&configs, allow_injection) {
+        return crate::admin_api::handlers::imposters::injection_disallowed_response();
+    }
 
     let count = configs.len();
     match manager.apply_config(configs).await {
@@ -274,7 +290,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_reload_no_source_is_noop() {
         let manager = Arc::new(ImposterManager::new());
-        let resp = handle_reload(manager, None).await;
+        let resp = handle_reload(manager, None, false).await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -300,7 +316,7 @@ mod tests {
         });
 
         let manager = Arc::new(ImposterManager::new());
-        let resp = handle_reload(manager.clone(), Some(source)).await;
+        let resp = handle_reload(manager.clone(), Some(source), false).await;
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
@@ -351,7 +367,7 @@ mod tests {
         let manager = Arc::new(ImposterManager::new());
 
         // Initial reload creates the imposter with the first script version resolved.
-        let resp = handle_reload(manager.clone(), Some(source.clone())).await;
+        let resp = handle_reload(manager.clone(), Some(source.clone()), true).await;
         assert_eq!(resp.status(), StatusCode::OK);
         let script_code = |manager: &ImposterManager| {
             let imposter = manager.get_imposter(19479).expect("imposter exists");
@@ -371,7 +387,7 @@ mod tests {
         // Edit the referenced file (the configfile itself is untouched) and reload again.
         std::fs::write(&script_path, r#"fn respond(ctx) { http(503, "second") }"#)
             .expect("write script (second version)");
-        let resp = handle_reload(manager.clone(), Some(source)).await;
+        let resp = handle_reload(manager.clone(), Some(source), true).await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
             script_code(&manager).as_deref(),
@@ -392,5 +408,100 @@ mod tests {
     fn test_handle_logs_with_pagination() {
         let resp = handle_logs(Some("startIndex=10&endIndex=50"));
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ===== Issue #612: POST /admin/reload is the third config door and must gate too =====
+
+    /// Reload from `path`, then read back whether port 19481's stub carries a decorate behavior.
+    #[tokio::test]
+    async fn test_handle_reload_rejects_injection_when_flag_off() {
+        use http_body_util::BodyExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19481,"protocol":"http","stubs":[
+                {"responses":[{"is":{"statusCode":200,"body":"original"}}]}
+            ]}]}"#,
+        )
+        .expect("write clean config");
+        let source = Arc::new(crate::config_loader::ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        });
+
+        let manager = Arc::new(ImposterManager::new());
+        let resp = handle_reload(manager.clone(), Some(source.clone()), false).await;
+        assert_eq!(resp.status(), StatusCode::OK, "clean config reloads");
+        assert!(manager.get_imposter(19481).is_ok());
+
+        // Edit the config to add a decorate behavior — a script surface.
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19481,"protocol":"http","stubs":[
+                {"responses":[{"is":{"statusCode":200,"body":"decorated"},
+                 "_behaviors":{"decorate":"function (req, res) { res.body = 'pwned'; }"}}]}
+            ]}]}"#,
+        )
+        .expect("write scripted config");
+
+        let resp = handle_reload(manager.clone(), Some(source), false).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "a decorate behavior without --allowInjection must be refused on reload"
+        );
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert_eq!(
+            body["errors"][0]["code"], "invalid injection",
+            "must use the Mountebank envelope: {body}"
+        );
+
+        // Validate-before-touch: the running imposter is untouched by the refused reload.
+        let imposter = manager.get_imposter(19481).expect("imposter still running");
+        let stubs = imposter.get_stubs();
+        let body_of = |r: &crate::imposter::StubResponse| match r {
+            crate::imposter::StubResponse::Is { is, .. } => is.body.clone(),
+            other => panic!("expected an Is response, got {other:?}"),
+        };
+        assert_eq!(
+            body_of(&stubs[0].responses[0]),
+            Some(serde_json::json!("original")),
+            "the refused reload must leave the running imposter unchanged"
+        );
+
+        manager.delete_all().await;
+    }
+
+    // AC8: with the flag set, the same scripted reload applies.
+    #[tokio::test]
+    async fn test_handle_reload_applies_injection_when_flag_set() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(
+            &path,
+            r#"{"imposters":[{"port":19482,"protocol":"http","stubs":[
+                {"responses":[{"is":{"statusCode":200,"body":"decorated"},
+                 "_behaviors":{"decorate":"function (req, res) { res.body = 'ok'; }"}}]}
+            ]}]}"#,
+        )
+        .expect("write scripted config");
+        let source = Arc::new(crate::config_loader::ConfigSource::File {
+            path,
+            no_parse: false,
+        });
+
+        let manager = Arc::new(ImposterManager::new());
+        let resp = handle_reload(manager.clone(), Some(source), true).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "--allowInjection must permit a decorate behavior on reload"
+        );
+        assert!(manager.get_imposter(19482).is_ok());
+
+        manager.delete_all().await;
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -186,7 +186,7 @@ async fn route_by_path(
         (&Method::GET, "/config") => return system::handle_config(allow_injection),
         (&Method::GET, "/logs") => return system::handle_logs(query),
         (&Method::POST, "/admin/reload") => {
-            return system::handle_reload(manager, config_source).await;
+            return system::handle_reload(manager, config_source, allow_injection).await;
         }
         (&Method::GET, "/metrics") => return system::handle_metrics(manager).await,
         _ => {}

--- a/crates/rift-http-proxy/src/injection_gate.rs
+++ b/crates/rift-http-proxy/src/injection_gate.rs
@@ -1,0 +1,104 @@
+//! The `--allowInjection` classifier: does a stub carry a Mountebank scripting surface?
+//!
+//! Extracted from the admin imposter handlers (issue #612) so every door that admits an imposter
+//! config — `POST/PUT /imposters`, `--configfile`, `--datadir`, and `POST /admin/reload` — asks
+//! one classifier the same question. The gate used to live behind the admin API only, so the same
+//! document was refused by an HTTP POST and executed when loaded from a file.
+//!
+//! This module only *classifies*. Each door owns its own failure semantics (400, startup abort,
+//! or per-file skip), which is why the response builder stays with the admin handlers.
+
+use crate::imposter::{ImposterConfig, Predicate, PredicateOperation, Stub, StubResponse};
+
+/// True if `config`'s stubs carry a scripting surface gated by `--allowInjection`.
+pub(crate) fn config_uses_script_surface(config: &ImposterConfig) -> bool {
+    stubs_contain_script_surface(&config.stubs)
+}
+
+/// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`
+/// (issue #355 Item 4): an inject response, a decorate behavior (`_behaviors.decorate` / a
+/// proxy's `addDecorateBehavior`), a `_behaviors.shellTransform` (runs a host shell command),
+/// a `wait` behavior expressed as a JS function (which this engine now executes on Boa), a
+/// predicate `inject`, a `predicateGenerators.inject`, or `_rift.script`. Mirrors Mountebank's
+/// `allowInjection` gate.
+pub(crate) fn stubs_contain_script_surface(stubs: &[Stub]) -> bool {
+    stubs.iter().any(|stub| {
+        stub.predicates.iter().any(predicate_has_inject)
+            || stub.responses.iter().any(response_has_script_surface)
+    })
+}
+
+/// True if `predicate` (or anything nested under a `not`/`or`/`and`) is an `inject` predicate.
+pub(crate) fn predicate_has_inject(predicate: &Predicate) -> bool {
+    match &predicate.operation {
+        PredicateOperation::Inject(_) => true,
+        PredicateOperation::Not(inner) => predicate_has_inject(inner),
+        PredicateOperation::Or(preds) | PredicateOperation::And(preds) => {
+            preds.iter().any(predicate_has_inject)
+        }
+        _ => false,
+    }
+}
+
+/// True if `response` uses any script surface: an inject response, a decorate behavior, a
+/// shellTransform behavior, a JS-function `wait` behavior, or `_rift.script`.
+fn response_has_script_surface(response: &StubResponse) -> bool {
+    match response {
+        StubResponse::Inject { .. } => true,
+        StubResponse::RiftScript { rift } => rift.script.is_some(),
+        StubResponse::Is {
+            behaviors, rift, ..
+        } => {
+            let behavior_is_scripted = behaviors.as_ref().is_some_and(raw_behaviors_are_scripted);
+            behavior_is_scripted || rift.as_ref().is_some_and(|r| r.script.is_some())
+        }
+        StubResponse::Proxy { proxy } => {
+            proxy.add_decorate_behavior.is_some()
+                || proxy
+                    .predicate_generators
+                    .iter()
+                    .any(|g| g.get("inject").and_then(|v| v.as_str()).is_some())
+        }
+        StubResponse::Fault { .. } => false,
+    }
+}
+
+/// True if a raw `_behaviors` block carries a scripting surface: `decorate` (JS/Rhai),
+/// `shellTransform` (runs a host shell command — B1), or a `wait` that is not plainly numeric
+/// (executed on Boa since issue #355 Item 6 — B2).
+///
+/// Read from the raw JSON rather than a parsed [`ResponseBehaviors`](crate::behaviors::ResponseBehaviors)
+/// deliberately (issue #610). The gate's question is only "could this execute code?", which the
+/// script-relevant keys answer on their own — so a block the *executor's* parser rejects can still
+/// be classified, and the gate never has to agree with that parser to stay closed. Parsing first
+/// and treating a parse failure as safe was the fail-open bug; treating it as *scripted* fixed the
+/// hole but 400'd `{"repeat": 2.0}` as an injection error, which is neither true nor this gate's
+/// business.
+///
+/// Fail-closed lives in `wait_is_plainly_numeric`: a `wait` is waved through only when it is
+/// provably a delay, never merely because it failed to parse.
+fn raw_behaviors_are_scripted(behaviors: &serde_json::Value) -> bool {
+    let Some(obj) = behaviors.as_object() else {
+        // Not an object (e.g. an array) — no key this gate recognizes, so nothing it can
+        // classify as executable. Such a block does not parse into `ResponseBehaviors` either,
+        // so it is inert: dropped at construction, with `new_is` logging the drop.
+        return false;
+    };
+    let scripted_key_present = obj.contains_key("decorate") || obj.contains_key("shellTransform");
+    let wait_is_scripted = obj.get("wait").is_some_and(|w| !wait_is_plainly_numeric(w));
+    scripted_key_present || wait_is_scripted
+}
+
+/// True only for the two wait spellings that cannot execute code: a fixed millisecond number and
+/// the `{min, max}` range. Everything else — a bare JS string, `{"inject": ...}`, or a shape this
+/// gate does not recognize — is treated as executable (issue #610).
+fn wait_is_plainly_numeric(wait: &serde_json::Value) -> bool {
+    if wait.is_number() {
+        return true;
+    }
+    wait.as_object().is_some_and(|o| {
+        o.len() == 2
+            && o.get("min").is_some_and(|v| v.is_number())
+            && o.get("max").is_some_and(|v| v.is_number())
+    })
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -19,6 +19,10 @@ pub fn install_default_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
+// The `--allowInjection` classifier, shared by every door that admits an imposter config
+// (admin API, --configfile, --datadir, POST /admin/reload) so they cannot diverge (issue #612)
+pub(crate) mod injection_gate;
+
 // ===== Admin HTTP server (control plane — server crate only) =====
 pub mod admin_api;
 

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -337,10 +337,11 @@ impl ServerBuilder {
         };
 
         if let Some(ref configfile) = cli.configfile {
-            load_imposters_from_file(&manager, configfile, cli.no_parse).await?;
+            load_imposters_from_file(&manager, configfile, cli.no_parse, cli.allow_injection)
+                .await?;
         }
         if let Some(ref datadir) = cli.datadir {
-            load_imposters_from_datadir(&manager, datadir).await?;
+            load_imposters_from_datadir(&manager, datadir, cli.allow_injection).await?;
         }
 
         // Bind the metrics server now so a `:0` request can report its port. A bind failure
@@ -658,11 +659,70 @@ async fn metrics_accept_loop(
     Ok(())
 }
 
+/// The gated surfaces, named the same way by every door (issue #612). The list only — each door
+/// appends its own clause, so this must not carry one.
+const GATED_SCRIPT_SURFACES: &str = "inject/decorate/shellTransform/JS-function wait";
+
+/// The startup error for a `--configfile` whose imposters need `--allowInjection` (issue #612),
+/// or `None` when every imposter is admissible. One message listing every offender, so the
+/// operator fixes the file in a single pass instead of restarting into the next error.
+fn configfile_injection_error(
+    path: &Path,
+    configs: &[ImposterConfig],
+    allow_injection: bool,
+) -> Option<String> {
+    if allow_injection {
+        return None;
+    }
+    let offenders: Vec<String> = configs
+        .iter()
+        .filter(|config| crate::injection_gate::config_uses_script_surface(config))
+        .map(|config| match config.port {
+            Some(port) => port.to_string(),
+            None => "<auto-assigned>".to_string(),
+        })
+        .collect();
+    if offenders.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}: imposter(s) on port(s) {} use {GATED_SCRIPT_SURFACES}. \
+         Restart with --allowInjection to allow this, or remove the scripting from the config.",
+        path.display(),
+        offenders.join(", "),
+    ))
+}
+
+/// Split parsed datadir configs into those that may be served and those gated by `--allowInjection`
+/// (issue #612). A datadir file is skipped rather than fatal: `{port}.json` is persisted from
+/// admin-API writes, so a leftover script-bearing file from an earlier `--allowInjection` run must
+/// fail closed without bricking startup for every other imposter.
+fn partition_gated_datadir(
+    parsed: Vec<LoadedImposter>,
+    allow_injection: bool,
+) -> (Vec<LoadedImposter>, Vec<SkippedImposterFile>) {
+    if allow_injection {
+        return (parsed, Vec::new());
+    }
+    let (gated, servable): (Vec<_>, Vec<_>) = parsed
+        .into_iter()
+        .partition(|(_, config)| crate::injection_gate::config_uses_script_surface(config));
+    let gated = gated
+        .into_iter()
+        .map(|(path, _)| SkippedImposterFile {
+            path,
+            reason: format!("uses {GATED_SCRIPT_SURFACES}, which require --allowInjection"),
+        })
+        .collect();
+    (servable, gated)
+}
+
 /// Load imposters from a JSON config file
 async fn load_imposters_from_file(
     manager: &Arc<ImposterManager>,
     path: &PathBuf,
     no_parse: bool,
+    allow_injection: bool,
 ) -> anyhow::Result<()> {
     info!("Loading imposters from configfile: {:?}", path);
 
@@ -670,6 +730,11 @@ async fn load_imposters_from_file(
         path: path.clone(),
         no_parse,
     })?;
+
+    // Refuse before creating anything: a gated configfile must not half-load (issue #612).
+    if let Some(message) = configfile_injection_error(path, &configs, allow_injection) {
+        anyhow::bail!(message);
+    }
 
     for config in configs {
         info!(
@@ -776,6 +841,7 @@ fn read_and_parse_datadir(
 async fn load_imposters_from_datadir(
     manager: &Arc<ImposterManager>,
     datadir: &PathBuf,
+    allow_injection: bool,
 ) -> anyhow::Result<()> {
     info!("Loading imposters from datadir: {:?}", datadir);
 
@@ -790,6 +856,8 @@ async fn load_imposters_from_datadir(
     // B1/B2 defense-in-depth against a datadir re-resolution reading `/etc/passwd`).
     let base = ScriptBaseDir::DatadirRelative(datadir.clone());
     let (parsed, mut skipped) = read_and_parse_datadir(datadir, &base)?;
+    let (parsed, gated) = partition_gated_datadir(parsed, allow_injection);
+    skipped.extend(gated);
 
     for (path, config) in parsed {
         info!("Loading imposter on port {:?} from {:?}", config.port, path);
@@ -1048,5 +1116,285 @@ mod tests {
         let cli = Cli::try_parse_from(["rift"]).expect("default parse");
         assert!(!cli.nologfile);
         assert!(cli.log.is_none());
+    }
+
+    // ===== Issue #612: the --allowInjection gate on the config doors =====
+    //
+    // A config file and a datadir file must get the same security answer as POST /imposters:
+    // a script surface without --allowInjection is refused. Before this, the same document was
+    // 400'd by the admin API but loaded and executed via --configfile.
+
+    fn config_from(json: serde_json::Value) -> ImposterConfig {
+        serde_json::from_value(json).expect("valid imposter config")
+    }
+
+    fn inject_response_config(port: u16) -> ImposterConfig {
+        config_from(serde_json::json!({
+            "port": port,
+            "protocol": "http",
+            "stubs": [{"responses": [{"inject": "function (req) { return {body: 'x'}; }"}]}],
+        }))
+    }
+
+    /// The `examples/latency-testing.json` shape from the issue's Evidence section: that file
+    /// spells its scripted wait as the `{"inject": ...}` object form, not a bare string.
+    fn js_wait_config(port: u16) -> ImposterConfig {
+        config_from(serde_json::json!({
+            "port": port,
+            "protocol": "http",
+            "stubs": [{"responses": [{
+                "is": {"statusCode": 200, "body": "ok"},
+                "_behaviors": {"wait": {"inject": "function() { return 100; }"}},
+            }]}],
+        }))
+    }
+
+    fn clean_config(port: u16) -> ImposterConfig {
+        config_from(serde_json::json!({
+            "port": port,
+            "protocol": "http",
+            "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "ok"}}]}],
+        }))
+    }
+
+    // AC1: an inject response in a configfile aborts startup, and the message must be actionable —
+    // it names the file, the offending port, and the flag that would allow it.
+    #[test]
+    fn configfile_injection_error_names_file_port_and_flag() {
+        let path = PathBuf::from("/cfg/imposters.json");
+        let err = configfile_injection_error(&path, &[inject_response_config(4545)], false)
+            .expect("an inject response without --allowInjection must abort startup");
+        assert!(err.contains("/cfg/imposters.json"), "names the file: {err}");
+        assert!(err.contains("4545"), "names the offending port: {err}");
+        assert!(err.contains("--allowInjection"), "names the flag: {err}");
+    }
+
+    // AC2: a JS-function wait is a script surface too — the exact config that the admin API
+    // already 400s but --configfile used to execute.
+    #[test]
+    fn configfile_injection_error_flags_js_function_wait() {
+        let path = PathBuf::from("/cfg/latency-testing.json");
+        let err = configfile_injection_error(&path, &[js_wait_config(4545)], false)
+            .expect("a JS-function wait without --allowInjection must abort startup");
+        assert!(err.contains("--allowInjection"), "got: {err}");
+    }
+
+    // AC3: the flag is the whole point — with it set, the same config loads.
+    #[test]
+    fn configfile_injection_error_none_when_flag_set() {
+        let path = PathBuf::from("/cfg/imposters.json");
+        assert!(
+            configfile_injection_error(&path, &[inject_response_config(4545)], true).is_none(),
+            "--allowInjection must permit an inject response"
+        );
+    }
+
+    // AC4: no false positives — a script-free config loads with the flag off.
+    #[test]
+    fn configfile_injection_error_none_for_clean_config() {
+        let path = PathBuf::from("/cfg/imposters.json");
+        assert!(
+            configfile_injection_error(&path, &[clean_config(4545)], false).is_none(),
+            "a config with no script surface must load without --allowInjection"
+        );
+    }
+
+    // Design requirement: one message listing every offender, so the operator fixes the file in a
+    // single pass instead of restarting into the next error.
+    #[test]
+    fn configfile_injection_error_lists_every_offending_port_at_once() {
+        let path = PathBuf::from("/cfg/imposters.json");
+        let configs = vec![
+            inject_response_config(4545),
+            clean_config(4546),
+            js_wait_config(4547),
+        ];
+        let err = configfile_injection_error(&path, &configs, false).expect("offenders present");
+        assert!(err.contains("4545"), "lists the first offender: {err}");
+        assert!(err.contains("4547"), "lists the second offender: {err}");
+        assert!(
+            !err.contains("4546"),
+            "must not name the clean imposter: {err}"
+        );
+    }
+
+    // A port-less (auto-assigned) config must still be nameable in the error, not silently omitted.
+    #[test]
+    fn configfile_injection_error_labels_a_portless_config() {
+        let path = PathBuf::from("/cfg/imposters.json");
+        let portless = config_from(serde_json::json!({
+            "protocol": "http",
+            "stubs": [{"responses": [{"inject": "function (req) { return {}; }"}]}],
+        }));
+        let err = configfile_injection_error(&path, &[portless], false)
+            .expect("a port-less offender must still abort startup");
+        assert!(
+            err.contains("<auto-assigned>"),
+            "a port-less offender must still be labelled, not silently omitted: {err}"
+        );
+        assert!(err.contains("--allowInjection"), "got: {err}");
+    }
+
+    // AC5: a datadir gates per file and fails closed — the leftover scripted file is skipped and
+    // named, while the clean file is still served. A persisted `{port}.json` from an earlier
+    // --allowInjection run must not brick startup for everything else.
+    #[test]
+    fn partition_gated_datadir_skips_only_the_scripted_file() {
+        let parsed = vec![
+            (
+                PathBuf::from("/data/4501.json"),
+                inject_response_config(4501),
+            ),
+            (PathBuf::from("/data/4502.json"), clean_config(4502)),
+        ];
+        let (servable, gated) = partition_gated_datadir(parsed, false);
+
+        assert_eq!(servable.len(), 1, "the clean file stays servable");
+        assert_eq!(servable[0].0, PathBuf::from("/data/4502.json"));
+
+        assert_eq!(gated.len(), 1, "the scripted file is skipped");
+        assert_eq!(gated[0].path, PathBuf::from("/data/4501.json"));
+        assert_eq!(
+            gated[0].reason,
+            "uses inject/decorate/shellTransform/JS-function wait, which require --allowInjection",
+            "the operator-facing skip reason must read cleanly, naming the flag once"
+        );
+
+        let summary = format_skipped_summary(&gated).expect("a gated file yields a summary");
+        assert!(
+            summary.contains("/data/4501.json") && summary.contains("NOT being served"),
+            "the gated file flows into the existing skip summary: {summary}"
+        );
+    }
+
+    // AC6: with the flag set, nothing is gated.
+    #[test]
+    fn partition_gated_datadir_keeps_everything_when_flag_set() {
+        let parsed = vec![
+            (
+                PathBuf::from("/data/4501.json"),
+                inject_response_config(4501),
+            ),
+            (PathBuf::from("/data/4502.json"), clean_config(4502)),
+        ];
+        let (servable, gated) = partition_gated_datadir(parsed, true);
+        assert_eq!(servable.len(), 2, "--allowInjection serves both");
+        assert!(gated.is_empty(), "nothing is gated with the flag set");
+    }
+
+    // ===== #612 door-level: the gate must be WIRED, not merely present =====
+    //
+    // The helper tests above prove the classifier decides correctly. They cannot prove the doors
+    // ask it — and #612 was exactly that failure: a call-site that never consulted the gate. These
+    // drive the real loaders, so dropping the gate call (or bailing after the create loop) fails
+    // here even though every helper test would still pass.
+
+    fn write_json(path: &Path, value: serde_json::Value) {
+        std::fs::write(path, serde_json::to_string(&value).expect("json")).expect("write");
+    }
+
+    #[tokio::test]
+    async fn load_imposters_from_file_aborts_before_creating_any_imposter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        // A clean imposter listed *before* the offender: if the gate ran per-imposter inside the
+        // create loop instead of up front, 19601 would already be bound and serving.
+        write_json(
+            &path,
+            serde_json::json!({"imposters": [
+                {"port": 19601, "protocol": "http",
+                 "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "ok"}}]}]},
+                {"port": 19602, "protocol": "http",
+                 "stubs": [{"responses": [{"inject": "function (req) { return {body: 'x'}; }"}]}]},
+            ]}),
+        );
+
+        let manager = Arc::new(ImposterManager::new());
+        let err = load_imposters_from_file(&manager, &path, false, false)
+            .await
+            .expect_err("a gated configfile must abort startup");
+        assert!(err.to_string().contains("--allowInjection"), "got: {err}");
+
+        assert!(
+            manager.get_imposter(19601).is_err(),
+            "all-or-nothing: the clean imposter must not be half-loaded before the abort"
+        );
+        assert!(
+            manager.get_imposter(19602).is_err(),
+            "the offender must not load"
+        );
+
+        manager.delete_all().await;
+    }
+
+    // The literal repro from the issue's Evidence section: the shipped example is refused by the
+    // admin API without --allowInjection, and must now be refused through --configfile too.
+    #[tokio::test]
+    async fn load_imposters_from_file_refuses_the_shipped_latency_example() {
+        let example =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/latency-testing.json");
+        assert!(example.exists(), "fixture missing: {}", example.display());
+
+        let manager = Arc::new(ImposterManager::new());
+        let err = load_imposters_from_file(&manager, &example, false, false)
+            .await
+            .expect_err("examples/latency-testing.json uses a JS-function wait; it must be gated");
+        assert!(err.to_string().contains("--allowInjection"), "got: {err}");
+
+        manager.delete_all().await;
+    }
+
+    #[tokio::test]
+    async fn load_imposters_from_datadir_serves_the_clean_file_and_skips_the_scripted_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_json(
+            &dir.path().join("19603.json"),
+            serde_json::json!({"port": 19603, "protocol": "http",
+                "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "ok"}}]}]}),
+        );
+        write_json(
+            &dir.path().join("19604.json"),
+            serde_json::json!({"port": 19604, "protocol": "http",
+                "stubs": [{"responses": [{"inject": "function (req) { return {body: 'x'}; }"}]}]}),
+        );
+
+        let manager = Arc::new(ImposterManager::new());
+        let datadir = dir.path().to_path_buf();
+        load_imposters_from_datadir(&manager, &datadir, false)
+            .await
+            .expect("a gated datadir file is skipped, never fatal");
+
+        assert!(
+            manager.get_imposter(19603).is_ok(),
+            "the clean file must still be served — one gated file cannot brick startup"
+        );
+        assert!(
+            manager.get_imposter(19604).is_err(),
+            "the scripted file must not be served without --allowInjection"
+        );
+
+        manager.delete_all().await;
+    }
+
+    #[tokio::test]
+    async fn load_imposters_from_datadir_serves_the_scripted_file_with_the_flag() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_json(
+            &dir.path().join("19605.json"),
+            serde_json::json!({"port": 19605, "protocol": "http",
+                "stubs": [{"responses": [{"inject": "function (req) { return {body: 'x'}; }"}]}]}),
+        );
+
+        let manager = Arc::new(ImposterManager::new());
+        let datadir = dir.path().to_path_buf();
+        load_imposters_from_datadir(&manager, &datadir, true)
+            .await
+            .expect("datadir load succeeds");
+        assert!(
+            manager.get_imposter(19605).is_ok(),
+            "--allowInjection must serve the scripted file"
+        );
+
+        manager.delete_all().await;
     }
 }

--- a/crates/rift-http-proxy/tests/issue_612_configfile_injection_gate.rs
+++ b/crates/rift-http-proxy/tests/issue_612_configfile_injection_gate.rs
@@ -1,0 +1,58 @@
+//! Issue #612: the `--allowInjection` gate must be wired into the `--configfile` startup door,
+//! not just the admin API.
+//!
+//! Lives in its own test binary rather than `embedded_server.rs` on purpose: that binary's
+//! `run_metrics_server_serves_metrics` depends on a sibling test having already recorded a `rift_`
+//! metric into the process-global registry (it fails when run alone, on master too), so adding a
+//! test there perturbs its scheduling and makes it flake.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+
+// The unit tests in `server.rs` cover the gate's *decision*, and the door tests cover the loader
+// calling it. Only a real `Cli::try_parse_from(...) -> ServerBuilder::start()` proves the CLI flag
+// is threaded all the way to that door — which is the wiring #612 reported as missing. A hardcoded
+// flag anywhere on that path fails here while every unit test still passes.
+#[tokio::test]
+async fn server_builder_gates_a_scripted_configfile_on_allow_injection() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("imposters.json");
+    std::fs::write(
+        &path,
+        r#"{"imposters":[{"port":19607,"protocol":"http","stubs":[
+            {"responses":[{"inject":"function (req) { return {body: 'x'}; }"}]}]}]}"#,
+    )
+    .expect("write scripted config");
+
+    let cli_with = |extra: &[&str]| {
+        let mut args = vec![
+            "rift",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--metrics-port",
+            "0",
+            "--configfile",
+            path.to_str().expect("utf8 path"),
+        ];
+        args.extend_from_slice(extra);
+        Cli::try_parse_from(args).expect("cli parse")
+    };
+
+    let err = ServerBuilder::from_cli(cli_with(&[]))
+        .start()
+        .await
+        .err()
+        .expect("a scripted configfile without --allow-injection must abort startup");
+    assert!(
+        err.to_string().contains("--allowInjection"),
+        "the startup error must name the flag: {err}"
+    );
+
+    let running = ServerBuilder::from_cli(cli_with(&["--allow-injection"]))
+        .start()
+        .await
+        .expect("--allow-injection must permit the same configfile");
+    running.shutdown().await;
+}

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -250,13 +250,14 @@ Demonstrates both scripting engines (Rhai, JavaScript) with equivalent functiona
 ### Start
 
 ```bash
-# Using local binary
-./target/release/rift --configfile docs/demo/imposters-scripting-engines.json
+# Using local binary. --allowInjection is required: this demo runs inject/_rift.script, and the
+# configfile door enforces the same injection gate as the admin API (issue #612).
+./target/release/rift --configfile docs/demo/imposters-scripting-engines.json --allowInjection
 
 # Or using Docker
 docker run -p 2525:2525 -p 4560:4560 \
   -v $(pwd)/docs/demo/imposters-scripting-engines.json:/imposters.json:ro \
-  zainalpour/rift-proxy:latest --configfile /imposters.json
+  zainalpour/rift-proxy:latest --configfile /imposters.json --allowInjection
 ```
 
 ### Test All Engines (Port 4560)

--- a/docs/demo/docker-compose-retry-proxy.yml
+++ b/docs/demo/docker-compose-retry-proxy.yml
@@ -9,7 +9,9 @@ services:
       - "4560:4560"   # Retry proxy imposter
     volumes:
       - ./imposters-retry-proxy.json:/imposters.json:ro
-    command: ["--configfile", "/imposters.json", "--loglevel", "debug"]
+    # --allow-injection: this demo uses inject/_rift.script, which the configfile door
+    # gates since issue #612 — without it rift refuses to start.
+    command: ["--configfile", "/imposters.json", "--loglevel", "debug", "--allow-injection"]
     depends_on:
       - upstream
 

--- a/docs/demo/docker-compose-scripting-engines.yml
+++ b/docs/demo/docker-compose-scripting-engines.yml
@@ -9,7 +9,9 @@ services:
     environment:
       - RUST_LOG=info
       - MB_PORT=2525
-    command: ["--configfile", "/imposters.json"]
+    # --allow-injection: this demo uses inject/_rift.script, which the configfile door
+    # gates since issue #612 — without it rift refuses to start.
+    command: ["--configfile", "/imposters.json", "--allow-injection"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:2525/"]
       interval: 5s

--- a/docs/demo/docker-compose-scripting.yml
+++ b/docs/demo/docker-compose-scripting.yml
@@ -9,7 +9,9 @@ services:
     environment:
       - RUST_LOG=info
       - MB_PORT=2525
-    command: ["--configfile", "/imposters.json"]
+    # --allow-injection: this demo uses inject/_rift.script, which the configfile door
+    # gates since issue #612 — without it rift refuses to start.
+    command: ["--configfile", "/imposters.json", "--allow-injection"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:2525/"]
       interval: 5s

--- a/docs/features/fault-injection.md
+++ b/docs/features/fault-injection.md
@@ -59,6 +59,12 @@ wrote when you read the imposter back.
 A function wait requires **`--allowInjection`** (either spelling), the same as Mountebank — without
 it, creating the imposter returns `400 invalid injection`.
 
+That gate applies to every door an imposter can arrive through, not just the admin API (issue
+#612): a `--configfile` carrying a function wait **aborts startup** naming the offending port, a
+`--datadir` file carrying one is **skipped** and listed in the startup skip summary, and
+`POST /admin/reload` returns `400 invalid injection` and leaves the running imposters unchanged.
+So `examples/latency-testing.json` needs `--allowInjection` however you load it.
+
 For a simple random range with no JavaScript, use the range form instead:
 
 ```json

--- a/scripts/verify-docs-examples.sh
+++ b/scripts/verify-docs-examples.sh
@@ -79,7 +79,10 @@ trap stop_rift EXIT
 # Start rift with a config file on $ADMIN_PORT and wait until the admin API answers (imposters up).
 start_rift() {
   local config="$1"
-  "$RIFT_BIN" --configfile "$config" --port "$ADMIN_PORT" >/dev/null 2>&1 &
+  # --allow-injection: part of the corpus (the scripting demos) legitimately carries inject /
+  # _rift.script, and since issue #612 the configfile door enforces the gate like the admin API
+  # does — without the flag those documented configs correctly refuse to boot.
+  "$RIFT_BIN" --configfile "$config" --port "$ADMIN_PORT" --allow-injection >/dev/null 2>&1 &
   RIFT_PID=$!
   local i
   for i in $(seq 1 60); do

--- a/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
+++ b/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
@@ -348,7 +348,7 @@ This matches Mountebank's behavior for automatic port assignment.
 | `--host` | ✅ Yes | ✅ Yes | ✅ **Complete** | Bind hostname |
 | `--configfile` | ✅ Yes | ✅ Yes | ✅ **Complete** | Single config file path |
 | `--datadir` | ✅ Yes | ✅ Yes | ✅ **Complete** | Load all .json from directory |
-| `--allowInjection` | ✅ Yes | ✅ Yes | ✅ **Complete** | JavaScript injection enabled |
+| `--allowInjection` | ✅ Yes | ✅ Yes | ✅ **Complete** | JavaScript injection enabled. Enforced on every door that admits an imposter: the admin API, `--configfile`, `--datadir`, and `POST /admin/reload` (issue #612). See the divergence note below. |
 | `--localOnly` | ✅ Yes | ✅ Yes | ✅ **Complete** | Bind to localhost only |
 | `--loglevel` | ✅ Yes | ✅ Yes | ✅ **Complete** | debug, info, warn, error |
 | `--nologfile` | ✅ Yes | ✅ Yes | ✅ **Complete** | Stdout logging only |
@@ -358,6 +358,27 @@ This matches Mountebank's behavior for automatic port assignment.
 | `--ipWhitelist` | ✅ Yes | ✅ Yes | ✅ **Complete** | IP whitelist (comma-separated) |
 | `--mock` | ✅ Yes | ✅ Yes | ✅ **Complete** | Mock mode flag |
 | `--origin` | ✅ Yes | ✅ Yes | ✅ **Complete** | CORS allowed origin |
+
+**`--allowInjection` on config-file load — same gate, stricter exit (issue #612):**
+
+Both engines refuse a config file whose imposters carry a scripting surface (`inject` response or
+predicate, `predicateGenerators.inject`, `decorate`, `shellTransform`, a JS-function `wait`, or
+Rift's `_rift.script`) unless `--allowInjection` is set. Mountebank enforces this because it loads
+a config file by PUTting it through its own imposter validation; Rift applies the same classifier
+its admin API uses, so a document gets one security answer through every door.
+
+The **exit behaviour** diverges:
+
+| | Mountebank | Rift |
+|---|---|---|
+| `--configfile` with injection, no flag | logs the failed self-PUT and stays up (that imposter is not served) | **aborts startup**, naming the file and every offending port |
+| `--datadir` file with injection, no flag | not served | file is skipped and named in the startup skip summary; other imposters still load |
+| `POST /admin/reload` with injection, no flag | n/a (Rift extension) | `400 invalid injection`; running imposters unchanged |
+
+Same security outcome — the scripting never executes. Rift fails fast on `--configfile` rather
+than starting up in a state the operator did not ask for. `--datadir` is a per-file skip instead:
+`{port}.json` files are persisted from admin-API writes, so a leftover script-bearing file from an
+earlier `--allowInjection` run must fail closed without bricking startup for everything else.
 
 **Environment Variable Support:**
 - ✅ `MB_PORT` - Admin API port


### PR DESCRIPTION
Enforces the `--allowInjection` gate on the three config doors that bypassed it, per the triage decision and design in #612.

**The hole**
The gate only ever guarded the admin API. `examples/latency-testing.json` was refused by `POST /imposters` without `--allowInjection` and loaded and executed via `--configfile`. `--datadir` was worse: its `{port}.json` files are persisted from admin-API writes, so running once with `--allowInjection` and restarting without it kept executing the persisted scripts — the gate failed open across restarts. `POST /admin/reload` was ungated and network-reachable.

**The fix** — one classifier, three doors, per-door semantics as specified:

| Door | Behavior with a script surface and the flag off |
|---|---|
| `--configfile` | aborts startup, naming the file and every offending port in one message |
| `--datadir` | skips the file, fails closed via the existing `SkippedImposterFile` summary |
| `POST /admin/reload` | `400 invalid injection` before `apply_config`; running imposters untouched |

The classifier moved **verbatim** (byte-identical, diffed against master — only visibility changed), so the admin gate's behavior, including the #610 fail-closed properties, is unchanged. `reject_stubs_if_injection_disallowed` / `injection_disallowed_response` stay in the admin handlers and delegate.

**Deviation from the spec, please confirm**
Implementation detail 1 says `scripting::injection_gate`, `pub(crate)`, and "All in `crates/rift-http-proxy`", justified by "`scripting` already hosts `validate_stubs`". In rift-http-proxy `crate::scripting` is a **re-export of `rift_mock_core::scripting`** — `validate_stubs` lives in the other crate — so `pub mod scripting` here would collide with that re-export, and putting it in rift-mock-core would break both "all in rift-http-proxy" and `pub(crate)`. It landed at `crate::injection_gate` (crate-root, `pub(crate)`): both unambiguous constraints and the intent (neutral module, out of the admin handler) are honored; only the module name differs.

**Tests** — every AC from the issue, plus the wiring
The first round tested only the extracted helpers. Since #612 was a *call-site wiring* failure rather than a classifier bug, that would have let the same regression back in silently — so the doors are now driven directly: `load_imposters_from_file` (including loading the real `examples/latency-testing.json`), `load_imposters_from_datadir`, and a `ServerBuilder::from_cli(...).start()` test proving the CLI flag reaches the loader. Verified by deleting just the gate *calls*: 3 door tests fail while all 9 helper tests still pass.

The `ServerBuilder` test lives in its own binary rather than `embedded_server.rs` — that binary's `run_metrics_server_serves_metrics` is order-dependent (it fails in isolation on master too; filed as #617), and adding a test there perturbs its scheduling.

**Filed from this work, not fixed here**
- #616 — a **fourth** ungated door: `rift-ffi`'s `rift_serve_admin` takes `allowInjection` and passes it to the admin API, but its `configFile`/inline-`config` loads apply with no gate. Out of scope per this issue's "All in `crates/rift-http-proxy`" + 3-door enumeration, and fixing it needs a cross-crate visibility decision that contradicts the specified `pub(crate)`.
- #617 — the order-dependent metrics test above.

**Docs**: CHANGELOG (Security), the compatibility matrix (`--allowInjection` row + a divergence table: mb logs the failed self-PUT and stays up, Rift fails startup fast), and `docs/features/fault-injection.md`, whose "returns `400 invalid injection`" line was now incomplete for `--configfile`.

**Verification**: `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` 0; `cargo clippy -p rift-http-proxy --no-default-features` 0; `cargo test --workspace` 1826 passed / 0 failed.

Closes #612