### PR TITLE
fix(predicates): query-string key percent-decoding is inconsistent across the two parse_query_string helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ record.
 
 ### Fixed
 
+- **Query-parameter *names* are now percent-decoded everywhere, so `?first%20name=bob` matches a
+  predicate on `first name` on every path.** Rift has four query/form parsers, and two of them
+  decoded only the value, leaving the key raw — so the same request got a different answer
+  depending on which path evaluated it: the imposter's predicate matching saw the key `first name`
+  while `deepEquals` predicates, rule matching (`_rift.match.query`), response templates, and the
+  request context handed to behaviors all saw `first%20name` and failed to find it. Mountebank
+  decodes both key and value (Node's `querystring.parse` unescapes keys), so the raw-key paths were
+  also a compatibility divergence. An undecodable key (e.g. `%FF`) passes through raw, consistent
+  with Rift's decode contract for values. **Behavior change:** a config that relied on matching the
+  raw encoded key name (e.g. a matcher literally named `first%20name`) will no longer match; name
+  the matcher with the decoded key instead. Two parameters whose names differ only by encoding
+  (e.g. `a%2Bb` and `a+b`) now decode to the same key and merge under each path's existing
+  duplicate-key rule, as they already did on the imposter's matching path.
+
 - **`"wait": {"inject": "function(){...}"}` now works — it was silently doing nothing.** The
   object spelling of a function wait is what `docs/features/fault-injection.md`, the shipped
   `examples/latency-testing.json`, and the SDKs all use, but the engine's `WaitBehavior` had no

--- a/crates/rift-mock-core/src/behaviors/request.rs
+++ b/crates/rift-mock-core/src/behaviors/request.rs
@@ -42,7 +42,7 @@ impl RequestContext {
                     Some((k, v)) => (k, v),
                     None => (pair, ""),
                 };
-                let decoded_key = key.to_string();
+                let decoded_key = crate::util::decode_or_raw(key);
                 let decoded_value = crate::util::decode_or_raw(value);
                 query_map
                     .entry(decoded_key)
@@ -96,6 +96,30 @@ mod tests {
         let uri: hyper::Uri = "/p?k=hello%20world".parse().unwrap();
         let ctx = RequestContext::from_request("GET", &uri, &hyper::HeaderMap::new(), None);
         assert_eq!(ctx.query.get("k").map(String::as_str), Some("hello world"));
+    }
+
+    // Issue #614: the key was left raw while the value was decoded, so a behavior reading the
+    // request context saw a different parameter name than predicate matching did.
+    #[test]
+    fn from_request_decodes_an_encoded_query_key() {
+        let uri: hyper::Uri = "/p?a%20b=1".parse().unwrap();
+        let ctx = RequestContext::from_request("GET", &uri, &hyper::HeaderMap::new(), None);
+        assert_eq!(
+            ctx.query.get("a b").map(String::as_str),
+            Some("1"),
+            "an encoded key must be decoded, matching imposter::parse_query_string"
+        );
+    }
+
+    #[test]
+    fn from_request_passes_through_an_undecodable_query_key() {
+        let uri: hyper::Uri = "/p?%FF=v".parse().unwrap();
+        let ctx = RequestContext::from_request("GET", &uri, &hyper::HeaderMap::new(), None);
+        assert_eq!(
+            ctx.query.get("%FF").map(String::as_str),
+            Some("v"),
+            "an undecodable key must pass through raw, not collapse to an empty key"
+        );
     }
 
     // Issue #480 — the request context is now built from `req.headers().clone()`, whose names are

--- a/crates/rift-mock-core/src/extensions/matcher.rs
+++ b/crates/rift-mock-core/src/extensions/matcher.rs
@@ -231,6 +231,7 @@ pub fn find_matching_rule<'a>(
 mod tests {
     use super::*;
     use crate::config::{FaultConfig, LatencyFault, MatchConfig};
+    use crate::predicate::QueryMatcher;
 
     fn create_test_rule(id: &str, methods: Vec<&str>, path: PathMatch) -> Rule {
         Rule {
@@ -255,6 +256,26 @@ mod tests {
             },
             upstream: None, // No upstream filter for tests
         }
+    }
+
+    // Issue #614: end-to-end pin through the matcher's own `parse_query_string` (deep_equals'),
+    // which left keys raw — so a rule keyed on a decoded parameter *name* never matched a request
+    // that percent-encoded it, while the imposter path matched the same request.
+    #[test]
+    fn test_query_matcher_matches_percent_encoded_key_name() {
+        let mut rule = create_test_rule("test", vec!["GET"], PathMatch::Any);
+        rule.match_config.query = vec![QueryMatcher::Simple {
+            name: "first name".to_string(),
+            value: "bob".to_string(),
+        }];
+        let compiled = CompiledRule::compile(rule).unwrap();
+        let headers = HeaderMap::new();
+
+        let uri = "http://localhost/?first%20name=bob".parse().unwrap();
+        assert!(
+            compiled.matches(&Method::GET, &uri, &headers),
+            "a rule on the decoded key name must match a request that percent-encodes it"
+        );
     }
 
     #[test]

--- a/crates/rift-mock-core/src/predicate/deep_equals.rs
+++ b/crates/rift-mock-core/src/predicate/deep_equals.rs
@@ -134,9 +134,12 @@ pub fn parse_query_string(query: Option<&str>) -> HashMap<String, String> {
     if let Some(q) = query {
         for pair in q.split('&') {
             if let Some((key, value)) = pair.split_once('=') {
-                params.insert(key.to_string(), crate::util::decode_or_raw(value));
+                params.insert(
+                    crate::util::decode_or_raw(key),
+                    crate::util::decode_or_raw(value),
+                );
             } else if !pair.is_empty() {
-                params.insert(pair.to_string(), String::new());
+                params.insert(crate::util::decode_or_raw(pair), String::new());
             }
         }
     }
@@ -265,6 +268,36 @@ mod tests {
             params.get("k"),
             Some(&"%FF".to_string()),
             "an undecodable value must pass through raw, not become empty"
+        );
+    }
+
+    // Issue #614: this helper decoded only the value, leaving the key raw, so a predicate on an
+    // encoded parameter *name* matched or not depending on which helper evaluated it. Mountebank
+    // decodes both (Node's `querystring.parse` unescapes keys).
+    #[test]
+    fn test_query_string_decodes_encoded_key() {
+        let params = parse_query_string(Some("first%20name=bob"));
+        assert_eq!(
+            params.get("first name"),
+            Some(&"bob".to_string()),
+            "an encoded key must be decoded, matching imposter::parse_query_string"
+        );
+
+        let undecodable = parse_query_string(Some("%FF=v"));
+        assert_eq!(
+            undecodable.get("%FF"),
+            Some(&"v".to_string()),
+            "an undecodable key must pass through raw, not collapse to an empty key"
+        );
+    }
+
+    #[test]
+    fn test_query_string_decodes_bare_param_key() {
+        let params = parse_query_string(Some("first%20name"));
+        assert_eq!(
+            params.get("first name"),
+            Some(&String::new()),
+            "a bare param's key must be decoded on the same terms as a valued one"
         );
     }
 }


### PR DESCRIPTION
Rift's two query-string parsers were inconsistent: two decoded only values and left keys raw, while Mountebank decodes both. This fix decodes keys on the raw-key paths using `crate::util::decode_or_raw`, restoring Mountebank compatibility.

Behavior change: configs matching a literally-encoded key name no longer match.

Closes #614