### PR TITLE
security(ffi): rift_serve_admin configFile/inline config bypasses the allowInjection gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,22 @@ record.
 
 ### Security
 
+- **`allowInjection` is now enforced on the FFI's `configFile` door (`rift_serve_admin`).** The
+  embedded admin plane honoured `allowInjection` for imposters submitted through it, but the
+  `configFile` option loaded and executed a scripted imposter regardless — so an embedding host
+  that passed `allowInjection: false` and pointed Rift at a config file it did not fully control
+  (ops-provisioned, mounted, edited out-of-band) still ran `inject`/`decorate`/`shellTransform`/
+  JS-function `wait`. This was the last door left open by the previous entry, which closed the
+  CLI's `--configfile`/`--datadir`. A scripted `configFile` now fails the serve outright — `NULL`
+  plus a `rift_last_error` naming the offending ports — so nothing is applied.
+
+  **Unchanged, and deliberately so:** in-process config from the embedding host — the inline
+  `config` option, `rift_apply_config`, `rift_create_imposter` — remains **ungated**. The gate's
+  subject is a config *document that crossed a trust boundary*, not the host: a caller holding the
+  C-ABI can already execute code in the process, so gating its own JSON would restrict nobody while
+  breaking hosts that legitimately drive script imposters over the C-ABI. The trust boundary is now
+  documented in `docs/embedding/ffi.md`.
+
 - **A function `wait` requires `--allowInjection` in both spellings.** The `--allowInjection`
   admission gate classified only the bare-string function wait as a scripting surface, so the
   newly-accepted `{"inject": ...}` form would have executed JavaScript with injection disabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ dependencies = [
  "rift-mock-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -41,6 +41,8 @@ parking_lot = "0.12"
 reqwest.workspace = true
 # Mint a committed CA (cert+key PEM) on disk in the intercept CA-reuse gate test (issue #429).
 rcgen = "0.13"
+# Write imposter config files on disk for the `configFile` allowInjection gate tests (issue #616).
+tempfile = "3.8"
 
 [features]
 default = ["redis-backend", "javascript"]

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -37,6 +37,7 @@ use rift_http_proxy::admin_api::{
     AdminApiServer, RunningAdminApi, filter_proxy_responses, filter_proxy_stubs,
 };
 use rift_http_proxy::config_loader::{self, ConfigSource};
+use rift_http_proxy::injection_gate;
 use rift_http_proxy::intercept_control::{
     InterceptControl, InterceptStartError, InterceptStartOptions, InterceptStatus,
 };
@@ -221,9 +222,13 @@ struct ServeOptions {
     metrics_port: Option<u16>,
     config_file: Option<String>,
     config: Option<Value>,
-    /// Gate script/inject imposters submitted THROUGH the admin plane (issue #492). Default false,
-    /// preserving the previous behavior. Direct FFI calls (`rift_create_imposter`, …) are ungated
-    /// by design — the host process is already trusted; this only governs the in-process admin API.
+    /// Gate script/inject imposters that reach Rift across a trust boundary: submitted THROUGH the
+    /// admin plane (issue #492) or read off disk via `configFile` (issue #616). Default false,
+    /// preserving the previous behavior.
+    ///
+    /// In-process config from the embedding host — `config` below, `rift_apply_config`,
+    /// `rift_create_imposter` — is ungated by design: that host can already execute code in this
+    /// process, so gating its own JSON would restrict nobody.
     allow_injection: Option<bool>,
 }
 
@@ -1740,6 +1745,30 @@ fn warn_failed(report: &ApplyReport, source: &str) {
     }
 }
 
+/// The rejection for a `configFile` whose imposters need `allowInjection` (issue #616), or `None`
+/// when every imposter is admissible. One message listing every offender, so a host fixing the file
+/// sees all of them at once.
+///
+/// `configFile` names a path, and the content behind it is read off disk — it is not necessarily
+/// authored by the embedding host, so it crosses a trust boundary and is gated exactly like the
+/// CLI's `--configfile` (issue #612). The host's own in-process config (`config`,
+/// `rift_apply_config`, `rift_create_imposter`) is the trusted path and stays ungated (issue #492).
+fn gated_config_file_error(configs: &[ImposterConfig], allow_injection: bool) -> Option<String> {
+    if allow_injection {
+        return None;
+    }
+    let offenders = injection_gate::gated_offender_ports(configs);
+    if offenders.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "configFile load: imposter(s) on port(s) {} use {}, which require allowInjection. \
+         Set \"allowInjection\": true to allow this, or remove the scripting from the config.",
+        offenders.join(", "),
+        injection_gate::GATED_SCRIPT_SURFACES,
+    ))
+}
+
 /// Bind the admin (and optional metrics) plane per `opts`, returning the plane plus the JSON
 /// response body. Errors are `String`s (mapped to `last_error` by the caller).
 async fn build_admin_plane(
@@ -1749,6 +1778,7 @@ async fn build_admin_plane(
     let host = opts.host.as_deref().unwrap_or("127.0.0.1");
     let port = opts.port.unwrap_or(0);
     let api_key = opts.api_key.clone();
+    let allow_injection = opts.allow_injection.unwrap_or(false);
 
     // Parse both addresses up front, before any side effects (imposter creation / binding).
     let addr: SocketAddr = format!("{host}:{port}")
@@ -1776,6 +1806,9 @@ async fn build_admin_plane(
             };
             let configs = config_loader::load_configs(&source)
                 .map_err(|e| format!("configFile load: {e}"))?;
+            if let Some(err) = gated_config_file_error(&configs, allow_injection) {
+                return Err(err);
+            }
             let report = handle
                 .manager
                 .apply_config(configs)
@@ -1814,7 +1847,7 @@ async fn build_admin_plane(
     // `rift_start_intercept` is then visible to `GET /intercept`, and `POST /intercept` feeds
     // `rift_intercept_add_rules` — a double-start across surfaces 409s/-1s consistently.
     let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key)
-        .with_allow_injection(opts.allow_injection.unwrap_or(false))
+        .with_allow_injection(allow_injection)
         .with_intercept(handle.intercept.clone());
     if let Some(source) = config_source {
         server = server.with_config_source(source);

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -335,10 +335,163 @@ fn ffi_serve_admin_allow_injection_gates_the_admin_plane() {
     }
 }
 
+// A scripted imposter config used by the `configFile` gate tests below (issue #616).
+fn scripted_config_json(port: u16) -> String {
+    format!(
+        r#"{{"imposters": [{{"port": {port}, "protocol": "http",
+             "stubs": [{{"responses": [{{"inject": "function (config) {{ return {{ statusCode: 200, body: 'hi' }}; }}"}}]}}]}}]}}"#
+    )
+}
+
+// Issue #616: `configFile` names a path, and the content behind it is dereferenced off disk — it is
+// not necessarily authored by the embedding host (ops-provisioned, mounted, edited out-of-band), so
+// it crosses a trust boundary and is gated exactly like the CLI's `--configfile` (issue #612).
+// Contrast `ffi_serve_admin_inline_config_inject_is_ungated` below: in-process JSON is the trusted
+// host path and stays ungated. The gate rejects the whole serve up front, so nothing is applied.
+#[test]
+fn ffi_serve_admin_config_file_inject_requires_allow_injection() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, scripted_config_json(19976)).expect("write config");
+        let path_json = serde_json::json!(path.to_str().expect("utf8 path"));
+
+        let h = rift_start();
+        let opts = cstr(&format!(
+            r#"{{"allowInjection": false, "configFile": {path_json}}}"#
+        ));
+        assert!(
+            rift_serve_admin(h, opts.as_ptr()).is_null(),
+            "a scripted configFile must be rejected when allowInjection is off"
+        );
+
+        let err = rift_last_error();
+        assert!(!err.is_null(), "a gated configFile records last_error");
+        let msg = CStr::from_ptr(err).to_str().expect("utf8").to_owned();
+        rift_free(err);
+        assert!(
+            msg.contains("allowInjection"),
+            "the rejection must name the gate that blocked it, got: {msg}"
+        );
+        assert!(
+            msg.contains("19976"),
+            "the rejection must name the offending port so the file can be fixed, got: {msg}"
+        );
+
+        // The gate runs before apply_config, so a rejected file leaves nothing behind. Asserted
+        // rather than inferred: a refactor that moved the gate after apply_config would still
+        // return NULL and still set last_error, and only this check would notice the imposter it
+        // had already created.
+        let listed = take_json(rift_list_imposters(h, std::ptr::null()));
+        let v: serde_json::Value = serde_json::from_str(&listed).expect("imposters json");
+        let ports: Vec<u64> = v["imposters"]
+            .as_array()
+            .expect("imposters array")
+            .iter()
+            .filter_map(|i| i["port"].as_u64())
+            .collect();
+        assert!(
+            !ports.contains(&19976),
+            "a rejected configFile must apply nothing, got ports: {ports:?}"
+        );
+
+        rift_stop(h);
+    }
+}
+
+// Issue #616: the same file loads once the host opts in, so the gate is a gate and not a ban.
+#[test]
+fn ffi_serve_admin_config_file_inject_loads_with_allow_injection() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(&path, scripted_config_json(19977)).expect("write config");
+        let path_json = serde_json::json!(path.to_str().expect("utf8 path"));
+
+        let h = rift_start();
+        let admin = serve_admin(
+            h,
+            &format!(r#"{{"allowInjection": true, "configFile": {path_json}}}"#),
+        );
+        let admin_url = admin["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("admin /imposters reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("imposters array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(
+                ports.contains(&19977),
+                "allowInjection=true must load the scripted configFile, got ports: {ports:?}"
+            );
+        });
+
+        rift_stop(h);
+    }
+}
+
+// Issue #616: the gate must classify, not blanket-reject — a configFile with no scripting surface
+// still loads with allowInjection off.
+#[test]
+fn ffi_serve_admin_config_file_without_script_loads_ungated() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("imposters.json");
+        std::fs::write(
+            &path,
+            r#"{"imposters": [{"port": 19978, "protocol": "http",
+                 "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "plain"}}]}]}]}"#,
+        )
+        .expect("write config");
+        let path_json = serde_json::json!(path.to_str().expect("utf8 path"));
+
+        let h = rift_start();
+        let admin = serve_admin(
+            h,
+            &format!(r#"{{"allowInjection": false, "configFile": {path_json}}}"#),
+        );
+        let admin_url = admin["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        rt().block_on(async {
+            let imps: serde_json::Value = reqwest::get(format!("{admin_url}/imposters"))
+                .await
+                .expect("admin /imposters reachable")
+                .json()
+                .await
+                .expect("json");
+            let ports: Vec<u64> = imps["imposters"]
+                .as_array()
+                .expect("imposters array")
+                .iter()
+                .filter_map(|i| i["port"].as_u64())
+                .collect();
+            assert!(
+                ports.contains(&19978),
+                "a non-scripted configFile must load with allowInjection off, got ports: {ports:?}"
+            );
+        });
+
+        rift_stop(h);
+    }
+}
+
 // Issue #492: `allowInjection` gates only imposters submitted THROUGH the running admin plane.
 // A script imposter supplied via rift_serve_admin's own `config` (startup) is applied directly by
 // the manager — the trusted host path — so it is created even with allowInjection off. This pins
 // that intentional asymmetry so a future change can't silently start gating the startup path.
+//
+// Issue #616 reaffirmed this: `allowInjection` gates untrusted config *documents*, not untrusted
+// *hosts*. An in-process caller that can pass this JSON can already run code in the process and
+// could hand the same document to the ungated `rift_apply_config`, so gating it would restrict
+// nobody. `configFile` is gated (see above) because its content comes off disk, not from the host.
 #[test]
 fn ffi_serve_admin_inline_config_inject_is_ungated() {
     unsafe {

--- a/crates/rift-http-proxy/src/injection_gate.rs
+++ b/crates/rift-http-proxy/src/injection_gate.rs
@@ -1,18 +1,51 @@
 //! The `--allowInjection` classifier: does a stub carry a Mountebank scripting surface?
 //!
 //! Extracted from the admin imposter handlers (issue #612) so every door that admits an imposter
-//! config — `POST/PUT /imposters`, `--configfile`, `--datadir`, and `POST /admin/reload` — asks
-//! one classifier the same question. The gate used to live behind the admin API only, so the same
-//! document was refused by an HTTP POST and executed when loaded from a file.
+//! config — `POST/PUT /imposters`, `--configfile`, `--datadir`, `POST /admin/reload`, and the
+//! FFI's `rift_serve_admin` `configFile` (issue #616) — asks one classifier the same question.
+//! The gate used to live behind the admin API only, so the same document was refused by an HTTP
+//! POST and executed when loaded from a file.
 //!
 //! This module only *classifies*. Each door owns its own failure semantics (400, startup abort,
-//! or per-file skip), which is why the response builder stays with the admin handlers.
+//! per-file skip, or FFI NULL), which is why the response builder stays with the admin handlers.
+//!
+//! The gate's subject is the *document*, not the caller: it asks whether config that crossed a
+//! trust boundary carries executable surface. In-process config supplied by an embedding host
+//! (`rift_apply_config`, `rift_create_imposter`, `rift_serve_admin`'s inline `config`) is the
+//! trusted host path and is deliberately never gated (issue #492) — that host can already execute
+//! code in the process, so gating its own JSON would restrict nobody.
 
 use crate::imposter::{ImposterConfig, Predicate, PredicateOperation, Stub, StubResponse};
 
-/// True if `config`'s stubs carry a scripting surface gated by `--allowInjection`.
-pub(crate) fn config_uses_script_surface(config: &ImposterConfig) -> bool {
+/// The gated surfaces, named the same way by every door (issue #612). The list only — each door
+/// appends its own clause, so this must not carry one.
+pub const GATED_SCRIPT_SURFACES: &str = "inject/decorate/shellTransform/JS-function wait";
+
+/// True if `config`'s stubs carry a scripting surface gated by `--allowInjection`: an inject
+/// response, a `decorate` behavior, a `shellTransform`, a `wait` expressed as a JS function, a
+/// predicate `inject`, a `predicateGenerators.inject`, or `_rift.script`.
+///
+/// The classifier behind every `allowInjection` door. A door calls this to decide admission and
+/// supplies its own failure semantics — this only answers the question, and answers it identically
+/// for all of them. Classification fails **closed**: a `_behaviors` block that cannot be parsed is
+/// treated as scripted rather than admitted as safe.
+pub fn config_uses_script_surface(config: &ImposterConfig) -> bool {
     stubs_contain_script_surface(&config.stubs)
+}
+
+/// The explicit ports of every config in `configs` that trips [`config_uses_script_surface`], as a
+/// door would name them to a human; empty when all are admissible. Shared so the `--configfile` and
+/// FFI `configFile` doors list offenders identically — each still writes its own message, because
+/// their remedies differ (`--allowInjection` vs `"allowInjection": true`).
+pub fn gated_offender_ports(configs: &[ImposterConfig]) -> Vec<String> {
+    configs
+        .iter()
+        .filter(|config| config_uses_script_surface(config))
+        .map(|config| match config.port {
+            Some(port) => port.to_string(),
+            None => "<auto-assigned>".to_string(),
+        })
+        .collect()
 }
 
 /// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -21,7 +21,7 @@ pub fn install_default_crypto_provider() {
 
 // The `--allowInjection` classifier, shared by every door that admits an imposter config
 // (admin API, --configfile, --datadir, POST /admin/reload) so they cannot diverge (issue #612)
-pub(crate) mod injection_gate;
+pub mod injection_gate;
 
 // ===== Admin HTTP server (control plane — server crate only) =====
 pub mod admin_api;

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -10,6 +10,7 @@ use crate::extensions::metrics;
 use crate::imposter::{
     ImposterConfig, ImposterManager, ScriptBaseDir, TlsDefaults, resolve_scripts,
 };
+use crate::injection_gate::GATED_SCRIPT_SURFACES;
 use crate::intercept_control::{InterceptControl, InterceptStartOptions};
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
@@ -659,10 +660,6 @@ async fn metrics_accept_loop(
     Ok(())
 }
 
-/// The gated surfaces, named the same way by every door (issue #612). The list only — each door
-/// appends its own clause, so this must not carry one.
-const GATED_SCRIPT_SURFACES: &str = "inject/decorate/shellTransform/JS-function wait";
-
 /// The startup error for a `--configfile` whose imposters need `--allowInjection` (issue #612),
 /// or `None` when every imposter is admissible. One message listing every offender, so the
 /// operator fixes the file in a single pass instead of restarting into the next error.
@@ -674,14 +671,7 @@ fn configfile_injection_error(
     if allow_injection {
         return None;
     }
-    let offenders: Vec<String> = configs
-        .iter()
-        .filter(|config| crate::injection_gate::config_uses_script_surface(config))
-        .map(|config| match config.port {
-            Some(port) => port.to_string(),
-            None => "<auto-assigned>".to_string(),
-        })
-        .collect();
+    let offenders = crate::injection_gate::gated_offender_ports(configs);
     if offenders.is_empty() {
         return None;
     }

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -110,12 +110,27 @@ rift_free(result);
   `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false}`.
   `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
   `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
-- **`allowInjection`** (default `false`): whether the admin plane accepts script/`inject` imposters
-  submitted **through it** (`POST /imposters` etc.), mirroring the `--allowInjection` CLI flag.
-  Note the deliberate asymmetry: **direct FFI calls** (`rift_create_imposter`, `rift_replace_stubs`,
-  …) are **ungated** — the host process is already trusted, so script imposters always work over the
-  C-ABI. `allowInjection` only governs the in-process HTTP admin surface; leave it `false` unless you
-  expose that surface to less-trusted callers and want script imposters permitted there too.
+- **`allowInjection`** (default `false`): whether Rift admits script/`inject` imposters
+  (`inject`/`decorate`/`shellTransform`/JS-function `wait`/`_rift.script`), mirroring the
+  `--allowInjection` CLI flag. Leave it `false` unless you intend to permit them.
+
+  **What the gate protects.** `allowInjection` gates config **documents that cross a trust
+  boundary**, not untrusted *hosts*. A config the embedding host hands over in-process is trusted;
+  one that arrives over HTTP or is read off disk is not:
+
+  | Door | Gated by `allowInjection`? | Why |
+  |---|---|---|
+  | Admin plane (`POST /imposters`, …) | **yes** (#492) | Arrives over HTTP, possibly from a less-trusted caller |
+  | `configFile` | **yes** (#616) | A path dereferenced to disk content the host may not have authored — ops-provisioned, mounted, or edited out-of-band. Same class as the CLI's `--configfile`/`--datadir` |
+  | `POST /admin/reload` (re-reads `configFile`) | **yes** (#612) | Same file, same flag — a file edited to add scripting after a clean start is refused on reload |
+  | Inline `config` | no (#492) | Authored in-process by the host |
+  | `rift_create_imposter`, `rift_replace_stubs`, `rift_apply_config`, … | no (#492) | Authored in-process by the host |
+
+  The in-process doors are **ungated by design**, not an oversight: a caller who can reach the
+  C-ABI can already execute code in this process, so gating its own JSON would restrict nobody
+  while breaking hosts that legitimately drive script imposters over the C-ABI. If you load config
+  from a file you do not fully control, keep `allowInjection: false` — a scripted `configFile` then
+  fails the serve outright (`NULL` + `rift_last_error`) rather than loading, so nothing is applied.
 - **Returns** (caller frees): `{"adminPort":...,"adminUrl":"...","metricsPort":...}`, or `NULL` on
   error (bad JSON, bind failure, or already serving — one admin plane per handle).
 


### PR DESCRIPTION
## Summary

- `rift_serve_admin` honoured `allowInjection` for imposters submitted through the admin plane, but its `configFile` option loaded and executed scripted imposters (inject/decorate/shellTransform/JS-function wait/_rift.script) regardless. This closes the last door left open by #612/#618, which gated the CLI's `--configfile`/`--datadir`.
- A scripted `configFile` with `allowInjection: false` now fails the serve outright (NULL + `rift_last_error` naming the offending ports); the gate runs before `apply_config`, so nothing is applied.

## Scope — narrowed from the issue as filed, per the triage decision on the issue

- ONLY the `configFile` door is gated. Its content is read off disk and may not be authored by the host, so it crosses a trust boundary — same class as `--configfile`.
- Inline `config`, `rift_apply_config` and `rift_create_imposter` remain **ungated by design** (#492). `allowInjection` gates config *documents that cross a trust boundary*, not untrusted *hosts*: a caller holding the C-ABI can already execute code in the process, so gating its own JSON would restrict nobody, and rift-node depends on the ungated C-ABI contract. The #492 tripwire test `ffi_serve_admin_inline_config_inject_is_ungated` is kept, untouched and passing.
- The trust boundary is now documented in `docs/embedding/ffi.md`.

## Implementation notes

- `injection_gate` is now `pub` in rift-http-proxy (visibility option 1 from triage — rift-ffi already depends on that crate). Only `config_uses_script_surface`, `GATED_SCRIPT_SURFACES` and a new `gated_offender_ports` are exported; `stubs_contain_script_surface` stays `pub(crate)`.
- `GATED_SCRIPT_SURFACES` moved from server.rs into injection_gate.rs (one definition, every door names the surfaces identically), and the duplicated offender-listing is hoisted into `gated_offender_ports` so the `--configfile` and FFI doors share it.

## Tests

3 new FFI integration tests (gated / allowed-with-flag / no-false-positive). The gated test asserts NULL, that the error names the gate and the offending port, AND that nothing was applied — that last assertion was verified to have teeth by temporarily moving the gate after `apply_config`, which fails it while the NULL/error assertions still pass.

## Verification

clippy clean; `cargo test --workspace` green (round_trip 42/42); docs-examples pass.

Closes #616