### PR TITLE
perf: replace blocking std::fs with async I/O in tokio async paths (tui + imposter)

### DIFF
--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -1018,13 +1018,17 @@ impl ImposterManager {
         };
         let path = datadir.join(format!("{port}.json"));
         tokio::spawn(async move {
-            if path.exists()
-                && let Err(e) = tokio::fs::remove_file(&path).await
-            {
-                error!(
+            match tokio::fs::remove_file(&path).await {
+                Ok(()) => {}
+                // An absent file is the desired end state, not a failure: the imposter may never
+                // have been persisted, or the file was already removed. Handling NotFound here
+                // (rather than pre-checking `exists()`) also closes the TOCTOU window between
+                // check and unlink.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => error!(
                     "Failed to remove persisted imposter {} at {:?}: {}",
                     port, path, e
-                );
+                ),
             }
         });
     }
@@ -1111,6 +1115,38 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         assert!(!file.exists(), "file should be removed after delete");
+    }
+
+    /// Deleting an imposter whose datadir file is already gone must still succeed: an absent file
+    /// is the desired end state, not a failure (issue #564). Pins that dropping the `exists()`
+    /// pre-check did not turn a missing file into a surfaced error.
+    #[tokio::test]
+    async fn test_delete_imposter_succeeds_when_datadir_file_already_removed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = ImposterManager::with_datadir(Some(dir.path().to_path_buf()));
+
+        let config = serde_json::from_value(serde_json::json!({
+            "protocol": "http",
+            "port": 19503,
+            "stubs": []
+        }))
+        .unwrap();
+
+        manager.create_imposter(config).await.expect("create");
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Remove the file out from under the manager, so the unlink races with an absent file.
+        let file = dir.path().join("19503.json");
+        std::fs::remove_file(&file).expect("pre-remove the persisted file");
+        assert!(!file.exists(), "precondition: file is already gone");
+
+        manager
+            .delete_imposter(19503)
+            .await
+            .expect("delete must succeed when the datadir file is already gone");
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert!(!file.exists(), "file must still be absent after delete");
     }
 
     #[tokio::test]

--- a/crates/rift-tui/src/app/commands/io.rs
+++ b/crates/rift-tui/src/app/commands/io.rs
@@ -85,9 +85,9 @@ impl App {
     }
 
     /// Save content to file
-    pub fn save_to_file(&mut self, path: &str, content: &str) {
+    pub async fn save_to_file(&mut self, path: &str, content: &str) {
         let expanded_path = Self::expand_path(path);
-        match std::fs::write(&expanded_path, content) {
+        match tokio::fs::write(&expanded_path, content).await {
             Ok(_) => {
                 self.set_status(format!("Saved to {expanded_path}"), StatusLevel::Success);
                 self.overlay = Overlay::None;
@@ -131,7 +131,7 @@ impl App {
         self.is_loading = true;
         let expanded_path = Self::expand_path(path);
 
-        match std::fs::read_to_string(&expanded_path) {
+        match tokio::fs::read_to_string(&expanded_path).await {
             Ok(content) => {
                 // Validate the content before importing
                 let report = validate_imposter_json(&content, &expanded_path);
@@ -206,7 +206,11 @@ impl App {
         let expanded_folder = Self::expand_path(folder);
 
         let path = std::path::Path::new(&expanded_folder);
-        if !path.is_dir() {
+        let is_dir = tokio::fs::metadata(path)
+            .await
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        if !is_dir {
             self.set_status(
                 format!("{expanded_folder} is not a directory"),
                 StatusLevel::Error,
@@ -218,11 +222,24 @@ impl App {
         let mut imported = 0;
         let mut failed = 0;
 
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
+        if let Ok(mut entries) = tokio::fs::read_dir(path).await {
+            loop {
+                // An unreadable entry must neither truncate the scan nor pass as success: `break`
+                // would silently skip every remaining file while still reporting "Imported N",
+                // and the pre-#564 `.flatten()` skipped it but left it uncounted. Tokio's
+                // `ReadDir` stays valid after an `Err` (the failed entry is already consumed), so
+                // continuing advances to the next entry and always terminates.
+                let entry = match entries.next_entry().await {
+                    Ok(Some(entry)) => entry,
+                    Ok(None) => break,
+                    Err(_) => {
+                        failed += 1;
+                        continue;
+                    }
+                };
                 let file_path = entry.path();
                 if file_path.extension().map(|e| e == "json").unwrap_or(false)
-                    && let Ok(content) = std::fs::read_to_string(&file_path)
+                    && let Ok(content) = tokio::fs::read_to_string(&file_path).await
                 {
                     if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
                         let url = format!("{}/imposters", self.client.base_url());
@@ -293,7 +310,7 @@ impl App {
         let expanded_path = Self::expand_path(path);
 
         match self.client.export_all_imposters().await {
-            Ok(json) => match std::fs::write(&expanded_path, &json) {
+            Ok(json) => match tokio::fs::write(&expanded_path, &json).await {
                 Ok(_) => {
                     self.set_status(format!("Exported to {expanded_path}"), StatusLevel::Success);
                     self.overlay = Overlay::None;
@@ -318,7 +335,7 @@ impl App {
         let path = std::path::Path::new(&expanded_folder);
 
         // Create folder if it doesn't exist
-        if let Err(e) = std::fs::create_dir_all(path) {
+        if let Err(e) = tokio::fs::create_dir_all(path).await {
             self.set_status(format!("Failed to create folder: {e}"), StatusLevel::Error);
             self.is_loading = false;
             return;
@@ -336,7 +353,7 @@ impl App {
                         format!("{}.json", imp.port)
                     };
                     let file_path = path.join(filename);
-                    if std::fs::write(&file_path, &json).is_ok() {
+                    if tokio::fs::write(&file_path, &json).await.is_ok() {
                         exported += 1;
                     } else {
                         failed += 1;

--- a/crates/rift-tui/src/app/events.rs
+++ b/crates/rift-tui/src/app/events.rs
@@ -488,7 +488,9 @@ impl App {
                     return;
                 }
                 match action {
-                    FileAction::SaveExport { content, .. } => self.save_to_file(&path, &content),
+                    FileAction::SaveExport { content, .. } => {
+                        self.save_to_file(&path, &content).await
+                    }
                     FileAction::ImportFile => self.import_from_file(&path).await,
                     FileAction::ImportFolder => self.import_from_folder(&path).await,
                     FileAction::ExportAll => self.export_all_to_file(&path).await,


### PR DESCRIPTION
Converts the one-shot blocking `std::fs` calls that run on tokio async paths to `tokio::fs`:

- `rift-tui/src/app/commands/io.rs` — `save_to_file` (now `async`; its one caller awaits it), `import_from_file`, `import_from_folder`, `export_all_to_file`, `export_to_folder`. No `std::fs` remains in this file.
- `rift-mock-core` `remove_persisted_imposter` — drops the sync `path.exists()` pre-check (a blocking stat inside an async task, and a TOCTOU window) in favour of handling `NotFound` from `remove_file`. Every non-`NotFound` error is still logged at `error!`.

### Scope corrections from triage
- This does **not** unfreeze the TUI during long imports, and isn't meant to: the event loop is serial and is blocked on the awaited network POSTs regardless of fs blocking. Backgrounding imports is a separate, larger UX change.
- `resolve_scripts`' sync reads are left alone — they belong to #550's `spawn_blocking` scope.
- Clipboard fns (arboard is inherently sync) and dialog fns (no I/O) are untouched.

### Two deviations from the triage sketch, both deliberate
1. **`import_from_folder` loop.** The sketched `while let Ok(Some(entry)) = entries.next_entry().await` **stops** the loop on a directory-read error, whereas master's `.flatten()` **skipped** the bad entry and continued. That silently truncates the scan while still reporting `StatusLevel::Success` "Imported N imposters" — a data-path swallow. Implemented instead as an explicit `match` that counts the failure and continues, restoring master's parity *and* surfacing it as "Imported N, M failed". Verified against the pinned tokio 1.48.0 (`src/fs/read_dir.rs`): a failed entry is already consumed from the underlying `ReadDir`, so `continue` makes forward progress and always terminates.
2. **`io.rs:209 path.is_dir()`** was also a blocking stat inside the async `import_from_folder` — the same defect class as the `exists()` being removed — so it is converted to `tokio::fs::metadata(..).await.map(|m| m.is_dir()).unwrap_or(false)`. Exact parity: `Path::is_dir()` also returns false on any error.

### Tests
Adds `test_delete_imposter_succeeds_when_datadir_file_already_removed`. Note this is a **regression net, not a red-first gate** — it passes on the unchanged code too, since today's `exists()` check already skips the unlink. The real gates for this conversion are the compile (`save_to_file`'s async signature is enforced by its caller) and the absence of any `std::fs`/sync-stat on the async path. `io.rs` has no unit tests and its functions require a live admin client, so per triage the conversion relies on compile + existing suites.

### Docs
n/a — internal refactor with no user-facing surface; the CHANGELOG omits internal refactors by its own stated policy.

### Verification
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (54 suites) all exit 0.

Closes #564