### PR TITLE
perf(admin): blocking std::fs I/O inside the async POST /admin/reload handler

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -148,12 +148,27 @@ pub async fn handle_reload(
     };
 
     // Parse before touching state — a bad config leaves the running imposters intact.
-    let configs = match crate::config_loader::load_configs(&source) {
-        Ok(configs) => configs,
-        Err(e) => {
+    //
+    // On the blocking pool (issue #550): `load_configs` is synchronous — many small `std::fs`
+    // reads plus EJS/regex/serde work — and unlike startup, reload is network-triggered and
+    // repeatable, so a large datadir or a stalled mount would pin a runtime worker for the whole
+    // read. Awaited here, so the parse still completes before anything mutates.
+    let configs = match tokio::task::spawn_blocking(move || {
+        crate::config_loader::load_configs(&source)
+    })
+    .await
+    {
+        Ok(Ok(configs)) => configs,
+        Ok(Err(e)) => {
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Reload failed (imposters unchanged): {e}"),
+            );
+        }
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Reload task failed: {e}"),
             );
         }
     };


### PR DESCRIPTION
`handle_reload` called the synchronous `config_loader::load_configs` — many small `std::fs` reads plus EJS/regex/serde work — directly on a tokio worker thread. Unlike the startup read, `POST /admin/reload` is network-triggered and repeatable, so a large `--datadir` (datadir files include persisted proxy-recorded stubs, so MB-scale reads are realistic) or a file on a stalled mount blocks a runtime worker for the whole read, stalling unrelated in-flight requests.

Wraps that single call site in `tokio::task::spawn_blocking`, matching the `handle_verify` precedent.

### Why this shape (per triage)
- **`spawn_blocking`, not `tokio::fs`**: the work is a mixed batch of many small reads *plus* CPU, so per-op `tokio::fs` would only make N dispatches to the same blocking pool with worse ergonomics.
- **The loader stays synchronous**: `script_cli.rs` calls it from a non-async CLI context and startup blocks legitimately, so wrapping only the reload call site scopes the change correctly — no signature changes, no ripple.
- **Invariants preserved**: the task is awaited before any mutation, so parse-fully-before-`apply_config` still holds and a bad config still leaves the running imposters untouched. The #612 validate-before-touch injection gate is unmoved.

### Error handling
Error strings are byte-identical to master. The only new arm is `JoinError` → 500 `"Reload task failed: {e}"`, matching `handle_verify`'s shape. This is **strictly better than master's behaviour**: previously a panic inside `load_configs` unwound into the hyper connection task, killing the connection with no response at all; the caller now gets a clean 500 and other imposters are unaffected. Review confirmed the security gate cannot be bypassed on any failure path — the only route to `reload_is_gated`/`apply_config` is the success arm, so a load or join failure can never apply an unvalidated config.

### Tests
No new behaviour to test (per triage). The 5 existing async tests pin the ordering invariants this refactor could realistically have broken and all pass: `test_handle_reload_no_source_is_noop`, `test_handle_reload_partial_failure_returns_report`, `test_handle_reload_picks_up_edited_file_referenced_script`, plus the two #612 injection-gate tests. Honest caveat: no test asserts on the error strings (a gap that predates this PR and is not widened here) — parity is guaranteed by the literals being untouched.

### Docs
n/a — internal perf fix with no user-facing surface. The analogous #475 `spawn_blocking` offload likewise added no CHANGELOG entry.

### Verification
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (54 suites) all exit 0.

Closes #550