### PR TITLE
perf(proxy): redundant full HeaderMap/Method/Uri clones per request on the hot path

### DIFF
--- a/crates/rift-mock-core/src/proxy/forwarding.rs
+++ b/crates/rift-mock-core/src/proxy/forwarding.rs
@@ -140,10 +140,6 @@ pub async fn forward_with_recording(
     req: Request<hyper::body::Incoming>,
     upstream_uri: &str,
 ) -> Response<BoxBody<Bytes, hyper::Error>> {
-    let method = req.method().clone();
-    let uri = req.uri().clone();
-    let headers = req.headers().clone();
-
     // For recording modes, we need to collect the body to create a signature
     let mode = recording_store.mode();
     if mode == ProxyMode::ProxyTransparent {
@@ -151,8 +147,15 @@ pub async fn forward_with_recording(
         return forward_request_streaming(http_client, req, upstream_uri).await;
     }
 
+    // Past this point every recording mode consumes the request body, so take ownership of the
+    // parts here rather than cloning Method/Uri/HeaderMap up front (issue #545).
+    let (parts, body) = req.into_parts();
+    let method = parts.method;
+    let uri = parts.uri;
+    let headers = parts.headers;
+
     // Collect body for signature creation
-    let body_bytes = match req.collect().await {
+    let body_bytes = match body.collect().await {
         Ok(collected) => collected.to_bytes(),
         Err(e) => {
             error!("Failed to collect request body for recording: {}", e);

--- a/crates/rift-mock-core/src/proxy/handler.rs
+++ b/crates/rift-mock-core/src/proxy/handler.rs
@@ -42,11 +42,12 @@ pub async fn handle_request(
     req: Request<hyper::body::Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     let start_time = std::time::Instant::now();
+    // Method is an enum tag for standard verbs (effectively free to clone) and is needed for
+    // metrics after `req` is consumed below. Uri/HeaderMap stay borrowed until a fault path
+    // actually needs owned copies (issue #545).
     let method = req.method().clone();
-    let uri = req.uri().clone();
-    let headers = req.headers().clone();
 
-    debug!("Received request: {} {}", method, uri);
+    debug!("Received request: {} {}", method, req.uri());
 
     let upstream = select_upstream(ctx.router, ctx.upstreams, &req)
         .map(|(url, name)| UpstreamService {
@@ -79,7 +80,7 @@ pub async fn handle_request(
         .iter()
         .enumerate()
         .find(|(idx, rule)| {
-            rule.matches(&method, &uri, &headers)
+            rule.matches(req.method(), req.uri(), req.headers())
                 && rule_applies_to_upstream(&ctx.rule_upstreams[*idx], upstream.name.as_deref())
         })
         .map(|(idx, _)| idx);
@@ -143,25 +144,26 @@ async fn handle_script_rules(
     upstream: &UpstreamService,
     start_time: std::time::Instant,
 ) -> RuleHandlingResult {
-    let request_info = RequestInfo::from_request(&req);
-
-    // Find first matching script rule that applies to selected upstream
+    // Match against borrows from `req` first so a request that hits no script rule (the common
+    // case when scripts are configured but this one doesn't apply) never pays for the
+    // Method/Uri/HeaderMap clones RequestInfo would build.
     let matching_script =
         scripting
             .compiled_scripts
             .iter()
             .find(|(_, compiled_rule, rule_upstream)| {
-                compiled_rule.matches(
-                    &request_info.method,
-                    &request_info.uri,
-                    &request_info.headers,
-                ) && rule_applies_to_upstream(rule_upstream, upstream.name.as_deref())
+                compiled_rule.matches(req.method(), req.uri(), req.headers())
+                    && rule_applies_to_upstream(rule_upstream, upstream.name.as_deref())
             });
 
     let Some((compiled_script, compiled_rule, _)) = matching_script else {
         return RuleHandlingResult::NoFault(req);
     };
     info!("Request matched script rule: {}", compiled_rule.id);
+
+    // A script matched, so `req` is committed to being consumed below (script context, cache
+    // key, forwarding) — build the owned RequestInfo now, immediately before body collection.
+    let request_info = RequestInfo::from_request(&req);
 
     // Collect body for script (needed for script context)
     let body_bytes = match req.collect().await {
@@ -464,9 +466,15 @@ async fn handle_yaml_rule(
 ) -> RuleHandlingResult {
     // Decide fault
     let fault_decision = decide_fault(&rule.rule.fault, &rule.id);
-    let request_info = RequestInfo::from_request(&req);
 
     match fault_decision {
+        // Sampled no-fault is the common case at low fault probabilities, and this arm hands
+        // `req` straight back — hoisted above the RequestInfo build so that path stays
+        // allocation-free (issue #545).
+        FaultDecision::None => {
+            debug!("No fault injected for matched rule: {}", rule.id);
+            RuleHandlingResult::NoFault(req)
+        }
         FaultDecision::TcpFault {
             fault_type,
             rule_id,
@@ -476,7 +484,7 @@ async fn handle_yaml_rule(
             // Record metrics
             metrics::record_error_injection(&rule_id, 0);
             let duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
-            metrics::record_proxy_duration(request_info.method.as_str(), duration_ms, "tcp_fault");
+            metrics::record_proxy_duration(req.method().as_str(), duration_ms, "tcp_fault");
 
             // Return appropriate error based on fault type
             let (status, body) = match fault_type {
@@ -516,24 +524,24 @@ async fn handle_yaml_rule(
             // Record metrics
             metrics::record_error_injection(&rule_id, status);
             let duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
-            metrics::record_proxy_duration(request_info.method.as_str(), duration_ms, "error");
-            metrics::record_request(request_info.method.as_str(), status);
+            metrics::record_proxy_duration(req.method().as_str(), duration_ms, "error");
+            metrics::record_request(req.method().as_str(), status);
 
             // Build request context for behaviors
             let request_context = RequestContext::from_request(
-                request_info.method.as_str(),
-                &request_info.uri,
-                &request_info.headers,
+                req.method().as_str(),
+                req.uri(),
+                req.headers(),
                 None, // Body not available for YAML rules
             );
 
             // Process template variables in response body if present
             let mut processed_body = if has_template_variables(&body) {
                 let request_data = RequestData::new(
-                    request_info.method.as_str(),
-                    request_info.uri.path(),
-                    request_info.uri.query(),
-                    &request_info.headers,
+                    req.method().as_str(),
+                    req.uri().path(),
+                    req.uri().query(),
+                    req.headers(),
                     None,
                 );
                 process_template(&body, &request_data)
@@ -657,6 +665,7 @@ async fn handle_yaml_rule(
             duration_ms,
             rule_id,
         } => {
+            let request_info = RequestInfo::from_request(&req);
             info!(
                 "Injecting latency fault: {}ms, rule={}",
                 duration_ms, rule_id
@@ -699,10 +708,6 @@ async fn handle_yaml_rule(
             response.set_header_value(&X_RIFT_RULE_ID, &rule_id);
             response.set_header_value(&X_RIFT_LATENCY_MS, &duration_ms.to_string());
             RuleHandlingResult::Response(response.into_boxed())
-        }
-        FaultDecision::None => {
-            debug!("No fault injected for matched rule: {}", rule.id);
-            RuleHandlingResult::NoFault(req)
         }
     }
 }


### PR DESCRIPTION
`RequestInfo::from_request` clones Method + Uri + a full `HeaderMap`. The proxy built those eagerly, so the common no-fault pass-through paid 2-3 full HeaderMap clones for nothing. Applies the triage's theme — **borrow until the point of no return** — across four sites:

1. **`handle_request` top** — dropped the `uri`/`headers` clones; the matcher now borrows `req.method()/uri()/headers()`. The `Method` clone stays: an enum tag for standard verbs, effectively free, and metrics need it after `req` moves.
2. **`handle_script_rules`** — matches against borrows first; `RequestInfo` is built only after a rule matches. A no-match is now allocation-free (previously every request paid a full clone set whenever scripts were configured).
3. **`handle_yaml_rule`** — the `FaultDecision::None` arm is hoisted above the build and returns `NoFault(req)`, so the sampled-no-fault path (the common one at low fault probabilities) allocates nothing.
4. **`forward_with_recording`** — three clones replaced by `req.into_parts()`. This is the site the **issue itself missed**; the owner's triage caught it.

`forward_request_streaming`'s owned set is deliberately **kept** — one owned Method/Uri/HeaderMap per actual upstream forward, since `forward_request_with_body` consumes them.

### Result
\`RequestInfo::from_request\` now appears at exactly **two** sites, both genuine points of no return: after a script rule matches (immediately before \`req.collect()\`), and in the \`Latency\` arm (the only fault arm where \`collect()\` consumes \`req\`). Review caught that the \`TcpFault\` and \`Error\` arms never consume \`req\` at all — \`TcpFault\` was cloning a whole Uri+HeaderMap solely to read \`.method.as_str()\` once — so both now borrow instead.

### Correctness
This is a pure control-flow restructure with no behaviour change:
- **The reordered match is safe by construction**: \`FaultDecision\` has 4 plain data variants and the match has no guards and no catch-all, so constructor patterns are order-independent.
- **Metrics parity was verified call-site by call-site** against master — identical in count and in reported arguments.
- **\`into_parts\` ordering**: the \`ProxyTransparent\` early-return still precedes it (compiler-enforced — that path needs the owned \`req\`), and \`body.collect()\` is equivalent to master's \`req.collect()\`, which also discarded \`version\`/\`extensions\`.

### Tests
Behaviour-parity gate, not red-first: "we allocated fewer HeaderMaps" isn't observable from a functional test without disproportionate allocation instrumentation, and this adds no semantics. Existing proxy handler + fault-injection integration tests cover it; \`ProxyTransparent\` is the default mode, so the \`into_parts\` early-return is exercised by every default-mode proxy test. Most of the refactor is compiler-enforced. The perf gate in CI (\`matcher_bench\` / \`perf.yml\`) guards against regression.

### Scope
Not a duplicate of #561 — disjoint pipelines (the proxy fault-injection engine here vs the imposter serve path there; \`imposter/handler.rs:150-151\` documents the split). This one's cost is HeaderMap clone multiplicity; #561's is body-sized copies.

### Docs
n/a — internal restructure, no user-facing surface or API change.

### Verification
\`cargo fmt --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, and \`cargo test --workspace\` (54 suites) all exit 0.

Closes #545