### PR TITLE
perf(imposter): redundant per-request clones/allocations on the request hot path

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1150,7 +1150,7 @@ mod requests_filter_tests {
         manager.create_imposter(config).await.expect("create");
         let imposter = manager.get_imposter(port).expect("imposter");
         for r in recorded {
-            imposter.record_request(r);
+            imposter.record_request(r.clone());
         }
         manager
     }
@@ -1544,7 +1544,7 @@ mod requests_filter_tests {
         manager.create_imposter(cfg).await.expect("create");
         let imposter = manager.get_imposter(port).expect("imposter");
         for r in recorded {
-            imposter.record_request(r);
+            imposter.record_request(r.clone());
         }
         manager
     }
@@ -1679,7 +1679,7 @@ mod requests_filter_tests {
         let m = manager_with(19757, None, &[]).await;
         let imposter = m.get_imposter(19757).expect("imposter");
         for i in 0..(crate::imposter::MAX_RECORDED_REQUESTS + 5) {
-            imposter.record_request(&rec_at(&format!("/{i}"), "A"));
+            imposter.record_request(rec_at(&format!("/{i}"), "A"));
         }
 
         // Indices 1..=5 were evicted; a cursor at 2 never received 3..=5.
@@ -1803,7 +1803,7 @@ mod verify_tests {
         manager.create_imposter(config).await.expect("create");
         let imposter = manager.get_imposter(port).expect("imposter");
         for r in recorded {
-            imposter.record_request(r);
+            imposter.record_request(r.clone());
         }
         manager
     }
@@ -1971,7 +1971,7 @@ mod replace_all_tests {
         manager
             .get_imposter(19766)
             .expect("imposter")
-            .record_request(&RecordedRequest {
+            .record_request(RecordedRequest {
                 request_from: "127.0.0.1:5000".to_string(),
                 method: "GET".to_string(),
                 path: "/seen".to_string(),

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -1435,7 +1435,7 @@ mod tests {
 
         use crate::imposter::journal::MAX_RECORDED_REQUESTS;
         for _ in 0..MAX_RECORDED_REQUESTS + 10 {
-            imposter.record_request(&req);
+            imposter.record_request(req.clone());
         }
 
         let recorded = imposter.get_recorded_requests();
@@ -1471,9 +1471,9 @@ mod tests {
                 timestamp: "2026-01-01T00:00:00Z".to_string(),
             }
         };
-        imposter.record_request(&req("A"));
-        imposter.record_request(&req("B"));
-        imposter.record_request(&req("A"));
+        imposter.record_request(req("A"));
+        imposter.record_request(req("B"));
+        imposter.record_request(req("A"));
         for _ in 0..3 {
             imposter.increment_request_count();
         }

--- a/crates/rift-mock-core/src/imposter/core/recording.rs
+++ b/crates/rift-mock-core/src/imposter/core/recording.rs
@@ -13,26 +13,37 @@ impl Imposter {
 
     /// Record a request (when body recording is enabled), tagged with its resolved flow id.
     ///
+    /// Takes `req` by value (issue #561): the caller's owned `RecordedRequest` is never used
+    /// again afterward, so this used to pay a full clone (up to 10 MB) just to satisfy the
+    /// by-value `RequestJournal::record`. It is now moved into the journal directly, and cloned
+    /// only in the (uncommon) case an SSE subscriber also needs its own copy.
+    ///
     /// Returns the journal index assigned to the entry, or `None` when nothing was recorded
     /// (recording is off) or the backend has no stable indices (issue #603).
-    pub fn record_request(&self, req: &RecordedRequest) -> Option<u64> {
+    pub fn record_request(&self, req: RecordedRequest) -> Option<u64> {
         if !self.config.record_requests {
             return None;
         }
         let flow_id = self.resolve_flow_id_recorded(&req.headers);
-        let index = self
-            .journal
-            .record_indexed(self.journal_port(), &flow_id, req.clone());
         // Fan the recorded request out to the admin SSE stream (issue #461). Guard on an active
         // subscriber first so the hot path never clones the request for nobody. The journal
         // index rides along (issue #603) so a client that reconnects or lags can reconcile with
         // `?since=<index>` instead of re-polling the whole journal.
-        if let Some(bus) = &self.event_bus
-            && bus.has_subscribers()
-        {
-            bus.publish_request(self.journal_port(), flow_id, index, req.clone());
+        match self.event_bus.as_ref().filter(|bus| bus.has_subscribers()) {
+            Some(bus) => {
+                // A subscriber needs its own copy after this call, so clone once for the journal
+                // and move the original into `publish_request`.
+                let index = self
+                    .journal
+                    .record_indexed(self.journal_port(), &flow_id, req.clone());
+                bus.publish_request(self.journal_port(), flow_id, index, req);
+                index
+            }
+            // Nobody is listening: move `req` straight into the journal, no clone at all.
+            None => self
+                .journal
+                .record_indexed(self.journal_port(), &flow_id, req),
         }
-        index
     }
 
     /// Read recorded requests with the backend's completeness flag intact, so embedders

--- a/crates/rift-mock-core/src/imposter/core/responses.rs
+++ b/crates/rift-mock-core/src/imposter/core/responses.rs
@@ -148,6 +148,20 @@ impl Imposter {
         let Some(response) = self.next_stub_response(stub_state)? else {
             return Ok(None);
         };
-        Ok(execute_stub_response_with_rift(response))
+        // This wrapper's own contract stays owned (it backs the debug/preview paths, not the
+        // request hot path) — clone here rather than push a lifetime through its signature.
+        Ok(execute_stub_response_with_rift(response).map(
+            |(status, headers, body, behaviors, rift, mode, is_fault)| {
+                (
+                    status,
+                    headers,
+                    body,
+                    behaviors,
+                    rift.cloned(),
+                    mode,
+                    is_fault,
+                )
+            },
+        ))
     }
 }

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -313,9 +313,9 @@ mod tests {
     #[test]
     fn matched_and_total_count_all_predicates_anded() {
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/a", &[], None));
-        imp.record_request(&rec("POST", "/a", &[], None));
-        imp.record_request(&rec("GET", "/b", &[], None));
+        imp.record_request(rec("GET", "/a", &[], None));
+        imp.record_request(rec("POST", "/a", &[], None));
+        imp.record_request(rec("GET", "/b", &[], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([{ "equals": { "method": "GET", "path": "/a" } }])),
@@ -331,8 +331,8 @@ mod tests {
     #[test]
     fn empty_predicates_match_everything() {
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/a", &[], None));
-        imp.record_request(&rec("GET", "/b", &[], None));
+        imp.record_request(rec("GET", "/a", &[], None));
+        imp.record_request(rec("GET", "/b", &[], None));
         let out = imp.verify(&VerifyOptions::default()).expect("verify");
         assert_eq!(out.matched, 2);
         assert_eq!(out.total, 2);
@@ -341,9 +341,9 @@ mod tests {
     #[test]
     fn include_requests_returns_the_matching_requests() {
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/keep", &[], None));
-        imp.record_request(&rec("GET", "/drop", &[], None));
-        imp.record_request(&rec("GET", "/keep", &[], None));
+        imp.record_request(rec("GET", "/keep", &[], None));
+        imp.record_request(rec("GET", "/drop", &[], None));
+        imp.record_request(rec("GET", "/keep", &[], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([{ "equals": { "path": "/keep" } }])),
@@ -360,9 +360,9 @@ mod tests {
     fn closest_picks_most_satisfied_clauses_and_reports_failures() {
         let imp = imposter(None);
         // Satisfies neither clause.
-        imp.record_request(&rec("DELETE", "/x", &[], None));
+        imp.record_request(rec("DELETE", "/x", &[], None));
         // Satisfies method only (1 of 2) — the closest.
-        imp.record_request(&rec("GET", "/x", &[], None));
+        imp.record_request(rec("GET", "/x", &[], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([
@@ -387,8 +387,8 @@ mod tests {
         let imp = imposter(None);
         // Both satisfy the method clause (1 of 1 failing overall since path never matches),
         // so the tie is broken toward the later-recorded request.
-        imp.record_request(&rec("GET", "/first", &[], None));
-        imp.record_request(&rec("GET", "/second", &[], None));
+        imp.record_request(rec("GET", "/first", &[], None));
+        imp.record_request(rec("GET", "/second", &[], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([
@@ -409,9 +409,9 @@ mod tests {
     #[test]
     fn flow_id_scopes_total_and_matched() {
         let imp = imposter(Some("header:X-Space"));
-        imp.record_request(&rec("GET", "/a", &[("X-Space", "blue")], None));
-        imp.record_request(&rec("GET", "/a", &[("X-Space", "green")], None));
-        imp.record_request(&rec("GET", "/a", &[("X-Space", "blue")], None));
+        imp.record_request(rec("GET", "/a", &[("X-Space", "blue")], None));
+        imp.record_request(rec("GET", "/a", &[("X-Space", "green")], None));
+        imp.record_request(rec("GET", "/a", &[("X-Space", "blue")], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([{ "equals": { "path": "/a" } }])),
@@ -427,8 +427,8 @@ mod tests {
     fn flow_id_scopes_under_the_default_imposter_port_source() {
         // With no flow_id_source declared, every request's flow is the imposter port ("0" here).
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/a", &[], None));
-        imp.record_request(&rec("GET", "/a", &[], None));
+        imp.record_request(rec("GET", "/a", &[], None));
+        imp.record_request(rec("GET", "/a", &[], None));
 
         let matching = VerifyOptions {
             flow_id: Some("0".to_string()),
@@ -450,7 +450,7 @@ mod tests {
         // Regression: the `ip` field must compare against the bare IP recovered from `request_from`
         // (`ip:port`), not an empty string — otherwise every `ip` predicate silently mis-counts.
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/a", &[], None)); // request_from = 127.0.0.1:5000
+        imp.record_request(rec("GET", "/a", &[], None)); // request_from = 127.0.0.1:5000
 
         let opts = VerifyOptions {
             predicates: preds(json!([{ "equals": { "ip": "127.0.0.1" } }])),
@@ -464,7 +464,7 @@ mod tests {
         // A header recorded with two values collapses to its last, mirroring live matching's
         // single-value view.
         let imp = imposter(None);
-        imp.record_request(&rec(
+        imp.record_request(rec(
             "GET",
             "/a",
             &[("X-Dup", "first"), ("X-Dup", "second")],
@@ -493,7 +493,7 @@ mod tests {
         // A compound (`or`) predicate implicates no single field, so `actual` is the whole-request
         // view rather than a field-keyed projection.
         let imp = imposter(None);
-        imp.record_request(&rec("GET", "/c", &[], None));
+        imp.record_request(rec("GET", "/c", &[], None));
 
         let opts = VerifyOptions {
             predicates: preds(json!([
@@ -516,7 +516,7 @@ mod tests {
         // A jsonpath/xpath selector rewrites the effective body, so no single request field is
         // implicated — `actual` is the whole-request view.
         let imp = imposter(None);
-        imp.record_request(&rec("POST", "/a", &[], Some(r#"{"foo":"bar"}"#)));
+        imp.record_request(rec("POST", "/a", &[], Some(r#"{"foo":"bar"}"#)));
 
         let opts = VerifyOptions {
             predicates: preds(json!([

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -34,6 +34,7 @@ use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
 
 use rand::Rng;
+use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -212,16 +213,14 @@ async fn handle_request_inner(
     // Increment request count
     imposter.increment_request_count();
 
-    // Extract parts we need before consuming the request body
-    let method = req.method().to_string();
-    let uri = req.uri().clone();
-    // Clone the original validated HeaderMap up front for the request context, instead of rebuilding
-    // one from the title-cased HashMap below (which re-validated every header per request, issue
-    // #480). `RequestContext::from_request` title-cases the names itself, so the map's own casing
-    // (hyper stores lowercase) does not change the resulting context.
-    let headers_for_context = req.headers().clone();
-    let headers_clone: HashMap<String, String> = req
-        .headers()
+    // Extract parts we need before consuming the request body. `into_parts()` (issue #561) hands
+    // back owned `method`/`uri`/`headers` for free — no `.clone()` needed to get an owned
+    // `HeaderMap` for the request context, unlike the old `req.headers().clone()`.
+    let (parts, body) = req.into_parts();
+    let method = parts.method.to_string();
+    let uri = parts.uri;
+    let headers_for_context = parts.headers;
+    let headers_clone: HashMap<String, String> = headers_for_context
         .iter()
         .map(|(k, v)| {
             (
@@ -235,7 +234,7 @@ async fn handle_request_inner(
     // collapses to one value and stays the single-value view used for matching/context).
     let headers_multi: HashMap<String, Vec<String>> = if imposter.config.record_requests {
         let mut map: HashMap<String, Vec<String>> = HashMap::new();
-        for (k, v) in req.headers().iter() {
+        for (k, v) in headers_for_context.iter() {
             map.entry(header_to_title_case(k.as_str()))
                 .or_default()
                 .push(v.to_str().unwrap_or("").to_string());
@@ -256,15 +255,11 @@ async fn handle_request_inner(
     }
 
     // Collect request body with size limit to prevent memory exhaustion
-    let limited_body = Limited::new(req.into_body(), MAX_REQUEST_BODY_SIZE);
-    let body_string = match limited_body.collect().await {
+    let limited_body = Limited::new(body, MAX_REQUEST_BODY_SIZE);
+    let body_bytes = match limited_body.collect().await {
         Ok(collected) => {
             let bytes = collected.to_bytes();
-            if bytes.is_empty() {
-                None
-            } else {
-                Some(String::from_utf8_lossy(&bytes).to_string())
-            }
+            if bytes.is_empty() { None } else { Some(bytes) }
         }
         Err(_) => {
             return Ok(build_response_with_headers(
@@ -276,10 +271,13 @@ async fn handle_request_inner(
             ));
         }
     };
-
-    // Build request context for behaviors
-    let request_context =
-        RequestContext::from_request(&method, &uri, &headers_for_context, body_string.as_deref());
+    // Borrow the body as UTF-8 without forcing an allocation for the common valid-UTF-8 case
+    // (issue #561): `from_utf8_lossy` returns `Cow::Borrowed` then, so only genuinely invalid
+    // UTF-8 pays a copy here. `body_bytes` stays alive for the rest of the function so this
+    // borrow remains valid; callers that need an owned `String` (`RecordedRequest`,
+    // `ScriptRequest`, thread-moved debug/inject requests) materialize one at that boundary.
+    let body_string: Option<std::borrow::Cow<'_, str>> =
+        body_bytes.as_deref().map(String::from_utf8_lossy);
 
     // Record request if enabled
     if imposter.config.record_requests {
@@ -289,10 +287,10 @@ async fn handle_request_inner(
             path: path.clone(),
             query: parse_query_string(&query_str),
             headers: headers_multi,
-            body: body_string.clone(),
+            body: body_string.as_deref().map(str::to_string),
             timestamp: chrono::Utc::now().to_rfc3339(),
         };
-        imposter.record_request(&recorded);
+        imposter.record_request(recorded);
     }
 
     // Find matching stub
@@ -326,7 +324,9 @@ async fn handle_request_inner(
         let debug_imposter = Arc::clone(&imposter);
         let (dbg_method, dbg_path, dbg_query) = (method.clone(), path.clone(), query_str.clone());
         let dbg_headers = headers_clone.clone();
-        let dbg_body = body_string.clone();
+        // Materialize an owned copy here (issue #561): `body_string` borrows from `body_bytes`,
+        // which does not outlive this `spawn_blocking` closure's `'static` bound.
+        let dbg_body = body_string.as_deref().map(str::to_string);
         let handle = tokio::task::spawn_blocking(move || {
             handle_debug_request(
                 &debug_imposter,
@@ -479,7 +479,9 @@ async fn handle_request_inner(
                 path: path.clone(),
                 query: parse_query_string(&query_str),
                 headers: headers_clone.clone(),
-                body: body_string.clone(),
+                // Owned boundary (issue #561): the inject job is submitted to a `'static` worker
+                // closure, so `body_string`'s borrow can't cross it.
+                body: body_string.as_deref().map(str::to_string),
             };
 
             match execute_mountebank_inject_bounded(
@@ -562,7 +564,9 @@ async fn handle_request_inner(
             // them case-insensitively (e.g. `request.headers["x-flow-id"]`) regardless of the
             // wire casing; this matches the engine docs and HTTP header semantics.
             let script_request = ScriptRequest {
-                raw_body: Some(body_string.clone().unwrap_or_default()),
+                // Owned boundary (issue #561): `ScriptRequest` is moved into the script engine's
+                // worker job, so the body must be materialized here rather than borrowed.
+                raw_body: Some(body_string.as_deref().unwrap_or_default().to_string()),
                 method: method.clone(),
                 path: path.clone(),
                 headers: headers_clone
@@ -572,7 +576,7 @@ async fn handle_request_inner(
                 // Domain-optional parse: a request body may legitimately not be JSON, and the
                 // script contract exposes that as `null` rather than an error (issue #611).
                 body: body_string
-                    .as_ref()
+                    .as_deref()
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or(serde_json::Value::Null),
                 query: parse_query_string(&query_str),
@@ -790,7 +794,7 @@ async fn handle_request_inner(
             }
 
             // Apply _rift.fault extensions (probabilistic faults)
-            if let Some(ref rift) = rift_ext
+            if let Some(rift) = rift_ext
                 && let Some(ref fault_config) = rift.fault
                 && let Some(response) = apply_rift_fault(fault_config, &mut status, &mut body).await
             {
@@ -813,7 +817,7 @@ async fn handle_request_inner(
             // template-injection hole (an unauthenticated caller could reach `state.*`/force errors)
             // and would also break the module's "a literal `{{` is served verbatim" promise for
             // reflected text. Off by default so recorded fixtures with a literal `{{` are untouched.
-            if rift_ext.as_ref().is_some_and(|r| r.templated) {
+            if rift_ext.is_some_and(|r| r.templated) {
                 let request_data = RequestData::new(
                     method_str,
                     path_str,
@@ -922,6 +926,25 @@ async fn handle_request_inner(
                     }
                 }
 
+                // Lazy request context (issue #561): only copy/lookup/decorate/shellTransform read
+                // it, and `RequestContext::from_request` re-parses the query, retitles every
+                // header, and copies the body — so a wait/repeat-only stub (or any non-`is`
+                // response) must not pay for it.
+                //
+                // Built on first read rather than behind a hand-maintained "does anything below
+                // need this?" predicate: such a predicate has to be kept in sync with consumers
+                // 100+ lines away, and getting it wrong would hand one an empty-but-valid context —
+                // wrong output, no error. Here a consumer that forgets to ask simply cannot exist.
+                let request_context: OnceCell<RequestContext> = OnceCell::new();
+                let build_request_context = || {
+                    RequestContext::from_request(
+                        &method,
+                        &uri,
+                        &headers_for_context,
+                        body_string.as_deref(),
+                    )
+                };
+
                 // copy/lookup are pure token substitution — apply them across each value of
                 // multi-value headers so multiplicity survives (e.g. multiple Set-Cookie;
                 // RFC 7230 §3.2.2 forbids folding Set-Cookie). decorate uses a single-value
@@ -932,7 +955,7 @@ async fn handle_request_inner(
                         &body,
                         &mut headers,
                         &parsed_behaviors.copy,
-                        &request_context,
+                        request_context.get_or_init(build_request_context),
                     );
                 }
                 if !parsed_behaviors.lookup.is_empty() {
@@ -940,7 +963,7 @@ async fn handle_request_inner(
                         &body,
                         &mut headers,
                         &parsed_behaviors.lookup,
-                        &request_context,
+                        request_context.get_or_init(build_request_context),
                         csv_cache(),
                     );
                 }
@@ -976,7 +999,7 @@ async fn handle_request_inner(
                         .collect();
                     match apply_decorate_bounded(
                         decorate_script.clone(),
-                        request_context.clone(),
+                        request_context.get_or_init(build_request_context).clone(),
                         body.clone(),
                         status,
                         single,
@@ -1052,7 +1075,7 @@ async fn handle_request_inner(
                     // starving unrelated requests multiplexed on it.
                     let shell_result = {
                         let cmd = cmd.clone();
-                        let rc = request_context.clone();
+                        let rc = request_context.get_or_init(build_request_context).clone();
                         let body_in = body.clone();
                         tokio::task::spawn_blocking(move || {
                             apply_shell_transform(&cmd, &rc, &body_in, status)

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -1614,7 +1614,7 @@ mod tests {
         assert!(report.failed.is_empty());
 
         let untouched = manager.get_imposter(19410).unwrap();
-        untouched.record_request(&recorded("/cycled"));
+        untouched.record_request(recorded("/cycled"));
         assert_eq!(next_body(&untouched.stubs.load()[0]), "a1");
 
         let p2_changed = imposter_cfg(json!({
@@ -1660,7 +1660,7 @@ mod tests {
         }));
         manager.apply_config(vec![initial]).await.expect("create");
         let before = manager.get_imposter(19420).unwrap();
-        before.record_request(&recorded("/a"));
+        before.record_request(recorded("/a"));
 
         let renamed = imposter_cfg(json!({
             "protocol": "http", "port": 19420, "recordRequests": true, "name": "renamed",

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -126,7 +126,7 @@ pub fn execute_stub_response_with_rift(
     HashMap<String, Vec<String>>,
     String,
     Option<std::sync::Arc<crate::behaviors::ResponseBehaviors>>,
-    Option<RiftResponseExtension>,
+    Option<&RiftResponseExtension>,
     ResponseMode,
     bool,
 )> {
@@ -168,7 +168,10 @@ pub fn execute_stub_response_with_rift(
                 headers,
                 body,
                 behaviors_parsed.clone(),
-                rift.clone(),
+                // Borrowed, not cloned (issue #561): the lifetime elides from `response`, and
+                // every caller only reads this on the hot path — an owned copy is materialized
+                // only where a caller genuinely needs one (see `execute_stub_with_rift`).
+                rift.as_ref(),
                 mode,
                 false,
             ))


### PR DESCRIPTION
Cuts the per-request allocations on the **imposter serve** path, ranked by bytes × frequency. (Disjoint from #545, which is the proxy fault-injection engine — that one's cost is HeaderMap multiplicity; this one's is body-sized copies × every request.)

Triage found the issue **understated** it: `RequestContext::from_request` doesn't just clone — it re-parses the query, rebuilds the title-cased header map a *second* time, and copies the body again. And it was built for **every** request, including ones that match nothing, while being read only by copy/lookup/decorate/shellTransform.

### What changed
1. **`RequestContext` is built on first read** — the biggest win. A wait/repeat-only stub, or any non-`is` response, no longer pays a full body copy plus a duplicate header map for data nobody reads.
2. **`req.into_parts()` at ingest** — hyper hands over owned method/uri/headers; drops two clones.
3. **`Cow` body** — a valid-UTF-8 body is no longer reallocated by `from_utf8_lossy(..).to_string()`. Owned copies are materialized only at the four boundaries that genuinely need `'static` data: `RecordedRequest`, `ScriptRequest.raw_body`, the debug `spawn_blocking` closure, and the inject job.
4. **`record_request` takes its argument by value** — the handler already built an owned `RecordedRequest` and never used it again, so cloning it into the journal was a second full copy of a body up to 10 MB. The no-subscriber path now does **zero** clones; with an SSE subscriber it does one instead of two.
5. **`_rift` extension returned by borrow** rather than cloned.

### Deliberately kept
- `is.headers.clone()` — mutation needs ownership on four paths (templating, copy, lookup, decorate), and it's typically <1 KB.
- The title-cased header map — it is the **matcher's** header input and feeds the debug/proxy/script paths; it is not a behaviours detail.
- The single owned `RecordedRequest` snapshot — `recordRequests` semantics require one copy. This deletes the *second*, not the first.

### On the lazy build
The obvious implementation is a "does anything below need this?" predicate with an empty `RequestContext::default()` fallback. Review rightly pushed back: that predicate has to stay in sync with consumers 100+ lines away, and getting it wrong hands one an **empty-but-valid** context — wrong output, no error, the same silent-wrong shape as #606/#608/#610/#611. It also can't be caught by the suite: `decorate` and `shellTransform` have no test that reads request fields (the one shellTransform test runs `printf`, ignoring `MB_REQUEST`), so a mis-wired predicate would ship green.

So there is no predicate. A `OnceCell` builds the context on first read; a consumer that forgets to ask cannot exist, and the empty-context state doesn't either. Less code than the gate.

### Verification
Behaviour-parity gate — this adds no semantics, and allocation counts aren't functionally observable without instrumentation triage deemed optional. Items 2-5 are compile-enforced; item 1 is now structural rather than predicate-maintained. Covered by `imposter/tests.rs`, the admin-api integration tests, and the recording-cap tests. The criterion matcher bench + `perf.yml` sit *below* these clones — they prove no regression but won't show the win.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (54 suites) all exit 0.

### Split out, not bundled
The `from_utf8_lossy` binary-corruption concern is filed separately (#636) — it changes the recorded-request wire format, which is a semantic change, not a perf fix.

### Docs
n/a — internal restructure; no user-facing surface and no API change (`execute_stub_with_rift`'s public contract is unchanged).

Closes #561
