### PR TITLE
fix: log admin API server errors

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/types.rs
+++ b/crates/rift-http-proxy/src/admin_api/types.rs
@@ -93,9 +93,19 @@ pub struct RiftImposterExtensions {
     pub flow_state: Option<serde_json::Value>,
 }
 
-// Error types + `error_response` + the `From<ImposterError>` conversion moved to
-// `rift_mock_core::response` (issue #203). Re-exported so admin call sites are unchanged.
-pub use rift_mock_core::response::error_response;
+// Error types + the `From<ImposterError>` conversion moved to
+// `rift_mock_core::response` (issue #203). Keep an admin-local wrapper for `error_response` so
+// every Admin API 5xx response has a server-side trace (issue #628).
+pub fn error_response(status: StatusCode, message: &str) -> Response<Full<Bytes>> {
+    if status.is_server_error() {
+        tracing::error!(
+            status = status.as_u16(),
+            message = %message,
+            "admin API error response"
+        );
+    }
+    rift_mock_core::response::error_response(status, message)
+}
 
 /// Request to add a stub
 #[derive(Debug, Deserialize)]
@@ -206,7 +216,6 @@ pub(crate) fn serialize_or_500<T: Serialize>(
     body: &T,
 ) -> Result<String, Box<Response<Full<Bytes>>>> {
     serde_json::to_string_pretty(body).map_err(|e| {
-        tracing::error!(error = %e, "failed to serialize admin API response body");
         Box::new(error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             &format!("failed to serialize response body: {e}"),

--- a/crates/rift-mock-core/src/response/mod.rs
+++ b/crates/rift-mock-core/src/response/mod.rs
@@ -47,10 +47,13 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 StatusCode::NOT_FOUND,
                 &format!("Imposter not found on port {p}"),
             ),
-            ImposterError::BindError(p, e) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Failed to bind port {p}: {e}"),
-            ),
+            ImposterError::BindError(p, e) => {
+                tracing::error!(port = p, error = %e, "failed to bind imposter port");
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("Failed to bind port {p}: {e}"),
+                )
+            }
             ImposterError::InvalidProtocol(p) => {
                 error_response(StatusCode::BAD_REQUEST, &format!("Invalid protocol: {p}"))
             }
@@ -64,10 +67,13 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 StatusCode::CONFLICT,
                 &format!("A stub with id '{id}' already exists"),
             ),
-            ImposterError::PersistError(msg) => error_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                &format!("Persistence error: {msg}"),
-            ),
+            ImposterError::PersistError(msg) => {
+                tracing::error!(error = %msg, "failed to persist imposter state");
+                error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &format!("Persistence error: {msg}"),
+                )
+            }
             ImposterError::Tls(msg) => error_response(
                 StatusCode::BAD_REQUEST,
                 &format!("TLS configuration error: {msg}"),


### PR DESCRIPTION
## Summary

- wrap Admin API `error_response` locally so direct Admin API 5xx responses are logged centrally
- log `BindError` (500) and `PersistError` (503) in the admin-only `From<ImposterError>` conversion path
- avoid logging in the shared core response helper, which is also used by the proxy data plane
- keep response bodies and statuses unchanged

Fixes #628.

## Validation

- `git diff --check`
- local Rust tests could not be run because `cargo` is not available on this machine; the full GitHub CI matrix is the validation gate
