### PR TITLE
perf(scripting): DecisionCache hashes all headers, resulting in ~0% cache hit rate

### DIFF
--- a/crates/rift-mock-core/src/config/mod.rs
+++ b/crates/rift-mock-core/src/config/mod.rs
@@ -205,6 +205,38 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+    /// `docs/performance/index.md` tells users to put `decision_cache` on the **proxy** config next
+    /// to `script_rules` — NOT inside the imposter `_rift` block. That distinction is load-bearing:
+    /// neither `Config` nor `DecisionCacheConfigFile` sets `deny_unknown_fields`, so a wrong doc is
+    /// silently DROPPED rather than rejected — the knob would do nothing, with no error, while the
+    /// degenerate-cache warning kept telling the user to set the key they had already set.
+    ///
+    /// The docs-examples CI gate only boots the enumerated `docs/demo/*.json` files and never parses
+    /// inline doc snippets, so this test is what actually holds that doc honest (issue #630).
+    #[test]
+    fn documented_decision_cache_block_parses_on_the_proxy_config() {
+        let yaml = r#"
+listen:
+  port: 8080
+decision_cache:
+  enabled: true
+  max_size: 10000
+  ttl_seconds: 300
+  key_headers: ["X-Tenant", "X-Feature-Flag"]
+"#;
+        let config: Config = serde_yaml::from_str(yaml)
+            .expect("the documented decision_cache block must deserialize on the proxy Config");
+        let dc = config
+            .decision_cache
+            .expect("decision_cache must be parsed, not silently dropped");
+        assert_eq!(
+            dc.key_headers.as_deref(),
+            Some(&["X-Tenant".to_string(), "X-Feature-Flag".to_string()][..]),
+            "the documented key_headers spelling must be the one serde accepts"
+        );
+        assert_eq!(dc.max_size, 10000);
+    }
+
     use super::*;
     use crate::recording::ProxyMode;
 

--- a/crates/rift-mock-core/src/config/scripting.rs
+++ b/crates/rift-mock-core/src/config/scripting.rs
@@ -113,6 +113,16 @@ pub struct DecisionCacheConfigFile {
     /// TTL for cache entries in seconds (0 = no expiration)
     #[serde(default = "default_decision_cache_ttl_seconds")]
     pub ttl_seconds: u64,
+    /// Headers that participate in the cache key (issue #630).
+    ///
+    /// Omitted (the default) keys on **every** header, which is always correct but degenerates to a
+    /// ~0% hit rate whenever a per-request-unique header (`x-request-id`, `traceparent`, `date`) is
+    /// present — the cache then costs more than it saves. Setting this is an assertion that your
+    /// scripts' fault decisions depend on at most these headers; it cannot be inferred, because the
+    /// script is handed every header and may branch on any of them. Names are matched
+    /// case-insensitively. An empty list keys on no headers at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_headers: Option<Vec<String>>,
 }
 
 fn default_decision_cache_enabled() -> bool {
@@ -133,6 +143,43 @@ impl Default for DecisionCacheConfigFile {
             enabled: default_decision_cache_enabled(),
             max_size: default_decision_cache_max_size(),
             ttl_seconds: default_decision_cache_ttl_seconds(),
+            key_headers: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod decision_cache_config_tests {
+    use super::DecisionCacheConfigFile;
+
+    /// `key_headers` must match its siblings' casing. This config block has no `rename_all`, so
+    /// `max_size`/`ttl_seconds` are snake_case on the wire; a camelCase `keyHeaders` would force
+    /// users to mix conventions inside one object (issue #630).
+    #[test]
+    fn key_headers_is_snake_case_like_its_siblings() {
+        let cfg: DecisionCacheConfigFile = serde_json::from_str(
+            r#"{"enabled": true, "max_size": 10, "ttl_seconds": 5, "key_headers": ["X-Tenant"]}"#,
+        )
+        .expect("snake_case key_headers must deserialize");
+        assert_eq!(
+            cfg.key_headers.as_deref(),
+            Some(&["X-Tenant".to_string()][..])
+        );
+    }
+
+    /// Omitting it is the default and must stay that way — it is what preserves today's
+    /// key-on-every-header behaviour for every existing config.
+    #[test]
+    fn key_headers_defaults_to_none_and_is_not_serialized() {
+        let cfg: DecisionCacheConfigFile =
+            serde_json::from_str(r#"{"enabled": true, "max_size": 10, "ttl_seconds": 5}"#)
+                .expect("config without key_headers must deserialize");
+        assert!(cfg.key_headers.is_none());
+
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert!(
+            !json.contains("key_headers"),
+            "an unset allowlist must not appear on the wire: {json}"
+        );
     }
 }

--- a/crates/rift-mock-core/src/proxy/handler.rs
+++ b/crates/rift-mock-core/src/proxy/handler.rs
@@ -190,24 +190,28 @@ async fn handle_script_rules(
     // Parse query parameters from URI
     let query_params = crate::predicate::parse_query_string(request_info.uri.query());
 
+    // Key first: `key_headers` only borrows, so the map can then move into the script request
+    // rather than being cloned (it was cloned only because the old key build consumed it).
+    //
+    // Only the KEY is filtered — the script still receives every header, which is what makes the
+    // allowlist a user assertion rather than something rift could infer (issue #630).
+    let cache_key = CacheKey::new(
+        request_info.method.to_string(),
+        request_info.uri.path().to_string(),
+        scripting.decision_cache.key_headers(&headers_map),
+        &body_json,
+        compiled_rule.id.clone(),
+    );
+
     let script_request = ScriptRequest {
         raw_body: Some(String::from_utf8_lossy(&body_bytes).into_owned()),
         method: request_info.method.to_string(),
         path: request_info.uri.path().to_string(),
-        headers: headers_map.clone(),
+        headers: headers_map,
         body: body_json.clone(),
         query: query_params,
         path_params: HashMap::new(),
     };
-
-    // Create cache key
-    let cache_key = CacheKey::new(
-        request_info.method.to_string(),
-        request_info.uri.path().to_string(),
-        headers_map.into_iter().collect(),
-        &body_json,
-        compiled_rule.id.clone(),
-    );
 
     // Determine if caching should be used
     // If flow_state is configured (not NoOpFlowStore), disable caching

--- a/crates/rift-mock-core/src/proxy/server.rs
+++ b/crates/rift-mock-core/src/proxy/server.rs
@@ -201,6 +201,7 @@ impl ProxyServer {
                     enabled: cache_cfg.enabled,
                     max_size: cache_cfg.max_size,
                     ttl_seconds: cache_cfg.ttl_seconds,
+                    key_headers: cache_cfg.key_headers.clone(),
                 }
             } else {
                 DecisionCacheConfig::default()

--- a/crates/rift-mock-core/src/scripting/decision_cache.rs
+++ b/crates/rift-mock-core/src/scripting/decision_cache.rs
@@ -1,11 +1,12 @@
 use crate::scripting::FaultDecision;
 use lru::LruCache;
 use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// Configuration for the decision cache
 #[derive(Clone, Debug)]
@@ -17,6 +18,8 @@ pub struct DecisionCacheConfig {
     pub max_size: usize,
     /// TTL for cache entries in seconds (0 = no expiration)
     pub ttl_seconds: u64,
+    /// Headers that participate in the cache key. `None` keys on every header (issue #630).
+    pub key_headers: Option<Vec<String>>,
 }
 
 impl Default for DecisionCacheConfig {
@@ -25,6 +28,7 @@ impl Default for DecisionCacheConfig {
             enabled: true,
             max_size: 10000,
             ttl_seconds: 300, // 5 minutes
+            key_headers: None,
         }
     }
 }
@@ -124,6 +128,19 @@ impl CacheMetrics {
     }
 }
 
+/// A cache doing no useful work is worse than no cache — it pays hashing, allocation and lock
+/// traffic per request and returns nothing — but nothing consumes `metrics()`, so the state is
+/// otherwise invisible (issue #630). These bound a once-per-process warning.
+const DEGENERATE_MIN_LOOKUPS: u64 = 4096;
+const DEGENERATE_HIT_RATE: f64 = 0.01;
+
+/// True when enough lookups have happened to judge, and effectively none of them hit. Pure so the
+/// threshold logic is testable without a log-capture subscriber.
+fn is_degenerate(hits: u64, misses: u64) -> bool {
+    let total = hits + misses;
+    total >= DEGENERATE_MIN_LOOKUPS && (hits as f64 / total as f64) < DEGENERATE_HIT_RATE
+}
+
 /// Counters kept outside the cache lock. Each is updated independently, so a `metrics()` snapshot
 /// is not a consistent point-in-time view across counters — nothing consumes them that way today.
 #[derive(Debug, Default)]
@@ -147,6 +164,9 @@ pub struct DecisionCache {
     /// under the exclusive lock on every steady-state insert.
     cache: Option<Mutex<LruCache<CacheKey, CacheEntry>>>,
     metrics: AtomicMetrics,
+    /// Latches the degenerate-cache warning so a pathological key shape is reported once, not
+    /// once per request.
+    degenerate_warned: AtomicBool,
 }
 
 impl DecisionCache {
@@ -166,6 +186,7 @@ impl DecisionCache {
             config,
             cache,
             metrics: AtomicMetrics::default(),
+            degenerate_warned: AtomicBool::new(false),
         }
     }
 
@@ -199,9 +220,58 @@ impl DecisionCache {
             }
             None => {
                 trace!("Cache miss for key: {:?}", key);
-                self.metrics.misses.fetch_add(1, Ordering::Relaxed);
+                let misses = self.metrics.misses.fetch_add(1, Ordering::Relaxed) + 1;
+                // Sampled: the check reads a second atomic and does a float divide, so it must not
+                // ride every miss. Only the true-miss arm samples — an expiring entry means the key
+                // IS being reused, which is the opposite of the shape being detected.
+                if misses.is_multiple_of(DEGENERATE_MIN_LOOKUPS) {
+                    self.warn_if_degenerate(misses);
+                }
                 None
             }
+        }
+    }
+
+    /// Report a cache that is doing no useful work — once per process (issue #630).
+    ///
+    /// The usual cause is a per-request-unique header (`x-request-id`, `traceparent`, `date`) in
+    /// the key, which makes every key unique: 0% hits, and the cache is pure overhead on the hot
+    /// path. Without this the state is silent, because nothing reads `metrics()`.
+    fn warn_if_degenerate(&self, misses: u64) {
+        let hits = self.metrics.hits.load(Ordering::Relaxed);
+        if !is_degenerate(hits, misses) {
+            return;
+        }
+        if self.degenerate_warned.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        warn!(
+            hits,
+            misses,
+            "decision cache hit rate is ~0%: it is costing more than it saves. A per-request-unique \
+             header (x-request-id, traceparent, date) in the cache key makes every key unique — set \
+             `scripting.decision_cache.key_headers` to the headers your scripts actually read."
+        );
+    }
+
+    /// The header subset that participates in the cache key (issue #630).
+    ///
+    /// `None` keys on every header — correct but degenerate whenever any header is per-request
+    /// unique. `Some(allow)` is the user asserting their scripts' decisions depend on at most
+    /// those headers; the key cannot be narrowed automatically, because the cached value is a
+    /// user script's decision and the script is handed every header. Matching is
+    /// case-insensitive: config is human-written (`X-Tenant`), the wire name arrives lowercased.
+    pub fn key_headers(&self, headers: &HashMap<String, String>) -> Vec<(String, String)> {
+        match &self.config.key_headers {
+            None => headers
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+            Some(allow) => headers
+                .iter()
+                .filter(|(k, _)| allow.iter().any(|a| a.eq_ignore_ascii_case(k)))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }
     }
 
@@ -351,6 +421,7 @@ mod tests {
             enabled: true,
             max_size: 100,
             ttl_seconds: 0, // No expiration for this test
+            key_headers: None,
         };
 
         let cache = DecisionCache::new(config);
@@ -396,6 +467,7 @@ mod tests {
             enabled: true,
             max_size: 100,
             ttl_seconds: 1, // 1 second TTL
+            key_headers: None,
         };
 
         let cache = DecisionCache::new(config);
@@ -431,6 +503,7 @@ mod tests {
             enabled: true,
             max_size: 3,
             ttl_seconds: 0,
+            key_headers: None,
         };
 
         let cache = DecisionCache::new(config);
@@ -504,6 +577,7 @@ mod tests {
             enabled: false,
             max_size: 100,
             ttl_seconds: 0,
+            key_headers: None,
         };
 
         let cache = DecisionCache::new(config);
@@ -582,6 +656,7 @@ mod tests {
             enabled: true,
             max_size: 100,
             ttl_seconds: 1,
+            key_headers: None,
         };
 
         let cache = DecisionCache::new(config);
@@ -631,6 +706,7 @@ mod tests {
             enabled: true,
             max_size: 0,
             ttl_seconds: 0,
+            key_headers: None,
         });
 
         cache.insert(key_n(0), FaultDecision::None);
@@ -648,6 +724,7 @@ mod tests {
             enabled: true,
             max_size: 1,
             ttl_seconds: 0,
+            key_headers: None,
         });
 
         cache.insert(key_n(0), FaultDecision::None);
@@ -668,6 +745,7 @@ mod tests {
             enabled: true,
             max_size: MAX,
             ttl_seconds: 0,
+            key_headers: None,
         });
 
         for i in 0..(MAX + OVERFLOW) {
@@ -692,6 +770,7 @@ mod tests {
             enabled: true,
             max_size: MAX,
             ttl_seconds: 0,
+            key_headers: None,
         });
 
         for i in 0..MAX {
@@ -732,6 +811,7 @@ mod tests {
             enabled: true,
             max_size: 16,
             ttl_seconds: 0,
+            key_headers: None,
         }));
 
         let threads: Vec<_> = (0..8)
@@ -752,5 +832,118 @@ mod tests {
         }
 
         assert!(cache.size() <= 16, "cache must stay bounded under races");
+    }
+
+    fn cfg_with_key_headers(key_headers: Option<Vec<String>>) -> DecisionCache {
+        DecisionCache::new(DecisionCacheConfig {
+            enabled: true,
+            max_size: 16,
+            ttl_seconds: 0,
+            key_headers,
+        })
+    }
+
+    fn headers_of(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    fn key_from(cache: &DecisionCache, headers: &HashMap<String, String>) -> CacheKey {
+        CacheKey::new(
+            "GET".to_string(),
+            "/api".to_string(),
+            cache.key_headers(headers),
+            &json!({}),
+            "rule1".to_string(),
+        )
+    }
+
+    /// Default (`None`) must key on every header — byte-identical to pre-#630 behaviour.
+    #[test]
+    fn key_headers_none_keys_on_every_header() {
+        let cache = cfg_with_key_headers(None);
+        let a = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t1"), ("x-request-id", "r1")]),
+        );
+        let b = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t1"), ("x-request-id", "r2")]),
+        );
+        assert_ne!(
+            a, b,
+            "with no allowlist every header participates, so a differing x-request-id must split the key"
+        );
+    }
+
+    /// The whole point of #630: a per-request-unique header must not split the key once the user
+    /// has declared what their scripts actually read.
+    #[test]
+    fn key_headers_allowlist_ignores_unlisted_headers() {
+        let cache = cfg_with_key_headers(Some(vec!["x-tenant".to_string()]));
+        let a = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t1"), ("x-request-id", "r1")]),
+        );
+        let b = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t1"), ("x-request-id", "r2")]),
+        );
+        assert_eq!(a, b, "an unlisted header must not participate in the key");
+    }
+
+    #[test]
+    fn key_headers_allowlist_still_splits_on_listed_headers() {
+        let cache = cfg_with_key_headers(Some(vec!["x-tenant".to_string()]));
+        let a = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t1"), ("x-request-id", "r1")]),
+        );
+        let b = key_from(
+            &cache,
+            &headers_of(&[("x-tenant", "t2"), ("x-request-id", "r1")]),
+        );
+        assert_ne!(a, b, "a listed header must still split the key");
+    }
+
+    /// Config is written by humans (`X-Tenant`); hyper lowercases the wire name (`x-tenant`).
+    #[test]
+    fn key_headers_allowlist_is_case_insensitive() {
+        let cache = cfg_with_key_headers(Some(vec!["X-Tenant".to_string()]));
+        let kept = cache.key_headers(&headers_of(&[("x-tenant", "t1"), ("x-request-id", "r1")]));
+        assert_eq!(
+            kept,
+            vec![("x-tenant".to_string(), "t1".to_string())],
+            "a config-cased allowlist entry must match the lowercased wire header"
+        );
+    }
+
+    /// An empty allowlist is a legitimate declaration: "no header affects my decisions".
+    #[test]
+    fn key_headers_empty_allowlist_drops_all_headers() {
+        let cache = cfg_with_key_headers(Some(vec![]));
+        assert!(
+            cache
+                .key_headers(&headers_of(&[("x-tenant", "t1")]))
+                .is_empty(),
+            "an empty allowlist keys on no headers at all"
+        );
+    }
+
+    #[test]
+    fn degenerate_cache_is_detected_only_after_enough_lookups_and_below_the_floor() {
+        // Too few lookups to judge, even at 0%.
+        assert!(!is_degenerate(0, DEGENERATE_MIN_LOOKUPS - 1));
+        // ~0% hit rate over a meaningful sample: the #630 condition.
+        assert!(is_degenerate(0, DEGENERATE_MIN_LOOKUPS));
+        assert!(is_degenerate(1, DEGENERATE_MIN_LOOKUPS * 100));
+        // A healthy cache must never trip it.
+        assert!(!is_degenerate(
+            DEGENERATE_MIN_LOOKUPS,
+            DEGENERATE_MIN_LOOKUPS
+        ));
+        assert!(!is_degenerate(50, 50));
     }
 }

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -157,6 +157,42 @@ cat results/ADMIN_BENCHMARK_REPORT.md
 3. **Avoid unnecessary behaviors** - Each behavior adds overhead
 4. **Use native formats** - JSON body predicates are faster than string matching
 
+### For Script Fault Injection
+
+Script fault decisions are memoized in a decision cache, keyed on the request. By default the key
+includes **every** request header. That is always correct, but if your traffic carries a
+per-request-unique header — `x-request-id`, `traceparent`, `x-amzn-trace-id`, `date` — then every
+key is unique, nothing ever hits, and the cache becomes pure overhead: it pays hashing, allocation
+and lock traffic on the hot path and returns nothing.
+
+Rift cannot narrow the key for you: the cached value is *your* script's decision, and your script is
+handed every header, so it may branch on any of them. Dropping a header from the key that your
+script actually reads would serve one request's decision to a different request. So the allowlist is
+opt-in — it is your assertion about what your scripts read:
+
+```yaml
+# Proxy config (the same file that carries `script_rules`) — NOT the imposter `_rift` block.
+listen:
+  port: 8080
+script_rules:
+  - # ...
+decision_cache:
+  enabled: true
+  max_size: 10000
+  ttl_seconds: 300
+  key_headers: ["X-Tenant", "X-Feature-Flag"]
+```
+
+Only the listed headers enter the cache key; names are matched case-insensitively, and an empty
+list (`[]`) declares that no header affects your decisions. Your scripts still receive **all**
+headers either way — this only changes what makes two requests "the same" for caching.
+
+If the cache degenerates to a ~0% hit rate, Rift logs a warning once per process telling you so,
+rather than silently burning CPU.
+
+> The cache is only consulted on the fault-injection proxy path with `script_rules` configured and
+> flow state **not** configured — stateful scripts are never cached.
+
 ### For Lowest Latency
 
 1. **Minimize stub count** - Fewer stubs = faster matching


### PR DESCRIPTION
The decision cache keys on **every** request header. Any per-request-unique header — `x-request-id`, `traceparent`, `x-amzn-trace-id`, `date` — therefore makes every key unique: 0% hits, the cache pinned at `max_size`, and every request paying hashing, allocation and an exclusive lock acquisition for nothing. #631 bounded the *cost* (O(1) eviction, no poison cliff) but not the uselessness. And nothing consumes `metrics()`/`hit_rate()`, so the state is silent.

### Why this is opt-in rather than automatic
The cached value is a **user script's** `FaultDecision`, and the script is handed the full header map. It may branch on any header. So narrowing the key without knowing what the script reads means two requests differing only in an un-keyed header collide, and the second is served the first's decision — wrong output, no error. That rules out the tempting fixes:

- **A default volatile-header denylist** (`x-request-id`, `traceparent`…): `traceparent`'s sampling flag is exactly the sort of thing a fault script might key on. Trading a perf bug for a correctness bug.
- **Deriving the key from rule predicates**: predicates gate *matching*; the script body reads more than the predicates test.

The fully-automatic design — record the script's actual header read-set on a miss and key on that — needs header-access instrumentation inside the Rhai/Boa APIs. That's the ceiling, not the plan, for a cache hot on one optional path.

So `key_headers` is the user asserting what their scripts read:

\`\`\`yaml
decision_cache:
  key_headers: ["X-Tenant", "X-Feature-Flag"]
\`\`\`

Only those headers enter the **key**; scripts still receive **all** headers. Matching is case-insensitive (config is human-written `X-Tenant`; hyper lowercases the wire name). `[]` declares that no header affects decisions. Omitted — the default — keys on every header exactly as today.

### Making the degenerate state loud
A cache at ~0% hit rate now logs once per process (latched) naming the likely cause and the knob, sampled every 4096 misses on the true-miss arm. This finally gives the never-consumed metrics a consumer. The expiry arm deliberately doesn't sample: an entry expiring means the key *is* being reused — the opposite of the shape being detected.

### Tests
Six gate tests, verified RED before the change (`key_headers`/`is_degenerate` didn't exist): allowlist ignores unlisted headers / still splits on listed ones, case-insensitivity, empty allowlist, `None` parity, and the degenerate-detection thresholds. `is_degenerate` is a pure fn so the threshold logic is testable without a log-capture subscriber — the remaining warn path is a load, a latch and a format string.

Two serde tests pin the wire spelling. `key_headers` is snake_case deliberately: `DecisionCacheConfigFile` has no `rename_all`, and its siblings (`max_size`, `ttl_seconds`) and parent (`decision_cache`, `script_pool`) are all snake_case — camelCase would force mixed conventions inside one object.

One more test earns its place: `documented_decision_cache_block_parses_on_the_proxy_config`. Review caught that my first draft of the docs nested `decision_cache` under the imposter `_rift` block, where it does not exist. Nothing denies unknown fields, so a user copying that would have had the whole block **silently dropped** — the knob doing nothing while the new warning told them to set the key they'd just set. The docs-examples CI gate only boots the enumerated `docs/demo/*.json` files and never parses inline doc snippets, so that mistake was ungated; this test is what now holds the doc honest. (I confirmed the silent drop with a throwaway probe before fixing it.)

### Docs
\`docs/performance/index.md\` gains a "For Script Fault Injection" section explaining the *contract* — why rift can't infer the allowlist, and that scripts still see every header — not just the knob.

### Verification
\`cargo fmt --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, \`cargo test --workspace\` (54 suites), and the docs-examples gate all pass.

Closes #630