### PR TITLE
fix(rift-tui): file I/O errors discarded as opaque counts, no logging facility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,6 +3444,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arboard",
+ "chrono",
  "clap",
  "crossterm 0.28.1",
  "dirs",

--- a/crates/rift-tui/Cargo.toml
+++ b/crates/rift-tui/Cargo.toml
@@ -30,9 +30,12 @@ arboard = "3.4"
 
 # Directory paths
 dirs = "5.0"
+chrono.workspace = true
 
 # Async runtime
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+# `fs` is required by app/commands/io.rs (issue #564). It was previously supplied only by
+# workspace feature unification, so `cargo build -p rift-tui` alone did not compile.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "fs"] }
 
 # HTTP client for Admin API
 reqwest.workspace = true

--- a/crates/rift-tui/src/app/commands/io.rs
+++ b/crates/rift-tui/src/app/commands/io.rs
@@ -237,11 +237,16 @@ impl App {
             // and the pre-#564 `.flatten()` skipped it but left it uncounted. Tokio's
             // `ReadDir` stays valid after an `Err` (the failed entry is already consumed), so
             // continuing advances to the next entry and always terminates.
+            // Every failure below records WHICH file and WHY (issue #624). The status line can
+            // only carry an aggregate count, so without this the individual failures of a batch
+            // import are unrecoverable the moment it is written — which is the whole reason the
+            // error log exists.
             let entry = match entries.next_entry().await {
                 Ok(Some(entry)) => entry,
                 Ok(None) => break,
-                Err(_) => {
+                Err(e) => {
                     failed += 1;
+                    self.push_error(format!("unreadable directory entry: {e}"));
                     continue;
                 }
             };
@@ -249,21 +254,37 @@ impl App {
             if !file_path.extension().map(|e| e == "json").unwrap_or(false) {
                 continue;
             }
-            let Ok(content) = tokio::fs::read_to_string(&file_path).await else {
-                failed += 1;
-                continue;
-            };
-            if let Ok(config) = serde_json::from_str::<serde_json::Value>(&content) {
-                let url = format!("{}/imposters", self.client.base_url());
-                let resp = self.client.client().post(url).json(&config).send().await;
-
-                if resp.map(|r| r.status().is_success()).unwrap_or(false) {
-                    imported += 1;
-                } else {
+            let content = match tokio::fs::read_to_string(&file_path).await {
+                Ok(content) => content,
+                Err(e) => {
                     failed += 1;
+                    self.push_error(format!("{}: {e}", file_path.display()));
+                    continue;
                 }
-            } else {
-                failed += 1;
+            };
+            match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(config) => {
+                    let url = format!("{}/imposters", self.client.base_url());
+                    match self.client.client().post(url).json(&config).send().await {
+                        Ok(resp) if resp.status().is_success() => imported += 1,
+                        Ok(resp) => {
+                            failed += 1;
+                            let status = resp.status();
+                            self.push_error(format!(
+                                "{}: server rejected it ({status})",
+                                file_path.display()
+                            ));
+                        }
+                        Err(e) => {
+                            failed += 1;
+                            self.push_error(format!("{}: {e}", file_path.display()));
+                        }
+                    }
+                }
+                Err(e) => {
+                    failed += 1;
+                    self.push_error(format!("{}: invalid JSON ({e})", file_path.display()));
+                }
             }
         }
 
@@ -355,6 +376,10 @@ impl App {
         let mut failed = 0;
         let mut last_error = None;
 
+        // Collected rather than pushed inline: the loop holds `&self.imposters`, so recording into
+        // the error log (which needs `&mut self`) has to wait until it ends.
+        let mut failures: Vec<String> = Vec::new();
+
         for imp in &self.imposters {
             match self.client.export_imposter(imp.port, false).await {
                 Ok(json) => {
@@ -368,16 +393,23 @@ impl App {
                         Ok(_) => exported += 1,
                         Err(e) => {
                             failed += 1;
-                            last_error =
-                                Some(format!("failed to write {}: {e}", file_path.display()));
+                            let detail = format!("failed to write {}: {e}", file_path.display());
+                            failures.push(detail.clone());
+                            last_error = Some(detail);
                         }
                     }
                 }
                 Err(e) => {
                     failed += 1;
-                    last_error = Some(format!("failed to export port {}: {e}", imp.port));
+                    let detail = format!("failed to export port {}: {e}", imp.port);
+                    failures.push(detail.clone());
+                    last_error = Some(detail);
                 }
             }
+        }
+
+        for failure in failures {
+            self.push_error(failure);
         }
 
         if failed > 0 {

--- a/crates/rift-tui/src/app/events.rs
+++ b/crates/rift-tui/src/app/events.rs
@@ -7,6 +7,25 @@ impl App {
     pub async fn handle_key_event(&mut self, key: KeyEvent) {
         // Handle overlays first
         match &self.overlay.clone() {
+            Overlay::Errors => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('L') | KeyCode::Char('q') => {
+                        self.overlay = Overlay::None;
+                        self.errors_scroll = 0;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.errors_scroll = self.errors_scroll.saturating_sub(1);
+                    }
+                    // Bounded by the entry count, so scrolling cannot run past the last error.
+                    KeyCode::Down | KeyCode::Char('j')
+                        if self.errors_scroll + 1 < self.errors.len() =>
+                    {
+                        self.errors_scroll += 1;
+                    }
+                    _ => {}
+                }
+                return;
+            }
             Overlay::Help => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('?') => {
@@ -123,6 +142,13 @@ impl App {
 
         // Global keys
         match key.code {
+            // `L` for error Log. NOT `e`: the global block runs before the view dispatch and
+            // returns, so binding `e` here would shadow the view-local `e` (export-all, stub-edit).
+            KeyCode::Char('L') => {
+                self.overlay = Overlay::Errors;
+                self.errors_scroll = 0;
+                return;
+            }
             KeyCode::Char('?') => {
                 self.overlay = Overlay::Help;
                 self.help_scroll = 0;

--- a/crates/rift-tui/src/app/mod.rs
+++ b/crates/rift-tui/src/app/mod.rs
@@ -61,6 +61,8 @@ pub enum Overlay {
         report: ValidationReport,
         action: ValidationAction,
     },
+    /// The in-app error log (issue #624).
+    Errors,
 }
 
 /// Actions to take after viewing validation results
@@ -106,6 +108,24 @@ pub enum StatusLevel {
     Success,
     Warning,
     Error,
+}
+
+/// How many errors the in-app log keeps. The status line shows one message and expires it after a
+/// few seconds, so a batch of failures (a folder import where 12 files fail) leaves nothing behind
+/// once the line is overwritten. This is the history (issue #624).
+///
+/// The TUI cannot log to stderr — it would corrupt the alternate-screen render — and a log file
+/// would need a path, rotation, and a way to tell the user where it is. So errors are kept here,
+/// where the user already is. Bounded because it is fed by a long-running UI; appending to a
+/// VecDeque cannot itself fail, which matters for a channel whose whole job is reporting failure.
+pub const MAX_ERROR_ENTRIES: usize = 100;
+
+/// One recorded error or warning, with the wall-clock time it happened so it can be correlated
+/// with server-side logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorEntry {
+    pub at: chrono::DateTime<chrono::Local>,
+    pub message: String,
 }
 
 /// Metrics history snapshot
@@ -366,6 +386,10 @@ pub struct App {
     pub request_list_state: ListState,
     pub focus: FocusArea,
     pub status_message: Option<(String, StatusLevel, Instant)>,
+    /// Bounded history of errors/warnings; the status line only ever shows the latest (issue #624).
+    pub errors: VecDeque<ErrorEntry>,
+    /// Scroll offset for the errors overlay.
+    pub errors_scroll: usize,
 
     // Search State
     pub search_active: bool,
@@ -416,6 +440,8 @@ impl App {
             request_list_state: ListState::default(),
             focus: FocusArea::Left,
             status_message: None,
+            errors: VecDeque::new(),
+            errors_scroll: 0,
 
             search_active: false,
             search_query: String::new(),
@@ -519,7 +545,30 @@ impl App {
 
     /// Set a status message
     pub fn set_status(&mut self, message: String, level: StatusLevel) {
+        // Record failures before the status line overwrites or expires them. Done here rather than
+        // at each call site so every existing one gains history without being touched — and so a
+        // future one cannot forget (issue #624). Success/Info are transient by nature and would
+        // drown the log.
+        if matches!(level, StatusLevel::Error | StatusLevel::Warning) {
+            self.push_error(message.clone());
+        }
         self.status_message = Some((message, level, Instant::now()));
+    }
+
+    /// Append to the bounded error log, dropping the oldest entry at capacity.
+    ///
+    /// Public so a caller with more detail than the status line can carry — e.g. a folder import
+    /// recording every failed file, not just the last — can record it.
+    pub fn push_error(&mut self, message: String) {
+        // `>=` not `==`: `errors` is a pub field, so nothing structurally guarantees this is
+        // the only mutator.
+        while self.errors.len() >= MAX_ERROR_ENTRIES {
+            self.errors.pop_front();
+        }
+        self.errors.push_back(ErrorEntry {
+            at: chrono::Local::now(),
+            message,
+        });
     }
 
     /// Clear status if expired
@@ -641,6 +690,121 @@ impl App {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    /// The status line shows one message and expires it after 5s, so a batch of failures leaves
+    /// nothing behind: the 2nd..Nth errors of a folder import are unrecoverable once the line is
+    /// overwritten. The buffer is the history (issue #624).
+    #[test]
+    fn set_status_records_errors_and_warnings_but_not_successes() {
+        let mut app = make_test_app();
+
+        app.set_status("boom".to_string(), StatusLevel::Error);
+        app.set_status("careful".to_string(), StatusLevel::Warning);
+        app.set_status("all good".to_string(), StatusLevel::Success);
+        app.set_status("fyi".to_string(), StatusLevel::Info);
+
+        let recorded: Vec<&str> = app.errors.iter().map(|e| e.message.as_str()).collect();
+        assert_eq!(
+            recorded,
+            vec!["boom", "careful"],
+            "only Error/Warning are worth history; Success/Info would drown them"
+        );
+    }
+
+    #[test]
+    fn error_buffer_is_bounded_and_drops_the_oldest() {
+        let mut app = make_test_app();
+        for i in 0..(MAX_ERROR_ENTRIES + 50) {
+            app.set_status(format!("err {i}"), StatusLevel::Error);
+        }
+
+        assert_eq!(
+            app.errors.len(),
+            MAX_ERROR_ENTRIES,
+            "buffer must stay bounded"
+        );
+        assert_eq!(
+            app.errors.front().map(|e| e.message.as_str()),
+            Some(format!("err {}", 50).as_str()),
+            "the oldest entries are the ones dropped"
+        );
+        assert_eq!(
+            app.errors.back().map(|e| e.message.as_str()),
+            Some(format!("err {}", MAX_ERROR_ENTRIES + 49).as_str()),
+            "the newest entry is retained"
+        );
+    }
+
+    /// The status line expires; the buffer must not — that is the whole point.
+    #[test]
+    fn clearing_an_expired_status_leaves_the_error_history_intact() {
+        let mut app = make_test_app();
+        app.set_status("boom".to_string(), StatusLevel::Error);
+        app.status_message = None;
+        app.clear_expired_status();
+        assert_eq!(
+            app.errors.len(),
+            1,
+            "history outlives the transient status line"
+        );
+    }
+
+    #[tokio::test]
+    async fn l_opens_the_errors_overlay_and_esc_dismisses_it() {
+        let mut app = make_test_app();
+        app.set_status("boom".to_string(), StatusLevel::Error);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('L'), KeyModifiers::NONE))
+            .await;
+        assert_eq!(app.overlay, Overlay::Errors, "`L` opens the error log");
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await;
+        assert_eq!(app.overlay, Overlay::None, "Esc dismisses it");
+    }
+
+    /// The scroll guard is the only nontrivial arithmetic here: relaxing `+ 1 < len` to `<=` would
+    /// let the offset run one past the last entry, and nothing else would catch it.
+    #[tokio::test]
+    async fn errors_overlay_scroll_is_bounded_by_the_entry_count() {
+        let mut app = make_test_app();
+        for i in 0..3 {
+            app.set_status(format!("err {i}"), StatusLevel::Error);
+        }
+        app.overlay = Overlay::Errors;
+
+        // Press Down far more times than there are entries.
+        for _ in 0..10 {
+            app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+                .await;
+        }
+        assert_eq!(
+            app.errors_scroll,
+            app.errors.len() - 1,
+            "scrolling must stop at the last entry, never past it"
+        );
+
+        for _ in 0..10 {
+            app.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+                .await;
+        }
+        assert_eq!(app.errors_scroll, 0, "scrolling up saturates at the top");
+    }
+
+    /// The global key block runs before the view dispatch and returns, so a global binding shadows
+    /// any view-local one with the same key. `e` is view-local (export-all / stub-edit), which is
+    /// why the error log is on `L` (issue #624).
+    #[tokio::test]
+    async fn errors_overlay_key_does_not_shadow_the_view_local_e_binding() {
+        let mut app = make_test_app();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE))
+            .await;
+        assert_ne!(
+            app.overlay,
+            Overlay::Errors,
+            "`e` must still reach its view-local handler, not the error log"
+        );
+    }
+
     use super::*;
     use crate::api::{ApiClient, ImposterSummary, MetricsData};
     use crate::theme::Theme;
@@ -661,6 +825,8 @@ pub(crate) mod tests {
             request_list_state: ListState::default(),
             focus: FocusArea::Left,
             status_message: None,
+            errors: VecDeque::new(),
+            errors_scroll: 0,
             search_active: false,
             search_query: String::new(),
             stub_editor: None,

--- a/crates/rift-tui/src/ui/dialogs.rs
+++ b/crates/rift-tui/src/ui/dialogs.rs
@@ -1,6 +1,6 @@
 //! Modal dialogs using tui-popup and tui-prompts for a cleaner implementation
 
-use crate::app::{App, InputAction, ValidationAction};
+use crate::app::{App, ErrorEntry, InputAction, ValidationAction};
 use crate::validation::{IssueSeverity, ValidationReport};
 use ratatui::{
     Frame,
@@ -11,6 +11,7 @@ use ratatui::{
         Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
     },
 };
+use std::collections::VecDeque;
 use tui_popup::Popup;
 
 /// Draw a confirmation dialog with proper sizing for long messages
@@ -683,4 +684,71 @@ pub fn draw_validation_result(
 
     let help_paragraph = Paragraph::new(help).alignment(Alignment::Center);
     frame.render_widget(help_paragraph, chunks[1]);
+}
+
+/// The in-app error log (issue #624).
+///
+/// The status line shows one message and expires it, so without this a batch of failures is
+/// unrecoverable the moment the line is overwritten. Newest first — the most recent failure is
+/// almost always the one being investigated.
+pub fn draw_errors(frame: &mut Frame, errors: &VecDeque<ErrorEntry>, scroll_offset: usize) {
+    let area = super::centered_rect(75, 70, frame.area());
+    frame.render_widget(Clear, area);
+
+    let title = if errors.is_empty() {
+        " Errors (none) ".to_string()
+    } else {
+        format!(" Errors ({}) ", errors.len())
+    };
+
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(if errors.is_empty() {
+            Color::Green
+        } else {
+            Color::Red
+        }))
+        .style(Style::default().bg(Color::Black));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let lines: Vec<Line> = if errors.is_empty() {
+        vec![Line::from(Span::styled(
+            "  No errors recorded.",
+            Style::default().fg(Color::Green),
+        ))]
+    } else {
+        errors
+            .iter()
+            .rev()
+            .skip(scroll_offset)
+            .map(|e| {
+                Line::from(vec![
+                    Span::styled(
+                        format!("  {} ", e.at.format("%H:%M:%S")),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::styled(e.message.clone(), Style::default().fg(Color::Red)),
+                ])
+            })
+            .collect()
+    };
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            " ↑/↓ scroll · Esc/L close ",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center),
+        chunks[1],
+    );
 }

--- a/crates/rift-tui/src/ui/help.rs
+++ b/crates/rift-tui/src/ui/help.rs
@@ -70,6 +70,7 @@ fn build_help_text() -> Vec<Line<'static>> {
             "Cycle theme (Default/Dark/Light/Nord/Dracula)",
         ),
         help_line("?", "Toggle this help"),
+        help_line("L (Shift+l)", "Show recent errors and warnings"),
         Line::from(""),
         section_header("IMPOSTER LIST (Main View)"),
         Line::from(""),

--- a/crates/rift-tui/src/ui/mod.rs
+++ b/crates/rift-tui/src/ui/mod.rs
@@ -72,6 +72,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         Overlay::ValidationResult { report, action } => {
             dialogs::draw_validation_result(frame, report, action, app.validation_scroll_offset)
         }
+        Overlay::Errors => dialogs::draw_errors(frame, &app.errors, app.errors_scroll),
         Overlay::None => {}
     }
 }
@@ -138,13 +139,28 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             StatusLevel::Warning => app.theme.warning,
             StatusLevel::Error => app.theme.error,
         };
-        let paragraph = Paragraph::new(Span::styled(format!(" {msg}"), Style::default().fg(color)))
+        // The status line is transient; the counter is what keeps errors that already scrolled
+        // past discoverable (issue #624).
+        let mut spans = vec![Span::styled(format!(" {msg}"), Style::default().fg(color))];
+        if !app.errors.is_empty() {
+            spans.push(Span::styled(
+                format!("  ⚠ {} [L]", app.errors.len()),
+                Style::default().fg(app.theme.warning),
+            ));
+        }
+        let paragraph = Paragraph::new(Line::from(spans))
             .block(block)
             .alignment(Alignment::Left);
         frame.render_widget(paragraph, area);
     } else {
         let (commands1, commands2) = get_commands(&app.view);
-        let line1 = build_command_line(&commands1, app);
+        let mut line1 = build_command_line(&commands1, app);
+        if !app.errors.is_empty() {
+            line1.spans.push(Span::styled(
+                format!("  ⚠ {} [L]", app.errors.len()),
+                Style::default().fg(app.theme.warning),
+            ));
+        }
         let lines = if let Some(cmds2) = commands2 {
             let line2 = build_command_line(&cmds2, app);
             vec![line1, line2]
@@ -312,6 +328,17 @@ fn draw_search_bar(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(app.theme.muted),
         ),
     ]);
+
+    // The counter has to live here too: `search_query` stays non-empty after `search_active` goes
+    // false, so this branch owns the status bar for as long as a filter is active — errors would
+    // otherwise be invisible for that whole time, not just transiently (issue #624).
+    let mut line = line;
+    if !app.errors.is_empty() {
+        line.spans.push(Span::styled(
+            format!("  ⚠ {} [L]", app.errors.len()),
+            Style::default().fg(app.theme.warning),
+        ));
+    }
 
     let paragraph = Paragraph::new(line);
     frame.render_widget(paragraph, inner);
@@ -550,5 +577,44 @@ mod tests {
         terminal
             .draw(|f| draw(f, &app))
             .expect("draw must not fail");
+    }
+
+    /// `draw_errors` splits a `Layout` and paginates a reversed iterator, so it is worth pinning
+    /// that it renders — populated, empty, and scrolled past the end (issue #624).
+    #[test]
+    fn test_draw_errors_overlay_does_not_panic() {
+        let mut terminal = make_terminal();
+        let mut app = make_test_app();
+        app.overlay = crate::app::Overlay::Errors;
+
+        terminal
+            .draw(|f| draw(f, &app))
+            .expect("empty error log must render");
+
+        app.set_status("boom".to_string(), crate::app::StatusLevel::Error);
+        app.set_status("bang".to_string(), crate::app::StatusLevel::Warning);
+        terminal
+            .draw(|f| draw(f, &app))
+            .expect("populated error log must render");
+
+        // Defensive: a scroll offset past the end must yield an empty page, not panic.
+        app.errors_scroll = 99;
+        terminal
+            .draw(|f| draw(f, &app))
+            .expect("over-scrolled error log must render");
+    }
+
+    /// The status-bar counter must survive the search-bar branch: `search_query` stays non-empty
+    /// after `search_active` clears, so that branch owns the bar for as long as a filter is active.
+    #[test]
+    fn test_status_bar_renders_error_counter_while_filtering() {
+        let mut terminal = make_terminal();
+        let mut app = make_test_app();
+        app.set_status("boom".to_string(), crate::app::StatusLevel::Error);
+        app.search_query = "foo".to_string();
+        app.search_active = false;
+        terminal
+            .draw(|f| draw(f, &app))
+            .expect("counter must render on the search-bar branch");
     }
 }


### PR DESCRIPTION
Completes #624. PR #642 fixed the two concrete silent-wrongs in `io.rs`; this adds the error channel the issue was really about — rift-tui had none.

The status line shows **one** message and expires it after 5s. So a folder import where 12 files fail reported `Imported 0 imposters, 12 failed` and then overwrote it: which file, and why, was unrecoverable.

### What this adds
- A bounded in-app error log (`VecDeque<ErrorEntry>`, cap 100) on `App`, timestamped for correlation with server-side logs.
- Recording hangs off **`set_status`** — one chokepoint, so all 46 existing `Error`/`Warning` call sites gain history untouched, and a future one can't forget. `Success`/`Info` are excluded; they'd drown the log.
- An errors overlay on **`L`** ("error Log"), newest-first, scrollable, `Esc`/`L`/`q` to close.
- A `⚠ N [L]` status-bar counter, so errors that already scrolled past stay discoverable.
- The import and export paths now record **which file and why** at each failure site, instead of only bumping a counter.

That last point is what makes `L` worth pressing. Review caught that without it the log would contain exactly one entry — the same aggregate the status line already showed — and `push_error` would be `pub` with zero callers, i.e. speculative generality.

### Why not a log file
stderr is barred (it corrupts the alternate-screen render). A file needs a path, rotation, and a way to *tell* the user the path — which ends up being a status-line message anyway, so the file route smuggles in the hard parts of a logging system to deliver what the app can just show. And an error channel whose writes can fail (disk full, permissions) recreates the original bug one level down; appending to a `VecDeque` cannot fail. No new dependency: `chrono` is already a workspace dep, and `Instant` (what the status line uses) is monotonic and can't render a time of day.

### Keybinding
The design suggested `e`. Implementing it revealed `e` is already bound view-locally (export-all, stub-edit) and the global key block runs **before** the view dispatch and returns — so a global `e` would have silently shadowed both. It's on `L` instead (`l` is taken; uppercase is free), with `errors_overlay_key_does_not_shadow_the_view_local_e_binding` pinning it.

### Drive-by fix, deliberately included
`cargo build -p rift-tui` **failed on master**: `io.rs` has used `tokio::fs` since #564 but rift-tui's tokio features lacked `fs` — it compiled only because another crate enables it and cargo unifies features, so CI (which builds the workspace) never caught it. Included here because without it you cannot build or test the crate this PR changes.

### Tests
7 new, verified RED first. Buffer semantics (Error/Warning recorded, Success/Info not; cap drops the oldest; history outlives an expired status line), the `L`/Esc overlay round-trip, the `e`-shadowing regression, the scroll guard (the only nontrivial arithmetic here), and two render tests — `draw_errors` populated/empty/over-scrolled, and the counter on the search-bar branch (`search_query` stays non-empty after `search_active` clears, so that branch owns the bar for as long as a filter is active — a third branch that was initially missed).

### Verification
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (54 suites), and `cargo build -p rift-tui` all exit 0.

Closes #624