### PR TITLE
fix: recorded request bodies silently corrupted for non-UTF-8 payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ record.
 
 ### Fixed
 
+- **Binary request bodies are no longer silently corrupted when recorded or handed to scripts.**
+  Request bodies went through `String::from_utf8_lossy`, which replaces every invalid byte with
+  U+FFFD — so a protobuf, gzip or image upload was recorded as something the client never sent,
+  irreversibly and with no error. Rift records and replays real traffic, so reading a recording back
+  or round-tripping it silently produced wrong bytes. A non-UTF-8 body is now base64-encoded and
+  marked `"_mode": "binary"` on the recorded request, mirroring how binary *response* bodies have
+  always been represented; scripts get the base64 body plus `isBinary` on `ctx.request`. This is
+  additive: `_mode` is absent for text bodies, so existing recordings and all-text traffic are
+  unchanged. The fault-injection proxy path had the same bug and is fixed too. Where rift genuinely
+  cannot classify the body (the `decorate` and predicate-`inject` paths), `isBinary` is absent
+  rather than `false` — a script can tell "text" from "unknown" instead of being told something
+  untrue.
+
 - **Query-parameter *names* are now percent-decoded everywhere, so `?first%20name=bob` matches a
   predicate on `first name` on every path.** Rift has four query/form parsers, and two of them
   decoded only the value, leaving the key raw — so the same request got a different answer

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1112,6 +1112,7 @@ mod redact_tests {
 #[cfg(test)]
 mod requests_filter_tests {
     use super::*;
+    use crate::imposter::ResponseMode;
     use http_body_util::BodyExt;
     use std::collections::HashMap;
 
@@ -1122,6 +1123,7 @@ mod requests_filter_tests {
             headers.insert("X-Tenant".to_string(), vec![t.to_string()]);
         }
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1".to_string(),
             method: "GET".to_string(),
             path: "/p".to_string(),
@@ -1779,11 +1781,13 @@ mod requests_filter_tests {
 #[cfg(test)]
 mod verify_tests {
     use super::*;
+    use crate::imposter::ResponseMode;
     use http_body_util::BodyExt;
     use std::collections::HashMap;
 
     fn rec(method: &str, path: &str) -> RecordedRequest {
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1:5000".to_string(),
             method: method.to_string(),
             path: path.to_string(),
@@ -1872,6 +1876,7 @@ mod verify_tests {
 #[cfg(test)]
 mod replace_all_tests {
     use super::*;
+    use crate::imposter::ResponseMode;
     use http_body_util::BodyExt;
 
     const BASE: &str = "http://localhost:2525";
@@ -1972,6 +1977,7 @@ mod replace_all_tests {
             .get_imposter(19766)
             .expect("imposter")
             .record_request(RecordedRequest {
+                mode: ResponseMode::Text,
                 request_from: "127.0.0.1:5000".to_string(),
                 method: "GET".to_string(),
                 path: "/seen".to_string(),

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -138,12 +138,14 @@ pub(crate) fn request_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
     use std::collections::HashMap;
 
     fn req_with_header(name: &str, value: &str) -> RecordedRequest {
         let mut headers = HashMap::new();
         headers.insert(name.to_string(), vec![value.to_string()]);
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1".to_string(),
             method: "GET".to_string(),
             path: "/".to_string(),

--- a/crates/rift-http-proxy/src/script_cli.rs
+++ b/crates/rift-http-proxy/src/script_cli.rs
@@ -225,6 +225,9 @@ fn fixture_to_script_request(fixture: RequestFixture) -> crate::scripting::Scrip
         path_params: fixture.path_params,
         body: fixture.body,
         raw_body,
+        // `--request` fixtures are authored as JSON, so a binary body can't be expressed here
+        // (issue #636 covers the live serve/proxy paths, not this offline debugging fixture).
+        mode: crate::imposter::ResponseMode::Text,
     }
 }
 

--- a/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
+++ b/crates/rift-http-proxy/tests/issue_356_yaml_file_scripts.rs
@@ -11,6 +11,7 @@
 
 use rift_http_proxy::backends::InMemoryFlowStore;
 use rift_http_proxy::config_loader::{ConfigSource, load_configs};
+use rift_http_proxy::imposter::ResponseMode;
 use rift_http_proxy::imposter::StubResponse;
 use rift_http_proxy::scripting::{FaultDecision, RhaiEngine, ScriptRequest};
 use std::sync::Arc;
@@ -41,6 +42,7 @@ fn req(attempt_tag: &str) -> ScriptRequest {
         query: Default::default(),
         path_params: Default::default(),
         raw_body: None,
+        mode: ResponseMode::Text,
     }
 }
 

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -1424,6 +1424,7 @@ mod tests {
         };
         let imposter = Imposter::new(config).expect("test imposter");
         let req = RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1".to_string(),
             method: "GET".to_string(),
             path: "/".to_string(),
@@ -1462,6 +1463,7 @@ mod tests {
             let mut headers = std::collections::HashMap::new();
             headers.insert("X-Mock-Space".to_string(), vec![space.to_string()]);
             RecordedRequest {
+                mode: ResponseMode::Text,
                 request_from: "127.0.0.1".to_string(),
                 method: "GET".to_string(),
                 path: "/".to_string(),

--- a/crates/rift-mock-core/src/imposter/core/proxy.rs
+++ b/crates/rift-mock-core/src/imposter/core/proxy.rs
@@ -59,7 +59,11 @@ impl Imposter {
                         path: path.to_string(),
                         query: query_map,
                         headers: headers.clone(),
+                        // `body` is already the classified string from the caller (base64 for a
+                        // binary request body, issue #636); this path doesn't thread the mode
+                        // flag through separately, so default to `Text`.
                         body: body.map(|b| b.to_string()),
+                        mode: None,
                     };
                     let inject_preds =
                         execute_predicate_generator_inject(inject_fn, &mb_request, &predicates)?;

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -271,6 +271,7 @@ fn request_field(req: &RecordedRequest, key: &str) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
     use crate::imposter::types::ImposterConfig;
     use serde_json::json;
 
@@ -296,6 +297,7 @@ mod tests {
                 .push((*v).to_string());
         }
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1:5000".to_string(),
             method: method.to_string(),
             path: path.to_string(),

--- a/crates/rift-mock-core/src/imposter/events.rs
+++ b/crates/rift-mock-core/src/imposter/events.rs
@@ -163,9 +163,11 @@ impl AdminEventBus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
 
     fn rec() -> RecordedRequest {
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1:5000".to_string(),
             method: "GET".to_string(),
             path: "/x".to_string(),

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -272,12 +272,30 @@ async fn handle_request_inner(
         }
     };
     // Borrow the body as UTF-8 without forcing an allocation for the common valid-UTF-8 case
-    // (issue #561): `from_utf8_lossy` returns `Cow::Borrowed` then, so only genuinely invalid
-    // UTF-8 pays a copy here. `body_bytes` stays alive for the rest of the function so this
-    // borrow remains valid; callers that need an owned `String` (`RecordedRequest`,
-    // `ScriptRequest`, thread-moved debug/inject requests) materialize one at that boundary.
-    let body_string: Option<std::borrow::Cow<'_, str>> =
-        body_bytes.as_deref().map(String::from_utf8_lossy);
+    // (issue #561): valid UTF-8 stays `Cow::Borrowed`, so only genuinely invalid UTF-8 pays a
+    // copy here. `body_bytes` stays alive for the rest of the function so this borrow remains
+    // valid; callers that need an owned `String` (`RecordedRequest`, `ScriptRequest`,
+    // thread-moved debug/inject requests) materialize one at that boundary.
+    //
+    // Invalid UTF-8 (a binary body: protobuf, gzip, an image upload) used to go through
+    // `from_utf8_lossy`, which silently replaces the offending bytes with U+FFFD — the recorded
+    // request, predicate matches, and script/inject bodies then no longer reflect what the
+    // client sent, irreversibly (issue #636). Base64-encode it instead, mirroring the response
+    // side's `encode_body_for_stub` (issue #117): every consumer below gets a lossless string
+    // representation, and `mode` tells them which kind they have.
+    let (body_string, body_mode): (Option<std::borrow::Cow<'_, str>>, ResponseMode) =
+        match body_bytes.as_deref() {
+            None => (None, ResponseMode::Text),
+            Some(bytes) => match std::str::from_utf8(bytes) {
+                Ok(text) => (Some(std::borrow::Cow::Borrowed(text)), ResponseMode::Text),
+                Err(_) => (
+                    Some(std::borrow::Cow::Owned(
+                        base64::engine::general_purpose::STANDARD.encode(bytes),
+                    )),
+                    ResponseMode::Binary,
+                ),
+            },
+        };
 
     // Record request if enabled
     if imposter.config.record_requests {
@@ -288,6 +306,7 @@ async fn handle_request_inner(
             query: parse_query_string(&query_str),
             headers: headers_multi,
             body: body_string.as_deref().map(str::to_string),
+            mode: body_mode.clone(),
             timestamp: chrono::Utc::now().to_rfc3339(),
         };
         imposter.record_request(recorded);
@@ -482,6 +501,7 @@ async fn handle_request_inner(
                 // Owned boundary (issue #561): the inject job is submitted to a `'static` worker
                 // closure, so `body_string`'s borrow can't cross it.
                 body: body_string.as_deref().map(str::to_string),
+                mode: Some(body_mode.clone()),
             };
 
             match execute_mountebank_inject_bounded(
@@ -567,6 +587,7 @@ async fn handle_request_inner(
                 // Owned boundary (issue #561): `ScriptRequest` is moved into the script engine's
                 // worker job, so the body must be materialized here rather than borrowed.
                 raw_body: Some(body_string.as_deref().unwrap_or_default().to_string()),
+                mode: body_mode.clone(),
                 method: method.clone(),
                 path: path.clone(),
                 headers: headers_clone

--- a/crates/rift-mock-core/src/imposter/journal.rs
+++ b/crates/rift-mock-core/src/imposter/journal.rs
@@ -276,9 +276,11 @@ impl RequestJournal for LocalJournal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
 
     fn req(path: &str) -> RecordedRequest {
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "t".into(),
             method: "GET".into(),
             path: path.into(),

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -1069,6 +1069,7 @@ fn imposter_level_differs(a: &ImposterConfig, b: &ImposterConfig) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
 
     #[tokio::test]
     async fn test_create_imposter_writes_to_datadir() {
@@ -1585,6 +1586,7 @@ mod tests {
 
     fn recorded(path: &str) -> RecordedRequest {
         RecordedRequest {
+            mode: ResponseMode::Text,
             request_from: "127.0.0.1".to_string(),
             method: "GET".to_string(),
             path: path.to_string(),

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -464,7 +464,12 @@ pub(crate) fn predicate_matches_inner(
                     // Reuse the once-per-request query map instead of re-parsing (issue #480).
                     query: query_map.clone(),
                     headers: headers.clone(),
+                    // `body` is already the classified string from the caller (base64 for a
+                    // binary request body, issue #636); this predicate-inject path doesn't thread
+                    // the mode flag through separately, so default to `Text` — the script still
+                    // sees the correct (base64) string, it just can't ask `isBinary`.
                     body: body.map(|b| b.to_string()),
+                    mode: None,
                 };
                 execute_predicate_inject(inject_fn, &mb_request, imposter_port)
             }

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -320,6 +320,10 @@ pub fn apply_js_or_rhai_decorate(
                 query: request.query.clone(),
                 headers: request.headers.clone(),
                 body: request.body.clone(),
+                // `RequestContext` doesn't track binary/text, so the classification is genuinely
+                // unknown here — say so rather than asserting `Text` over a possibly-base64 body
+                // (issue #636). `isBinary` is then absent for decorate scripts, not falsely false.
+                mode: None,
             };
             // `execute_mountebank_config_decorate` calls `decorate_fn` as a function value
             // (`{decorate_fn}(__config)`), so a bare body with no `function`/arrow wrapper (the
@@ -382,6 +386,10 @@ pub fn apply_js_or_rhai_decorate(
                 query: request.query.clone(),
                 headers: request.headers.clone(),
                 body: request.body.clone(),
+                // `RequestContext` doesn't track binary/text, so the classification is genuinely
+                // unknown here — say so rather than asserting `Text` over a possibly-base64 body
+                // (issue #636). `isBinary` is then absent for decorate scripts, not falsely false.
+                mode: None,
             };
 
             match crate::scripting::execute_mountebank_decorate(

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -65,6 +65,12 @@ pub struct RecordedRequest {
     pub headers: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
+    /// Whether `body` is UTF-8 text or a base64-encoded binary body (issue #636), mirroring
+    /// `IsResponse::mode` (issue #117). `#[serde(default)]` so recordings from before this field
+    /// existed deserialize as `Text`; omitted on serialize for a text body so recordings and
+    /// wire traffic that are all text stay byte-identical to pre-#636 output.
+    #[serde(rename = "_mode", default, skip_serializing_if = "is_text_mode")]
+    pub mode: ResponseMode,
     pub timestamp: String,
 }
 
@@ -1804,5 +1810,64 @@ mod tests {
             serde_json::from_value(json!({ "probability": 0.25, "type": "reset" })).unwrap();
         assert_eq!(object.kind(), "reset");
         assert_eq!(object.probability(), 0.25);
+    }
+
+    // Issue #636: a text-bodied `RecordedRequest` must serialize byte-identically to the
+    // pre-#636 shape — no `_mode` key at all — so existing recordings and all-text traffic are
+    // unaffected by this change.
+    #[test]
+    fn recorded_request_text_body_omits_mode_field() {
+        let req = RecordedRequest {
+            request_from: "127.0.0.1:1234".to_string(),
+            method: "POST".to_string(),
+            path: "/x".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: Some("hello".to_string()),
+            mode: ResponseMode::Text,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let value = serde_json::to_value(&req).expect("serializes");
+        assert!(
+            value.get("_mode").is_none(),
+            "a text body must not carry `_mode` on the wire: {value}"
+        );
+        assert_eq!(value["body"], "hello");
+    }
+
+    // Issue #636: a binary body serializes with `_mode: "binary"` and the base64 payload in
+    // `body`, mirroring the response side's `IsResponse::mode` (issue #117).
+    #[test]
+    fn recorded_request_binary_body_carries_mode_field() {
+        let req = RecordedRequest {
+            request_from: "127.0.0.1:1234".to_string(),
+            method: "POST".to_string(),
+            path: "/x".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: Some("//4A".to_string()), // base64 of [0xFF, 0xFE, 0x00]
+            mode: ResponseMode::Binary,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let value = serde_json::to_value(&req).expect("serializes");
+        assert_eq!(value["_mode"], "binary");
+        assert_eq!(value["body"], "//4A");
+    }
+
+    // Issue #636: a recording written before `_mode` existed has no such key at all — it must
+    // still deserialize, defaulting to `Text` (the historical, only-ever behavior).
+    #[test]
+    fn recorded_request_without_mode_field_deserializes_as_text() {
+        let value = json!({
+            "requestFrom": "127.0.0.1:1234",
+            "method": "GET",
+            "path": "/x",
+            "query": {},
+            "headers": {},
+            "body": "hello",
+            "timestamp": "2026-01-01T00:00:00Z",
+        });
+        let req: RecordedRequest = serde_json::from_value(value).expect("deserializes");
+        assert_eq!(req.mode, ResponseMode::Text);
     }
 }

--- a/crates/rift-mock-core/src/proxy/handler.rs
+++ b/crates/rift-mock-core/src/proxy/handler.rs
@@ -36,6 +36,24 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
+/// Classify a request body for `ScriptRequest::raw_body`/`mode` (issue #636). A binary body
+/// (protobuf, gzip, an image upload) is not valid UTF-8; `from_utf8_lossy` used to silently
+/// replace the offending bytes with U+FFFD, corrupting `raw_body` for every script that reads
+/// it. Base64-encode it instead, like the imposter serve path (`imposter/handler.rs`) and the
+/// response-side precedent (`util::encode_body_for_stub`, issue #117).
+fn classify_script_request_body(body_bytes: &[u8]) -> (String, crate::imposter::ResponseMode) {
+    match std::str::from_utf8(body_bytes) {
+        Ok(text) => (text.to_string(), crate::imposter::ResponseMode::Text),
+        Err(_) => {
+            use base64::Engine;
+            (
+                base64::engine::general_purpose::STANDARD.encode(body_bytes),
+                crate::imposter::ResponseMode::Binary,
+            )
+        }
+    }
+}
+
 /// Handle an incoming request with fault injection and forwarding.
 pub async fn handle_request(
     ctx: &RequestHandlerContext<'_>,
@@ -187,6 +205,8 @@ async fn handle_script_rules(
     let body_json: serde_json::Value =
         serde_json::from_slice(&body_bytes).unwrap_or(serde_json::Value::Null);
 
+    let (raw_body, body_mode) = classify_script_request_body(&body_bytes);
+
     // Parse query parameters from URI
     let query_params = crate::predicate::parse_query_string(request_info.uri.query());
 
@@ -204,7 +224,8 @@ async fn handle_script_rules(
     );
 
     let script_request = ScriptRequest {
-        raw_body: Some(String::from_utf8_lossy(&body_bytes).into_owned()),
+        raw_body: Some(raw_body),
+        mode: body_mode,
         method: request_info.method.to_string(),
         path: request_info.uri.path().to_string(),
         headers: headers_map,
@@ -757,6 +778,28 @@ pub fn rule_applies_to_upstream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Issue #636: a binary body must round-trip through base64, not get mangled by
+    // `from_utf8_lossy`'s U+FFFD replacement.
+    #[test]
+    fn classify_script_request_body_base64_round_trips_invalid_utf8() {
+        let original: &[u8] = &[0xFF, 0xFE, 0x00, 0x01, 0x02];
+        let (raw_body, mode) = classify_script_request_body(original);
+        assert_eq!(mode, crate::imposter::ResponseMode::Binary);
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&raw_body)
+            .expect("valid base64");
+        assert_eq!(decoded, original);
+    }
+
+    // A valid-UTF-8 body stays plain text with `Text` mode — the common case is unaffected.
+    #[test]
+    fn classify_script_request_body_text_stays_text() {
+        let (raw_body, mode) = classify_script_request_body(b"hello world");
+        assert_eq!(mode, crate::imposter::ResponseMode::Text);
+        assert_eq!(raw_body, "hello world");
+    }
 
     #[test]
     fn test_rule_applies_to_upstream_no_filter() {

--- a/crates/rift-mock-core/src/scripting/bounded.rs
+++ b/crates/rift-mock-core/src/scripting/bounded.rs
@@ -223,10 +223,12 @@ fn run_should_inject_with_abort(
 mod tests {
     use super::*;
     use crate::extensions::flow_state::NoOpFlowStore;
+    use crate::imposter::ResponseMode;
     use std::time::Instant;
 
     fn req() -> ScriptRequest {
         ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".into(),
             path: "/hang".into(),
@@ -510,6 +512,7 @@ mod tests {
                 query: HashMap::new(),
                 headers: HashMap::new(),
                 body: None,
+                mode: Some(ResponseMode::Text),
             }
         }
 

--- a/crates/rift-mock-core/src/scripting/js_engine.rs
+++ b/crates/rift-mock-core/src/scripting/js_engine.rs
@@ -1,4 +1,5 @@
 use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result};
+use crate::imposter::ResponseMode;
 use crate::scripting::{
     FaultDecision, PredicateGeneratorError, ScriptCtxExtras, ScriptCtxInput, ScriptRequest,
     ScriptResponseContext, ScriptResult, ScriptResultBody, ScriptStubContext, entrypoints,
@@ -495,6 +496,7 @@ pub(crate) fn declared_functions_js(script: &str) -> Result<Vec<String>> {
     SCRIPT_RESULT_REGISTRY.with(|r| r.borrow_mut().clear());
 
     let dummy_request = ScriptRequest {
+        mode: ResponseMode::Text,
         method: "GET".to_string(),
         path: "/".to_string(),
         headers: std::collections::HashMap::new(),
@@ -2154,6 +2156,14 @@ pub struct MountebankRequest {
     pub query: std::collections::HashMap<String, String>,
     pub headers: std::collections::HashMap<String, String>,
     pub body: Option<String>,
+    /// Whether `body` is UTF-8 text or a base64-encoded binary body (issue #636). Mirrors
+    /// `ResponseMode`/`_mode` on the response side so an inject function can tell which it got.
+    ///
+    /// `None` where the caller genuinely does not know — the decorate and predicate-inject paths
+    /// do not thread the classification through. Unknown is represented rather than defaulted to
+    /// `Text`, because a body that is base64 while the flag says "text" is worse than no flag: it
+    /// invites `if (isBinary) … else JSON.parse(body)` and fails it silently.
+    pub mode: Option<ResponseMode>,
 }
 
 /// Create a Mountebank-style request object
@@ -2224,6 +2234,21 @@ fn create_mountebank_request_object(
     } else {
         obj.set(js_string!("body"), JsValue::undefined(), false, context)
             .map_err(|e| anyhow!("Failed to set body: {e}"))?;
+    }
+
+    // Issue #636: `body` is base64 text for a binary request, not the raw bytes (JS strings
+    // can't hold arbitrary bytes) — `isBinary` lets an inject function tell the two apart
+    // instead of treating base64 as if it were the literal body.
+    // Absent, not `false`, when the caller could not classify the body — a script must be able to
+    // distinguish "text" from "unknown".
+    if let Some(mode) = &request.mode {
+        obj.set(
+            js_string!("isBinary"),
+            JsValue::from(*mode == ResponseMode::Binary),
+            false,
+            context,
+        )
+        .map_err(|e| anyhow!("Failed to set isBinary: {e}"))?;
     }
 
     Ok(obj.into())
@@ -2943,6 +2968,7 @@ function respond(ctx) {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -2970,6 +2996,7 @@ function respond(ctx) {
     fn js_respond_loop_limit_terminates() {
         set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
@@ -2992,6 +3019,7 @@ function respond(ctx) {
     fn js_respond_under_limit_runs() {
         set_current_flow_store(Arc::new(InMemoryFlowStore::new(300)));
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/".to_string(),
@@ -3023,6 +3051,7 @@ function respond(ctx) {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -3063,6 +3092,7 @@ function respond(ctx) {
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -3111,6 +3141,7 @@ function respond(ctx) {
         headers.insert("x-flow-id".to_string(), "flow-123".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -3170,6 +3201,7 @@ function respond(ctx) {
         headers.insert("content-type".to_string(), "application/json".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/bytecode".to_string(),
@@ -3214,6 +3246,7 @@ function respond(ctx) {
 
         // Test with high value
         let request1 = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
@@ -3241,6 +3274,7 @@ function respond(ctx) {
 
         // Test with low value
         let request2 = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "POST".to_string(),
             path: "/api/test".to_string(),
@@ -3274,6 +3308,7 @@ function respond(ctx) {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -3322,6 +3357,7 @@ function respond(ctx) {
         query.insert("page".to_string(), "42".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -3364,6 +3400,7 @@ function respond(ctx) {
         path_params.insert("action".to_string(), "update".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "POST".to_string(),
             path: "/users/123/update".to_string(),
@@ -3395,6 +3432,7 @@ function respond(ctx) {
     #[test]
     fn test_decorate_with_logger_arg() {
         let request = MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: "GET".to_string(),
             path: "/test".to_string(),
             query: HashMap::new(),
@@ -3427,6 +3465,7 @@ function respond(ctx) {
     #[test]
     fn predicate_generator_inject_script_error_returns_err() {
         let request = MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: "GET".to_string(),
             path: "/api/users".to_string(),
             query: HashMap::new(),
@@ -3456,6 +3495,7 @@ function respond(ctx) {
     #[test]
     fn predicate_generator_inject_invalid_output_returns_err() {
         let request = MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: "GET".to_string(),
             path: "/api/users".to_string(),
             query: HashMap::new(),
@@ -3486,6 +3526,7 @@ function respond(ctx) {
     #[test]
     fn test_decorate_with_state_arg() {
         let request = MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: "GET".to_string(),
             path: "/test".to_string(),
             query: HashMap::new(),
@@ -3516,6 +3557,7 @@ function respond(ctx) {
     // Issue #305 gate: `config =>` decorate convention in Boa + CommonJS require().
     fn config_req() -> MountebankRequest {
         MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: "POST".to_string(),
             path: "/req".to_string(),
             query: HashMap::new(),
@@ -3679,6 +3721,7 @@ function respond(ctx) {
 
     fn mb_req(method: &str, path: &str) -> MountebankRequest {
         MountebankRequest {
+            mode: Some(ResponseMode::Text),
             method: method.to_string(),
             path: path.to_string(),
             query: HashMap::new(),
@@ -4133,6 +4176,7 @@ function respond(ctx) {
 
         fn req(headers: HashMap<String, String>, raw_body: Option<&str>) -> ScriptRequest {
             ScriptRequest {
+                mode: ResponseMode::Text,
                 method: "POST".to_string(),
                 path: "/api/orders".to_string(),
                 headers,

--- a/crates/rift-mock-core/src/scripting/mod.rs
+++ b/crates/rift-mock-core/src/scripting/mod.rs
@@ -1,4 +1,5 @@
 use crate::extensions::flow_state::{CasOutcome, FlowStore, flow_result};
+use crate::imposter::ResponseMode;
 use anyhow::{Result, anyhow};
 use rhai::Dynamic;
 use serde_json::Value;
@@ -404,6 +405,10 @@ pub struct ScriptRequest {
     /// parsed `body`; ctx-building then falls back to re-serializing `body` (loses exact
     /// whitespace but not shape) so callers migrated ad hoc from `body` alone still work.
     pub raw_body: Option<String>,
+    /// Whether `raw_body` is UTF-8 text or a base64-encoded binary body (issue #636). Mirrors
+    /// `ResponseMode`/`_mode` on the response side so scripts can tell which they got instead of
+    /// silently treating base64 as text.
+    pub mode: ResponseMode,
 }
 
 /// Wrapper for FlowStore that can be used in scripts (Rhai and JavaScript)
@@ -894,6 +899,7 @@ mod tests {
     #[test]
     fn test_script_request_creation() {
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "POST".to_string(),
             path: "/api/users".to_string(),
@@ -913,6 +919,7 @@ mod tests {
         headers.insert("Authorization".to_string(), "Bearer token".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/data".to_string(),
@@ -935,6 +942,7 @@ mod tests {
         query.insert("limit".to_string(), "10".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/items".to_string(),
@@ -954,6 +962,7 @@ mod tests {
         path_params.insert("action".to_string(), "edit".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "PUT".to_string(),
             path: "/api/users/123/edit".to_string(),
@@ -968,6 +977,7 @@ mod tests {
     #[test]
     fn test_script_request_clone() {
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "DELETE".to_string(),
             path: "/api/items/456".to_string(),
@@ -984,6 +994,7 @@ mod tests {
     #[test]
     fn test_script_request_debug() {
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -1117,6 +1128,7 @@ mod tests {
         let engine = ScriptEngine::new("rhai", script, "test-rule").unwrap();
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),

--- a/crates/rift-mock-core/src/scripting/rhai_engine.rs
+++ b/crates/rift-mock-core/src/scripting/rhai_engine.rs
@@ -1,4 +1,5 @@
 use crate::extensions::flow_state::{CasOutcome, FlowStore};
+use crate::imposter::ResponseMode;
 use anyhow::{Result, anyhow};
 use rhai::{AST, Dynamic, Engine, Map, Scope};
 use serde_json::Value;
@@ -689,6 +690,13 @@ fn build_request_ctx_map(request: &ScriptRequest) -> Map {
     });
     m.insert("json".into(), parse_json_or_unit(&raw));
     m.insert("body".into(), Dynamic::from(raw));
+    // Issue #636: `body` is base64 text for a binary request, not the raw bytes (a Rhai string
+    // can't hold arbitrary bytes) — `isBinary` lets a script tell the two apart instead of
+    // treating base64 as if it were the literal body.
+    m.insert(
+        "isBinary".into(),
+        Dynamic::from(request.mode == ResponseMode::Binary),
+    );
 
     m
 }
@@ -889,6 +897,7 @@ mod tests {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "POST".to_string(),
             path: "/test".to_string(),
@@ -928,6 +937,7 @@ mod tests {
         let store: Arc<dyn FlowStore> = Arc::new(InMemoryFlowStore::new(300));
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/api/test".to_string(),
@@ -972,6 +982,7 @@ mod tests {
         headers.insert("x-flow-id".to_string(), "flow123".to_string());
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -1020,6 +1031,7 @@ mod tests {
         headers1.insert("x-user-id".to_string(), "beta-user-123".to_string());
 
         let request1 = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -1039,6 +1051,7 @@ mod tests {
         headers2.insert("x-user-id".to_string(), "regular-user-456".to_string());
 
         let request2 = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -1077,6 +1090,7 @@ mod tests {
         // Execute same AST multiple times with reusable engine
         for i in 0..10 {
             let request = ScriptRequest {
+                mode: ResponseMode::Text,
                 raw_body: None,
                 method: "GET".to_string(),
                 path: "/cache-test".to_string(),
@@ -1120,6 +1134,7 @@ mod tests {
 
         fn req(headers: HashMap<String, String>, raw_body: Option<&str>) -> ScriptRequest {
             ScriptRequest {
+                mode: ResponseMode::Text,
                 method: "POST".to_string(),
                 path: "/api/orders".to_string(),
                 headers,

--- a/crates/rift-mock-core/src/scripting/script_pool.rs
+++ b/crates/rift-mock-core/src/scripting/script_pool.rs
@@ -408,6 +408,7 @@ impl Drop for ScriptPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::imposter::ResponseMode;
 
     #[test]
     fn test_pool_creation() {
@@ -678,6 +679,7 @@ mod tests {
         let pool = ScriptPool::new(config).unwrap();
 
         let make_request = || ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -779,6 +781,7 @@ mod tests {
         .unwrap();
 
         let make_request = || ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -851,6 +854,7 @@ mod tests {
         .unwrap();
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),
@@ -918,6 +922,7 @@ mod tests {
         };
 
         let request = ScriptRequest {
+            mode: ResponseMode::Text,
             raw_body: None,
             method: "GET".to_string(),
             path: "/test".to_string(),

--- a/crates/rift-mock-core/tests/issue_636_binary_request_bodies.rs
+++ b/crates/rift-mock-core/tests/issue_636_binary_request_bodies.rs
@@ -1,0 +1,192 @@
+//! Issue #636: a binary request body (protobuf, gzip, an image upload) used to go through
+//! `String::from_utf8_lossy`, silently replacing the offending bytes with U+FFFD. The recorded
+//! request, predicate matches, and script/inject bodies then no longer reflected what the client
+//! actually sent — irreversibly, with no error.
+//!
+//! These tests drive the real imposter serve loop end-to-end (`ImposterManager` + reqwest, same
+//! pattern as `handler_error_responses.rs`) and assert:
+//!   - a binary body round-trips through the recorded request's base64 `body` + `_mode: "binary"`
+//!   - a `_rift.script` (Rhai) request sees the same base64 body plus an `isBinary` flag
+//!   - a text body is completely unaffected (no `_mode`, plain string body)
+
+#![cfg(feature = "javascript")]
+
+use rift_mock_core::imposter::{ImposterManager, ResponseMode};
+use std::time::Duration;
+
+async fn create(manager: &ImposterManager, cfg: serde_json::Value) -> u16 {
+    let config = serde_json::from_value(cfg).expect("valid imposter config");
+    let port = manager.create_imposter(config).await.expect("create");
+    // Give the listener a moment to bind before the request (matches the sibling HTTP tests).
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    port
+}
+
+// A binary body must be recorded losslessly: `body` base64-decodes back to the exact bytes the
+// client sent, and `mode` is `Binary` (serialized as `_mode: "binary"`).
+#[tokio::test]
+async fn binary_request_body_round_trips_through_recorded_request() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        serde_json::json!({
+            "port": 0, "protocol": "http", "recordRequests": true,
+            "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+        }),
+    )
+    .await;
+
+    let original: &[u8] = &[0xFF, 0xFE, 0x00, 0x01, 0x02, 0xC0, 0xC1];
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/x"))
+        .body(original.to_vec())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let imposter = manager.get_imposter(port).expect("imposter exists");
+    let recorded = imposter.get_recorded_requests();
+    assert_eq!(recorded.len(), 1, "exactly one request was recorded");
+    let req = &recorded[0];
+
+    assert_eq!(
+        req.mode,
+        ResponseMode::Binary,
+        "an invalid-UTF-8 body must be classified as binary"
+    );
+    let body = req.body.as_deref().expect("body present");
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(body)
+        .expect("recorded body must be valid base64");
+    assert_eq!(
+        decoded, original,
+        "the recorded body must decode back to the exact original bytes"
+    );
+
+    // Pin the wire shape too: `_mode` must be present and `"binary"` on the JSON the admin API
+    // would actually serve.
+    let value = serde_json::to_value(req).expect("serializes");
+    assert_eq!(value["_mode"], "binary");
+
+    manager.delete_all().await;
+}
+
+// A text body must be completely unaffected by the #636 change: no `_mode` field at all, and the
+// recorded `body` is the exact text (not base64).
+#[tokio::test]
+async fn text_request_body_recorded_unchanged_with_no_mode_field() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        serde_json::json!({
+            "port": 0, "protocol": "http", "recordRequests": true,
+            "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/x"))
+        .body("hello world")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let imposter = manager.get_imposter(port).expect("imposter exists");
+    let recorded = imposter.get_recorded_requests();
+    assert_eq!(recorded.len(), 1);
+    let req = &recorded[0];
+
+    assert_eq!(req.mode, ResponseMode::Text);
+    assert_eq!(req.body.as_deref(), Some("hello world"));
+
+    let value = serde_json::to_value(req).expect("serializes");
+    assert!(
+        value.get("_mode").is_none(),
+        "a text body must not carry `_mode` on the wire: {value}"
+    );
+
+    manager.delete_all().await;
+}
+
+// A `_rift.script` (Rhai) handler must see the base64 body plus `isBinary: true` for a binary
+// request — never the pre-#636 U+FFFD-mangled text, and never silently indistinguishable from a
+// real text body.
+#[tokio::test]
+async fn rift_script_request_exposes_binary_body_and_flag() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        serde_json::json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": { "script": { "engine": "rhai", "code":
+                        "fn respond(ctx) { http(200, #{isBinary: ctx.request.isBinary, body: ctx.request.body}) }"
+                    } }
+                }]
+            }]
+        }),
+    )
+    .await;
+
+    let original: &[u8] = &[0xFF, 0xFE, 0x00, 0x01, 0x02, 0xC0, 0xC1];
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/x"))
+        .body(original.to_vec())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let body: serde_json::Value = resp.json().await.expect("json body");
+    assert_eq!(
+        body["isBinary"], true,
+        "the script must see isBinary: true for a binary body, got: {body}"
+    );
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(body["body"].as_str().expect("body is a string"))
+        .expect("script-visible body must be valid base64");
+    assert_eq!(decoded, original);
+
+    manager.delete_all().await;
+}
+
+// Sanity check the flag flips back to `false` for an ordinary text body — the `isBinary` field
+// must actually distinguish the two, not just always report `true`/`false`.
+#[tokio::test]
+async fn rift_script_request_text_body_is_not_binary() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        serde_json::json!({
+            "port": 0, "protocol": "http",
+            "stubs": [{
+                "responses": [{
+                    "_rift": { "script": { "engine": "rhai", "code":
+                        "fn respond(ctx) { http(200, #{isBinary: ctx.request.isBinary, body: ctx.request.body}) }"
+                    } }
+                }]
+            }]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/x"))
+        .body("plain text")
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    let body: serde_json::Value = resp.json().await.expect("json body");
+    assert_eq!(body["isBinary"], false);
+    assert_eq!(body["body"], "plain text");
+
+    manager.delete_all().await;
+}

--- a/docs/mountebank/imposters.md
+++ b/docs/mountebank/imposters.md
@@ -231,6 +231,34 @@ curl http://localhost:2525/imposters/4545
 }
 ```
 
+### Binary Request Bodies
+
+A request body that is not valid UTF-8 (protobuf, gzip, an image upload) cannot be recorded as text
+without destroying it. Such a body is recorded base64-encoded and marked with `_mode: "binary"`,
+mirroring how binary **response** bodies are represented:
+
+```json
+{
+  "requests": [
+    {
+      "method": "POST",
+      "path": "/api/upload",
+      "body": "iVBORw0KGgoAAAANSUhEUg==",
+      "_mode": "binary",
+      "timestamp": "2024-01-15T10:30:00.000Z"
+    }
+  ]
+}
+```
+
+The `body` is standard base64 (with padding). `_mode` is **absent** for a normal text/JSON body, so
+recordings of text traffic are unchanged — check for it rather than assuming it is present.
+
+Scripts see the same distinction: `ctx.request.body` carries the base64 string and
+`ctx.request.isBinary` is `true`. Where rift cannot determine the encoding (the `decorate` and
+predicate-`inject` paths do not carry it), `isBinary` is **absent** rather than `false` — so a
+script can tell "text" apart from "unknown" instead of being told something untrue.
+
 ---
 
 ## Managing Imposters


### PR DESCRIPTION
`String::from_utf8_lossy` on request bodies replaces every invalid byte with U+FFFD, so a protobuf, gzip or image upload was **recorded as something the client never sent** — irreversibly, with no error. rift records and replays real traffic, so reading a recording back, or round-tripping it, silently produced wrong bytes.

### The fix mirrors an existing convention rather than inventing one
Binary **response** bodies have been base64 + `_mode: "binary"` since #117 (`util::encode_body_for_stub`, `IsResponse::mode`). Request bodies now do the same:

- Classify once from the bytes: valid UTF-8 keeps the borrowed, allocation-free path from #561; only genuinely invalid input pays a base64 copy.
- `RecordedRequest` gains `#[serde(rename = "_mode", default, skip_serializing_if = ...)] mode`, reusing the existing `ResponseMode` and `is_text_mode` helper.
- **The fault-injection proxy path (`proxy/handler.rs`) had the identical bug** — missed by the issue, fixed here.

### Additive by construction
`_mode` is **absent** for text bodies, so existing recordings, existing consumers and all-text traffic are byte-identical. Old recordings without `_mode` deserialize as `Text`. A test pins exactly that, because it is the property that matters most.

### Where the encoding isn't known, we say so
Four sites (`decorate` config-JS ×2, predicate-`inject`, predicateGenerator-`inject`) don't carry the classification. The first cut defaulted them to `Text` — but their `body` may already be base64, so the flag would have asserted "text" over a binary body. Review rightly called that a **new** silent-wrong: pre-change no script could be misled, because no flag existed; post-change the feature's whole purpose is for scripts to *trust* `isBinary`, and a false `false` invites `if (isBinary) … else JSON.parse(body)` and fails it silently.

So `MountebankRequest.mode` is `Option<ResponseMode>` and `isBinary` is **omitted** where unknown — a script can distinguish "text" from "unknown" instead of being told something untrue. That is the "make invalid states unrepresentable" rule applied, and it is far cheaper than threading the mode through every predicate-matching signature. (`ScriptRequest`/`RecordedRequest` keep a plain `ResponseMode`: both production sites always classify.)

### Predicates
A binary body now matches against the base64 string (Mountebank's binary-mode behaviour). Text bodies see a byte-identical string to before, so no predicate path changes for them; JSON/jsonpath are unaffected — a binary body was never parseable JSON.

### Tests
4 end-to-end (binary round-trips to the original bytes with `_mode: "binary"`; text records unchanged with no `_mode`; `_rift.script` sees base64 + `isBinary`; text is not flagged binary), plus unit tests pinning the serde shape in both directions and the old-recording default.

### Docs
`docs/mountebank/imposters.md` gains a "Binary Request Bodies" section next to Recording Requests, mirroring the response-side `_mode` docs — including that `_mode`/`isBinary` are *absent* rather than false, so consumers check rather than assume. CHANGELOG entry added: this is the one user-facing wire change in the recent batch.

### Follow-up filed
`intercept.rs` has the same `from_utf8_lossy` defect on the TLS-intercept forward-proxy path — pre-existing, untouched here, filed separately.

### Verification
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (55 suites), and the docs-examples gate all pass.

Closes #636