### PR TITLE
feat(proxy): declare the intercept listener and rules in --configfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **The intercept listener and its rules can be declared in `--configfile`.** Imposters were
+  declarative but intercept rules were not: they could only be installed at runtime over
+  `POST /intercept/rules`, so every containerized intercept deployment needed a second "bootstrap"
+  container to `curl` the admin API after boot. That sidecar exits `0` once it has posted the rule,
+  which Kubernetes' `restartPolicy: Always` treats as a crash — the usual workaround is keeping a
+  whole pod alive with `sleep` — and because `depends_on` ordering can't be gated on it, the system
+  under test could start *before* the rule existed and hit the unmatched-host default. A config file
+  may now carry an optional top-level `intercept` block (`{host?, port?, ca?, rules[]}`) alongside
+  its `imposters`, so one declarative file brings up the listener with its rules already installed:
+  `rift --configfile config.json`, no admin call and no sidecar. The rules are seeded *before* the
+  listener binds, so there is no window in which it accepts traffic without them. The block reuses
+  the `POST /intercept` body shape and the existing rule schema verbatim; `POST /intercept` and the
+  FFI `rift_start_intercept` gain the same optional `rules` array, so any surface can start-and-seed
+  in one call. Optional and additive: a config without the block, and any existing payload without
+  `rules`, behave exactly as before. Supplying the block together with `--intercept-*` flags is a
+  startup error rather than a silent precedence guess, and a rule using an `inject` predicate
+  requires `--allowInjection` just as a config-file imposter's scripting surface does. The block is
+  read from the `{"imposters": [...]}` wrapper form; writing one into a single-imposter document is
+  a startup error naming the fix, never a block that silently does nothing. `POST /admin/reload`
+  continues to apply imposters only, and now returns a `warnings` entry (and logs one) when the
+  reloaded file carries an `intercept` block, so an edit to it never looks applied when it wasn't.
+
 ## [0.13.6] - 2026-07-15
 
 ### Fixed

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1451,6 +1451,9 @@ pub unsafe extern "C" fn rift_start_intercept(
                     InterceptStartError::Ca(err) => {
                         format!("rift_start_intercept: CA setup failed: {err:#}")
                     }
+                    InterceptStartError::Rules(err) => {
+                        format!("rift_start_intercept: rule seeding failed: {err}")
+                    }
                     InterceptStartError::Bind(err) => {
                         format!("rift_start_intercept: bind failed: {err}")
                     }
@@ -1769,11 +1772,56 @@ fn gated_config_file_error(configs: &[ImposterConfig], allow_injection: bool) ->
     ))
 }
 
+/// The `configFile` gate for the file's `intercept` block (issue #655). Same boundary, same
+/// question, same remedy as [`gated_config_file_error`] — a rule's only executable surface is an
+/// `inject` predicate.
+fn gated_intercept_rules_error(
+    rules: &[rift_http_proxy::intercept_rules::InterceptRule],
+    allow_injection: bool,
+) -> Option<String> {
+    if allow_injection {
+        return None;
+    }
+    let offenders: Vec<String> = rules
+        .iter()
+        .enumerate()
+        .filter(|(_, rule)| injection_gate::intercept_rule_uses_script_surface(rule))
+        .map(|(index, _)| format!("#{index}"))
+        .collect();
+    if offenders.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "configFile load: intercept rule(s) {} use an inject predicate, which requires \
+         allowInjection. Set \"allowInjection\": true to allow this, or remove the injection.",
+        offenders.join(", "),
+    ))
+}
+
 /// Bind the admin (and optional metrics) plane per `opts`, returning the plane plus the JSON
 /// response body. Errors are `String`s (mapped to `last_error` by the caller).
+///
+/// A `configFile` `intercept` block binds a listener partway through (issue #655), so a later
+/// failure must not leave it running: the handle survives a failed `rift_serve_admin`, and an
+/// orphaned listener would make every retry fail forever with `AlreadyRunning` — blaming a
+/// listener the caller never successfully started. Only a listener *this call* started is stopped;
+/// one from an earlier `rift_start_intercept` is not ours to touch.
 async fn build_admin_plane(
     handle: &RiftHandle,
     opts: &ServeOptions,
+) -> Result<(AdminPlane, String), String> {
+    let mut started_intercept = false;
+    let result = build_admin_plane_inner(handle, opts, &mut started_intercept).await;
+    if result.is_err() && started_intercept {
+        handle.intercept.stop().await;
+    }
+    result
+}
+
+async fn build_admin_plane_inner(
+    handle: &RiftHandle,
+    opts: &ServeOptions,
+    started_intercept: &mut bool,
 ) -> Result<(AdminPlane, String), String> {
     let host = opts.host.as_deref().unwrap_or("127.0.0.1");
     let port = opts.port.unwrap_or(0);
@@ -1804,14 +1852,29 @@ async fn build_admin_plane(
                 path: PathBuf::from(path),
                 no_parse: false,
             };
-            let configs = config_loader::load_configs(&source)
+            let loaded = config_loader::load_configs_full(&source)
                 .map_err(|e| format!("configFile load: {e}"))?;
-            if let Some(err) = gated_config_file_error(&configs, allow_injection) {
+            if let Some(err) = gated_config_file_error(&loaded.imposters, allow_injection) {
                 return Err(err);
+            }
+            // The file's `intercept` block (issue #655) gives an embedded host the same
+            // declarative listener the CLI gets — started before the imposters are applied so a
+            // block that cannot bind fails the call outright rather than half-applying the file.
+            // Gated identically to the imposters around it: the file crossed the same boundary.
+            if let Some(block) = loaded.intercept {
+                if let Some(err) = gated_intercept_rules_error(&block.rules, allow_injection) {
+                    return Err(err);
+                }
+                handle
+                    .intercept
+                    .start(block)
+                    .await
+                    .map_err(|e| format!("configFile intercept: {e}"))?;
+                *started_intercept = true;
             }
             let report = handle
                 .manager
-                .apply_config(configs)
+                .apply_config(loaded.imposters)
                 .await
                 .map_err(|e| format!("configFile apply: {e}"))?;
             warn_failed(&report, "configFile");

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -2209,3 +2209,180 @@ fn ffi_admin_longtail_scenario_and_flow_edges() {
         rift_stop(h);
     }
 }
+
+// ===== configFile `intercept` block over FFI (issue #655) =====
+
+/// Write a config file declaring an imposter plus an `intercept` block that forwards to it.
+fn intercept_config_file(dir: &std::path::Path, imposter_port: u16, predicates: &str) -> String {
+    let path = dir.join("intercept-config.json");
+    std::fs::write(
+        &path,
+        format!(
+            r#"{{"imposters": [{{ "port": {imposter_port}, "protocol": "http",
+                   "stubs": [{{ "responses": [{{ "is": {{ "statusCode": 200, "body": "from-imposter" }} }}] }}] }}],
+               "intercept": {{ "port": 0, "rules": [
+                   {{ "host": "cdn.example.com"{predicates},
+                      "action": {{ "forward": {{ "port": {imposter_port}}} }} }} ] }} }}"#
+        ),
+    )
+    .expect("write config");
+    serde_json::json!(path.to_str().expect("utf8 path")).to_string()
+}
+
+/// Issue #655 AC7: an embedded host booting from a `configFile` gets the listener **and** its rules
+/// with no extra FFI call — the same declarative parity the CLI has. Without this the FFI block
+/// handling could be deleted wholesale and nothing would fail.
+#[test]
+fn ffi_serve_admin_config_file_seeds_the_intercept_block() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_json = intercept_config_file(dir.path(), 19655, "");
+
+        let h = rift_start();
+        let info = take_json(rift_serve_admin(
+            h,
+            cstr(&format!(r#"{{"port": 0, "configFile": {path_json}}}"#)).as_ptr(),
+        ));
+        let info: serde_json::Value = serde_json::from_str(&info).expect("serve json");
+        let admin_port = info["adminPort"].as_u64().expect("adminPort");
+
+        // The block started the listener and seeded its rule — no rift_start_intercept, no
+        // rift_intercept_add_rules. `list_rules` errors with "intercept not started" if the block
+        // was ignored, so this asserts both halves at once.
+        let listed: serde_json::Value =
+            serde_json::from_str(&take_json(rift_intercept_list_rules(h))).expect("rules json");
+        let rules = listed.as_array().expect("rules array");
+        assert_eq!(
+            rules.len(),
+            1,
+            "the config block's rule is seeded: {listed}"
+        );
+        assert_eq!(rules[0]["host"].as_str(), Some("cdn.example.com"));
+
+        // ...and the listener actually works: drive real HTTPS through it to the imposter the same
+        // file declared.
+        let ca_pem = take_json(rift_intercept_ca_pem(h));
+        rt().block_on(async move {
+            let status: serde_json::Value =
+                reqwest::get(format!("http://127.0.0.1:{admin_port}/intercept"))
+                    .await
+                    .expect("GET /intercept")
+                    .json()
+                    .await
+                    .expect("intercept status json");
+            let intercept_port = status["interceptPort"].as_u64().expect("interceptPort");
+            assert!(intercept_port > 0, "the block bound a real port");
+
+            let client = reqwest::Client::builder()
+                .proxy(reqwest::Proxy::https(format!("http://127.0.0.1:{intercept_port}")).unwrap())
+                .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+                .build()
+                .unwrap();
+            let resp = client
+                .get("https://cdn.example.com/datafile.json")
+                .send()
+                .await
+                .expect("intercepted and forwarded");
+            assert_eq!(resp.status(), 200);
+            assert_eq!(resp.text().await.unwrap(), "from-imposter");
+        });
+
+        rift_stop(h);
+    }
+}
+
+/// Issue #655 AC7 (gate half): a `configFile` crosses a trust boundary, so an `inject` predicate in
+/// its intercept block is refused without `allowInjection` — mirroring the imposter gate on the same
+/// door. The gate runs before the listener starts, so a rejected file must leave nothing bound.
+#[test]
+fn ffi_serve_admin_config_file_intercept_inject_requires_allow_injection() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_json = intercept_config_file(
+            dir.path(),
+            19656,
+            r#", "predicates": [{ "inject": "function (request) { return true; }" }]"#,
+        );
+
+        let h = rift_start();
+        assert!(
+            rift_serve_admin(
+                h,
+                cstr(&format!(
+                    r#"{{"port": 0, "allowInjection": false, "configFile": {path_json}}}"#
+                ))
+                .as_ptr()
+            )
+            .is_null(),
+            "an inject predicate in the intercept block must be rejected when allowInjection is off"
+        );
+
+        let err = rift_last_error();
+        assert!(!err.is_null(), "a gated block records last_error");
+        let msg = CStr::from_ptr(err).to_str().expect("utf8").to_owned();
+        rift_free(err);
+        assert!(
+            msg.contains("allowInjection"),
+            "the rejection must name the gate that blocked it, got: {msg}"
+        );
+
+        // Nothing may be left behind: no listener bound, and no imposter applied. Asserted rather
+        // than inferred — a refactor moving the gate after `intercept.start`/`apply_config` would
+        // still return NULL and still set last_error, and only these checks would notice.
+        assert!(
+            rift_intercept_list_rules(h).is_null(),
+            "a rejected configFile must not leave an intercept listener running"
+        );
+        let listed = take_json(rift_list_imposters(h, std::ptr::null()));
+        assert!(
+            !listed.contains("19656"),
+            "a rejected configFile must apply no imposters, got: {listed}"
+        );
+
+        rift_stop(h);
+    }
+}
+
+/// Issue #655: the `intercept` block binds a listener partway through `rift_serve_admin`, so a
+/// failure *after* that point must roll it back. Otherwise the handle is poisoned: the caller sees
+/// the serve fail, retries, and gets `AlreadyRunning` forever — blamed on a listener they never
+/// successfully started. Driven through a real admin-bind failure (the port is already held).
+#[test]
+fn ffi_serve_admin_failure_after_intercept_start_leaves_no_listener() {
+    unsafe {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_json = intercept_config_file(dir.path(), 19657, "");
+
+        // Hold a port so the admin bind — which happens after the block starts — must fail.
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+        let taken_port = occupied.local_addr().unwrap().port();
+
+        let h = rift_start();
+        assert!(
+            rift_serve_admin(
+                h,
+                cstr(&format!(
+                    r#"{{"host": "127.0.0.1", "port": {taken_port}, "configFile": {path_json}}}"#
+                ))
+                .as_ptr()
+            )
+            .is_null(),
+            "serve must fail when the admin port is already held"
+        );
+
+        // The rollback: a retry can start intercept, which is impossible if the failed call left
+        // its listener bound (that would be AlreadyRunning).
+        let started = rift_start_intercept(h, cstr(r#"{"port":0}"#).as_ptr());
+        assert!(
+            !started.is_null(),
+            "a failed serve must not leave its intercept listener bound: {}",
+            CStr::from_ptr(rift_last_error())
+                .to_str()
+                .unwrap_or("<no error>")
+        );
+        rift_free(started);
+
+        rift_stop(h);
+        drop(occupied);
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -109,6 +109,9 @@ async fn start_from_bytes(body: &[u8], control: &InterceptControl) -> Response<F
         Err(e) => {
             let status = match e {
                 InterceptStartError::AlreadyRunning => StatusCode::CONFLICT,
+                // Same code the runtime rule route returns for a full store, so one condition has
+                // one status whichever door reports it (issue #655).
+                InterceptStartError::Rules(_) => StatusCode::TOO_MANY_REQUESTS,
                 _ => StatusCode::BAD_REQUEST,
             };
             error_response(status, &e.to_string())

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Response, StatusCode};
 use std::sync::Arc;
+use tracing::warn;
 
 /// GET / - Root endpoint (Mountebank-compatible format)
 pub fn handle_root(base_url: &str) -> Response<Full<Bytes>> {
@@ -153,25 +154,41 @@ pub async fn handle_reload(
     // reads plus EJS/regex/serde work — and unlike startup, reload is network-triggered and
     // repeatable, so a large datadir or a stalled mount would pin a runtime worker for the whole
     // read. Awaited here, so the parse still completes before anything mutates.
-    let configs = match tokio::task::spawn_blocking(move || {
-        crate::config_loader::load_configs(&source)
-    })
-    .await
-    {
-        Ok(Ok(configs)) => configs,
-        Ok(Err(e)) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Reload failed (imposters unchanged): {e}"),
-            );
-        }
-        Err(e) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Reload task failed: {e}"),
-            );
-        }
+    let loaded =
+        match tokio::task::spawn_blocking(move || crate::config_loader::load_configs_full(&source))
+            .await
+        {
+            Ok(Ok(loaded)) => loaded,
+            Ok(Err(e)) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("Reload failed (imposters unchanged): {e}"),
+                );
+            }
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("Reload task failed: {e}"),
+                );
+            }
+        };
+
+    // The `intercept` block is applied at boot only (issue #655): re-seeding would duplicate or
+    // clobber rules added at runtime, and rebinding the listener is a lifecycle change reload does
+    // not own. The party that needs to know is the client that just asked for the reload, and a
+    // server-side log is invisible to it (doubly so over FFI, where tracing may go nowhere) — so
+    // the response body carries the warning and the log is a `warn!`, not an `info!`: the caller
+    // asked for something that deliberately did not happen.
+    let warnings: Vec<String> = if loaded.intercept.is_some() {
+        let warning = "the config file's `intercept` block is applied at startup only and was NOT \
+                       re-applied; imposters were reloaded. Use /intercept/rules to change rules \
+                       at runtime, or restart to re-read the block.";
+        warn!("Reload: {warning}");
+        vec![warning.to_string()]
+    } else {
+        Vec::new()
     };
+    let configs = loaded.imposters;
 
     // Validate-before-touch: refuse a gated config before anything mutates, so a refused reload
     // leaves the running imposters exactly as they were (issue #612).
@@ -181,16 +198,21 @@ pub async fn handle_reload(
 
     let count = configs.len();
     match manager.apply_config(configs).await {
-        Ok(report) if report.failed.is_empty() => json_response(
-            StatusCode::OK,
-            &serde_json::json!({
+        Ok(report) if report.failed.is_empty() => {
+            let mut body = serde_json::json!({
                 "message": format!("Reloaded {count} imposter(s)"),
                 "created": report.created,
                 "replaced": report.replaced,
                 "stubPatched": report.stub_patched,
                 "deleted": report.deleted,
-            }),
-        ),
+            });
+            // Additive: absent entirely when there is nothing to warn about, so existing clients
+            // and their parsers are unaffected.
+            if !warnings.is_empty() {
+                body["warnings"] = serde_json::json!(warnings);
+            }
+            json_response(StatusCode::OK, &body)
+        }
         // A reload failure is a server-side config problem, not a bad client request — report 5xx.
         // Validation errors are caught before anything mutates (running imposters intact, Err
         // below); per-port failures here are residual apply errors (e.g. a bind failure on a

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -3,6 +3,7 @@
 //! running state is touched), so a parse error is returned rather than applied.
 
 use crate::imposter::{ImposterConfig, ScriptBaseDir, resolve_scripts};
+use crate::intercept_control::InterceptStartOptions;
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -50,16 +51,39 @@ pub enum ConfigSource {
     Dir(PathBuf),
 }
 
+/// Everything a config source declares: the imposters, plus the optional `intercept` block that
+/// brings up the intercept listener with its rules already installed (issue #655).
+#[derive(Debug, Default)]
+pub struct LoadedConfig {
+    pub imposters: Vec<ImposterConfig>,
+    /// `None` when the document declares no `intercept` block — the overwhelmingly common case, and
+    /// byte-for-byte the pre-#655 behaviour. Only the `{ "imposters": [...] }` wrapper object has
+    /// somewhere to put one; a bare array and a `--datadir` never yield a block.
+    pub intercept: Option<InterceptStartOptions>,
+}
+
 /// Parse the source into imposter configs without creating any imposters. A parse error is
 /// returned so the caller (startup or hot-reload) decides whether to apply the result.
+///
+/// Imposters only: the `intercept` block is boot-only, so `POST /admin/reload` — which goes through
+/// here — keeps reloading imposters and leaves the running listener alone (issue #655). Callers that
+/// need the block use [`load_configs_full`].
 pub fn load_configs(source: &ConfigSource) -> anyhow::Result<Vec<ImposterConfig>> {
+    load_configs_full(source).map(|loaded| loaded.imposters)
+}
+
+/// Parse the source into everything it declares, including the optional `intercept` block.
+pub fn load_configs_full(source: &ConfigSource) -> anyhow::Result<LoadedConfig> {
     match source {
         ConfigSource::File { path, no_parse } => load_file(path, *no_parse),
-        ConfigSource::Dir(dir) => load_dir(dir),
+        ConfigSource::Dir(dir) => load_dir(dir).map(|imposters| LoadedConfig {
+            imposters,
+            intercept: None,
+        }),
     }
 }
 
-fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>> {
+fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
     let raw = std::fs::read_to_string(path)?;
     let content = if no_parse {
         raw
@@ -68,11 +92,32 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>>
     };
 
     let trimmed = content.trim_start();
+    let mut intercept = None;
     let mut configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
         // Single imposter, or a `{ "imposters": [...] }` wrapper (Mountebank format).
         let value: serde_json::Value = serde_json::from_str(&content)?;
         match value.get("imposters") {
-            Some(imposters) => serde_json::from_value(imposters.clone())?,
+            Some(imposters) => {
+                // Only the wrapper carries siblings, so this is the one shape with somewhere to
+                // declare an intercept listener (issue #655). `InterceptStartOptions` is
+                // `deny_unknown_fields`, so a typo here is a startup error rather than a config
+                // block that silently does nothing.
+                intercept = value
+                    .get("intercept")
+                    .map(|block| serde_json::from_value(block.clone()))
+                    .transpose()
+                    .map_err(|e| anyhow::anyhow!("invalid `intercept` block: {e}"))?;
+                serde_json::from_value(imposters.clone())?
+            }
+            // A single-imposter document has no `imposters` key, so it has no wrapper to carry a
+            // listener declaration — and `ImposterConfig` ignores unknown fields, so an `intercept`
+            // key here would be dropped without a word: no listener, no rule, no diagnostic, and a
+            // green boot (issue #655). Refuse instead; the remedy is one line of JSON.
+            None if value.get("intercept").is_some() => anyhow::bail!(
+                "an `intercept` block is only read from the `{{\"imposters\": [...], \"intercept\": {{...}}}}` \
+                 wrapper form, but this document has no `imposters` key, so the block would be ignored. \
+                 Wrap the imposter in `\"imposters\": [ ... ]` (use `[]` if the file declares none)."
+            ),
             None => vec![serde_json::from_value(value)?],
         }
     } else if trimmed.starts_with('[') {
@@ -93,7 +138,10 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<Vec<ImposterConfig>>
     for config in &mut configs {
         resolve_scripts(config, &base)?;
     }
-    Ok(configs)
+    Ok(LoadedConfig {
+        imposters: configs,
+        intercept,
+    })
 }
 
 fn load_dir(dir: &Path) -> anyhow::Result<Vec<ImposterConfig>> {
@@ -319,6 +367,186 @@ mod tests {
                 "the secret's content must never appear (it must not be read): {msg}"
             );
         }
+    }
+
+    // ===== Optional `intercept` block (issue #655) =====
+
+    const WITH_INTERCEPT: &str = r#"{
+        "imposters": [{"port":4545,"protocol":"http"}],
+        "intercept": {
+            "host": "0.0.0.0",
+            "port": 8080,
+            "rules": [{"host":"cdn.example.com","action":{"forward":{"port":4545}}}]
+        }
+    }"#;
+
+    /// AC2: the block is read from the same wrapper object that already carries `imposters`.
+    #[test]
+    fn load_configs_full_reads_intercept_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "cfg.json", WITH_INTERCEPT);
+        let loaded = load_configs_full(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .unwrap();
+
+        assert_eq!(loaded.imposters.len(), 1);
+        assert_eq!(loaded.imposters[0].port, Some(4545));
+        let intercept = loaded.intercept.expect("the intercept block is read");
+        assert_eq!(intercept.host.as_deref(), Some("0.0.0.0"));
+        assert_eq!(intercept.port, Some(8080));
+        assert_eq!(intercept.rules.len(), 1);
+        assert_eq!(intercept.rules[0].host.as_deref(), Some("cdn.example.com"));
+    }
+
+    /// AC2: absent block → exactly today's behaviour, imposters untouched.
+    #[test]
+    fn load_configs_full_without_intercept_block_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, body) in [
+            (
+                "wrap.json",
+                r#"{"imposters":[{"port":8001,"protocol":"http"}]}"#,
+            ),
+            ("single.json", r#"{"port":8000,"protocol":"http"}"#),
+            ("arr.json", r#"[{"port":8003,"protocol":"http"}]"#),
+        ] {
+            let path = write(dir.path(), name, body);
+            let loaded = load_configs_full(&ConfigSource::File {
+                path,
+                no_parse: false,
+            })
+            .unwrap();
+            assert_eq!(loaded.imposters.len(), 1, "{name}: imposters still load");
+            assert!(
+                loaded.intercept.is_none(),
+                "{name}: no block means no intercept"
+            );
+        }
+    }
+
+    /// A `--datadir` has no wrapper object to carry a block.
+    #[test]
+    fn load_configs_full_from_dir_has_no_intercept_block() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.json", r#"{"port":8100,"protocol":"http"}"#);
+        let loaded = load_configs_full(&ConfigSource::Dir(dir.path().to_path_buf())).unwrap();
+        assert_eq!(loaded.imposters.len(), 1);
+        assert!(loaded.intercept.is_none());
+    }
+
+    /// AC5: `POST /admin/reload` goes through `load_configs`, which must keep returning imposters
+    /// only — the block is boot-only, and a config carrying one must still reload its imposters
+    /// rather than erroring.
+    #[test]
+    fn load_configs_returns_imposters_only_for_a_config_with_a_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(dir.path(), "cfg.json", WITH_INTERCEPT);
+        let configs = load_configs(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .expect("a config with an intercept block still reloads its imposters");
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].port, Some(4545));
+    }
+
+    /// The block is `InterceptStartOptions`, which is `deny_unknown_fields` — a typo is a loud
+    /// startup error, not a silently-ignored listener.
+    #[test]
+    fn misspelled_intercept_field_is_a_load_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "typo.json",
+            r#"{"imposters":[],"intercept":{"prot":8080}}"#,
+        );
+        let err = load_configs_full(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .expect_err("a misspelled block field must fail the load");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("prot") || msg.contains("unknown field"),
+            "the error must name the offending field: {msg}"
+        );
+    }
+
+    /// An `intercept` key outside the wrapper form must be a loud error, never a silent no-op:
+    /// `ImposterConfig` ignores unknown fields, so the block would otherwise vanish and rift would
+    /// boot green with no listener. Both single-imposter spellings are covered — with and without
+    /// other imposter fields — because the intercept-only document (`{"intercept": {...}}`) also
+    /// parses as a *default* `ImposterConfig`, which would additionally conjure a phantom
+    /// auto-assigned-port imposter out of a file that declares none.
+    #[test]
+    fn intercept_block_outside_the_wrapper_form_is_a_loud_error() {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, body) in [
+            (
+                "single_plus_block.json",
+                r#"{"port":8000,"protocol":"http","intercept":{"port":8080,"rules":[]}}"#,
+            ),
+            (
+                "block_only.json",
+                r#"{"intercept":{"port":8080,"rules":[]}}"#,
+            ),
+        ] {
+            let path = write(dir.path(), name, body);
+            let err = load_configs_full(&ConfigSource::File {
+                path,
+                no_parse: false,
+            })
+            .expect_err("{name}: a block outside the wrapper must not be silently dropped");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("imposters"),
+                "{name}: the error must name the wrapper key that fixes it: {msg}"
+            );
+        }
+    }
+
+    /// The guard above must not fire on documents that never mentioned `intercept` — the
+    /// single-imposter shape stays exactly as it was.
+    #[test]
+    fn single_imposter_without_a_block_still_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "single.json",
+            r#"{"port":8000,"protocol":"http"}"#,
+        );
+        let loaded = load_configs_full(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .expect("a plain single-imposter config is unaffected");
+        assert_eq!(loaded.imposters.len(), 1);
+        assert_eq!(loaded.imposters[0].port, Some(8000));
+        assert!(loaded.intercept.is_none());
+    }
+
+    /// EJS runs before parsing, so the block gets env substitution like the rest of the file.
+    #[test]
+    fn intercept_block_supports_ejs_env_substitution() {
+        unsafe { std::env::set_var("RIFT_TEST_655_HOST", "flags.example.com") };
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "ejs.json",
+            r#"{"imposters":[],"intercept":{"rules":[{"host":"<%= process.env.RIFT_TEST_655_HOST %>","action":{"forward":{"port":4545}}}]}}"#,
+        );
+        let loaded = load_configs_full(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .unwrap();
+        assert_eq!(
+            loaded.intercept.expect("block").rules[0].host.as_deref(),
+            Some("flags.example.com")
+        );
+        unsafe { std::env::remove_var("RIFT_TEST_655_HOST") };
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/injection_gate.rs
+++ b/crates/rift-http-proxy/src/injection_gate.rs
@@ -48,6 +48,17 @@ pub fn gated_offender_ports(configs: &[ImposterConfig]) -> Vec<String> {
         .collect()
 }
 
+/// True if `rule` carries a scripting surface gated by `--allowInjection` (issue #655).
+///
+/// An intercept rule's only executable surface is a predicate `inject`: its `serve` action is a
+/// fixed status/headers/body stub and `forward` is a port number, so neither can carry script — a
+/// serve body that merely looks like JavaScript is inert data. Config-file rules therefore ask this
+/// the same question `--configfile` imposters answer via [`config_uses_script_surface`], so one
+/// document cannot be refused as an imposter stub and executed as an intercept predicate.
+pub fn intercept_rule_uses_script_surface(rule: &crate::intercept_rules::InterceptRule) -> bool {
+    rule.predicates.iter().any(predicate_has_inject)
+}
+
 /// True if any stub in `stubs` uses a Mountebank scripting surface gated by `--allowInjection`
 /// (issue #355 Item 4): an inject response, a decorate behavior (`_behaviors.decorate` / a
 /// proxy's `addDecorateBehavior`), a `_behaviors.shellTransform` (runs a host shell command),

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::intercept::InterceptListener;
-use crate::intercept_rules::{InterceptRules, InterceptState};
+use crate::intercept_rules::{InterceptRule, InterceptRules, InterceptState, RulesAtCapacity};
 use rift_mock_core::proxy::intercept_ca::{CaSource, CertificateAuthority, SniCertResolver};
 use serde::Serialize;
 
@@ -55,6 +55,12 @@ pub struct InterceptStartOptions {
     /// Generate a fresh CA and return its cert **and** key in the start response (issue #593).
     /// Only valid when no CA source is supplied — combining it with a path/PEM pair is a `400`.
     pub return_ca_key: Option<bool>,
+    /// Rules to install before the listener accepts anything (issue #655). Lets one declarative
+    /// document — a `--configfile` `intercept` block, a `POST /intercept` body, or an FFI start —
+    /// bring up a listener that is already correct, instead of requiring a follow-up
+    /// `POST /intercept/rules` that traffic can race.
+    #[serde(default)]
+    pub rules: Vec<InterceptRule>,
 }
 
 impl std::fmt::Debug for InterceptStartOptions {
@@ -71,6 +77,8 @@ impl std::fmt::Debug for InterceptStartOptions {
                 &self.ca_key_pem.as_ref().map(|_| "<redacted>"),
             )
             .field("return_ca_key", &self.return_ca_key)
+            // Count only: a rule's serve body can be an arbitrarily large payload.
+            .field("rules", &self.rules.len())
             .finish()
     }
 }
@@ -147,6 +155,10 @@ pub enum InterceptStartError {
     Ca(#[source] anyhow::Error),
     #[error("bind failed: {0}")]
     Bind(#[source] anyhow::Error),
+    /// Seeding the start-time rules exceeded [`MAX_RULES`](crate::intercept_rules::MAX_RULES).
+    /// Mapped to the same `429` the runtime `POST /intercept/rules` returns for a full store.
+    #[error(transparent)]
+    Rules(#[from] RulesAtCapacity),
 }
 
 impl InterceptControl {
@@ -221,7 +233,17 @@ impl InterceptControl {
         })?);
         let ca_export = return_ca_key.then(|| (ca.ca_cert_pem().to_string(), ca.ca_key_pem()));
 
+        // Seed BEFORE binding: once `bind` returns the listener is accepting, so rules installed
+        // after it could be raced by the first request, which would fall through to the
+        // unmatched-host default (issue #655). Seeding here makes a started listener correct by
+        // construction — and an over-capacity batch fails the start rather than binding a listener
+        // with a partial rule set.
         let rules = InterceptRules::new();
+        rules.extend(opts.rules).map_err(|e| {
+            tracing::warn!(error = %e, "intercept start: rule seeding failed");
+            InterceptStartError::Rules(e)
+        })?;
+
         let resolver = Arc::new(SniCertResolver::new(ca.clone()));
         let listener = InterceptListener::bind(addr, resolver, rules.clone())
             .await
@@ -482,6 +504,123 @@ mod tests {
             .await
             .expect_err("returnCaKey with CA paths must be rejected");
         assert!(matches!(err, InterceptStartError::Ca(_)));
+    }
+
+    // ===== Config-declared rules seeded at start (issue #655) =====
+
+    fn serve_rule(host: &str) -> InterceptRule {
+        InterceptRule {
+            host: Some(host.to_string()),
+            predicates: vec![],
+            action: crate::intercept_rules::InterceptAction::Serve(
+                crate::intercept_rules::ServeStub {
+                    status_code: 200,
+                    headers: Default::default(),
+                    body: Some("seeded".to_string()),
+                },
+            ),
+        }
+    }
+
+    /// AC1: rules supplied to `start` are in the store the listener matches against by the time
+    /// `start` returns — no second admin call, and (because seeding precedes `bind`) no window in
+    /// which the listener is live with an empty store.
+    #[tokio::test]
+    async fn start_seeds_rules_from_options() {
+        let control = InterceptControl::default();
+        control
+            .start(InterceptStartOptions {
+                rules: vec![serve_rule("a.example.com"), serve_rule("b.example.com")],
+                ..Default::default()
+            })
+            .await
+            .expect("start with seeded rules");
+
+        let listed = control.state().expect("running").rules.list();
+        assert_eq!(listed.len(), 2, "both config rules are in the live store");
+        assert_eq!(listed[0].host.as_deref(), Some("a.example.com"));
+        assert_eq!(
+            listed[1].host.as_deref(),
+            Some("b.example.com"),
+            "insertion order is preserved (first match wins depends on it)"
+        );
+        control.stop().await;
+    }
+
+    /// AC2 (unit half): an options payload without `rules` behaves exactly as before.
+    #[tokio::test]
+    async fn start_without_rules_leaves_store_empty() {
+        let control = InterceptControl::default();
+        control.start(defaults()).await.expect("start");
+        assert!(
+            control.state().expect("running").rules.is_empty(),
+            "no rules unless the caller supplied some"
+        );
+        control.stop().await;
+    }
+
+    /// AC6: runtime `POST /intercept/rules` / `DELETE` still layer on top of the seeded set.
+    #[tokio::test]
+    async fn seeded_rules_accept_runtime_additions_and_clear() {
+        let control = InterceptControl::default();
+        control
+            .start(InterceptStartOptions {
+                rules: vec![serve_rule("seeded.example.com")],
+                ..Default::default()
+            })
+            .await
+            .expect("start");
+        let rules = control.state().expect("running").rules;
+
+        rules
+            .add(serve_rule("runtime.example.com"))
+            .expect("runtime add on top of the seeded set");
+        let listed = rules.list();
+        assert_eq!(listed.len(), 2, "runtime rule layers on top, not replacing");
+        assert_eq!(listed[0].host.as_deref(), Some("seeded.example.com"));
+        assert_eq!(listed[1].host.as_deref(), Some("runtime.example.com"));
+
+        rules.clear();
+        assert!(rules.is_empty(), "DELETE clears seeded rules too");
+        control.stop().await;
+    }
+
+    /// Seeding failure fails `start` loudly (and therefore server boot) rather than binding a
+    /// listener with a partial rule set.
+    #[tokio::test]
+    async fn start_rejects_rules_over_capacity_without_binding() {
+        let control = InterceptControl::default();
+        let too_many = (0..crate::intercept_rules::MAX_RULES + 1)
+            .map(|i| serve_rule(&format!("h{i}.example.com")))
+            .collect();
+        let err = control
+            .start(InterceptStartOptions {
+                rules: too_many,
+                ..Default::default()
+            })
+            .await
+            .expect_err("an over-capacity rule set must fail the start");
+        assert!(matches!(err, InterceptStartError::Rules(_)));
+        assert!(
+            control.status().is_none(),
+            "no listener may be left behind by a failed seed"
+        );
+    }
+
+    /// The config block IS this struct: `rules` must parse from the same camelCase JSON the admin
+    /// `POST /intercept` body uses, and stay optional for pre-#655 payloads.
+    #[test]
+    fn rules_parse_from_json_and_default_to_empty() {
+        let seeded: InterceptStartOptions = serde_json::from_str(
+            r#"{"port":8080,"rules":[{"host":"cdn.example.com","action":{"forward":{"port":4545}}}]}"#,
+        )
+        .expect("rules parse from the shared camelCase shape");
+        assert_eq!(seeded.rules.len(), 1);
+        assert_eq!(seeded.port, Some(8080));
+
+        let legacy: InterceptStartOptions =
+            serde_json::from_str(r#"{"port":8080}"#).expect("a pre-#655 payload still parses");
+        assert!(legacy.rules.is_empty(), "rules defaults to empty");
     }
 
     #[tokio::test]

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -337,9 +337,16 @@ impl ServerBuilder {
             }
         };
 
+        let mut intercept_block = None;
         if let Some(ref configfile) = cli.configfile {
-            load_imposters_from_file(&manager, configfile, cli.no_parse, cli.allow_injection)
-                .await?;
+            intercept_block = load_imposters_from_file(
+                &manager,
+                configfile,
+                cli.no_parse,
+                cli.allow_injection,
+                &cli_intercept_flags(&cli),
+            )
+            .await?;
         }
         if let Some(ref datadir) = cli.datadir {
             load_imposters_from_datadir(&manager, datadir, cli.allow_injection).await?;
@@ -405,10 +412,14 @@ impl ServerBuilder {
         // every standalone server — flag or no flag (the issue's goal for the connect transport).
         // `--intercept-port` just eagerly starts the same listener the API would; a start error
         // still aborts startup, as before.
+        // The config file's `intercept` block (issue #655) and `--intercept-port` are two spellings
+        // of the same listener; supplying both was already refused when the file was loaded, so at
+        // most one of these arms can run. The block declares its own bind host, so unlike the flag
+        // it does not inherit the admin `host`.
         let intercept = InterceptControl::default();
-        if let Some(intercept_port) = cli.intercept_port {
-            intercept
-                .start(InterceptStartOptions {
+        let start_options = intercept_block.or_else(|| {
+            cli.intercept_port
+                .map(|intercept_port| InterceptStartOptions {
                     host: Some(host.to_string()),
                     port: Some(intercept_port),
                     ca_cert_path: cli
@@ -424,13 +435,25 @@ impl ServerBuilder {
                     // Cloned (not moved) because `cli` is borrowed for the rest of startup.
                     ..Default::default()
                 })
-                .await
-                .map_err(|e| anyhow::anyhow!("intercept: {e}"))?;
+        });
+        if let Some(options) = start_options {
+            let seeded_rules = options.rules.len();
+            if let Err(e) = intercept.start(options).await {
+                // Same contract as the admin-bind arm below: don't orphan a listener already bound
+                // by this call. #655 widens the ways this can fail (rule-capacity, and a CA/bind
+                // error declared by the config block rather than typed as a flag), and `start()` is
+                // an embedding seam callers retry — a held metrics port would fail the retry too.
+                if let Some(metrics) = metrics {
+                    metrics.shutdown().await;
+                }
+                return Err(anyhow::anyhow!("intercept: {e}"));
+            }
             info!(
-                "Rift intercept proxy listening (HTTPS forward-proxy) on {}",
+                "Rift intercept proxy listening (HTTPS forward-proxy) on {} with {} configured rule(s)",
                 intercept
                     .status()
-                    .expect("intercept listener bound after a successful start")
+                    .expect("intercept listener bound after a successful start"),
+                seeded_rules
             );
         }
         server = server.with_intercept(intercept.clone());
@@ -707,26 +730,110 @@ fn partition_gated_datadir(
     (servable, gated)
 }
 
-/// Load imposters from a JSON config file
+/// The `--intercept-*` flags the operator supplied, by long name; empty when none were.
+fn cli_intercept_flags(cli: &Cli) -> Vec<&'static str> {
+    [
+        ("--intercept-port", cli.intercept_port.is_some()),
+        ("--intercept-ca-cert", cli.intercept_ca_cert.is_some()),
+        ("--intercept-ca-key", cli.intercept_ca_key.is_some()),
+        (
+            "--intercept-ca-cert-pem",
+            cli.intercept_ca_cert_pem.is_some(),
+        ),
+        ("--intercept-ca-key-pem", cli.intercept_ca_key_pem.is_some()),
+    ]
+    .into_iter()
+    .filter(|(_, present)| *present)
+    .map(|(name, _)| name)
+    .collect()
+}
+
+/// The error for a config `intercept` block supplied alongside `--intercept-*` flags, or `None`
+/// when at most one source configures the listener (issue #655).
+///
+/// Two spellings of one listener is a config bug, so it is refused rather than resolved by a silent
+/// precedence rule the operator would have to know — the same fail-loud choice clap already makes
+/// for the CA path/PEM pairs.
+fn intercept_source_conflict_error(path: &Path, flags: &[&str]) -> Option<String> {
+    if flags.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}: the `intercept` block and {} both configure the intercept listener. \
+         Use one or the other — the block declares the listener, its CA, and its rules together. \
+         (Each of these flags also has a RIFT_INTERCEPT_* environment variable, which is the \
+         intended vehicle for the inline CA PEMs — check the environment, not just the command line.)",
+        path.display(),
+        flags.join(", ")
+    ))
+}
+
+/// The error for config-file intercept rules carrying a gated script surface, or `None` when every
+/// rule is admissible (issue #655). One message listing every offender, matching
+/// [`configfile_injection_error`]'s contract for imposters.
+fn configfile_intercept_injection_error(
+    path: &Path,
+    rules: &[crate::intercept_rules::InterceptRule],
+    allow_injection: bool,
+) -> Option<String> {
+    if allow_injection {
+        return None;
+    }
+    let offenders: Vec<String> = rules
+        .iter()
+        .enumerate()
+        .filter(|(_, rule)| crate::injection_gate::intercept_rule_uses_script_surface(rule))
+        .map(|(index, rule)| match &rule.host {
+            Some(host) => format!("#{index} ({host})"),
+            None => format!("#{index} (any host)"),
+        })
+        .collect();
+    if offenders.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}: intercept rule(s) {} use an inject predicate, which requires --allowInjection. \
+         Remove the injection or restart with --allowInjection.",
+        path.display(),
+        offenders.join(", ")
+    ))
+}
+
+/// Load imposters from a JSON config file, returning the file's optional `intercept` block for the
+/// caller to start the listener from (issue #655) — the block is parsed and validated here so the
+/// whole document is refused as one, before any imposter exists.
 async fn load_imposters_from_file(
     manager: &Arc<ImposterManager>,
     path: &PathBuf,
     no_parse: bool,
     allow_injection: bool,
-) -> anyhow::Result<()> {
+    intercept_flags: &[&str],
+) -> anyhow::Result<Option<InterceptStartOptions>> {
     info!("Loading imposters from configfile: {:?}", path);
 
-    let configs = config_loader::load_configs(&ConfigSource::File {
+    let loaded = config_loader::load_configs_full(&ConfigSource::File {
         path: path.clone(),
         no_parse,
     })?;
 
-    // Refuse before creating anything: a gated configfile must not half-load (issue #612).
-    if let Some(message) = configfile_injection_error(path, &configs, allow_injection) {
+    // Refuse before creating anything: a gated configfile must not half-load (issue #612). The
+    // intercept block is validated in the same breath, so a file that cannot bring up its listener
+    // never half-applies its imposters either.
+    if let Some(message) = configfile_injection_error(path, &loaded.imposters, allow_injection) {
         anyhow::bail!(message);
     }
+    if let Some(block) = &loaded.intercept {
+        if let Some(message) = intercept_source_conflict_error(path, intercept_flags) {
+            anyhow::bail!(message);
+        }
+        if let Some(message) =
+            configfile_intercept_injection_error(path, &block.rules, allow_injection)
+        {
+            anyhow::bail!(message);
+        }
+    }
 
-    for config in configs {
+    for config in loaded.imposters {
         info!(
             "Creating imposter on port {:?} from configfile",
             config.port
@@ -737,7 +844,7 @@ async fn load_imposters_from_file(
         }
     }
 
-    Ok(())
+    Ok(loaded.intercept)
 }
 
 /// Load imposters from a data directory
@@ -1300,7 +1407,7 @@ mod tests {
         );
 
         let manager = Arc::new(ImposterManager::new());
-        let err = load_imposters_from_file(&manager, &path, false, false)
+        let err = load_imposters_from_file(&manager, &path, false, false, &[])
             .await
             .expect_err("a gated configfile must abort startup");
         assert!(err.to_string().contains("--allowInjection"), "got: {err}");
@@ -1326,7 +1433,7 @@ mod tests {
         assert!(example.exists(), "fixture missing: {}", example.display());
 
         let manager = Arc::new(ImposterManager::new());
-        let err = load_imposters_from_file(&manager, &example, false, false)
+        let err = load_imposters_from_file(&manager, &example, false, false, &[])
             .await
             .expect_err("examples/latency-testing.json uses a JS-function wait; it must be gated");
         assert!(err.to_string().contains("--allowInjection"), "got: {err}");
@@ -1386,5 +1493,151 @@ mod tests {
         );
 
         manager.delete_all().await;
+    }
+
+    // ===== `intercept` config block: source conflict + injection gate (issue #655) =====
+
+    fn rule_from(value: serde_json::Value) -> crate::intercept_rules::InterceptRule {
+        serde_json::from_value(value).expect("valid intercept rule")
+    }
+
+    fn clean_rule() -> crate::intercept_rules::InterceptRule {
+        rule_from(serde_json::json!({
+            "host": "cdn.example.com",
+            "predicates": [{"equals": {"path": "/config.json"}}],
+            "action": {"forward": {"port": 4545}}
+        }))
+    }
+
+    fn inject_rule() -> crate::intercept_rules::InterceptRule {
+        rule_from(serde_json::json!({
+            "host": "evil.example.com",
+            "predicates": [{"inject": "function (req) { return true; }"}],
+            "action": {"serve": {"statusCode": 200}}
+        }))
+    }
+
+    /// AC3: the block and `--intercept-port` are two spellings of one listener. Supplying both is a
+    /// startup error naming the offending flag, not a silent precedence guess.
+    #[test]
+    fn intercept_conflict_names_every_supplied_flag() {
+        for (args, expected) in [
+            (vec!["rift", "--intercept-port", "8080"], "--intercept-port"),
+            (
+                vec![
+                    "rift",
+                    "--intercept-ca-cert",
+                    "c.pem",
+                    "--intercept-ca-key",
+                    "k.pem",
+                ],
+                "--intercept-ca-cert",
+            ),
+            (
+                vec![
+                    "rift",
+                    "--intercept-ca-cert-pem",
+                    "PEM",
+                    "--intercept-ca-key-pem",
+                    "PEM",
+                ],
+                "--intercept-ca-cert-pem",
+            ),
+        ] {
+            let cli = Cli::parse_from(args);
+            let flags = cli_intercept_flags(&cli);
+            let err = intercept_source_conflict_error(Path::new("/cfg/x.json"), &flags)
+                .expect("block + flag must conflict");
+            assert!(err.contains(expected), "names the flag: {err}");
+            assert!(err.contains("/cfg/x.json"), "names the file: {err}");
+        }
+    }
+
+    /// AC3 (negative): neither source alone conflicts — the block is additive, the flags keep working.
+    #[test]
+    fn intercept_conflict_absent_when_only_one_source() {
+        let cli = Cli::parse_from(["rift"]);
+        assert!(
+            cli_intercept_flags(&cli).is_empty(),
+            "no flags supplied means no conflict with a block"
+        );
+        assert!(
+            intercept_source_conflict_error(Path::new("/cfg/x.json"), &[]).is_none(),
+            "a block with no flags is the whole point of the feature"
+        );
+    }
+
+    /// AC4: an `inject` predicate arriving by config file is executable code crossing the same
+    /// trust boundary the imposter gate already guards — it must be refused without the flag.
+    #[test]
+    fn configfile_intercept_injection_error_names_file_rule_and_flag() {
+        let err = configfile_intercept_injection_error(
+            Path::new("/cfg/optimizely.json"),
+            &[clean_rule(), inject_rule()],
+            false,
+        )
+        .expect("an inject predicate without --allowInjection must abort startup");
+        assert!(
+            err.contains("/cfg/optimizely.json"),
+            "names the file: {err}"
+        );
+        assert!(err.contains("evil.example.com"), "names the rule: {err}");
+        assert!(err.contains("--allowInjection"), "names the flag: {err}");
+        assert!(
+            !err.contains("cdn.example.com"),
+            "must not name the clean rule: {err}"
+        );
+    }
+
+    /// The gate must see through `not`/`or`/`and` nesting, exactly as it does for imposter stubs —
+    /// otherwise wrapping the inject in a `not` walks straight past it.
+    #[test]
+    fn configfile_intercept_injection_error_sees_nested_inject() {
+        let nested = rule_from(serde_json::json!({
+            "host": "nested.example.com",
+            "predicates": [{"or": [
+                {"equals": {"path": "/a"}},
+                {"not": {"inject": "function (req) { return true; }"}}
+            ]}],
+            "action": {"serve": {"statusCode": 200}}
+        }));
+        assert!(
+            configfile_intercept_injection_error(Path::new("/cfg/x.json"), &[nested], false)
+                .is_some(),
+            "an inject nested under or/not must still be gated"
+        );
+    }
+
+    /// AC4 (negatives): the flag admits it, and a script-free rule set never trips the gate.
+    #[test]
+    fn configfile_intercept_injection_error_none_when_allowed_or_clean() {
+        assert!(
+            configfile_intercept_injection_error(Path::new("/cfg/x.json"), &[inject_rule()], true)
+                .is_none(),
+            "--allowInjection must permit an inject predicate"
+        );
+        assert!(
+            configfile_intercept_injection_error(Path::new("/cfg/x.json"), &[clean_rule()], false)
+                .is_none(),
+            "a rule with no script surface must load without --allowInjection"
+        );
+        assert!(
+            configfile_intercept_injection_error(Path::new("/cfg/x.json"), &[], false).is_none(),
+            "an empty rule set is admissible"
+        );
+    }
+
+    /// A `serve` action is a fixed stub and `forward` carries no script, so neither is a gated
+    /// surface — pinning that the gate does not over-reach into refusing ordinary rules.
+    #[test]
+    fn serve_and_forward_actions_are_not_script_surfaces() {
+        let serve = rule_from(serde_json::json!({
+            "action": {"serve": {"statusCode": 200, "body": "function (req) { return true; }"}}
+        }));
+        assert!(
+            configfile_intercept_injection_error(Path::new("/cfg/x.json"), &[serve], false)
+                .is_none(),
+            "a serve body that merely looks like JS is inert data, not an injection"
+        );
     }
 }

--- a/crates/rift-http-proxy/tests/intercept_configfile.rs
+++ b/crates/rift-http-proxy/tests/intercept_configfile.rs
@@ -1,0 +1,283 @@
+//! `--configfile` carries the intercept listener and its rules (issue #655).
+//!
+//! The property under test is the one the feature exists for: a single declarative file brings up
+//! the listener **with its rules already installed**, so a container needs no bootstrap sidecar and
+//! no `POST /intercept/rules`. Every test here therefore asserts against a server started from a
+//! config file alone — the only admin call any of them makes is `GET /intercept/ca.pem`, to obtain
+//! the trust anchor a real SUT would get from a mounted CA file.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+fn write_config(dir: &tempfile::TempDir, body: &str) -> PathBuf {
+    let path = dir.path().join("config.json");
+    let mut f = std::fs::File::create(&path).expect("create config");
+    f.write_all(body.as_bytes()).expect("write config");
+    path
+}
+
+fn cli_with_config(path: &Path, extra: &[&str]) -> Cli {
+    let mut args = vec![
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--configfile",
+        path.to_str().expect("utf-8 path"),
+    ];
+    args.extend_from_slice(extra);
+    Cli::parse_from(args)
+}
+
+/// Start expecting a startup abort, returning the rendered error chain. `RunningServer` is not
+/// `Debug`, so `expect_err` is unavailable; a server that starts when it must not is shut down
+/// before failing, so a broken gate cannot leave a listener bound for the rest of the suite.
+async fn start_expecting_error(cli: Cli, why: &str) -> String {
+    match ServerBuilder::from_cli(cli).start().await {
+        Ok(server) => {
+            server.shutdown().await;
+            panic!("{why}");
+        }
+        Err(e) => format!("{e:#}"),
+    }
+}
+
+/// A client that trusts only the intercept CA and proxies HTTPS through the listener — the SUT.
+fn sut_client(intercept: std::net::SocketAddr, ca_pem: &str) -> reqwest::Client {
+    reqwest::Client::builder()
+        .proxy(reqwest::Proxy::https(format!("http://{intercept}")).unwrap())
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap()
+}
+
+/// AC1/AC2 headline: listener up and rule installed from the file alone. No `POST /intercept`,
+/// no `POST /intercept/rules` — the bootstrap container this issue deletes.
+#[tokio::test]
+async fn configfile_intercept_block_serves_without_any_admin_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_config(
+        &dir,
+        r#"{
+            "imposters": [],
+            "intercept": {
+                "port": 0,
+                "rules": [
+                    { "host": "cdn.example.com",
+                      "predicates": [{ "equals": { "path": "/datafiles/key-a.json" } }],
+                      "action": { "serve": { "statusCode": 200,
+                                             "headers": { "content-type": "application/json" },
+                                             "body": "{\"featureX\":\"ON\"}" } } }
+                ]
+            }
+        }"#,
+    );
+
+    let server = ServerBuilder::from_cli(cli_with_config(&path, &[]))
+        .start()
+        .await
+        .expect("server starts with an intercept block");
+    let intercept = server
+        .intercept_addr()
+        .expect("the block binds the listener without --intercept-port");
+
+    let ca_pem = reqwest::get(format!("http://{}/intercept/ca.pem", server.admin_addr()))
+        .await
+        .expect("ca.pem")
+        .text()
+        .await
+        .unwrap();
+
+    let resp = sut_client(intercept, &ca_pem)
+        .get("https://cdn.example.com/datafiles/key-a.json")
+        .send()
+        .await
+        .expect("the SUT's hard-coded HTTPS call is intercepted");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
+
+    server.shutdown().await;
+}
+
+/// The driving use case end to end: one file declares the imposter *and* the rule that routes the
+/// intercepted CDN call to it. Proves the two halves of the file are wired to each other at boot.
+#[tokio::test]
+async fn configfile_intercept_block_forwards_to_a_declared_imposter() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_config(
+        &dir,
+        r#"{
+            "imposters": [
+                { "port": 24655, "protocol": "http", "name": "datafile",
+                  "stubs": [{ "responses": [{ "is": { "statusCode": 200,
+                                                      "body": "{\"flag\":\"from-imposter\"}" } }] }] }
+            ],
+            "intercept": {
+                "port": 0,
+                "rules": [{ "host": "cdn.example.com", "action": { "forward": { "port": 24655 } } }]
+            }
+        }"#,
+    );
+
+    let server = ServerBuilder::from_cli(cli_with_config(&path, &[]))
+        .start()
+        .await
+        .expect("server starts");
+    let intercept = server.intercept_addr().expect("listener bound");
+    let ca_pem = reqwest::get(format!("http://{}/intercept/ca.pem", server.admin_addr()))
+        .await
+        .expect("ca.pem")
+        .text()
+        .await
+        .unwrap();
+
+    let resp = sut_client(intercept, &ca_pem)
+        .get("https://cdn.example.com/datafiles/anything.json")
+        .send()
+        .await
+        .expect("intercepted and forwarded to the imposter");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.text().await.unwrap(),
+        r#"{"flag":"from-imposter"}"#,
+        "the response must come from the imposter declared in the same file"
+    );
+
+    server.shutdown().await;
+}
+
+/// AC6 e2e: the seeded set is a starting point, not a closed set — runtime admin calls still layer.
+#[tokio::test]
+async fn runtime_admin_rules_layer_on_top_of_the_seeded_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_config(
+        &dir,
+        r#"{
+            "imposters": [],
+            "intercept": {
+                "port": 0,
+                "rules": [{ "host": "seeded.example.com",
+                            "action": { "serve": { "statusCode": 200, "body": "from-config" } } }]
+            }
+        }"#,
+    );
+
+    let server = ServerBuilder::from_cli(cli_with_config(&path, &[]))
+        .start()
+        .await
+        .expect("server starts");
+    let admin = server.admin_addr();
+    let intercept = server.intercept_addr().expect("listener bound");
+    let ca_pem = reqwest::get(format!("http://{admin}/intercept/ca.pem"))
+        .await
+        .expect("ca.pem")
+        .text()
+        .await
+        .unwrap();
+
+    // The config-seeded rule is visible to the admin API — one store, two doors.
+    let listed = reqwest::get(format!("http://{admin}/intercept/rules"))
+        .await
+        .expect("list rules")
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        listed.contains("seeded.example.com"),
+        "the config-seeded rule must be listed by the admin API: {listed}"
+    );
+
+    let added = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept/rules"))
+        .body(r#"{"host":"runtime.example.com","action":{"serve":{"statusCode":200,"body":"from-admin"}}}"#)
+        .send()
+        .await
+        .expect("add a rule at runtime");
+    assert_eq!(added.status(), 201);
+
+    let client = sut_client(intercept, &ca_pem);
+    let seeded = client
+        .get("https://seeded.example.com/x")
+        .send()
+        .await
+        .expect("seeded rule still matches");
+    assert_eq!(seeded.text().await.unwrap(), "from-config");
+    let runtime = client
+        .get("https://runtime.example.com/x")
+        .send()
+        .await
+        .expect("runtime rule matches too");
+    assert_eq!(runtime.text().await.unwrap(), "from-admin");
+
+    server.shutdown().await;
+}
+
+/// AC2: a config file with no block is byte-for-byte today's behaviour — no listener.
+#[tokio::test]
+async fn configfile_without_intercept_block_leaves_listener_off() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_config(&dir, r#"{"imposters":[{"port":24656,"protocol":"http"}]}"#);
+    let server = ServerBuilder::from_cli(cli_with_config(&path, &[]))
+        .start()
+        .await
+        .expect("server starts");
+    assert!(
+        server.intercept_addr().is_none(),
+        "no block and no flag must leave the listener off"
+    );
+    server.shutdown().await;
+}
+
+/// AC3: two spellings of one listener is a startup error, not a silent precedence guess.
+#[tokio::test]
+async fn configfile_block_conflicts_with_intercept_port_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_config(
+        &dir,
+        r#"{"imposters":[],"intercept":{"port":0,"rules":[]}}"#,
+    );
+    let msg = start_expecting_error(
+        cli_with_config(&path, &["--intercept-port", "0"]),
+        "an intercept block plus --intercept-port must abort startup",
+    )
+    .await;
+    assert!(msg.contains("--intercept-port"), "names the flag: {msg}");
+}
+
+/// AC4: the config-file door gates injection for rules exactly as it does for imposters — an
+/// `inject` predicate is executable code arriving by file.
+#[tokio::test]
+async fn configfile_intercept_rule_with_inject_is_refused_without_the_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = r#"{
+        "imposters": [],
+        "intercept": { "port": 0, "rules": [
+            { "host": "evil.example.com",
+              "predicates": [{ "inject": "function (req) { return true; }" }],
+              "action": { "serve": { "statusCode": 200 } } }
+        ]}
+    }"#;
+    let path = write_config(&dir, body);
+
+    let msg = start_expecting_error(
+        cli_with_config(&path, &[]),
+        "an inject predicate without --allowInjection must abort startup",
+    )
+    .await;
+    assert!(
+        msg.contains("--allowInjection"),
+        "the error must name the flag that would allow it: {msg}"
+    );
+
+    // The flag is the whole point: with it set, the same file boots.
+    let server = ServerBuilder::from_cli(cli_with_config(&path, &["--allow-injection"]))
+        .start()
+        .await
+        .expect("--allowInjection admits the same config");
+    assert!(server.intercept_addr().is_some());
+    server.shutdown().await;
+}

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -74,6 +74,13 @@ at boot. It is no longer the only way to enable it: a server started without the
 the runtime lifecycle endpoints (`POST`/`GET`/`DELETE /intercept`), so intercept can be turned on at
 runtime over the admin API. The flag and the endpoints drive the same single listener.
 
+A third way, and the only declarative one, is an
+[`intercept` block in `--configfile`]({{ site.baseurl }}/features/intercept-proxy/#declare-it-in-the-config-file):
+it starts the listener **with its rules already installed**, so a container needs no post-boot admin
+call. The block and these `--intercept-*` flags are two spellings of one listener — supplying both
+is a startup error rather than a silent precedence guess, so pick one. (Each flag also has a
+`RIFT_INTERCEPT_*` environment variable, which counts as supplying it.)
+
 ### API-key authentication
 
 `--api-key` (or `MB_APIKEY`) requires every admin API request to carry the token in the

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -40,6 +40,17 @@ docker run -v $(pwd)/imposters.json:/imposters.json \
   zainalpour/rift-proxy:latest --configfile /imposters.json
 ```
 
+### Top-level keys
+
+| Key | Purpose |
+|---|---|
+| `imposters` | The imposters to create — the Mountebank format above. |
+| `intercept` | *Optional, Rift extension.* Declares the [HTTPS intercept listener](../features/intercept-proxy.md#declare-it-in-the-config-file) and its rules, so a container needs no post-boot admin call to install them. |
+
+A file may also be a single imposter object (`{"port": 4545, ...}`) or a bare array of them; those
+shapes have nowhere to put an `intercept` block, so declaring one there is a startup error naming
+the fix rather than a block that silently does nothing.
+
 Or create dynamically via API:
 
 ```bash

--- a/docs/features/hot-reload.md
+++ b/docs/features/hot-reload.md
@@ -68,6 +68,25 @@ A successful reload returns `200` with the change set:
 }
 ```
 
+Reload applies **imposters only**. If the config file also declares an
+[`intercept` block](intercept-proxy.md#declare-it-in-the-config-file), it is *not* re-applied —
+re-seeding would duplicate or clobber rules added at runtime, and rebinding the listener is a
+lifecycle change reload does not own. So that an edit to the block never *looks* applied, the
+response says so explicitly (the field is absent otherwise):
+
+```json
+{
+  "message": "Reloaded 3 imposter(s)",
+  "warnings": [
+    "the config file's `intercept` block is applied at startup only and was NOT re-applied; ..."
+  ],
+  "created": [], "replaced": [], "stubPatched": [], "deleted": []
+}
+```
+
+Change intercept rules at runtime with `POST`/`DELETE /intercept/rules`, or restart to re-read the
+block.
+
 If some ports apply and others fail, the call returns `500` and reports both sides — the ports that
 did apply and the ones that failed:
 

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -88,6 +88,62 @@ a CA over the admin API instead, so the key is never printed to logs.)
 — it is no longer the only way to enable intercept. A server started **without** the flag still
 serves the lifecycle endpoints below, so a client can turn intercept on later.
 
+### Declare it in the config file
+
+The flags above start a listener with **no rules**, so a container has to `curl` the admin API after
+boot to install them — a bootstrap sidecar that exits `0` (and so crash-loops under Kubernetes'
+`restartPolicy: Always`), and a window where the SUT's first calls race the rule that isn't there
+yet. Instead, put an `intercept` block next to your imposters in `--configfile`: the listener binds
+with its rules **already installed**, so the server is correct the moment it is ready.
+
+```json
+{
+  "imposters": [
+    { "port": 4545, "protocol": "http", "name": "Optimizely datafile",
+      "stubs": [{ "responses": [{ "is": { "statusCode": 200, "body": "{\"featureX\":\"ON\"}" } }] }] }
+  ],
+  "intercept": {
+    "host": "0.0.0.0",
+    "port": 8080,
+    "caCertPath": "/certs/rift-ca-cert.pem",
+    "caKeyPath": "/certs/rift-ca-key.pem",
+    "rules": [
+      { "host": "cdn.example.com", "action": { "forward": { "port": 4545 } } }
+    ]
+  }
+}
+```
+
+```bash
+rift --configfile /config/optimizely.json   # listener up + rules installed; no admin call, no sidecar
+```
+
+The block is the same shape as the `POST /intercept` body — `host`, `port`, the CA fields
+(`caCertPath`/`caKeyPath` or inline `caCertPem`/`caKeyPem`), plus `rules[]` using the
+[rule schema](#configuring-rules-admin-api) verbatim. Notes:
+
+- **Optional and additive.** A config file without an `intercept` block behaves exactly as before.
+- **It lives in the wrapper form.** Only the `{ "imposters": [...] }` object can carry an
+  `intercept` block. Putting one in a single-imposter document (`{"port": 4545, ...}`) is a startup
+  error naming the fix, never a silently ignored block — add `"imposters": [ ... ]` around the
+  imposter, using `[]` if the file declares none. A bare top-level array, and a YAML config (which
+  is the array form), have nowhere to put a block at all.
+- **One source of truth.** Supplying the block *and* any `--intercept-*` flag is a startup error
+  rather than a silent precedence guess. Use one or the other.
+- **Runtime rules still layer on top.** `POST /intercept/rules` adds to the config-seeded set and
+  `DELETE /intercept/rules` clears it; `GET` lists both.
+- **`rules` works over the admin API and FFI too.** `POST /intercept` and `rift_start_intercept`
+  accept the same optional `rules` array, so any surface can start-and-seed in one call.
+- **Boot-only.** `POST /admin/reload` re-applies imposters only. When the reloaded file carries an
+  `intercept` block, the response body carries a `warnings` entry saying it was not re-applied (and
+  the server logs a warning), so an edit to the block never *looks* applied. Change rules at runtime
+  over the admin API, or restart to re-read the block.
+- **Injection is gated.** A rule whose predicates use `inject` needs `--allowInjection`, exactly as a
+  config-file imposter's scripting surface does — the file crossed the same trust boundary.
+
+An `intercept` block also gets EJS preprocessing like the rest of the file, so
+`"host": "<%= process.env.CDN_HOST %>"` works.
+
 ### Runtime lifecycle (admin API)
 
 Start, inspect, and stop the intercept listener at runtime over the admin API — no restart, and no


### PR DESCRIPTION
Imposters were declarative but intercept rules were not: they could only be installed at runtime over `POST /intercept/rules`, so every containerized intercept deployment needed a second "bootstrap" container to `curl` the admin API after boot. That sidecar exits `0` once it has posted the rule — which Kubernetes' `restartPolicy: Always` treats as a crash — and `depends_on` cannot be gated on it, so the SUT could start *before* the rule existed and hit the unmatched-host default.

A config file may now carry an optional top-level `intercept` block alongside its imposters:

```bash
rift --configfile /config/optimizely.json   # listener up + rules installed; no admin call, no sidecar
```

The rules are seeded **before** the listener binds, so there is no window in which it accepts traffic without them. The block reuses `InterceptStartOptions` verbatim, so `POST /intercept` and the FFI `rift_start_intercept` gain the same optional `rules` array and can start-and-seed in one call. Optional and additive — a config without the block, and any existing payload without `rules`, behave exactly as before.

## Failing loud rather than guessing

- Block + any `--intercept-*` flag → startup error, not a silent precedence guess (the message names the `RIFT_INTERCEPT_*` env vars too, since a flag may arrive from the environment).
- An `inject` predicate in a rule requires `--allowInjection` — the same gate config-file imposters pass; the file crossed the same trust boundary.
- A block outside the `{"imposters": [...]}` wrapper form is refused naming the fix. `ImposterConfig` ignores unknown fields, so it would otherwise vanish silently — a green boot with no listener (and `{"intercept": {...}}` alone would additionally conjure a phantom auto-port imposter).
- `POST /admin/reload` applies imposters only and returns a `warnings` entry when the reloaded file carries a block, so an edit to it never *looks* applied. A log alone is invisible to the caller that asked, and to FFI hosts where tracing goes nowhere.
- A failure after the FFI starts the block's listener rolls it back, so a failed `rift_serve_admin` cannot poison the handle with `AlreadyRunning` forever.

## Verification

- clippy `--workspace --all-features --tests -D warnings`: 0 warnings. Tests: **1,916 passed, 0 failed**.
- Gates are mutation-proven, not just green: removing the rule seeding fails exactly the 3 e2e tests that depend on installed rules; nulling the FFI block-handling fails both AC7 tests; removing the wrapper guard fails the silent-drop test.
- 4 review agents (correctness, silent-failure, test-coverage, idiom); the 6 blockers they raised are fixed in this diff.

## Follow-up filed

#657 — `POST /intercept/rules` bypasses the `--allowInjection` gate (pre-existing, proven by probe; held for triage). It is why this change gates at the config-file door rather than inside `InterceptControl::start`.

Closes #655
Milestone: none (standalone feature)