### PR TITLE
security(intercept): POST /intercept/rules bypasses the --allowInjection gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ record.
 
 ## [Unreleased]
 
+### Security
+
+- **`POST /intercept/rules` now obeys `--allowInjection`.** An intercept rule's predicates are
+  evaluated on every intercepted request, so an `inject` predicate is executable JavaScript — but
+  this door never asked the `--allowInjection` gate. The identical predicate was refused with `400`
+  by `POST /imposters` and executed by `POST /intercept/rules`, on a server started without the
+  flag and on an admin port that is unauthenticated unless `--apikey` is set. Since admin access is
+  deliberately *not* supposed to grant code execution — that is precisely what the flag gates —
+  this was a privilege escalation past rift's own stated boundary. Issue #612 swept every door that
+  admits config through one classifier; this is the door it missed. All rule doors now ask it:
+  `POST /intercept/rules`, the `rules` array on `POST /intercept`, and the `--configfile`
+  `intercept` block. The refusal is atomic and sees through `not`/`or`/`and` nesting — a batch
+  containing one gated rule stores none of it, and a refused start binds no listener.
+  **Behaviour change:** a rule with an `inject` predicate now needs `--allowInjection`, and gets the
+  same `400` and remedy message every other door gives. `serve`/`forward` actions carry no script
+  and are unaffected.
+
 ### Added
 
 - **The intercept listener and its rules can be declared in `--configfile`.** Imposters were

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -31,18 +31,19 @@ pub async fn route(
     query: Option<&str>,
     req: Request<Incoming>,
     control: &InterceptControl,
+    allow_injection: bool,
 ) -> Option<Response<Full<Bytes>>> {
     let rest = path.strip_prefix("/intercept")?;
     let resp = match (method, rest) {
         // Runtime lifecycle (issue #493) — operate on the shared slot, listener or not.
-        (&Method::POST, "") => handle_start(req, control).await,
+        (&Method::POST, "") => handle_start(req, control, allow_injection).await,
         (&Method::GET, "") => handle_status(control),
         (&Method::DELETE, "") => handle_stop(control).await,
         // Rule CRUD + CA/truststore — need a running listener's state. When none is running these
         // are a known route with an actionable body ("not running"), not the generic 404 an unknown
         // sub-path gets below — mirroring `GET /intercept`.
         (&Method::POST, "/rules") => match control.state() {
-            Some(state) => handle_add_rules(req, &state).await,
+            Some(state) => handle_add_rules(req, &state, allow_injection).await,
             None => not_running(),
         },
         (&Method::GET, "/rules") => match control.state() {
@@ -80,17 +81,25 @@ fn not_running() -> Response<Full<Bytes>> {
 /// `POST /intercept` — start the listener. Body is optional: absent, empty, or `{}` all mean
 /// defaults (`127.0.0.1:0`, fresh in-memory CA). `201` with the [`InterceptStatus`] body on
 /// success, `409` when already running, `400` for a bad body / options / CA / bind.
-async fn handle_start(req: Request<Incoming>, control: &InterceptControl) -> Response<Full<Bytes>> {
+async fn handle_start(
+    req: Request<Incoming>,
+    control: &InterceptControl,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
-    start_from_bytes(&body, control).await
+    start_from_bytes(&body, control, allow_injection).await
 }
 
 /// Parse start options from a (possibly empty) JSON body and drive `control.start`. Split out from
 /// `handle_start` so the `201`/`409`/`400` mapping is unit-testable without a `Request<Incoming>`.
-async fn start_from_bytes(body: &[u8], control: &InterceptControl) -> Response<Full<Bytes>> {
+async fn start_from_bytes(
+    body: &[u8],
+    control: &InterceptControl,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
     let opts: InterceptStartOptions = if body.is_empty() {
         InterceptStartOptions::default()
     } else {
@@ -104,6 +113,12 @@ async fn start_from_bytes(body: &[u8], control: &InterceptControl) -> Response<F
             }
         }
     };
+    // Rules seeded at start (issue #655) come through the same door as `POST /intercept/rules` and
+    // are executed the same way, so they ask the same question (issue #657). Before `start`, so a
+    // refused document binds no listener.
+    if rules_are_gated(&opts.rules, allow_injection) {
+        return crate::admin_api::handlers::imposters::injection_disallowed_response();
+    }
     match control.start(opts).await {
         Ok(started) => json_response(StatusCode::CREATED, &InterceptStatus::from_started(started)),
         Err(e) => {
@@ -154,18 +169,40 @@ enum RuleOrRules {
     Many(Vec<InterceptRule>),
 }
 
+/// True when `rules` carry a scripting surface `--allowInjection` has not enabled (issue #657) —
+/// the same classifier every other door asks, so one document gets one answer wherever it arrives.
+///
+/// A rule's predicates are evaluated per intercepted request (`InterceptRules::match_request` →
+/// `stub_matches`, which has no gate of its own), so an `inject` predicate admitted here is
+/// executable code. Callers must ask *before* storing or starting: the refusal is atomic, matching
+/// `POST /imposters` refusing the whole document rather than the offending part.
+fn rules_are_gated(rules: &[InterceptRule], allow_injection: bool) -> bool {
+    !allow_injection
+        && rules
+            .iter()
+            .any(crate::injection_gate::intercept_rule_uses_script_surface)
+}
+
 /// `POST /intercept/rules` — add one rule (a bare `InterceptRule` object) or many (a JSON array).
-async fn handle_add_rules(req: Request<Incoming>, state: &InterceptState) -> Response<Full<Bytes>> {
+async fn handle_add_rules(
+    req: Request<Incoming>,
+    state: &InterceptState,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
     let body = match collect_body(req).await {
         Ok(b) => b,
         Err(e) => return error_response(e.status_code(), &e.to_string()),
     };
-    add_rules_from_bytes(&body, state)
+    add_rules_from_bytes(&body, state, allow_injection)
 }
 
 /// Parse a rule (or array of rules) from a JSON body and add them to the store. Split out from
 /// `handle_add_rules` so the parse/store path is unit-testable without a `Request<Incoming>`.
-fn add_rules_from_bytes(body: &[u8], state: &InterceptState) -> Response<Full<Bytes>> {
+fn add_rules_from_bytes(
+    body: &[u8],
+    state: &InterceptState,
+    allow_injection: bool,
+) -> Response<Full<Bytes>> {
     let parsed: RuleOrRules = match serde_json::from_slice(body) {
         Ok(r) => r,
         Err(e) => {
@@ -175,6 +212,15 @@ fn add_rules_from_bytes(body: &[u8], state: &InterceptState) -> Response<Full<By
             );
         }
     };
+    // Gate before the store, on the whole document: one gated rule refuses the batch, so a
+    // refused request leaves the store exactly as it was.
+    let gated = match &parsed {
+        RuleOrRules::One(rule) => rules_are_gated(std::slice::from_ref(rule), allow_injection),
+        RuleOrRules::Many(rules) => rules_are_gated(rules, allow_injection),
+    };
+    if gated {
+        return crate::admin_api::handlers::imposters::injection_disallowed_response();
+    }
     let added = match parsed {
         RuleOrRules::One(rule) => {
             if let Err(e) = state.rules.add(rule.clone()) {
@@ -381,7 +427,7 @@ mod tests {
         let state = test_state();
         let json =
             br#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"brew"}}}"#;
-        let resp = add_rules_from_bytes(json, &state);
+        let resp = add_rules_from_bytes(json, &state, true);
         assert_eq!(resp.status(), StatusCode::CREATED);
         assert_eq!(state.rules.len(), 1);
         assert_eq!(
@@ -389,7 +435,7 @@ mod tests {
             Some("cdn.example.com")
         );
 
-        let bad = add_rules_from_bytes(b"{not json", &state);
+        let bad = add_rules_from_bytes(b"{not json", &state, true);
         assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
         assert_eq!(state.rules.len(), 1, "a rejected body must not add a rule");
     }
@@ -415,7 +461,7 @@ mod tests {
             .expect("fill to the cap");
 
         let one = br#"{"action":{"serve":{"statusCode":200}}}"#;
-        let resp = add_rules_from_bytes(one, &state);
+        let resp = add_rules_from_bytes(one, &state, true);
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(
             state.rules.len(),
@@ -424,7 +470,7 @@ mod tests {
         );
 
         let many = br#"[{"action":{"serve":{"statusCode":200}}}]"#;
-        let resp = add_rules_from_bytes(many, &state);
+        let resp = add_rules_from_bytes(many, &state, true);
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(
             state.rules.len(),
@@ -450,7 +496,7 @@ mod tests {
         // Add the rule through the ADMIN handler path (not InterceptRules::add directly).
         let json = br#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"admin-brewed"}}}"#;
         assert_eq!(
-            add_rules_from_bytes(json, &state).status(),
+            add_rules_from_bytes(json, &state, true).status(),
             StatusCode::CREATED
         );
 
@@ -505,7 +551,7 @@ mod tests {
         assert_eq!(handle_status(&control).status(), StatusCode::NOT_FOUND);
 
         // POST empty body → 201 with an OS-assigned port.
-        let started = start_from_bytes(b"", &control).await;
+        let started = start_from_bytes(b"", &control, true).await;
         assert_eq!(started.status(), StatusCode::CREATED);
         let body: StatusBody = serde_json::from_str(&read_body(started).await).unwrap();
         assert!(body.intercept_port > 0);
@@ -519,7 +565,7 @@ mod tests {
 
         // POST while running → 409.
         assert_eq!(
-            start_from_bytes(b"{}", &control).await.status(),
+            start_from_bytes(b"{}", &control, true).await.status(),
             StatusCode::CONFLICT
         );
 
@@ -533,13 +579,15 @@ mod tests {
     async fn start_rejects_unknown_field_and_bad_json() {
         let control = InterceptControl::default();
         assert_eq!(
-            start_from_bytes(br#"{"caCertpath":"x"}"#, &control)
+            start_from_bytes(br#"{"caCertpath":"x"}"#, &control, true)
                 .await
                 .status(),
             StatusCode::BAD_REQUEST
         );
         assert_eq!(
-            start_from_bytes(b"{not json", &control).await.status(),
+            start_from_bytes(b"{not json", &control, true)
+                .await
+                .status(),
             StatusCode::BAD_REQUEST
         );
         assert!(
@@ -552,7 +600,7 @@ mod tests {
     async fn start_serialized_body_is_deserializable_status() {
         // AC8/parity: the 201 body round-trips through the same shape the FFI returns.
         let control = InterceptControl::default();
-        let resp = start_from_bytes(b"", &control).await;
+        let resp = start_from_bytes(b"", &control, true).await;
         let json = read_body(resp).await;
         assert!(json.contains("interceptPort"));
         assert!(json.contains("interceptUrl"));
@@ -564,7 +612,7 @@ mod tests {
     #[tokio::test]
     async fn start_without_return_ca_key_omits_ca_fields() {
         let control = InterceptControl::default();
-        let json = read_body(start_from_bytes(b"{}", &control).await).await;
+        let json = read_body(start_from_bytes(b"{}", &control, true).await).await;
         assert!(!json.contains("caCertPem"), "no CA cert unless requested");
         assert!(!json.contains("caKeyPem"), "no CA key unless requested");
         let status_json = read_body(handle_status(&control)).await;
@@ -579,7 +627,7 @@ mod tests {
     #[tokio::test]
     async fn start_returns_ca_pair_when_requested() {
         let control = InterceptControl::default();
-        let resp = start_from_bytes(br#"{"returnCaKey":true}"#, &control).await;
+        let resp = start_from_bytes(br#"{"returnCaKey":true}"#, &control, true).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let v: serde_json::Value = serde_json::from_str(&read_body(resp).await).unwrap();
         let cert = v["caCertPem"].as_str().expect("caCertPem present");
@@ -596,7 +644,7 @@ mod tests {
         let control = InterceptControl::default();
         let body = br#"{"returnCaKey":true,"caCertPath":"c.pem","caKeyPath":"k.pem"}"#;
         assert_eq!(
-            start_from_bytes(body, &control).await.status(),
+            start_from_bytes(body, &control, true).await.status(),
             StatusCode::BAD_REQUEST
         );
         assert!(control.status().is_none(), "no listener left behind");
@@ -610,14 +658,16 @@ mod tests {
         let key_pem = ca.ca_key_pem();
         let control = InterceptControl::default();
         let body = serde_json::json!({"caCertPem": cert_pem, "caKeyPem": key_pem}).to_string();
-        let resp = start_from_bytes(body.as_bytes(), &control).await;
+        let resp = start_from_bytes(body.as_bytes(), &control, true).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         assert_eq!(control.state().unwrap().ca.ca_cert_pem(), cert_pem);
         control.stop().await;
 
         let half = serde_json::json!({"caCertPem": cert_pem}).to_string();
         assert_eq!(
-            start_from_bytes(half.as_bytes(), &control).await.status(),
+            start_from_bytes(half.as_bytes(), &control, true)
+                .await
+                .status(),
             StatusCode::BAD_REQUEST
         );
     }
@@ -634,5 +684,144 @@ mod tests {
 
     fn body_string(resp: Response<Full<Bytes>>) -> String {
         String::from_utf8(body_bytes(resp)).unwrap()
+    }
+
+    // ===== --allowInjection gate on the rule doors (issue #657) =====
+    //
+    // An intercept rule's predicates are executed per intercepted request (`match_request` →
+    // `stub_matches`, which has no injection gate of its own), so an `inject` predicate arriving
+    // here is executable code crossing the same trust boundary `POST /imposters` already guards.
+    // Two doors admit rules: `POST /intercept/rules` (always) and `POST /intercept` via the
+    // `rules` array (issue #655). Both must ask the same question.
+
+    const INJECT_RULE: &str = r#"{"host":"evil.example.com",
+        "predicates":[{"inject":"function (request) { return true; }"}],
+        "action":{"serve":{"statusCode":200,"body":"pwned"}}}"#;
+    const CLEAN_RULE: &str = r#"{"host":"cdn.example.com",
+        "predicates":[{"equals":{"path":"/config.json"}}],
+        "action":{"serve":{"statusCode":200,"body":"ok"}}}"#;
+    /// The inject nested under `or`/`not` — wrapping it must not walk past the gate.
+    const NESTED_INJECT_RULE: &str = r#"{"host":"nested.example.com",
+        "predicates":[{"or":[{"equals":{"path":"/a"}},
+                             {"not":{"inject":"function (request) { return true; }"}}]}],
+        "action":{"serve":{"statusCode":200,"body":"pwned"}}}"#;
+
+    fn assert_injection_refused(resp: Response<Full<Bytes>>) {
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_string(resp);
+        assert!(
+            body.contains("allowInjection"),
+            "the refusal must name the flag that would allow it, like every other door: {body}"
+        );
+    }
+
+    /// The async twin of [`assert_injection_refused`]: `body_bytes` builds its own runtime, so it
+    /// cannot be called from inside a `#[tokio::test]`. Same assertions, awaited instead.
+    async fn assert_injection_refused_async(resp: Response<Full<Bytes>>) {
+        let status = resp.status();
+        let body = read_body(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            body.contains("allowInjection"),
+            "the refusal must name the flag that would allow it, like every other door: {body}"
+        );
+    }
+
+    #[test]
+    fn add_rules_refuses_inject_predicate_without_allow_injection() {
+        let state = test_state();
+        assert_injection_refused(add_rules_from_bytes(INJECT_RULE.as_bytes(), &state, false));
+        assert!(
+            state.rules.is_empty(),
+            "a refused rule must not be stored — the proof it was gated before the store, not after"
+        );
+    }
+
+    #[test]
+    fn add_rules_refuses_nested_inject_without_allow_injection() {
+        let state = test_state();
+        assert_injection_refused(add_rules_from_bytes(
+            NESTED_INJECT_RULE.as_bytes(),
+            &state,
+            false,
+        ));
+        assert!(state.rules.is_empty());
+    }
+
+    /// Atomicity: a batch is one document. If any rule in it is gated, none of it is stored —
+    /// matching `POST /imposters` refusing the whole document rather than the offending part.
+    #[test]
+    fn add_rules_batch_with_one_inject_stores_nothing() {
+        let state = test_state();
+        let batch = format!("[{CLEAN_RULE},{INJECT_RULE}]");
+        assert_injection_refused(add_rules_from_bytes(batch.as_bytes(), &state, false));
+        assert!(
+            state.rules.is_empty(),
+            "the clean rule from a refused batch must not be stored either"
+        );
+    }
+
+    /// The flag is the whole point: with it set the same rule is admitted.
+    #[test]
+    fn add_rules_admits_inject_with_allow_injection() {
+        let state = test_state();
+        let resp = add_rules_from_bytes(INJECT_RULE.as_bytes(), &state, true);
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(state.rules.len(), 1);
+    }
+
+    /// No over-reach: an ordinary rule is unaffected by the gate.
+    #[test]
+    fn add_rules_admits_clean_rule_without_allow_injection() {
+        let state = test_state();
+        let resp = add_rules_from_bytes(CLEAN_RULE.as_bytes(), &state, false);
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(state.rules.len(), 1);
+    }
+
+    /// The second door (issue #655): `POST /intercept` can seed `rules` at start. It crosses the
+    /// same boundary, so it asks the same question — and a refused start binds no listener.
+    #[tokio::test]
+    async fn start_refuses_inject_rule_in_the_seeded_rules_array() {
+        let control = InterceptControl::default();
+        let body = format!(r#"{{"port":0,"rules":[{INJECT_RULE}]}}"#);
+        assert_injection_refused_async(start_from_bytes(body.as_bytes(), &control, false).await)
+            .await;
+        assert!(
+            control.status().is_none(),
+            "a refused start must not leave a listener bound"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_admits_seeded_inject_rule_with_allow_injection() {
+        let control = InterceptControl::default();
+        let body = format!(r#"{{"port":0,"rules":[{INJECT_RULE}]}}"#);
+        let resp = start_from_bytes(body.as_bytes(), &control, true).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(control.state().expect("running").rules.len(), 1);
+        control.stop().await;
+    }
+
+    /// No over-reach on the start door either: a *populated* but script-free `rules` array is
+    /// admitted without the flag. Distinct from the no-rules case below — a refactor that special-
+    /// cased "empty vs non-empty" would slip past that one.
+    #[tokio::test]
+    async fn start_admits_seeded_clean_rule_without_allow_injection() {
+        let control = InterceptControl::default();
+        let body = format!(r#"{{"port":0,"rules":[{CLEAN_RULE}]}}"#);
+        let resp = start_from_bytes(body.as_bytes(), &control, false).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(control.state().expect("running").rules.len(), 1);
+        control.stop().await;
+    }
+
+    /// A start with no rules is unaffected by the gate, flag or no flag.
+    #[tokio::test]
+    async fn start_without_rules_is_ungated() {
+        let control = InterceptControl::default();
+        let resp = start_from_bytes(b"{\"port\":0}", &control, false).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        control.stop().await;
     }
 }

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -94,9 +94,16 @@ pub async fn route_request(
     // sub-path/method or a control-less server both fall through to the ordinary 404.
     if path == "/intercept" || path.starts_with("/intercept/") {
         let resp = match intercept.as_ref() {
-            Some(control) => intercept::route(&method, &path, query.as_deref(), req, control)
-                .await
-                .unwrap_or_else(not_found),
+            Some(control) => intercept::route(
+                &method,
+                &path,
+                query.as_deref(),
+                req,
+                control,
+                allow_injection,
+            )
+            .await
+            .unwrap_or_else(not_found),
             None => not_found(),
         };
         return Ok(resp);

--- a/crates/rift-http-proxy/src/injection_gate.rs
+++ b/crates/rift-http-proxy/src/injection_gate.rs
@@ -6,14 +6,25 @@
 //! The gate used to live behind the admin API only, so the same document was refused by an HTTP
 //! POST and executed when loaded from a file.
 //!
+//! The intercept **rule** doors ask it too (issue #657): `POST /intercept/rules`, the `rules` array
+//! on `POST /intercept`, and the `--configfile` `intercept` block (issue #655). A rule's predicates
+//! are evaluated per intercepted request, so an `inject` there is executable code arriving over the
+//! same boundaries — the #612 sweep missed this door, and the same predicate was refused by
+//! `POST /imposters` and executed by `POST /intercept/rules`.
+//!
 //! This module only *classifies*. Each door owns its own failure semantics (400, startup abort,
 //! per-file skip, or FFI NULL), which is why the response builder stays with the admin handlers.
 //!
 //! The gate's subject is the *document*, not the caller: it asks whether config that crossed a
 //! trust boundary carries executable surface. In-process config supplied by an embedding host
-//! (`rift_apply_config`, `rift_create_imposter`, `rift_serve_admin`'s inline `config`) is the
-//! trusted host path and is deliberately never gated (issue #492) — that host can already execute
-//! code in the process, so gating its own JSON would restrict nobody.
+//! (`rift_apply_config`, `rift_create_imposter`, `rift_add_stub`, `rift_replace_stubs`,
+//! `rift_intercept_add_rules`, `rift_start_intercept`, and `rift_serve_admin`'s inline `config`)
+//! is the trusted host path and is deliberately never gated (issue #492) — that host can already
+//! execute code in the process, so gating its own JSON would restrict nobody.
+//!
+//! Both lists above are exhaustive on purpose, and adding a door means adding it to one of them:
+//! #657 happened because a door existed in neither, so "which doors ask the gate?" had to be
+//! re-derived from the code — and the answer was wrong.
 
 use crate::imposter::{ImposterConfig, Predicate, PredicateOperation, Stub, StubResponse};
 
@@ -48,13 +59,15 @@ pub fn gated_offender_ports(configs: &[ImposterConfig]) -> Vec<String> {
         .collect()
 }
 
-/// True if `rule` carries a scripting surface gated by `--allowInjection` (issue #655).
+/// True if `rule` carries a scripting surface gated by `--allowInjection` (issues #655, #657).
 ///
 /// An intercept rule's only executable surface is a predicate `inject`: its `serve` action is a
 /// fixed status/headers/body stub and `forward` is a port number, so neither can carry script — a
-/// serve body that merely looks like JavaScript is inert data. Config-file rules therefore ask this
-/// the same question `--configfile` imposters answer via [`config_uses_script_surface`], so one
-/// document cannot be refused as an imposter stub and executed as an intercept predicate.
+/// serve body that merely looks like JavaScript is inert data. Every door that admits a rule asks
+/// this — `POST /intercept/rules`, the `rules` array on `POST /intercept`, and the `--configfile`
+/// `intercept` block — the same question `--configfile` imposters answer via
+/// [`config_uses_script_surface`], so one document cannot be refused as an imposter stub and
+/// executed as an intercept predicate.
 pub fn intercept_rule_uses_script_surface(rule: &crate::intercept_rules::InterceptRule) -> bool {
     rule.predicates.iter().any(predicate_has_inject)
 }

--- a/crates/rift-http-proxy/tests/intercept_rules_injection_gate.rs
+++ b/crates/rift-http-proxy/tests/intercept_rules_injection_gate.rs
@@ -1,0 +1,153 @@
+//! `POST /intercept/rules` obeys `--allowInjection` (issue #657).
+//!
+//! An intercept rule's predicates are evaluated per intercepted request, so an `inject` predicate
+//! is executable code admitted over the admin API — which is unauthenticated unless `--apikey` is
+//! set. Before this fix the identical predicate was refused by `POST /imposters` and executed here.
+//!
+//! These drive the real server end to end, because the gate's value is that the JS never runs: a
+//! unit test on the handler proves the 400, only this proves nothing executed.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+
+/// The rule from the issue's probe: the script returns true only for `/pwned`, so a match proves
+/// the JS was evaluated per-request.
+const INJECT_RULE: &str = r#"{"host":"probe.example.com",
+    "predicates":[{"inject":"function (request) { return request.path === '/pwned'; }"}],
+    "action":{"serve":{"statusCode":200,"body":"INJECT-EXECUTED"}}}"#;
+
+fn cli(extra: &[&str]) -> Cli {
+    let mut args = vec![
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--intercept-port",
+        "0",
+    ];
+    args.extend_from_slice(extra);
+    Cli::parse_from(args)
+}
+
+/// Without the flag: refused with the same message every other door gives, nothing stored, and —
+/// the point — the script never runs.
+#[tokio::test]
+async fn intercept_rules_inject_is_refused_and_never_executes_without_the_flag() {
+    let server = ServerBuilder::from_cli(cli(&[]))
+        .start()
+        .await
+        .expect("start");
+    let admin = server.admin_addr();
+    let intercept = server.intercept_addr().expect("listener");
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept/rules"))
+        .body(INJECT_RULE)
+        .send()
+        .await
+        .expect("post rule");
+    assert_eq!(
+        resp.status(),
+        400,
+        "an inject predicate must be refused without --allowInjection"
+    );
+    let body = resp.text().await.unwrap_or_default();
+    assert!(
+        body.contains("allowInjection"),
+        "the refusal must name the flag that would allow it: {body}"
+    );
+
+    let listed = reqwest::get(format!("http://{admin}/intercept/rules"))
+        .await
+        .expect("list")
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(
+        listed.trim(),
+        "[]",
+        "a refused rule must not be stored: {listed}"
+    );
+
+    // The whole point: the script does not run. Without the fix this returned "INJECT-EXECUTED".
+    let ca_pem = reqwest::get(format!("http://{admin}/intercept/ca.pem"))
+        .await
+        .expect("ca")
+        .text()
+        .await
+        .unwrap();
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::https(format!("http://{intercept}")).unwrap())
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap();
+    let served = client
+        .get("https://probe.example.com/pwned")
+        .send()
+        .await
+        .expect("request");
+    let served_body = served.text().await.unwrap_or_default();
+    assert!(
+        !served_body.contains("INJECT-EXECUTED"),
+        "the refused rule's script must never execute, got: {served_body}"
+    );
+
+    server.shutdown().await;
+}
+
+/// With the flag: admitted and executed — the `/pwned` vs `/other` differential proves the engine
+/// really evaluates the predicate, so the test above is measuring a gate and not a broken engine.
+#[tokio::test]
+async fn intercept_rules_inject_executes_with_allow_injection() {
+    let server = ServerBuilder::from_cli(cli(&["--allow-injection"]))
+        .start()
+        .await
+        .expect("start");
+    let admin = server.admin_addr();
+    let intercept = server.intercept_addr().expect("listener");
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept/rules"))
+        .body(INJECT_RULE)
+        .send()
+        .await
+        .expect("post rule");
+    assert_eq!(resp.status(), 201, "--allowInjection must admit the rule");
+
+    let ca_pem = reqwest::get(format!("http://{admin}/intercept/ca.pem"))
+        .await
+        .expect("ca")
+        .text()
+        .await
+        .unwrap();
+    let client = reqwest::Client::builder()
+        .proxy(reqwest::Proxy::https(format!("http://{intercept}")).unwrap())
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap();
+
+    let hit = client
+        .get("https://probe.example.com/pwned")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(hit.text().await.unwrap(), "INJECT-EXECUTED");
+
+    let miss = client
+        .get("https://probe.example.com/other")
+        .send()
+        .await
+        .expect("request");
+    assert!(
+        !miss
+            .text()
+            .await
+            .unwrap_or_default()
+            .contains("INJECT-EXECUTED"),
+        "the script returns false for /other — proving it is evaluated per request"
+    );
+
+    server.shutdown().await;
+}

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -228,6 +228,14 @@ the predicate against the base64 string, e.g.
 `{ "equals": { "body": "H4sIAAAAAAAA/w==" } }`. A valid-UTF-8 (text or JSON) body is matched
 as-is, unchanged. Forwarding always relays the raw bytes regardless of classification.
 
+> **`inject` predicates require `--allowInjection`.** A rule's predicates are evaluated on every
+> intercepted request, so an `inject` predicate is executable JavaScript — the same surface
+> `--allowInjection` gates on imposter stubs. Without the flag, a rule carrying one (however deeply
+> nested under `not`/`or`/`and`) is refused with `400` and the whole request is rejected: a batch
+> containing one such rule stores none of it. This holds on every door that admits a rule —
+> `POST /intercept/rules`, the `rules` array on `POST /intercept`, and the `--configfile`
+> `intercept` block. `serve` and `forward` actions carry no script and are never gated.
+
 ### Serve an inline stub
 
 ```bash


### PR DESCRIPTION
An intercept rule's predicates are evaluated on **every intercepted request**, so an `inject` predicate is executable JavaScript. That door never asked the `--allowInjection` gate — the identical predicate was refused `400` by `POST /imposters` and **executed** by `POST /intercept/rules`, on a server started without the flag and on an admin port that is unauthenticated unless `--apikey` is set.

Admin access is deliberately *not* supposed to grant code execution — that is precisely what the flag gates — so this was a privilege escalation past rift's own stated boundary. Proven by probe before the fix:

```
POST /intercept/rules  ->  201 Created   (predicates: [{"inject": "... request.path === '/pwned' ..."}])
GET https://probe.example.com/pwned  ->  "INJECT-EXECUTED"     (the JS ran, returned true)
GET https://probe.example.com/other  ->  <unmatched default>   (the JS ran, returned false)
```

#612 extracted the classifier so every config-admitting door asks one question, and `injection_gate.rs`'s module doc enumerates the doors it swept. **This was the door missing from that list** — the same defect class as #612 and #616, both already fixed.

## What changed

All three rule doors now ask the gate: `POST /intercept/rules`, the `rules` array on `POST /intercept` (added by #655), and the `--configfile` `intercept` block (already gated by #655). The refusal is **atomic and runs before any state change** — one gated rule in a batch stores none of it, and a gated `rules` array fails the start before the listener binds. It sees through `not`/`or`/`and` nesting, reusing the same `predicate_has_inject` the imposter doors use.

**The FFI's direct mutators stay ungated, deliberately.** `rift_intercept_add_rules` / `rift_start_intercept` are the trusted in-process host path (#492) — the same category as `rift_apply_config`, where the host can already execute code in-process. Only documents crossing a trust boundary are gated. Two independent reviewers reached this conclusion separately. The one FFI-reachable door that *is* remote-ish — `rift_serve_admin`'s embedded admin plane — picks the gate up for free via `with_allow_injection`.

Both door lists in the module doc are now exhaustive **and say so**: this bug existed because a door was in neither list, so "which doors ask the gate?" had to be re-derived from the code — and the answer was wrong.

## Behaviour change

A rule with an `inject` predicate now needs `--allowInjection`, and gets the same `400` and remedy message every other door gives. `serve`/`forward` actions carry no script and are unaffected. Documented under `Security` in the CHANGELOG and in `docs/features/intercept-proxy.md`, per the owner's triage.

## Verification

- clippy `--workspace --all-features --tests -D warnings`: 0 warnings. Tests: **1,927 passed, 0 failed**. Docs-coverage gate: pass.
- **Mutation-proven**, not just green: neutering the classifier fails the refusal + batch-atomicity tests; moving the gate after the store fails the refusal tests.
- The e2e proves the *security property* — that the JS **never executes** — not merely that a 400 came back. The `/pwned` vs `/other` differential in the positive test rules out "the engine is broken" as a false explanation for the refusal passing.
- 4 review agents (correctness/opus, silent-failure, test-coverage, idiom): **zero blockers**. The gate was verified fail-closed on every input class (empty list, no-predicate rule, malformed body, nested `not`/`or`/`and`), and `PredicateOperation` was checked exhaustively — only `Not`/`Or`/`And` can nest a `Predicate`, so nothing can hide an `Inject` from the recursion.

Closes #657
Milestone: none (standalone security fix)