### PR TITLE
perf(scripting): hash the decision-cache key with foldhash, not SipHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "chrono",
  "criterion",
  "crossbeam",
+ "foldhash 0.2.0",
  "futures",
  "http-body-util",
  "hyper",

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -15,6 +15,10 @@ readme = "../../README.md"
 workspace = true
 
 [dependencies]
+# Fast, non-cryptographic hashing for the script decision cache (issue #654). Already in the tree
+# via hashbrown; a direct dep costs nothing. See `scripting::decision_cache` for why the key has no
+# hash-stability requirement across processes.
+foldhash = "0.2"
 # Async runtime
 tokio = { workspace = true, features = ["full"] }
 # TaskTracker for bounded connection-drain on imposter teardown (issue #596)

--- a/crates/rift-mock-core/src/scripting/decision_cache.rs
+++ b/crates/rift-mock-core/src/scripting/decision_cache.rs
@@ -2,7 +2,7 @@ use crate::scripting::FaultDecision;
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -135,7 +135,17 @@ impl CacheKey {
     /// cached decision for one TTL, and re-owning serde_json's number hashing to prevent it costs
     /// more than that is worth.
     fn hash_body(body: CacheKeyBody<'_>) -> u64 {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // `foldhash` rather than SipHash (`DefaultHasher`): this hash never leaves the process —
+        // it is an in-memory LRU key, never persisted and never sent over a wire — so it has no
+        // stability requirement across builds or runs, and SipHash's collision resistance buys
+        // nothing here. It costs, though: walking a ~200-node `Value` tree through SipHash was the
+        // dominant term in key construction (issue #654).
+        //
+        // `FixedState`, NOT `RandomState`: this `u64` is *stored* in the key and compared by `Eq`,
+        // so a per-call random seed would give the same body a different hash on every request and
+        // the cache would never hit again — silently, with every correctness test still green.
+        // (The LRU map's own hasher is randomly seeded; see `DecisionCache::new`.)
+        let mut hasher = foldhash::fast::FixedState::default().build_hasher();
         match body {
             CacheKeyBody::Json(value) => {
                 JSON_BODY_TAG.hash(&mut hasher);
@@ -232,7 +242,7 @@ pub struct DecisionCache {
     /// mutates and a read lock was never honest. The win here is a bounded critical section —
     /// `LruCache::push` evicts in O(1), where the previous `min_by_key` scanned all 10k entries
     /// under the exclusive lock on every steady-state insert.
-    cache: Option<Mutex<LruCache<CacheKey, CacheEntry>>>,
+    cache: Option<Mutex<LruCache<CacheKey, CacheEntry, foldhash::fast::RandomState>>>,
     metrics: AtomicMetrics,
     /// Latches the degenerate-cache warning so a pathological key shape is reported once, not
     /// once per request.
@@ -247,8 +257,18 @@ impl DecisionCache {
             config.enabled, config.max_size, config.ttl_seconds
         );
 
+        // `foldhash` for the map too (issue #654): `get`/`push` re-hash the *whole* key — the
+        // method/path/rule strings and every kept header — through the map's build hasher on every
+        // probe, so the lookup side pays SipHash as well, not just the body hash.
+        //
+        // `RandomState` here, unlike `hash_body`: the map holds one instance, so it is internally
+        // consistent for its whole life, and a per-process seed keeps keys built from
+        // network-controlled input (path, headers, body) from being collided on purpose.
         let cache = match (config.enabled, NonZeroUsize::new(config.max_size)) {
-            (true, Some(capacity)) => Some(Mutex::new(LruCache::new(capacity))),
+            (true, Some(capacity)) => Some(Mutex::new(LruCache::with_hasher(
+                capacity,
+                foldhash::fast::RandomState::default(),
+            ))),
             _ => None,
         };
 
@@ -1267,6 +1287,27 @@ mod tests {
         assert_ne!(json_null, empty, "a literal JSON null is not an empty body");
         assert_ne!(json_null, raw, "a literal JSON null is not a binary body");
         assert_ne!(empty, raw, "an empty body is not a binary body");
+    }
+
+    /// The body hash is **stored** in the key (`body_hash: u64`) and compared by `Eq`, so it must
+    /// be stable across calls for the life of the process — a per-call random seed would give the
+    /// same body a different hash every request, and the cache would never hit again while every
+    /// correctness test still passed. That is why `hash_body` seeds with `foldhash`'s `FixedState`
+    /// and not `RandomState` (issue #654); the LRU map's own hasher is a different question, and
+    /// is randomly seeded on purpose.
+    #[test]
+    fn hash_body_is_stable_across_calls() {
+        let body = serde_json::json!({"order": {"id": 7, "items": [1, 2, 3]}});
+        assert_eq!(
+            CacheKey::hash_body(CacheKeyBody::Json(&body)),
+            CacheKey::hash_body(CacheKeyBody::Json(&body)),
+            "a stored key hash seeded per call would never match itself again"
+        );
+        assert_eq!(
+            CacheKey::hash_body(CacheKeyBody::Raw(b"\x00\x01binary")),
+            CacheKey::hash_body(CacheKeyBody::Raw(b"\x00\x01binary")),
+            "the raw arm must be just as stable as the json arm"
+        );
     }
 
     /// A raw body whose bytes are the JSON text of a value must not collide with that parsed value:


### PR DESCRIPTION
The cache key is an **in-memory LRU key** — never persisted, never sent over a wire — so it has no stability requirement across builds or runs, and SipHash's collision resistance buys nothing. It costs, though: walking a ~200-node `serde_json::Value` tree through SipHash was the dominant term in key construction, which every request on the script-rule path pays *before* it can probe the cache.

Swapped in the two places the issue's accepted scope names:

- **`CacheKey::hash_body` → `FixedState`.** The `u64` is *stored* in the key and compared by `Eq`, so the seed must be fixed. `RandomState` would give the same body a different hash on every request and **the cache would never hit again — silently**, with most correctness tests still green. Three tests now fail if anyone makes that swap.
- **The LRU map → `RandomState`** via `LruCache::with_hasher`. `get`/`push` re-hash the *whole* key (method, path, rule id, every kept header) through the map's build hasher on every probe, so the lookup side paid SipHash too. `RandomState` is right here and wrong above: the map holds one instance, so it's self-consistent for life, and a per-process seed keeps keys built from network-controlled input from being collided on purpose.

## Measured — and the ≥3× AC is **not met**

On the issue's own bench (`decision_cache_key_new`), borrowed from the unmerged bench branch; A/B on this base with only the hasher differing:

| bench | before (SipHash) | after (foldhash) | |
|---|--:|--:|--:|
| `large_body_64_items` | 3.469 µs | **1.998 µs** | **1.74×** |
| `small_body` | 499.0 ns | 463.8 ns | 1.08× (no regression ✓) |

The AC asks for **≥3× and <1µs**. This is 1.74× and 2.0µs. **That target is not reachable within the accepted scope**, and the numbers say why:

- `small_body` key construction is 0.48µs, and its body hash is negligible — so **~0.48µs is fixed overhead** (`method`/`path` `String` allocs, the `header_pairs` `Vec` clone, the sort).
- Therefore of `large_body`'s 2.04µs, **~1.56µs (76%) is the tree walk** and ~0.48µs (24%) is that overhead.
- Direction 3 (clone elimination) was deferred with *"chase clones only if they still dominate"* — **they don't**. And even deleting *all* of it lands at ~1.56µs: 2.2×, still >1µs.
- Getting under 1µs means not walking the tree — i.e. hashing raw bytes for JSON too. That's ruled out: #653 chose structural hashing deliberately and #652 preserved it, so formatting and key order don't split the key.

So `Refs #654` rather than `Closes` — **the win is real and free, but the issue's stated goal isn't met.** Your call whether to close it or keep it open for the traversal question.

## Notes

- **Correctness intact**: 1,937 pass, 0 fail; clippy `-D warnings` clean. #652's tag/collision tests pass unchanged, as the AC requires.
- **Mutation-proven**: swapping `FixedState`→`RandomState` fails `hash_body_is_stable_across_calls`, `identical_non_json_bodies_share_a_key`, and #652's proxy test `identical_binary_bodies_still_hit_the_cache`. (`test_cache_basic_operations` passes through that mutation — it reuses one already-computed key — which is exactly how this could have shipped.)
- **No CHANGELOG**: internal perf with no user-facing surface, matching #653 (its direct sibling) and the whole #622–#643 perf cluster.
- The bench is **not** in this PR — it lives on your unmerged `test/rift-bench-scripting-proxy-coverage` branch. See the issue thread: that branch **no longer compiles against master** now that #652 changed `CacheKey::new`'s signature.

Refs #654