### PR TITLE
docs: savedRequests example says `request_from`; the engine sends `requestFrom`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -368,12 +368,12 @@ Get recorded requests (if `recordRequests: true`). Also available under the alia
 
 Multiple `match` clauses are AND-ed together. `since` is applied first, then the `match` clauses.
 
-**Response:** a JSON array of recorded requests. Each element carries `request_from` (the client
+**Response:** a JSON array of recorded requests. Each element carries `requestFrom` (the client
 `ip:port`); `body` is present only when the request had one.
 ```json
 [
   {
-    "request_from": "127.0.0.1:52344",
+    "requestFrom": "127.0.0.1:52344",
     "method": "GET",
     "path": "/api/users",
     "query": {},

--- a/docs/features/gateway.md
+++ b/docs/features/gateway.md
@@ -32,5 +32,5 @@ curl http://localhost:4545/api/users?id=1
 `/__rift/4545` with no trailing path dispatches to `/`. An unknown port returns `404`; a
 non-numeric port returns `400`.
 
-Recorded requests made through the gateway show `request_from` as the loopback address, since the
+Recorded requests made through the gateway show `requestFrom` as the loopback address, since the
 gateway is the imposter's local client.


### PR DESCRIPTION
`RecordedRequest` is `#[serde(rename_all = "camelCase")]` (`imposter/types.rs:58-60`), so the field goes out as **`requestFrom`** — which is what every code path already calls it (`verify.rs:242,257`, `predicates/fields.rs:94,293`). The docs said `request_from`.

That's not cosmetic: anyone following the `savedRequests` example got a field that is **never present** in the response, and a predicate written against it never matches.

## What changed

Three occurrences — one more than the issue lists:

| file | |
|---|---|
| `docs/api/index.md:371` | the prose |
| `docs/api/index.md:376` | the JSON example |
| `docs/features/gateway.md:35` | the same slip, not named in the issue |

Verified `grep -rn request_from docs/` now returns **zero**, and the edited JSON example still parses.

Engine side is correct and unchanged — this is docs-only. No CHANGELOG entry: it corrects documentation of existing behaviour rather than changing any.

Docs-coverage gate passes (self-test + run).

Closes #656