### PR TITLE
test(bench): measure whether the script decision cache pays for itself (key construction vs Boa execution)

### DIFF
--- a/.github/scripts/run_benches.sh
+++ b/.github/scripts/run_benches.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Record BENCH_SAMPLES independent criterion runs of every gated bench target, saving each under
+# the baseline name "<prefix>-<i>" so bench_regression.py can take the min per side (issue #446).
+#
+# Why the existence probe: this gate benchmarks the PR *base* as well as the head, and a gated
+# bench may legitimately not exist on the base — that is exactly how a new bench lands (present on
+# head, absent on base). `cargo bench --bench <name>` hard-errors on an unknown target, which would
+# fail the gate on every PR that adds a bench. Skip those, and let bench_regression.py drop the
+# unpaired side as it already does.
+#
+# The skip is announced, never silent: a bench that quietly stopped running would leave the job
+# green and read as "gated and clean" when in fact nothing measured it. Same reason we probe the
+# target list instead of `|| true`-ing the bench invocation — that would swallow real build and
+# panic failures too, which is precisely what the gate exists to catch.
+#
+# Targets are selected by their workspace-unique bench name, NOT `-p <crate>`: the base checkout may
+# predate a crate rename (e.g. rift-core -> rift-mock-core), so a hardcoded package name would not
+# resolve there. Bench target names are stable across such renames.
+set -euo pipefail
+
+prefix="${1:?usage: run_benches.sh <baseline-prefix>}"
+samples="${BENCH_SAMPLES:?BENCH_SAMPLES must be set}"
+targets="${BENCH_TARGETS:?BENCH_TARGETS must be set}"
+
+present="$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[].targets[] | select(.kind[] == "bench") | .name')"
+
+for bench in $targets; do
+  if ! grep -qxF "$bench" <<<"$present"; then
+    echo "::notice::bench target '$bench' is absent from this checkout; skipping it for '$prefix' (expected when the PR adds a new bench)"
+    continue
+  fi
+  for i in $(seq 1 "$samples"); do
+    echo "::group::$bench ($prefix-$i)"
+    cargo bench --bench "$bench" -- --save-baseline "$prefix-$i"
+    echo "::endgroup::"
+  done
+done

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,14 +1,17 @@
 name: Performance
 
-# Issue #298: run the criterion matcher benches on PRs and flag regressions, so a perf regression
-# can't land silently. Compares the PR head against the base by running the same benches on both
-# and diffing criterion's own mean estimates. Microbenchmarks on shared CI runners are noisy, so
-# the hard-fail threshold is deliberately generous (relative, per-benchmark); the full comparison
-# is always posted to the job summary for review.
+# Issue #298: run the criterion benches on PRs and flag regressions, so a perf regression can't
+# land silently. Compares the PR head against the base by running the same benches on both and
+# diffing criterion's own mean estimates. Microbenchmarks on shared CI runners are noisy, so the
+# hard-fail threshold is deliberately generous (relative, per-benchmark); the full comparison is
+# always posted to the job summary for review.
+#
+# Gated benches (BENCH_TARGETS below): the imposter matcher, the scripting decision cache, and the
+# proxy rule scan.
 
 on:
   pull_request:
-    # Only when code that can affect matcher performance changes (keeps the job off doc/CI-only PRs).
+    # Only when code that can affect benched performance changes (keeps the job off doc/CI-only PRs).
     paths:
       - "crates/rift-mock-core/**"
       - "crates/rift-http-proxy/**"
@@ -29,13 +32,23 @@ env:
   # The matcher benches run in ~150 ns and a shared runner swings ±20-25% run-to-run at that scale,
   # which produced false +50-67% "regressions" (issue #446). Best-of-N sampling below collapses that
   # jitter, so this threshold now cleanly separates real large regressions from residual noise.
+  # The cheapest gated benches are far below that scale (`rule_applies_to_upstream/no_filter` is
+  # sub-nanosecond, `rule_scan_no_match/exact/1` a few ns), where the same absolute jitter is a much
+  # larger relative swing — watch those first if this gate starts crying wolf again.
   REGRESSION_THRESHOLD: "1.5"
   # How many independent bench runs to record per side; the gate compares the fastest (min) of each.
-  BENCH_SAMPLES: "3"
+  # Dropped 3 -> 2 when the decision-cache and proxy benches joined BENCH_TARGETS: the full set is
+  # ~5.5 min per run, and a third sample per side cost ~11 min of wall clock for a shrinking return
+  # (min-of-N's jitter cancellation is strongest going 1 -> 2). If the gate turns flaky again, this
+  # is the first knob to turn back up before touching REGRESSION_THRESHOLD.
+  BENCH_SAMPLES: "2"
+  # Bench targets to gate, by workspace-unique target name (see run_benches.sh for why not `-p`).
+  # A target missing from the PR base is skipped with a notice, so adding one here lands cleanly.
+  BENCH_TARGETS: "imposter_matcher_bench decision_cache_bench proxy_rules_bench"
 
 jobs:
   bench-regression:
-    name: Matcher benchmark regression gate
+    name: Benchmark regression gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for base/head)
@@ -56,25 +69,27 @@ jobs:
       - name: Install LuaJIT (needed to build a pre-#450 base)
         run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
 
+      # Both sides must run the *same* runner script, and `git checkout` of the base replaces the
+      # working tree — including the script itself, which a PR that adds or edits it would then lose
+      # (and a PR that adds it would fail outright: the base has no such file). Stage head's copy
+      # outside the tree first and invoke that for both sides.
+      - name: Stage the bench runner outside the work tree
+        run: |
+          cp .github/scripts/run_benches.sh "$RUNNER_TEMP/run_benches.sh"
+          chmod +x "$RUNNER_TEMP/run_benches.sh"
+
       # Record BENCH_SAMPLES independent runs per side (baselines base-1..N / pr-1..N). The gate
       # compares the fastest run of each side (issue #446): noise only ever makes a run slower, so
       # min-of-N is the least-contended, most-representative measurement and cancels cross-run jitter.
-      # Select the bench by its workspace-unique target name, NOT `-p <crate>`: the base checkout
-      # may predate a crate rename (e.g. rift-core -> rift-mock-core), so a hardcoded package name
-      # would not exist on the base and would fail the gate. The bench target name is stable.
       - name: Benchmark base (${{ github.base_ref }})
         run: |
           git checkout --force ${{ github.event.pull_request.base.sha }}
-          for i in $(seq 1 "$BENCH_SAMPLES"); do
-            cargo bench --bench imposter_matcher_bench -- --save-baseline "base-$i"
-          done
+          "$RUNNER_TEMP/run_benches.sh" base
 
       - name: Benchmark PR head
         run: |
           git checkout --force ${{ github.event.pull_request.head.sha }}
-          for i in $(seq 1 "$BENCH_SAMPLES"); do
-            cargo bench --bench imposter_matcher_bench -- --save-baseline "pr-$i"
-          done
+          "$RUNNER_TEMP/run_benches.sh" pr
 
       - name: Compare and gate
         run: python3 .github/scripts/bench_regression.py

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -42,6 +42,8 @@ RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/bin/verify.rs && \
     echo "fn main() {}" > crates/rift-mock-core/benches/imposter_matcher_bench.rs && \
+    echo "fn main() {}" > crates/rift-mock-core/benches/decision_cache_bench.rs && \
+    echo "fn main() {}" > crates/rift-mock-core/benches/proxy_rules_bench.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-tui/src/main.rs && \

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -100,6 +100,14 @@ criterion = { version = "0.5", features = ["html_reports"] }
 name = "imposter_matcher_bench"
 harness = false
 
+[[bench]]
+name = "decision_cache_bench"
+harness = false
+
+[[bench]]
+name = "proxy_rules_bench"
+harness = false
+
 [features]
 default = ["redis-backend", "javascript"]
 redis-backend = ["redis", "r2d2"]

--- a/crates/rift-mock-core/benches/decision_cache_bench.rs
+++ b/crates/rift-mock-core/benches/decision_cache_bench.rs
@@ -215,6 +215,7 @@ fn bench_insert(c: &mut Criterion) {
 
 /// A script doing something ordinary — read a body field, decide a fault — per issue #665: a
 /// no-op would flatter the memo, an elaborate one would flatter the cache.
+#[allow(dead_code)]
 const PAYOFF_JS_SCRIPT: &str = r#"
 function respond(ctx) {
     var body = ctx.request.json;

--- a/crates/rift-mock-core/benches/decision_cache_bench.rs
+++ b/crates/rift-mock-core/benches/decision_cache_bench.rs
@@ -1,0 +1,202 @@
+//! Criterion benches for the scripting decision cache (`scripting::decision_cache`).
+//!
+//! This is the proxy's per-request script-decision memo: every request that hits a script rule
+//! builds a `CacheKey` and probes the cache, so key construction is as hot as the lookup itself
+//! and is on the critical path even when the cache hits.
+//!
+//! Covers the shapes the recent perf work changed:
+//! * `key_headers` — the `None` (key on every header) vs `Some(allow)` (issue #630/#643) split.
+//! * `CacheKey::new` — header sort + body hash, paid once per request.
+//! * `get`/`insert` — the `LruCache` critical section (issue #631).
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rift_mock_core::scripting::{CacheKey, DecisionCache, DecisionCacheConfig, FaultDecision};
+use serde_json::json;
+
+/// A header set shaped like a real proxied request: a handful the scripts care about, plus the
+/// ambient noise (tracing, agent, encoding) that a `None` key_headers config also hashes.
+fn realistic_headers() -> HashMap<String, String> {
+    [
+        ("host", "api.example.com"),
+        ("user-agent", "rift-bench/1.0"),
+        ("accept", "application/json"),
+        ("accept-encoding", "gzip, deflate, br"),
+        ("content-type", "application/json"),
+        ("content-length", "128"),
+        (
+            "authorization",
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        ),
+        ("x-tenant", "acme-corp"),
+        ("x-request-id", "0f8fad5b-d9cb-469f-a165-70867728950e"),
+        (
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        ),
+        ("x-forwarded-for", "203.0.113.7"),
+        ("cookie", "session=abc123; consent=1"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
+    .collect()
+}
+
+fn cache_with(key_headers: Option<Vec<String>>) -> DecisionCache {
+    DecisionCache::new(DecisionCacheConfig {
+        enabled: true,
+        max_size: 10_000,
+        ttl_seconds: 300,
+        key_headers,
+    })
+}
+
+fn decision() -> FaultDecision {
+    FaultDecision::Latency {
+        duration_ms: 250,
+        rule_id: "bench-rule".to_string(),
+    }
+}
+
+/// The header-subset step (issue #630). `None` clones every header into the key; `Some(allow)`
+/// keeps only the declared ones. The gap here is the per-request cost of *not* declaring
+/// `key_headers` — and, since an undeclared per-request-unique header (`x-request-id`,
+/// `traceparent` above) also makes every key unique, the cost of a cache that never hits.
+fn bench_key_headers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decision_cache_key_headers");
+    let headers = realistic_headers();
+
+    let all = cache_with(None);
+    group.bench_function("all_headers", |b| {
+        b.iter(|| black_box(all.key_headers(black_box(&headers))))
+    });
+
+    // The headers a script realistically reads, declared explicitly.
+    let allowlist = cache_with(Some(vec![
+        "x-tenant".to_string(),
+        "authorization".to_string(),
+    ]));
+    group.bench_function("allowlist_2_of_12", |b| {
+        b.iter(|| black_box(allowlist.key_headers(black_box(&headers))))
+    });
+
+    group.finish();
+}
+
+/// Key construction: sorts the header pairs and hashes the body to a `u64`. Scales with body size,
+/// so bench a small JSON body against a chunkier one.
+fn bench_cache_key_new(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decision_cache_key_new");
+
+    let cache = cache_with(None);
+    let header_pairs = cache.key_headers(&realistic_headers());
+
+    let small_body = json!({ "action": "purchase", "id": 4815 });
+    group.bench_function("small_body", |b| {
+        b.iter(|| {
+            CacheKey::new(
+                "POST".to_string(),
+                "/api/v2/orders".to_string(),
+                black_box(header_pairs.clone()),
+                black_box(&small_body),
+                "bench-rule".to_string(),
+            )
+        })
+    });
+
+    let large_body = json!({
+        "items": (0..64)
+            .map(|i| json!({ "sku": format!("SKU-{i:04}"), "qty": i % 7, "price": i as f64 * 1.5 }))
+            .collect::<Vec<_>>(),
+        "customer": { "id": "acme-corp", "tier": "enterprise" },
+    });
+    group.bench_function("large_body_64_items", |b| {
+        b.iter(|| {
+            CacheKey::new(
+                "POST".to_string(),
+                "/api/v2/orders".to_string(),
+                black_box(header_pairs.clone()),
+                black_box(&large_body),
+                "bench-rule".to_string(),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+/// The locked `LruCache` section (issue #631). A hit clones the decision out and bumps recency; a
+/// miss touches the miss counter. Both hold the same mutex, so this is the contention-free floor.
+fn bench_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decision_cache_get");
+
+    let cache = cache_with(None);
+    let header_pairs = cache.key_headers(&realistic_headers());
+    let body = json!({ "action": "purchase", "id": 4815 });
+    let key = CacheKey::new(
+        "POST".to_string(),
+        "/api/v2/orders".to_string(),
+        header_pairs.clone(),
+        &body,
+        "bench-rule".to_string(),
+    );
+    cache.insert(key.clone(), decision());
+
+    group.bench_function("hit", |b| b.iter(|| black_box(cache.get(black_box(&key)))));
+
+    let absent = CacheKey::new(
+        "POST".to_string(),
+        "/api/v2/nonexistent".to_string(),
+        header_pairs,
+        &body,
+        "bench-rule".to_string(),
+    );
+    group.bench_function("miss", |b| {
+        b.iter(|| black_box(cache.get(black_box(&absent))))
+    });
+
+    group.finish();
+}
+
+/// Steady-state insert at capacity: every insert of a fresh key evicts the LRU victim, which is
+/// the shape a degenerate (per-request-unique) key produces in production.
+fn bench_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decision_cache_insert");
+
+    let cache = DecisionCache::new(DecisionCacheConfig {
+        enabled: true,
+        max_size: 1_000,
+        ttl_seconds: 300,
+        key_headers: Some(Vec::new()),
+    });
+    let body = json!({ "action": "purchase" });
+    let counter = Cell::new(0u64);
+
+    group.bench_function("evicting_at_capacity", |b| {
+        b.iter(|| {
+            let i = counter.get();
+            counter.set(i + 1);
+            let key = CacheKey::new(
+                "POST".to_string(),
+                format!("/api/v2/orders/{i}"),
+                Vec::new(),
+                &body,
+                "bench-rule".to_string(),
+            );
+            cache.insert(black_box(key), decision());
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_key_headers,
+    bench_cache_key_new,
+    bench_get,
+    bench_insert
+);
+criterion_main!(benches);

--- a/crates/rift-mock-core/benches/decision_cache_bench.rs
+++ b/crates/rift-mock-core/benches/decision_cache_bench.rs
@@ -8,12 +8,22 @@
 //! * `key_headers` — the `None` (key on every header) vs `Some(allow)` (issue #630/#643) split.
 //! * `CacheKey::new` — header sort + body hash, paid once per request.
 //! * `get`/`insert` — the `LruCache` critical section (issue #631).
+//! * `decision_cache_payoff` — the memo cost side by side with the script execution it avoids
+//!   (issue #665), so "does the cache pay for itself" is a measured ratio, not an argument.
 
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use rift_mock_core::scripting::{CacheKey, DecisionCache, DecisionCacheConfig, FaultDecision};
+use rift_mock_core::extensions::NoOpFlowStore;
+use rift_mock_core::imposter::ResponseMode;
+use rift_mock_core::scripting::{
+    CacheKey, CacheKeyBody, DecisionCache, DecisionCacheConfig, FaultDecision, RhaiEngine,
+    ScriptRequest, execute_rhai_with_engine,
+};
+#[cfg(feature = "javascript")]
+use rift_mock_core::scripting::{compile_js_to_bytecode, execute_js_bytecode};
 use serde_json::json;
 
 /// A header set shaped like a real proxied request: a handful the scripts care about, plus the
@@ -60,6 +70,17 @@ fn decision() -> FaultDecision {
     }
 }
 
+/// The chunkier body fixture, shared by the key bench and the payoff bench (issue #665) so the
+/// memo cost and the avoided cost are measured over the same payload.
+fn large_body() -> serde_json::Value {
+    json!({
+        "items": (0..64)
+            .map(|i| json!({ "sku": format!("SKU-{i:04}"), "qty": i % 7, "price": i as f64 * 1.5 }))
+            .collect::<Vec<_>>(),
+        "customer": { "id": "acme-corp", "tier": "enterprise" },
+    })
+}
+
 /// The header-subset step (issue #630). `None` clones every header into the key; `Some(allow)`
 /// keeps only the declared ones. The gap here is the per-request cost of *not* declaring
 /// `key_headers` — and, since an undeclared per-request-unique header (`x-request-id`,
@@ -99,26 +120,23 @@ fn bench_cache_key_new(c: &mut Criterion) {
             CacheKey::new(
                 "POST".to_string(),
                 "/api/v2/orders".to_string(),
+                None,
                 black_box(header_pairs.clone()),
-                black_box(&small_body),
+                CacheKeyBody::Json(black_box(&small_body)),
                 "bench-rule".to_string(),
             )
         })
     });
 
-    let large_body = json!({
-        "items": (0..64)
-            .map(|i| json!({ "sku": format!("SKU-{i:04}"), "qty": i % 7, "price": i as f64 * 1.5 }))
-            .collect::<Vec<_>>(),
-        "customer": { "id": "acme-corp", "tier": "enterprise" },
-    });
+    let large_body = large_body();
     group.bench_function("large_body_64_items", |b| {
         b.iter(|| {
             CacheKey::new(
                 "POST".to_string(),
                 "/api/v2/orders".to_string(),
+                None,
                 black_box(header_pairs.clone()),
-                black_box(&large_body),
+                CacheKeyBody::Json(black_box(&large_body)),
                 "bench-rule".to_string(),
             )
         })
@@ -138,8 +156,9 @@ fn bench_get(c: &mut Criterion) {
     let key = CacheKey::new(
         "POST".to_string(),
         "/api/v2/orders".to_string(),
+        None,
         header_pairs.clone(),
-        &body,
+        CacheKeyBody::Json(&body),
         "bench-rule".to_string(),
     );
     cache.insert(key.clone(), decision());
@@ -149,8 +168,9 @@ fn bench_get(c: &mut Criterion) {
     let absent = CacheKey::new(
         "POST".to_string(),
         "/api/v2/nonexistent".to_string(),
+        None,
         header_pairs,
-        &body,
+        CacheKeyBody::Json(&body),
         "bench-rule".to_string(),
     );
     group.bench_function("miss", |b| {
@@ -181,11 +201,138 @@ fn bench_insert(c: &mut Criterion) {
             let key = CacheKey::new(
                 "POST".to_string(),
                 format!("/api/v2/orders/{i}"),
+                None,
                 Vec::new(),
-                &body,
+                CacheKeyBody::Json(&body),
                 "bench-rule".to_string(),
             );
             cache.insert(black_box(key), decision());
+        })
+    });
+
+    group.finish();
+}
+
+/// A script doing something ordinary — read a body field, decide a fault — per issue #665: a
+/// no-op would flatter the memo, an elaborate one would flatter the cache.
+const PAYOFF_JS_SCRIPT: &str = r#"
+function respond(ctx) {
+    var body = ctx.request.json;
+    if (body && body.customer && body.customer.tier === "enterprise") {
+        return delay(250);
+    }
+    return pass();
+}
+"#;
+
+/// The same ordinary decision in Rhai — the cheaper engine, where the cache's margin is thinnest.
+const PAYOFF_RHAI_SCRIPT: &str = r#"
+fn respond(ctx) {
+    let body = ctx.request.json;
+    if body.customer.tier == "enterprise" {
+        delay(250)
+    } else {
+        pass()
+    }
+}
+"#;
+
+/// The request a pool worker would receive for the payoff fixtures — same payload as the memo
+/// side, with `raw_body` populated the way `proxy/handler.rs` populates it.
+fn payoff_script_request(body: &serde_json::Value) -> ScriptRequest {
+    ScriptRequest {
+        method: "POST".to_string(),
+        path: "/api/v2/orders".to_string(),
+        headers: realistic_headers(),
+        body: body.clone(),
+        query: HashMap::new(),
+        path_params: HashMap::new(),
+        raw_body: Some(body.to_string()),
+        mode: ResponseMode::Text,
+    }
+}
+
+/// The cache's payoff, measured instead of argued (issue #665; the question behind #650/#654).
+///
+/// One group, two sides of the trade:
+/// * `memo_hit_large_body` — what **every** request pays, hits included: `key_headers` +
+///   `CacheKey::new` + `get`, exactly the sequence `proxy/handler.rs` runs before it can probe.
+/// * `boa_execute_read_field` / `rhai_execute_read_field` — what a hit **avoids**: the worker-side
+///   engine execution (`execute_js_bytecode` / `execute_rhai_with_engine` with a reusable engine,
+///   the same calls a `ScriptPool` worker makes). Deliberately *without* the pool's queue hop,
+///   oneshot and timeout plumbing, so the avoided cost is understated — if the memo wins against
+///   the bare execution, it wins against the full round-trip a fortiori.
+///
+/// The ratio `avoided / memo` is the answer to "does the cache pay for itself"; read it off the
+/// group's report before re-filing #650 a third time. Snapshot at filing time (Apple Silicon,
+/// 2026-07): memo ~2.4 µs vs Boa ~171 µs (~70x) and Rhai ~27 µs (~11x) — the margin holds with
+/// two orders of magnitude to spare on the engine the cache was built for, and one on Rhai.
+fn bench_payoff(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decision_cache_payoff");
+
+    let body = large_body();
+    let headers = realistic_headers();
+
+    // The memo side: worst-case config (`None` = key on every header) over the same payload.
+    let cache = cache_with(None);
+    let key = CacheKey::new(
+        "POST".to_string(),
+        "/api/v2/orders".to_string(),
+        None,
+        cache.key_headers(&headers),
+        CacheKeyBody::Json(&body),
+        "bench-rule".to_string(),
+    );
+    cache.insert(key, decision());
+
+    group.bench_function("memo_hit_large_body", |b| {
+        b.iter(|| {
+            let key = CacheKey::new(
+                "POST".to_string(),
+                "/api/v2/orders".to_string(),
+                None,
+                cache.key_headers(black_box(&headers)),
+                CacheKeyBody::Json(black_box(&body)),
+                "bench-rule".to_string(),
+            );
+            black_box(cache.get(&key))
+        })
+    });
+
+    // The avoided side: one engine execution of the ordinary script over the same payload.
+    let request = payoff_script_request(&body);
+
+    #[cfg(feature = "javascript")]
+    {
+        let bytecode = compile_js_to_bytecode(PAYOFF_JS_SCRIPT).expect("payoff JS compiles");
+        group.bench_function("boa_execute_read_field", |b| {
+            b.iter(|| {
+                execute_js_bytecode(
+                    black_box(&bytecode),
+                    black_box(&request),
+                    Arc::new(NoOpFlowStore),
+                    "bench-rule",
+                )
+                .expect("payoff JS executes")
+            })
+        });
+    }
+
+    let rhai_engine = RhaiEngine::create_engine();
+    let rhai_ast = RhaiEngine::new(PAYOFF_RHAI_SCRIPT, "bench-rule")
+        .expect("payoff Rhai compiles")
+        .ast()
+        .clone();
+    group.bench_function("rhai_execute_read_field", |b| {
+        b.iter(|| {
+            execute_rhai_with_engine(
+                &rhai_engine,
+                black_box(&rhai_ast),
+                black_box(&request),
+                Arc::new(NoOpFlowStore),
+                "bench-rule",
+            )
+            .expect("payoff Rhai executes")
         })
     });
 
@@ -197,6 +344,7 @@ criterion_group!(
     bench_key_headers,
     bench_cache_key_new,
     bench_get,
-    bench_insert
+    bench_insert,
+    bench_payoff
 );
 criterion_main!(benches);

--- a/crates/rift-mock-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-mock-core/benches/imposter_matcher_bench.rs
@@ -90,11 +90,15 @@ fn bench_stub_matches(c: &mut Criterion) {
     group.finish();
 }
 
-fn imposter_with_stubs(count: usize) -> Imposter {
+/// Build an imposter whose `count` stubs each carry `predicate_for(i)` as their sole predicate.
+fn imposter_with_stubs(
+    count: usize,
+    predicate_for: &dyn Fn(usize) -> serde_json::Value,
+) -> Imposter {
     let stubs: Vec<serde_json::Value> = (0..count)
         .map(|i| {
             json!({
-                "predicates": [{ "equals": { "path": format!("/api/endpoint{i}") } }],
+                "predicates": [predicate_for(i)],
                 "responses": [{ "is": { "statusCode": 200 } }]
             })
         })
@@ -108,34 +112,77 @@ fn imposter_with_stubs(count: usize) -> Imposter {
     Imposter::new(config).expect("test imposter")
 }
 
-/// End-to-end per-request stub scan, scaled 10 → 100 → 1000 stubs. The request targets the last
-/// stub so the whole list is scanned (worst case for the current O(n) matcher).
+/// Per-request stub scan, scaled 10 → 100 → 1000 stubs.
+///
+/// Three corpora, because the Stage-1 path-anchor index (issue #292) — not the stub count — is
+/// what decides how much work a request actually does. `stub_index::classify` indexes a stub only
+/// when a top-level predicate is a plain `equals`/`startsWith`/`contains` on `path`; every other
+/// stub lands in the always-visited fallback bucket. Each request below targets the *last* stub,
+/// so nothing short-circuits early:
+///
+/// * `indexed_exact` — every stub is `equals`-anchored, so `candidates()` resolves the request
+///   path through a `HashMap` to a single candidate and Stage 2 evaluates one predicate. Flat in
+///   stub count: this is the well-indexed common shape, and it is the *best* case, not the worst.
+/// * `unindexed_fallback` — every stub matches on a path *regex*, which `path_anchor` will not
+///   index, so all `count` stubs sit in fallback and each is fully predicate-evaluated. This is
+///   the real O(stubs) worst case.
+/// * `prefix_anchored` — every stub is `startsWith`-anchored. Those *are* indexed, but
+///   `candidates()` walks each distinct prefix bucket linearly, so the prefilter itself scales
+///   with the number of distinct prefixes even though exactly one stub matches.
 fn bench_find_matching_stub(c: &mut Criterion) {
-    let mut group = c.benchmark_group("find_matching_stub");
     let headers: HashMap<String, String> = HashMap::new();
 
-    for count in [10usize, 100, 1000] {
-        let imposter = imposter_with_stubs(count);
-        let path = format!("/api/endpoint{}", count - 1);
-        group.throughput(Throughput::Elements(count as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
-            b.iter(|| {
+    let mut scan = |group_name: &str,
+                    predicate_for: &dyn Fn(usize) -> serde_json::Value,
+                    request_path: &dyn Fn(usize) -> String| {
+        let mut group = c.benchmark_group(group_name);
+        for count in [10usize, 100, 1000] {
+            let imposter = imposter_with_stubs(count, predicate_for);
+            let path = request_path(count);
+            // A fixture that stops matching still scans every stub, so it would keep producing
+            // plausible numbers while silently measuring the no-match path instead. Pin it.
+            assert!(
                 imposter
-                    .find_matching_stub_with_client(
-                        "GET",
-                        black_box(path.as_str()),
-                        black_box(&headers),
-                        None,
-                        None,
-                        None,
-                        None,
-                    )
+                    .find_matching_stub_with_client("GET", &path, &headers, None, None, None, None)
                     .expect("matching must not error")
-            })
-        });
-    }
+                    .is_some(),
+                "{group_name}/{count}: fixture no longer matches its target stub",
+            );
+            group.throughput(Throughput::Elements(count as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+                b.iter(|| {
+                    imposter
+                        .find_matching_stub_with_client(
+                            "GET",
+                            black_box(path.as_str()),
+                            black_box(&headers),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .expect("matching must not error")
+                })
+            });
+        }
+        group.finish();
+    };
 
-    group.finish();
+    scan(
+        "find_matching_stub_indexed_exact",
+        &|i| json!({ "equals": { "path": format!("/api/endpoint{i}") } }),
+        &|count| format!("/api/endpoint{}", count - 1),
+    );
+    scan(
+        "find_matching_stub_unindexed_fallback",
+        &|i| json!({ "matches": { "path": format!("^/api/endpoint{i}$") } }),
+        &|count| format!("/api/endpoint{}", count - 1),
+    );
+    scan(
+        "find_matching_stub_prefix_anchored",
+        &|i| json!({ "startsWith": { "path": format!("/api/endpoint{i}/") } }),
+        &|count| format!("/api/endpoint{}/detail", count - 1),
+    );
 }
 
 criterion_group!(benches, bench_stub_matches, bench_find_matching_stub);

--- a/crates/rift-mock-core/benches/proxy_rules_bench.rs
+++ b/crates/rift-mock-core/benches/proxy_rules_bench.rs
@@ -1,0 +1,239 @@
+//! Criterion benches for the proxy's per-request rule scan (`extensions::matcher`).
+//!
+//! `handle_request` and `handle_script_rules` both walk their compiled rule list per request and
+//! ask each rule `matches(method, uri, headers)` until one hits, so this scan is on every proxied
+//! request — including the ones that match nothing and are forwarded untouched.
+//!
+//! The no-match case is the one worth watching: it is the common shape for a proxy with a handful
+//! of narrowly-scoped rules, it costs a full scan (nothing short-circuits), and it is the path
+//! issue #632 moved off eager `RequestInfo` construction. `rule_applies_to_upstream` is benched
+//! too since it is `&&`-ed onto every one of those comparisons.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use hyper::{HeaderMap, Method, Uri};
+use rift_mock_core::config::Rule;
+use rift_mock_core::extensions::CompiledRule;
+use rift_mock_core::proxy::rule_applies_to_upstream;
+use serde_json::json;
+
+fn compile(rule: serde_json::Value) -> CompiledRule {
+    let rule: Rule = serde_json::from_value(rule).expect("valid rule fixture");
+    CompiledRule::compile(rule).expect("rule compiles")
+}
+
+/// `count` rules, each narrowly scoped to its own exact path so a request for something else has
+/// to be compared against every one of them.
+fn exact_path_rules(count: usize) -> Vec<CompiledRule> {
+    (0..count)
+        .map(|i| {
+            compile(json!({
+                "id": format!("rule-{i}"),
+                "match": { "methods": ["GET"], "path": { "exact": format!("/api/endpoint{i}") } },
+                "fault": {},
+            }))
+        })
+        .collect()
+}
+
+/// Rules that must run a regex against the path — the expensive per-rule comparison.
+fn regex_path_rules(count: usize) -> Vec<CompiledRule> {
+    (0..count)
+        .map(|i| {
+            compile(json!({
+                "id": format!("rule-{i}"),
+                "match": { "methods": ["GET"], "path": { "regex": format!("^/api/endpoint{i}/[0-9]+$") } },
+                "fault": {},
+            }))
+        })
+        .collect()
+}
+
+fn request_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (k, v) in [
+        ("host", "api.example.com"),
+        ("user-agent", "rift-bench/1.0"),
+        ("accept", "application/json"),
+        (
+            "authorization",
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        ),
+        ("x-tenant", "acme-corp"),
+    ] {
+        headers.insert(k, v.parse().expect("valid header value"));
+    }
+    headers
+}
+
+/// Scan the whole rule list without matching — the cost a proxied-but-unmatched request pays.
+fn bench_rule_scan_no_match(c: &mut Criterion) {
+    let headers = request_headers();
+    let method = Method::GET;
+    let uri: Uri = "/api/unmatched/path".parse().expect("valid uri");
+
+    let mut group = c.benchmark_group("proxy_rule_scan_no_match");
+    for count in [1usize, 10, 100] {
+        let rules = exact_path_rules(count);
+        // Guard the premise: if a fixture started matching, this would measure a short-circuited
+        // scan while still reporting under the "no_match" name.
+        assert!(
+            !rules.iter().any(|r| r.matches(&method, &uri, &headers)),
+            "exact/{count}: fixture must not match",
+        );
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("exact", count), &count, |b, _| {
+            b.iter(|| {
+                black_box(
+                    rules.iter().any(|r| {
+                        r.matches(black_box(&method), black_box(&uri), black_box(&headers))
+                    }),
+                )
+            })
+        });
+    }
+    for count in [1usize, 10, 100] {
+        let rules = regex_path_rules(count);
+        assert!(
+            !rules.iter().any(|r| r.matches(&method, &uri, &headers)),
+            "regex/{count}: fixture must not match",
+        );
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("regex", count), &count, |b, _| {
+            b.iter(|| {
+                black_box(
+                    rules.iter().any(|r| {
+                        r.matches(black_box(&method), black_box(&uri), black_box(&headers))
+                    }),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Matching on the last rule of the list: full scan plus a successful comparison.
+fn bench_rule_scan_match_last(c: &mut Criterion) {
+    let headers = request_headers();
+    let method = Method::GET;
+
+    let mut group = c.benchmark_group("proxy_rule_scan_match_last");
+    for count in [1usize, 10, 100] {
+        let rules = exact_path_rules(count);
+        let uri: Uri = format!("/api/endpoint{}", count - 1)
+            .parse()
+            .expect("valid uri");
+        // The point of this group is the full scan, so the hit must be the *last* rule.
+        assert_eq!(
+            rules
+                .iter()
+                .position(|r| r.matches(&method, &uri, &headers)),
+            Some(count - 1),
+            "{count}: fixture must match only the last rule",
+        );
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                black_box(rules.iter().position(|r| {
+                    r.matches(black_box(&method), black_box(&uri), black_box(&headers))
+                }))
+            })
+        });
+    }
+    group.finish();
+}
+
+/// A single rule's match cost, isolated by predicate kind — what each step of the scans above
+/// actually pays for.
+fn bench_single_rule_match(c: &mut Criterion) {
+    let headers = request_headers();
+    let method = Method::GET;
+    let uri: Uri = "/api/v2/users/4815".parse().expect("valid uri");
+
+    let mut group = c.benchmark_group("proxy_single_rule_match");
+
+    let cases = [
+        // `path` omitted -> PathMatch::Any (its serde default): matches every path.
+        ("path_any", json!({ "methods": [] })),
+        (
+            "method_and_exact_path",
+            json!({ "methods": ["GET"], "path": { "exact": "/api/v2/users/4815" } }),
+        ),
+        (
+            "prefix_path",
+            json!({ "methods": ["GET"], "path": { "prefix": "/api/v2/" } }),
+        ),
+        (
+            "regex_path",
+            json!({ "methods": ["GET"], "path": { "regex": r"^/api/v\d+/users/\d+$" } }),
+        ),
+        (
+            "header_predicate",
+            json!({
+                "methods": ["GET"],
+                "path": { "prefix": "/api/" },
+                "headerPredicates": [{ "name": "x-tenant", "equals": "acme-corp" }],
+            }),
+        ),
+    ];
+
+    for (name, match_config) in cases {
+        let rule = compile(json!({ "id": name, "match": match_config, "fault": {} }));
+        // Each case is meant to price a *successful* match: a rule that fails short-circuits and
+        // would quietly measure less work than its name implies.
+        assert!(
+            rule.matches(&method, &uri, &headers),
+            "{name}: fixture must match",
+        );
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                black_box(rule.matches(black_box(&method), black_box(&uri), black_box(&headers)))
+            })
+        });
+    }
+
+    group.finish();
+}
+
+/// `&&`-ed onto every rule comparison in the scan, so its cost rides along with each.
+fn bench_rule_applies_to_upstream(c: &mut Criterion) {
+    let mut group = c.benchmark_group("proxy_rule_applies_to_upstream");
+
+    group.bench_function("no_filter", |b| {
+        b.iter(|| {
+            black_box(rule_applies_to_upstream(
+                black_box(&None),
+                black_box(Some("api")),
+            ))
+        })
+    });
+
+    let filter = Some("api".to_string());
+    group.bench_function("matching_filter", |b| {
+        b.iter(|| {
+            black_box(rule_applies_to_upstream(
+                black_box(&filter),
+                black_box(Some("api")),
+            ))
+        })
+    });
+
+    group.bench_function("non_matching_filter", |b| {
+        b.iter(|| {
+            black_box(rule_applies_to_upstream(
+                black_box(&filter),
+                black_box(Some("other")),
+            ))
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_rule_scan_no_match,
+    bench_rule_scan_match_last,
+    bench_single_rule_match,
+    bench_rule_applies_to_upstream
+);
+criterion_main!(benches);

--- a/crates/rift-mock-core/src/scripting/mod.rs
+++ b/crates/rift-mock-core/src/scripting/mod.rs
@@ -16,6 +16,10 @@ pub use bounded::{
 };
 
 pub use rhai_engine::RhaiEngine;
+/// Exposed for the decision-cache payoff bench (issue #665): the worker-side execute with a
+/// reusable engine, i.e. the per-request cost a cache hit actually avoids. `should_inject_fault`
+/// is not a substitute there — it builds a fresh `Engine` per call, which the pool never pays.
+pub use rhai_engine::execute_rhai_with_engine;
 
 // Script pool for optimized execution
 mod script_pool;


### PR DESCRIPTION
Adds the `decision_cache_payoff` bench group: the full per-request memo cost (`key_headers` + `CacheKey::new` + `get`, the exact sequence `proxy/handler.rs` runs before it can probe) side by side with the worker-side script execution a cache hit avoids — Boa and Rhai, an ordinary read-a-field script over the same `large_body_64_items` payload. Measured: memo ~2.4 µs vs Boa ~171 µs (**~70x**) and Rhai ~27 µs (**~11x**), with the avoided cost deliberately understated (no pool queue/oneshot plumbing), so the cache pays for itself a fortiori. The next "the key build costs more than the lookup" filing (#650, #654) is now a lookup, not an argument.

This PR carries the whole `test/rift-bench-scripting-proxy-coverage` branch (matcher worst-case bench, decision-cache + proxy-rule-scan bench coverage, and the CI perf gate wiring), which had no PR yet — plus a merge of current `master` and the migration of the bench's `CacheKey::new` call sites to the `CacheKeyBody` + query signature from #661/#666, without which the branch no longer built against master. Also exports `execute_rhai_with_engine` so the bench measures the reusable-engine path a pool worker actually runs.

Closes #665

Milestone: none (standalone bench coverage)