### PR TITLE
build(docker): drop curl via a built-in healthcheck and publish a static musl image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+# The Dockerfiles pin their bases by digest (issue #664) so builds are reproducible. A pin with
+# nobody bumping it is just a stale base, so Dependabot owns the bumps: it reads the tag next to
+# each digest and opens a PR when that tag moves.
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/crates/rift-http-proxy"
+      - "/crates/rift-lint"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build(docker)"
+
+  # The publish pipeline's own actions are a supply-chain surface too.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,10 +294,16 @@ jobs:
           mkdir -p ctx
           cp target/x86_64-unknown-linux-musl/release/rift-http-proxy ctx/rift-http-proxy
           chmod +x ctx/rift-http-proxy
-          # The binary must be static: a scratch image has no dynamic loader to fall back on.
+          # The binary must need no dynamic loader: scratch has none, so a dynamically linked
+          # binary would fail to exec at all. Rust's musl target emits a static-PIE, which `file`
+          # reports as "static-pie linked" rather than "statically linked" — both are static and
+          # both run here; only "dynamically linked" is disqualifying.
           file ctx/rift-http-proxy
-          file ctx/rift-http-proxy | grep -q 'statically linked' \
-            || { echo "[fail] musl binary is not statically linked — it cannot run on scratch" >&2; exit 1; }
+          file ctx/rift-http-proxy | grep -qE 'static-pie linked|statically linked' \
+            || { echo "[fail] musl binary is not static — it cannot run on scratch" >&2; exit 1; }
+          file ctx/rift-http-proxy | grep -q 'dynamically linked' \
+            && { echo "[fail] musl binary wants a dynamic loader that scratch does not have" >&2; exit 1; }
+          echo "[pass] binary is static and needs no loader"
 
       - name: Build the static image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
       # AC4: the flavor exists to have nothing for a scanner to report. Fail on ANY OS-package
       # vulnerability — there are no OS packages, so the only correct result is zero.
       - name: Scan for OS-level CVEs
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: rift-static:ci
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,20 @@ jobs:
           ./scripts/verify-docs-coverage.sh --self-test
           ./scripts/verify-docs-coverage.sh
 
+  image-hardening:
+    name: Image Hardening
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Issue #664: the images ship the rift binary and nothing else. Fail if curl creeps back in,
+      # a base image goes unpinned, a healthcheck starts shelling out again, or the publish
+      # pipeline stops attesting/signing. --self-test first proves the checker isn't a no-op.
+      - name: Verify image hardening
+        run: |
+          ./scripts/verify-image-hardening.sh --self-test
+          ./scripts/verify-image-hardening.sh
+
   docs-examples:
     name: Docs Examples
     runs-on: ubuntu-latest
@@ -249,6 +263,88 @@ jobs:
       # release self-containment gate's musl allowlist is validated here on a real musl artifact.
       - name: Assert the musl cdylib is self-contained
         run: ./scripts/check-ffi-selfcontained.sh target/x86_64-unknown-linux-musl/release/librift_ffi.so
+
+  static-image:
+    name: Static Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+
+      # Issue #664: same reasoning as the musl-cdylib gate above. docker-publish.yml only runs on
+      # release (workflow_call/dispatch), so without this job nothing builds or runs the `-static`
+      # image before it ships, and every claim about it would rest on grepping Dockerfile text.
+      # Reproduces the release build path exactly (cross + the same feature set, which drops
+      # mimalloc), then builds the scratch image and proves the container actually reports healthy.
+      - name: Build rift-http-proxy for musl
+        run: |
+          cross build --release --package rift-http-proxy --target x86_64-unknown-linux-musl \
+            --no-default-features --features javascript,redis-backend
+
+      - name: Assemble the build context
+        run: |
+          set -euo pipefail
+          mkdir -p ctx
+          cp target/x86_64-unknown-linux-musl/release/rift-http-proxy ctx/rift-http-proxy
+          chmod +x ctx/rift-http-proxy
+          # The binary must be static: a scratch image has no dynamic loader to fall back on.
+          file ctx/rift-http-proxy
+          file ctx/rift-http-proxy | grep -q 'statically linked' \
+            || { echo "[fail] musl binary is not statically linked — it cannot run on scratch" >&2; exit 1; }
+
+      - name: Build the static image
+        run: |
+          docker build -f crates/rift-http-proxy/Dockerfile.static -t rift-static:ci ctx
+
+      # The point of the whole flavor: the built-in probe reports healthy from a scratch image with
+      # no shell and no curl. This is what proves AC1 for real rather than by text-matching.
+      - name: The container reports healthy via the built-in probe
+        run: |
+          set -euo pipefail
+          docker run -d --name rift-static -p 2525:2525 rift-static:ci
+          for i in $(seq 1 30); do
+            status=$(docker inspect --format='{{.State.Health.Status}}' rift-static 2>/dev/null || echo starting)
+            echo "  health: $status"
+            [ "$status" = "healthy" ] && break
+            [ "$status" = "unhealthy" ] && { docker logs rift-static; exit 1; }
+            sleep 2
+          done
+          [ "$(docker inspect --format='{{.State.Health.Status}}' rift-static)" = "healthy" ] \
+            || { echo "[fail] static image never became healthy" >&2; docker logs rift-static; exit 1; }
+          # And the probe is usable directly, which is what the compose files and docs tell people
+          # to run.
+          docker exec rift-static rift healthcheck
+          echo "[pass] scratch image reports healthy via the built-in probe"
+
+      - name: The admin API actually serves from the static image
+        run: |
+          set -euo pipefail
+          curl -fsS http://localhost:2525/health | grep -q '"ok"' \
+            || { echo "[fail] admin API did not answer from the static image" >&2; exit 1; }
+          echo "[pass] admin API serves from scratch"
+
+      - name: Stop the container
+        if: always()
+        run: docker rm -f rift-static || true
+
+      # AC4: the flavor exists to have nothing for a scanner to report. Fail on ANY OS-package
+      # vulnerability — there are no OS packages, so the only correct result is zero.
+      - name: Scan for OS-level CVEs
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: rift-static:ci
+          format: table
+          exit-code: '1'
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          vuln-type: os
+          ignore-unfixed: false
 
   lint:
     name: Lint

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # cosign keyless signing exchanges this OIDC token for a short-lived Fulcio cert (issue #664).
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -95,7 +97,10 @@ jobs:
             VERSION=${{ steps.vars.outputs.VERSION }}
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
-          provenance: false
+          # Attestations (issue #664): enterprise image-curation pipelines verify these, and an
+          # unattested image is what gets rejected at their gate.
+          sbom: true
+          provenance: mode=max
 
       # Build and push arm64 image
       - name: Build and push arm64
@@ -110,7 +115,10 @@ jobs:
             VERSION=${{ steps.vars.outputs.VERSION }}
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
-          provenance: false
+          # Attestations (issue #664): enterprise image-curation pipelines verify these, and an
+          # unattested image is what gets rejected at their gate.
+          sbom: true
+          provenance: mode=max
 
       # Create and push multi-arch manifest
       - name: Create and push manifest
@@ -128,6 +136,198 @@ jobs:
             ${{ env.REGISTRY }}/${REPO}:${VERSION}-amd64 \
             ${{ env.REGISTRY }}/${REPO}:${VERSION}-arm64
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Sign the multi-arch index each tag actually resolves to — that digest is what a consumer
+      # pulls and what `cosign verify` checks. Keyless: the identity is this workflow, not a key
+      # anyone has to hold. Tags are deduped because :VERSION and :latest are the same index.
+      - name: Sign published images
+        run: |
+          # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
+          # list, the loop signs nothing, and the step still exits 0 — a publish that reports
+          # success having signed nothing. The signed-count assertion is the backstop.
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy"
+
+          DIGESTS=$(for TAG in "${VERSION}" latest; do
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
+              --format '{{.Manifest.Digest}}'
+          done | sort -u)
+
+          [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }
+
+          echo "$DIGESTS" | while read -r DIGEST; do
+            echo "signing ${REPO}@${DIGEST}"
+            cosign sign --yes "${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+          done
+
+          # Prove the attestations survived `imagetools create`: buildx attaches SBOM/provenance as
+          # separate manifests in each per-arch index, and this job merges those indexes into a new
+          # one. If that merge ever drops them, fail here rather than publish an image that claims
+          # attestations it does not carry.
+          echo "$DIGESTS" | while read -r DIGEST; do
+            REF="${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+            for KIND in SBOM Provenance; do
+              OUT=$(docker buildx imagetools inspect "$REF" --format "{{ json .${KIND} }}")
+              case "$OUT" in
+                ''|null|'{}') echo "::error::${REF} carries no ${KIND}"; exit 1 ;;
+                *) echo "  ${KIND} present on ${REF}" ;;
+              esac
+            done
+          done
+
+  # =============================================================================
+  # Build and push the static (scratch) rift-proxy flavor — issue #664.
+  #
+  # Uses the musl release binaries, which release.yml already builds with `cross`. They are
+  # genuinely static (rift's TLS is pure rustls/ring, no OpenSSL), so the image can be FROM
+  # scratch: no OS packages, nothing for a scanner to flag, nothing to patch.
+  # Published as `-static` tags alongside the Debian-based default.
+  # =============================================================================
+  build-rift-proxy-static:
+    name: Build rift-proxy (static)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # cosign keyless signing exchanges this OIDC token for a short-lived Fulcio cert (issue #664).
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Determine version
+        id: vars
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            VERSION="${{ inputs.tag }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="edge"
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
+      # Pre-built musl binaries from the GitHub Release (release.yml build matrix).
+      - name: Download linux-amd64 musl binary
+        run: |
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          mkdir -p binaries/amd64-musl
+          curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${VERSION}/rift-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
+            tar --wildcards -xzf - -C binaries/amd64-musl --strip-components=2 "*/bin/rift"
+          mv binaries/amd64-musl/rift binaries/amd64-musl/rift-http-proxy
+          chmod +x binaries/amd64-musl/rift-http-proxy
+
+      - name: Download linux-arm64 musl binary
+        run: |
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          mkdir -p binaries/arm64-musl
+          curl -fsSL "https://github.com/${{ github.repository }}/releases/download/${VERSION}/rift-${VERSION}-aarch64-unknown-linux-musl.tar.gz" | \
+            tar --wildcards -xzf - -C binaries/arm64-musl --strip-components=2 "*/bin/rift"
+          mv binaries/arm64-musl/rift binaries/arm64-musl/rift-http-proxy
+          chmod +x binaries/arm64-musl/rift-http-proxy
+
+      # The binary is static, but the image is still built per-platform so the manifest advertises
+      # the right architecture to a puller.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push amd64 (static)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./binaries/amd64-musl
+          file: ./crates/rift-http-proxy/Dockerfile.static
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy:${{ steps.vars.outputs.VERSION }}-static-amd64
+          build-args: |
+            VERSION=${{ steps.vars.outputs.VERSION }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
+          sbom: true
+          provenance: mode=max
+
+      - name: Build and push arm64 (static)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./binaries/arm64-musl
+          file: ./crates/rift-http-proxy/Dockerfile.static
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy:${{ steps.vars.outputs.VERSION }}-static-arm64
+          build-args: |
+            VERSION=${{ steps.vars.outputs.VERSION }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
+          sbom: true
+          provenance: mode=max
+
+      - name: Create and push static manifest
+        run: |
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy"
+
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${REPO}:${VERSION}-static \
+            ${{ env.REGISTRY }}/${REPO}:${VERSION}-static-amd64 \
+            ${{ env.REGISTRY }}/${REPO}:${VERSION}-static-arm64
+
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${REPO}:latest-static \
+            ${{ env.REGISTRY }}/${REPO}:${VERSION}-static-amd64 \
+            ${{ env.REGISTRY }}/${REPO}:${VERSION}-static-arm64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign published static images
+        run: |
+          # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
+          # list, the loop signs nothing, and the step still exits 0 — a publish that reports
+          # success having signed nothing. The signed-count assertion is the backstop.
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy"
+
+          DIGESTS=$(for TAG in "${VERSION}-static" latest-static; do
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
+              --format '{{.Manifest.Digest}}'
+          done | sort -u)
+
+          [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }
+
+          echo "$DIGESTS" | while read -r DIGEST; do
+            echo "signing ${REPO}@${DIGEST}"
+            cosign sign --yes "${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+          done
+
+          # Prove the attestations survived `imagetools create`: buildx attaches SBOM/provenance as
+          # separate manifests in each per-arch index, and this job merges those indexes into a new
+          # one. If that merge ever drops them, fail here rather than publish an image that claims
+          # attestations it does not carry.
+          echo "$DIGESTS" | while read -r DIGEST; do
+            REF="${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+            for KIND in SBOM Provenance; do
+              OUT=$(docker buildx imagetools inspect "$REF" --format "{{ json .${KIND} }}")
+              case "$OUT" in
+                ''|null|'{}') echo "::error::${REF} carries no ${KIND}"; exit 1 ;;
+                *) echo "  ${KIND} present on ${REF}" ;;
+              esac
+            done
+          done
+
   # =============================================================================
   # Build and push rift-lint using pre-built binaries from release
   # =============================================================================
@@ -136,6 +336,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # cosign keyless signing exchanges this OIDC token for a short-lived Fulcio cert (issue #664).
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -198,7 +400,10 @@ jobs:
             VERSION=${{ steps.vars.outputs.VERSION }}
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
-          provenance: false
+          # Attestations (issue #664): enterprise image-curation pipelines verify these, and an
+          # unattested image is what gets rejected at their gate.
+          sbom: true
+          provenance: mode=max
 
       # Build and push arm64 image
       - name: Build and push arm64
@@ -213,7 +418,10 @@ jobs:
             VERSION=${{ steps.vars.outputs.VERSION }}
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ steps.vars.outputs.BUILD_DATE }}
-          provenance: false
+          # Attestations (issue #664): enterprise image-curation pipelines verify these, and an
+          # unattested image is what gets rejected at their gate.
+          sbom: true
+          provenance: mode=max
 
       # Create and push multi-arch manifest
       - name: Create and push manifest
@@ -228,3 +436,45 @@ jobs:
           docker buildx imagetools create -t ${{ env.REGISTRY }}/${REPO}:latest \
             ${{ env.REGISTRY }}/${REPO}:${VERSION}-amd64 \
             ${{ env.REGISTRY }}/${REPO}:${VERSION}-arm64
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Sign the multi-arch index each tag actually resolves to — that digest is what a consumer
+      # pulls and what `cosign verify` checks. Keyless: the identity is this workflow, not a key
+      # anyone has to hold. Tags are deduped because :VERSION and :latest are the same index.
+      - name: Sign published images
+        run: |
+          # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
+          # list, the loop signs nothing, and the step still exits 0 — a publish that reports
+          # success having signed nothing. The signed-count assertion is the backstop.
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.VERSION }}"
+          REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-lint"
+
+          DIGESTS=$(for TAG in "${VERSION}" latest; do
+            docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
+              --format '{{.Manifest.Digest}}'
+          done | sort -u)
+
+          [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }
+
+          echo "$DIGESTS" | while read -r DIGEST; do
+            echo "signing ${REPO}@${DIGEST}"
+            cosign sign --yes "${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+          done
+
+          # Prove the attestations survived `imagetools create`: buildx attaches SBOM/provenance as
+          # separate manifests in each per-arch index, and this job merges those indexes into a new
+          # one. If that merge ever drops them, fail here rather than publish an image that claims
+          # attestations it does not carry.
+          echo "$DIGESTS" | while read -r DIGEST; do
+            REF="${{ env.REGISTRY }}/${REPO}@${DIGEST}"
+            for KIND in SBOM Provenance; do
+              OUT=$(docker buildx imagetools inspect "$REF" --format "{{ json .${KIND} }}")
+              case "$OUT" in
+                ''|null|'{}') echo "::error::${REF} carries no ${KIND}"; exit 1 ;;
+                *) echo "  ${KIND} present on ${REF}" ;;
+              esac
+            done
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **A `-static` image flavor: the same rift, on `FROM scratch`.** Published alongside the existing
+  tags as `zainalpour/rift-proxy:<version>-static` and `:latest-static`, built from the musl release
+  binaries the release workflow already produced. It contains the rift binary, a CA bundle and a
+  passwd entry — nothing else. No package manager ever runs in it, so an image scanner finds no OS
+  packages to report, which is the point: teams running rift in ephemeral test environments were
+  patching a Debian userland that rift never uses. This is possible because rift's TLS is pure
+  rustls pinned to `ring` with no OpenSSL anywhere, so the musl binaries are genuinely static. Two
+  differences from the default flavor, both documented: there is no shell (use exec-form commands),
+  and the musl builds omit the mimalloc allocator. Scripting and the Redis backend are present in
+  both, and HTTPS upstream proxying works in both — the CA bundle is copied in.
+- **`rift healthcheck`** — probes the admin API's `/health` and exits 0/1, reading `--host`/`--port`
+  (so `MB_HOST`/`MB_PORT`) exactly as the server does. It exists so an image needs no shell and no
+  curl to report its own health; `--url` probes something else, `--timeout` bounds it.
+- **Published images now carry an SBOM and max-mode provenance, and are signed with cosign keyless.**
+  The signing identity is the release workflow itself, so there is no key to distribute; `cosign
+  verify` is documented under Deployment → Docker. Enterprise image-curation pipelines check exactly
+  these, and an unattested image is what gets rejected at their gate.
+
+### Changed
+
+- **Every image base is now digest-pinned** (`image:tag@sha256:...`), with Dependabot owning the
+  bumps. `rustlang/rust:nightly` floats daily, so builds of the same commit were not reproducible.
+
+### Security
+
+- **The container images no longer install `curl`** ([CVE-2025-10148]).
+  curl was in the image for exactly one reason — to run the `HEALTHCHECK` line — and that line now
+  execs the binary's own `rift healthcheck` instead. The image's intent was always "just the rift
+  binary"; nothing else in it used curl. Downstream consumers were carrying a medium-severity
+  advisory in their test infrastructure on account of a probe.
+
+[CVE-2025-10148]: https://nvd.nist.gov/vuln/detail/cve-2025-10148
+
 ### Fixed
 
 - **Two requests differing only in their query string no longer share one cached script decision.**

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage
 # Using Rust nightly for if-let-chains feature (required by regress 0.10.5, a boa_engine dependency)
-FROM rustlang/rust:nightly AS builder
+# Digest-pinned (issue #664): `nightly` floats daily, so an unpinned tag makes this build
+# irreproducible. Dependabot reads the tag and bumps the digest.
+FROM rustlang/rust:nightly@sha256:3c0f3ff052e4e8981d3aabeb30db61658708cd4255a6df562ac8959d32b3478f AS builder
 
 WORKDIR /build
 
@@ -60,11 +62,15 @@ RUN find crates/rift-http-proxy/src -name '*.rs' -exec touch {} \; && \
 
 # Runtime stage
 # Using debian:trixie-slim (Debian 13/testing) for GLIBC_2.39+ compatibility with nightly Rust build
-FROM debian:trixie-slim
+# (the `-static` flavor — Dockerfile.static — has no such constraint).
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
-# Install CA certificates and curl
+# CA certificates only. `curl` used to be installed here purely to serve the HEALTHCHECK below;
+# `rift healthcheck` replaced it (issue #664), so the image no longer carries curl's CVE surface.
+# ca-certificates stays: hyper-rustls is built with `native-tokio` and loads this trust store at
+# runtime, so dropping it silently breaks HTTPS upstream proxying.
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy binary from builder
@@ -107,9 +113,10 @@ WORKDIR /data
 # Note: Docker publish (-p) works regardless of EXPOSE; this is documentation
 EXPOSE 2525 9090 4545-4550 8080-8090
 
-# Health check for admin API
+# Health check for admin API. Exec form (no shell): the probe is built into the binary, and it
+# reads MB_PORT/MB_HOST from the environment itself.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -fsS http://localhost:${MB_PORT:-2525}/ >/dev/null || exit 1
+  CMD ["/usr/local/bin/rift", "healthcheck"]
 
 # ============================================================
 # Environment Variables

--- a/crates/rift-http-proxy/Dockerfile.prebuilt
+++ b/crates/rift-http-proxy/Dockerfile.prebuilt
@@ -6,7 +6,8 @@
 #     --build-arg BINARY_PATH=./rift-http-proxy \
 #     -f Dockerfile.prebuilt .
 
-FROM debian:bookworm-slim
+# Digest-pinned (issue #664) so the published image is reproducible; Dependabot bumps it.
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 # Build args for metadata
 ARG VERSION=dev
@@ -14,9 +15,10 @@ ARG VCS_REF=unknown
 ARG BUILD_DATE=unknown
 ARG TARGETARCH
 
-# Install CA certificates and curl for health checks
+# CA certificates only — `rift healthcheck` replaced the curl-based probe (issue #664).
+# ca-certificates stays: hyper-rustls (`native-tokio`) loads this trust store for HTTPS upstreams.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy pre-built binary (provided via build context)
@@ -48,9 +50,9 @@ WORKDIR /data
 # Expose ports
 EXPOSE 2525 9090 4545-4550 8080-8090
 
-# Health check
+# Health check. Exec form (no shell): the probe is built into the binary and reads MB_PORT itself.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -fsS http://localhost:${MB_PORT:-2525}/ >/dev/null || exit 1
+  CMD ["/usr/local/bin/rift", "healthcheck"]
 
 # Environment variables
 ENV MB_PORT=2525

--- a/crates/rift-http-proxy/Dockerfile.static
+++ b/crates/rift-http-proxy/Dockerfile.static
@@ -1,0 +1,88 @@
+# Static (scratch) image for using the pre-built musl binaries from the release workflow.
+#
+# Why this flavor exists (issue #664): the Debian-based images carry a full OS userland that rift
+# never uses, and every package in it is CVE surface a downstream consumer has to chase — the
+# trigger was CVE-2025-10148 against a curl that only existed to serve the HEALTHCHECK. This image
+# contains the rift binary, a CA bundle, and a passwd entry. Nothing else. No package manager ever
+# runs, so an image scanner finds no OS packages to report.
+#
+# This works because rift's TLS is pure rustls pinned to `ring` (no OpenSSL anywhere in
+# Cargo.lock), so the release musl binaries are genuinely static and need no loader at runtime.
+#
+# Feature parity note: the musl release binaries are built `--no-default-features --features
+# javascript,redis-backend` (see release.yml), so scripting and the Redis backend are present but
+# the mimalloc allocator is not — that is the one difference from the Debian flavor.
+#
+# Usage:
+#   docker buildx build --platform linux/amd64 \
+#     --build-arg BINARY_PATH=./rift-http-proxy \
+#     -f Dockerfile.static .
+
+# Assemble everything that is not the binary. scratch has no shell, so nothing can be created in
+# the final stage — it can only be copied in.
+# Digest-pinned (issue #664); Dependabot reads the tag and bumps the digest.
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818 AS rootfs
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# A non-root uid needs a passwd entry to be a *name*; without one the container still runs as
+# 1000 but tools resolve it to a bare number. /data and /config are made here because the final
+# stage cannot mkdir them.
+RUN printf 'rift:x:1000:1000::/data:/sbin/nologin\n' > /rootfs-etc-passwd && \
+    printf 'rift:x:1000:\n' > /rootfs-etc-group && \
+    mkdir -p /rootfs/data /rootfs/config
+
+FROM scratch
+
+# Build args for metadata
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+# The CA bundle is not optional: hyper-rustls is built with `native-tokio`, so it loads the OS
+# trust store at runtime. Without this file every HTTPS upstream proxy fails.
+COPY --from=rootfs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=rootfs /rootfs-etc-passwd /etc/passwd
+COPY --from=rootfs /rootfs-etc-group /etc/group
+COPY --from=rootfs --chown=1000:1000 /rootfs/data /data
+COPY --from=rootfs --chown=1000:1000 /rootfs/config /config
+
+# The statically-linked musl binary (provided via build context, as in Dockerfile.prebuilt).
+# --chmod is explicit because there is no shell here to chmod it afterwards.
+COPY --chmod=755 rift-http-proxy /usr/local/bin/rift
+
+# OCI labels and metadata
+LABEL \
+  org.opencontainers.image.title="Rift HTTP Proxy (static)" \
+  org.opencontainers.image.description="Mountebank-compatible HTTP chaos engineering proxy — statically linked, no OS packages." \
+  org.opencontainers.image.url="https://github.com/EtaCassiopeia/rift" \
+  org.opencontainers.image.source="https://github.com/EtaCassiopeia/rift" \
+  org.opencontainers.image.version="$VERSION" \
+  org.opencontainers.image.revision="$VCS_REF" \
+  org.opencontainers.image.created="$BUILD_DATE" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.vendor="Rift" \
+  org.opencontainers.image.base.name="scratch"
+
+USER 1000:1000
+WORKDIR /data
+
+# Expose ports (see Dockerfile for the full rationale):
+# 2525 admin API, 9090 metrics, 4545-4550 + 8080-8090 imposter ports
+EXPOSE 2525 9090 4545-4550 8080-8090
+
+# Environment variables
+ENV MB_PORT=2525
+ENV MB_HOST=0.0.0.0
+ENV MB_LOGLEVEL=info
+ENV RIFT_METRICS_PORT=9090
+
+# Health check. Exec form is mandatory here — there is no shell to expand a string-form CMD, which
+# is exactly why the probe is built into the binary (issue #664).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/usr/local/bin/rift", "healthcheck"]
+
+ENTRYPOINT ["/usr/local/bin/rift"]
+CMD []

--- a/crates/rift-http-proxy/src/healthcheck.rs
+++ b/crates/rift-http-proxy/src/healthcheck.rs
@@ -1,0 +1,224 @@
+//! `rift healthcheck` (issue #664): probe a running server's admin API and exit non-zero when it
+//! is not healthy.
+//!
+//! This lives in the binary because the image has nothing else to probe with: the `-static` flavor
+//! is `FROM scratch`, so there is no shell and no curl — the container HEALTHCHECK can only exec
+//! the rift binary itself. Dropping curl is the point (CVE-2025-10148 landed in the image purely
+//! to serve a HEALTHCHECK line).
+//!
+//! Kept as plain, testable library functions — `main.rs`/[`dispatch`] are thin CLI wrappers (URL
+//! construction, printing, exit codes) around [`probe`], which tests call directly.
+
+use anyhow::{Context, Result, bail};
+use std::time::Duration;
+
+/// Probe `url`, succeeding only when it answers 2xx.
+///
+/// A non-2xx answer and a transport failure are both `Err`: for a liveness probe "the server told
+/// me it is broken" and "the server did not answer" are the same verdict.
+pub async fn probe(url: &str, timeout: Duration) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .context("failed to build the healthcheck client")?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("healthcheck request to {url} failed"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        bail!("healthcheck: {url} answered {status}");
+    }
+
+    Ok(())
+}
+
+/// The admin API health endpoint to probe, derived from the server's own `--host`/`--port`.
+pub fn default_url(host: &str, port: u16) -> String {
+    // `--host`/`MB_HOST` is a *bind* address: 0.0.0.0 (and ::) mean "listen on every interface",
+    // which is not a meaningful address to connect *to*. A server bound that way answers on
+    // loopback, which is where a probe running inside the same container should knock.
+    let host = match host {
+        "0.0.0.0" | "::" | "[::]" | "" => "127.0.0.1",
+        h => h,
+    };
+
+    // A bare IPv6 literal has to be bracketed in a URL authority, or the port reads as another hextet.
+    if host.contains(':') && !host.starts_with('[') {
+        format!("http://[{host}]:{port}/health")
+    } else {
+        format!("http://{host}:{port}/health")
+    }
+}
+
+/// `rift healthcheck`: probe the admin API. `Err` is the unhealthy verdict — `main` turns it into
+/// the non-zero exit Docker reads, and prints the cause for whoever runs `docker inspect`.
+///
+/// Runs on its own runtime and never touches the server bootstrap — a probe must not write the
+/// running server's PID file or log files out from under it.
+pub fn dispatch(url: Option<String>, host: &str, port: u16, timeout_secs: u64) -> Result<()> {
+    let url = url.unwrap_or_else(|| default_url(host, port));
+    // One outbound GET; a current-thread runtime is enough (and is what `script_cli` uses).
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to start the probe runtime")?;
+
+    runtime.block_on(probe(&url, Duration::from_secs(timeout_secs)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Serve `status_line` to every caller until dropped. Returns the bound address.
+    async fn spawn_server(status_line: &'static str) -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let body = r#"{"status":"ok"}"#;
+                let resp = format!(
+                    "HTTP/1.1 {status_line}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        addr
+    }
+
+    /// Accept connections but never answer, so a probe can only end by timing out.
+    async fn spawn_hung_server() -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock);
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn probe_accepts_2xx() {
+        let addr = spawn_server("200 OK").await;
+        let url = format!("http://{addr}/health");
+        assert!(probe(&url, Duration::from_secs(5)).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn probe_rejects_5xx() {
+        let addr = spawn_server("500 Internal Server Error").await;
+        let url = format!("http://{addr}/health");
+        let err = probe(&url, Duration::from_secs(5))
+            .await
+            .expect_err("a 500 is not healthy");
+        assert!(
+            err.to_string().contains("500"),
+            "error should name the status: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_rejects_4xx() {
+        // A reachable server with no /health route is still not a healthy rift.
+        let addr = spawn_server("404 Not Found").await;
+        let url = format!("http://{addr}/health");
+        assert!(probe(&url, Duration::from_secs(5)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn probe_reports_connection_refused() {
+        // Bind then drop: the port is now almost certainly free, so connecting is refused.
+        let addr = {
+            let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+            listener.local_addr().expect("local_addr")
+        };
+        let url = format!("http://{addr}/health");
+        assert!(probe(&url, Duration::from_secs(5)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn probe_times_out_on_a_hung_server() {
+        // Without a timeout the probe would hang here forever and only Docker's own --timeout
+        // would end it; the exit code has to come from us.
+        let addr = spawn_hung_server().await;
+        let url = format!("http://{addr}/health");
+        assert!(probe(&url, Duration::from_millis(200)).await.is_err());
+    }
+
+    #[test]
+    fn default_url_maps_bind_any_to_loopback() {
+        for bind_any in ["0.0.0.0", "::", "[::]", ""] {
+            assert_eq!(
+                default_url(bind_any, 2525),
+                "http://127.0.0.1:2525/health",
+                "{bind_any} is a bind address, not a connect address"
+            );
+        }
+    }
+
+    // `dispatch` is the whole CLI path below arg parsing: it must turn a healthy server into Ok and
+    // anything else into the Err that becomes the container's non-zero exit.
+    #[test]
+    fn dispatch_reports_ok_for_a_healthy_server() {
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let addr = rt.block_on(spawn_server("200 OK"));
+        // `dispatch` builds its own runtime, so call it off the async context.
+        let url = format!("http://{addr}/health");
+        std::thread::spawn(move || dispatch(Some(url), "127.0.0.1", 0, 5))
+            .join()
+            .expect("thread")
+            .expect("a 200 server is healthy");
+    }
+
+    #[test]
+    fn dispatch_reports_err_for_an_unhealthy_server() {
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let addr = rt.block_on(spawn_server("503 Service Unavailable"));
+        let url = format!("http://{addr}/health");
+        let err = std::thread::spawn(move || dispatch(Some(url), "127.0.0.1", 0, 5))
+            .join()
+            .expect("thread")
+            .expect_err("a 503 server is not healthy");
+        assert!(
+            err.to_string().contains("503"),
+            "should name the status: {err}"
+        );
+    }
+
+    // With no --url, dispatch must derive the target from --host/--port (how MB_PORT reaches it).
+    #[test]
+    fn dispatch_without_url_probes_the_admin_port() {
+        let rt = tokio::runtime::Runtime::new().expect("rt");
+        let addr = rt.block_on(spawn_server("200 OK"));
+        let port = addr.port();
+        std::thread::spawn(move || dispatch(None, "127.0.0.1", port, 5))
+            .join()
+            .expect("thread")
+            .expect("should have probed the derived admin URL");
+    }
+
+    #[test]
+    fn default_url_keeps_an_explicit_host() {
+        assert_eq!(
+            default_url("example.internal", 8080),
+            "http://example.internal:8080/health"
+        );
+    }
+
+    #[test]
+    fn default_url_brackets_an_ipv6_literal() {
+        assert_eq!(default_url("::1", 2525), "http://[::1]:2525/health");
+    }
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -47,3 +47,7 @@ pub mod script_cli;
 pub mod gateway;
 // CLI surface + ServerBuilder + metrics server; the `rift` binary is a thin caller
 pub mod server;
+
+/// `rift healthcheck` (issue #664): the container HEALTHCHECK probe, built into the binary so the
+/// image needs no shell or curl.
+pub mod healthcheck;

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -27,6 +27,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::Parser;
 use rift_http_proxy::admin_api::DEFAULT_ADMIN_PORT;
+use rift_http_proxy::healthcheck;
 use rift_http_proxy::script_cli;
 use rift_http_proxy::server::{Cli, Commands, ServerBuilder};
 use std::path::PathBuf;
@@ -41,6 +42,13 @@ fn main() -> Result<(), anyhow::Error> {
     // (and `cli.command`) stay intact for the Stop/Restart/Save/Replay dispatch below.
     if let Some(Commands::Script { action }) = cli.command.clone() {
         return script_cli::dispatch(action);
+    }
+
+    // Same treatment for `healthcheck` (issue #664), and for a second reason beyond skipping the
+    // bootstrap: the path below writes `--pidfile`, which would clobber the running server's PID
+    // file with the probe's own — every container health check.
+    if let Some(Commands::Healthcheck { url, timeout }) = cli.command.clone() {
+        return healthcheck::dispatch(url, &cli.host, cli.port, timeout);
     }
 
     // `--debug` is the server-flag spelling of debug mode (issue #360 Item 3); `RIFT_DEBUG` is
@@ -129,6 +137,11 @@ fn main() -> Result<(), anyhow::Error> {
         // match stays exhaustive and correct if that ever changes.
         Some(Commands::Script { action }) => {
             return script_cli::dispatch(action.clone());
+        }
+        // Likewise already handled above — and it must stay that way: reaching here would mean the
+        // probe had already overwritten `--pidfile` with its own PID.
+        Some(Commands::Healthcheck { url, timeout }) => {
+            return healthcheck::dispatch(url.clone(), &cli.host, cli.port, *timeout);
         }
         Some(Commands::Start) | None => {
             // Default behavior - start in Mountebank mode

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -26,6 +26,11 @@ use tracing::{debug, error, info, warn};
 /// Bounded grace given to in-flight metrics connections on `shutdown()` (issue #342).
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
+/// Default `rift healthcheck` timeout. Deliberately *under* the `--timeout=3s` the images'
+/// HEALTHCHECK lines allow, so a hung server makes the probe report an unhealthy verdict itself
+/// rather than race Docker's killer for it (equal budgets fire at the same instant).
+pub const DEFAULT_HEALTHCHECK_TIMEOUT_SECS: u64 = 2;
+
 /// Rift - A Mountebank-compatible HTTP chaos engineering proxy
 ///
 /// Rift starts an admin API on port 2525 (configurable) for creating imposters
@@ -219,6 +224,20 @@ pub enum Commands {
     Script {
         #[command(subcommand)]
         action: ScriptAction,
+    },
+
+    /// Probe a running server's admin API; exits 0 when healthy, 1 otherwise (issue #664).
+    ///
+    /// This is the container HEALTHCHECK: the `-static` image is `FROM scratch`, so there is no
+    /// shell and no curl to probe with.
+    Healthcheck {
+        /// URL to probe (default: the admin API's /health on --host/--port)
+        #[arg(long, value_name = "URL")]
+        url: Option<String>,
+
+        /// Give up after this many seconds
+        #[arg(long, value_name = "SECONDS", default_value_t = DEFAULT_HEALTHCHECK_TIMEOUT_SECS)]
+        timeout: u64,
     },
 }
 
@@ -986,6 +1005,64 @@ mod tests {
     fn test_no_parse_flag_accepted() {
         let cli = Cli::try_parse_from(["rift", "--noParse"]).expect("--noParse should be accepted");
         assert!(cli.no_parse);
+    }
+
+    // Issue #664: `rift healthcheck` is what the images run as their HEALTHCHECK, so its bare form
+    // must parse with no arguments and default to the admin port.
+    #[test]
+    fn healthcheck_parses_bare() {
+        let cli = Cli::try_parse_from(["rift", "healthcheck"]).expect("parse");
+        match cli.command {
+            Some(Commands::Healthcheck { url, timeout }) => {
+                assert!(url.is_none(), "no --url means probe the admin API");
+                assert_eq!(timeout, DEFAULT_HEALTHCHECK_TIMEOUT_SECS);
+            }
+            other => panic!("expected Healthcheck, got {other:?}"),
+        }
+        assert_eq!(cli.port, DEFAULT_ADMIN_PORT);
+    }
+
+    #[test]
+    fn healthcheck_accepts_url_and_timeout() {
+        let cli = Cli::try_parse_from([
+            "rift",
+            "healthcheck",
+            "--url",
+            "http://localhost:9090/metrics",
+            "--timeout",
+            "10",
+        ])
+        .expect("parse");
+        match cli.command {
+            Some(Commands::Healthcheck { url, timeout }) => {
+                assert_eq!(url.as_deref(), Some("http://localhost:9090/metrics"));
+                assert_eq!(timeout, 10);
+            }
+            other => panic!("expected Healthcheck, got {other:?}"),
+        }
+    }
+
+    // The probe has to follow the server's own --port, since that is how the container's MB_PORT
+    // reaches it.
+    #[test]
+    fn healthcheck_follows_the_servers_port_flag() {
+        let cli = Cli::try_parse_from(["rift", "--port", "3000", "healthcheck"]).expect("parse");
+        assert_eq!(cli.port, 3000);
+        assert!(matches!(cli.command, Some(Commands::Healthcheck { .. })));
+    }
+
+    // Its budget must stay strictly under the images' `HEALTHCHECK --timeout=3s`, or the probe
+    // races Docker's killer instead of reporting the unhealthy verdict itself. A const block makes
+    // raising the default past that budget a compile error rather than a test failure.
+    #[test]
+    fn healthcheck_default_timeout_is_under_the_dockerfile_budget() {
+        const DOCKERFILE_HEALTHCHECK_TIMEOUT_SECS: u64 = 3;
+        const {
+            assert!(
+                DEFAULT_HEALTHCHECK_TIMEOUT_SECS < DOCKERFILE_HEALTHCHECK_TIMEOUT_SECS,
+                "the probe's budget must be strictly under the Dockerfile HEALTHCHECK --timeout"
+            )
+        };
     }
 
     // Issue #532: skipped datadir files must be surfaced, not silently dropped.

--- a/crates/rift-lint/Dockerfile
+++ b/crates/rift-lint/Dockerfile
@@ -1,6 +1,7 @@
 # Build stage
 # Using Rust nightly for if-let-chains feature (required by regress 0.10.5, a boa_engine dependency)
-FROM rustlang/rust:nightly AS builder
+# Digest-pinned (issue #664); Dependabot reads the tag and bumps the digest.
+FROM rustlang/rust:nightly@sha256:3c0f3ff052e4e8981d3aabeb30db61658708cd4255a6df562ac8959d32b3478f AS builder
 
 WORKDIR /build
 
@@ -48,7 +49,8 @@ RUN find crates/rift-lint/src -name '*.rs' -exec touch {} \; && \
 
 # Runtime stage
 # Using debian:trixie-slim (Debian 13/testing) for GLIBC_2.39+ compatibility with nightly Rust build
-FROM debian:trixie-slim
+# Digest-pinned (issue #664); Dependabot reads the tag and bumps the digest.
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
 # Install CA certificates (needed for potential HTTPS validation in future)
 RUN apt-get update && \

--- a/crates/rift-lint/Dockerfile.prebuilt
+++ b/crates/rift-lint/Dockerfile.prebuilt
@@ -1,7 +1,8 @@
 # Dockerfile for using pre-built binaries from release workflow
 # This is much faster than compiling in Docker
 
-FROM debian:bookworm-slim
+# Digest-pinned (issue #664); Dependabot reads the tag and bumps the digest.
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 # Build args for metadata
 ARG VERSION=dev

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -371,6 +371,29 @@ rift-http-proxy script run scripts/echo.js --request fixtures/get-resource.json 
 | `--engine <ENGINE>` | Script engine (`rhai`/`js`); inferred from the file extension when omitted | (from extension) |
 | `--hook <HOOK>` | Entrypoint to run; only `respond` is wired for both engines today | `respond` |
 
+### healthcheck
+
+Probe a running server's admin API and exit `0` when it answers `2xx`, `1` otherwise. This is what
+the container images run as their `HEALTHCHECK` — the probe is built into the binary so the image
+needs no shell and no `curl`, which is what lets the `-static` image be `FROM scratch`
+(see [Docker]({{ site.baseurl }}/deployment/docker/)).
+
+With no arguments it probes `/health` on the admin API, reading `--host`/`--port` (and therefore
+`MB_HOST`/`MB_PORT`) exactly as the server does — so inside a container `rift healthcheck` needs no
+configuration. A bind-any host (`0.0.0.0`, `::`) is probed on loopback, since that is where a server
+bound to every interface answers.
+
+```bash
+rift-http-proxy healthcheck                                        # probes http://127.0.0.1:2525/health
+MB_PORT=3000 rift-http-proxy healthcheck                           # follows MB_PORT
+rift-http-proxy healthcheck --url http://localhost:9090/metrics    # probe something else
+```
+
+| Flag | Description | Default |
+|:-----|:------------|:--------|
+| `--url <URL>` | URL to probe instead of the admin API's `/health` | (from `--host`/`--port`) |
+| `--timeout <SECONDS>` | Give up and report unhealthy after this long. Kept under the images' `HEALTHCHECK --timeout=3s` so a hung server makes the probe report the verdict itself instead of being killed mid-probe | `2` |
+
 ---
 
 ## Additional CLI Tools

--- a/docs/demo/docker-compose-https.yml
+++ b/docs/demo/docker-compose-https.yml
@@ -32,7 +32,7 @@ services:
       - ./certs:/certs:ro
     command: ["--configfile", "/imposters.json", "--default-tls-cert", "/certs/server.crt", "--default-tls-key", "/certs/server.key"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9090/metrics"]
+      test: ["CMD", "rift", "healthcheck", "--url", "http://localhost:9090/metrics"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/demo/docker-compose-rift-features.yml
+++ b/docs/demo/docker-compose-rift-features.yml
@@ -11,7 +11,7 @@ services:
       - MB_PORT=2525
     command: ["--configfile", "/imposters.json"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docs/demo/docker-compose-scripting-engines.yml
+++ b/docs/demo/docker-compose-scripting-engines.yml
@@ -13,7 +13,7 @@ services:
     # gates since issue #612 — without it rift refuses to start.
     command: ["--configfile", "/imposters.json", "--allow-injection"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docs/demo/docker-compose-scripting.yml
+++ b/docs/demo/docker-compose-scripting.yml
@@ -13,7 +13,7 @@ services:
     # gates since issue #612 — without it rift refuses to start.
     command: ["--configfile", "/imposters.json", "--allow-injection"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docs/demo/docker-compose.yml
+++ b/docs/demo/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./imposters.json:/imposters.json:ro
     command: ["--configfile", "/imposters.json"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -26,6 +26,63 @@ docker run -p 2525:2525 zainalpour/rift-proxy:latest
 
 ---
 
+## Image Flavors
+
+Every release publishes two flavors of the same rift binary. They are interchangeable — same admin
+API, same imposter behaviour, same ports, same environment variables.
+
+| Tag | Base | Use it when |
+|:----|:-----|:------------|
+| `latest`, `X.Y.Z` | `debian:trixie-slim` | The default. |
+| `latest-static`, `X.Y.Z-static` | `scratch` | You want the smallest CVE surface — typically ephemeral CI/test environments. |
+
+```bash
+docker pull zainalpour/rift-proxy:latest-static
+docker run -p 2525:2525 zainalpour/rift-proxy:latest-static
+```
+
+The `-static` flavor is a statically-linked musl build on `FROM scratch`. It contains the rift
+binary, a CA certificate bundle, and a passwd entry — nothing else. No package manager ever runs in
+it, so an image scanner finds **no OS packages to report**: there is no base distro to keep patching
+just because rift is running in your test suite.
+
+Two consequences worth knowing before you switch:
+
+- **No shell.** There is no `/bin/sh`, so `docker exec ... sh`, string-form `command:` overrides, and
+  shell-form healthchecks do not work. Use exec form (`["rift", "healthcheck"]`) and pass flags
+  directly. The health probe is built into the binary precisely for this reason — see
+  [`rift healthcheck`]({{ site.baseurl }}/configuration/cli/).
+- **No mimalloc.** The musl binaries are built without the mimalloc allocator (it is a default
+  feature of the glibc builds). Scripting and the Redis backend are both present. If you are
+  benchmarking allocation-heavy workloads, use the default flavor.
+
+HTTPS upstream proxying works in both: the CA bundle is copied into the static image, because rift's
+TLS client loads the OS trust store at runtime.
+
+---
+
+## Verifying an Image
+
+Published images carry an SBOM and max-mode provenance, and are signed with
+[cosign](https://docs.sigstore.dev/) keyless — the signing identity is the release workflow itself,
+so there is no public key to distribute.
+
+```bash
+# Verify the signature and its provenance
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/EtaCassiopeia/rift/.github/workflows/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  zainalpour/rift-proxy:latest-static
+
+# Inspect the SBOM / provenance attestations
+docker buildx imagetools inspect zainalpour/rift-proxy:latest-static \
+  --format '{{ json .SBOM }}'
+docker buildx imagetools inspect zainalpour/rift-proxy:latest-static \
+  --format '{{ json .Provenance }}'
+```
+
+---
+
 ## Basic Configuration
 
 ### With Environment Variables
@@ -79,7 +136,7 @@ services:
       - ./imposters.json:/imposters.json:ro
     command: ["--configfile", "/imposters.json"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -146,7 +203,7 @@ services:
       - ./test/mocks:/mocks:ro
     command: ["--configfile", "/mocks/imposters.json"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -162,7 +219,7 @@ services:
       - "2525:2525"
       - "4545:4545"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -271,16 +328,25 @@ docker logs rift
 docker logs -f rift  # Follow
 ```
 
-### Execute Commands
+### Drive the Admin API
+
+The images ship the rift binary and nothing else — no curl, and in the `-static` flavor no shell
+either — so run these from the host against the published admin port rather than via `docker exec`.
 
 ```bash
 # Create imposter
-docker exec rift curl -X POST http://localhost:2525/imposters \
+curl -X POST http://localhost:2525/imposters \
   -H "Content-Type: application/json" \
   -d '{"port": 4545, "protocol": "http", "stubs": []}'
 
 # List imposters
-docker exec rift curl http://localhost:2525/imposters
+curl http://localhost:2525/imposters
+```
+
+The one thing worth running *inside* the container is the health probe, which is built in:
+
+```bash
+docker exec rift rift healthcheck && echo healthy
 ```
 
 ### Restart

--- a/scripts/verify-image-hardening.sh
+++ b/scripts/verify-image-hardening.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+#
+# Verify the container images stay lean and their publish pipeline stays attested (issue #664).
+#
+# The rift images ship one thing: the rift binary. Every extra OS package in them is CVE surface
+# a downstream consumer has to chase (CVE-2025-10148 in Debian's curl is what prompted this), and
+# curl was only ever there to serve the HEALTHCHECK. These checks keep it that way:
+#
+#   1. no image layer installs curl                     (it is gone; keep it gone)
+#   2. every HEALTHCHECK uses the built-in probe        (exec form: scratch has no shell)
+#   3. every FROM is digest-pinned                      (a floating tag is an unpinned dependency)
+#   4. every runtime stage keeps a CA bundle            (hyper-rustls native-tokio needs it)
+#   5. the static image installs no OS packages at all  (scratch/distroless, no apt/apk)
+#   6. no compose healthcheck shells out to curl        (breaks the moment curl leaves the image)
+#   7. published images get SBOM + provenance + cosign  (what image curators actually check)
+#   8. dependabot watches the docker ecosystem          (so the pins above get bumped)
+#
+# Usage:
+#   scripts/verify-image-hardening.sh              # check the repo
+#   scripts/verify-image-hardening.sh --self-test  # prove each check flags a planted violation
+#
+# Overridable so the self-test can point the checks at a mutated copy of the tree.
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+set -uo pipefail
+
+FAILURES=0
+
+fail() {
+  echo "  FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+ok() {
+  echo "  ok: $1"
+}
+
+# Repo-relative path: two Dockerfiles share the basename `Dockerfile`, so a bare basename in a
+# failure message doesn't say which image is broken.
+rel() {
+  echo "${1#"$ROOT"/}"
+}
+
+# Dockerfiles that build a published image. Discovered rather than listed so a new one is covered
+# by default — an image nobody remembered to add to a list is exactly the one that rots.
+dockerfiles() {
+  find "$ROOT/crates" -name 'Dockerfile*' -type f 2>/dev/null | sort
+}
+
+# Anything that can define a healthcheck for a rift container: real compose files, and the compose
+# snippets in the docs — a documented probe is copy-pasted into real deployments, so it rots the
+# same way a real one does.
+compose_files() {
+  {
+    find "$ROOT/docs" "$ROOT/tests" -name 'docker-compose*.yml' -type f 2>/dev/null
+    grep -rl 'healthcheck:' "$ROOT/docs" --include='*.md' 2>/dev/null
+  } | sort -u
+}
+
+# Strip comments so a check never matches an explanatory line about the thing it forbids.
+uncommented() {
+  sed -e 's/#.*$//' "$1"
+}
+
+# Only the lines belonging to the FINAL (runtime) stage of a Dockerfile. Builder stages are thrown
+# away, so what they install or mention says nothing about the shipped image — a check that reads
+# the whole file can be satisfied by a discarded stage.
+runtime_stage() {
+  uncommented "$1" | awk '
+    /^FROM[[:space:]]/ { delete lines; n = 0; next }
+    { lines[n++] = $0 }
+    END { for (i = 0; i < n; i++) print lines[i] }
+  '
+}
+
+# --- 1. no image layer installs curl ----------------------------------------
+check_no_curl_installed() {
+  echo "[1] no image layer installs curl"
+  local f found=0
+  for f in $(dockerfiles); do
+    # Only package-manager lines matter: curl on the *runner* (workflows) is fine, curl baked into
+    # an image layer is not.
+    if uncommented "$f" | grep -nE '(apt-get|apt|apk|yum|dnf)[[:space:]]+(-[^[:space:]]+[[:space:]]+)*(install|add)' \
+      | grep -qw 'curl'; then
+      fail "$(rel "$f") installs curl"
+      found=1
+    fi
+  done
+  [ "$found" -eq 0 ] && ok "no Dockerfile installs curl"
+}
+
+# --- 2. HEALTHCHECK uses the built-in probe, in exec form -------------------
+check_healthcheck_builtin() {
+  echo "[2] HEALTHCHECK uses the built-in probe (exec form)"
+  local f found=0
+  for f in $(dockerfiles); do
+    local hc
+    hc=$(uncommented "$f" | grep -E '^[[:space:]]*(HEALTHCHECK|[[:space:]]+CMD)' || true)
+    [ -z "$hc" ] && continue
+    if echo "$hc" | grep -q 'curl'; then
+      fail "$(rel "$f") HEALTHCHECK still shells out to curl"
+      found=1
+      continue
+    fi
+    # A CMD line belonging to a HEALTHCHECK must be exec form (a JSON array) and invoke the
+    # binary's own probe: scratch has no shell to expand a string-form CMD.
+    if echo "$hc" | grep -q 'HEALTHCHECK'; then
+      if ! echo "$hc" | grep -qE '\[[[:space:]]*"[^"]*rift[^"]*"[[:space:]]*,[[:space:]]*"healthcheck"'; then
+        fail "$(rel "$f") HEALTHCHECK is not exec-form \"rift\", \"healthcheck\""
+        found=1
+      fi
+    fi
+  done
+  [ "$found" -eq 0 ] && ok "all HEALTHCHECKs use the built-in probe in exec form"
+}
+
+# --- 3. every FROM is digest-pinned -----------------------------------------
+check_from_digest_pinned() {
+  echo "[3] every FROM is digest-pinned"
+  local f found=0
+  for f in $(dockerfiles); do
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      # `FROM scratch` is the empty image — it has no digest to pin, by definition.
+      echo "$line" | grep -qE '^FROM[[:space:]]+scratch([[:space:]]|$)' && continue
+      if ! echo "$line" | grep -q '@sha256:'; then
+        fail "$(rel "$f"): unpinned base -> $line"
+        found=1
+      fi
+    done < <(uncommented "$f" | grep -E '^FROM[[:space:]]' || true)
+  done
+  [ "$found" -eq 0 ] && ok "all FROM lines are digest-pinned (or scratch)"
+}
+
+# --- 4. runtime stages keep a CA bundle -------------------------------------
+check_ca_certificates() {
+  echo "[4] runtime stages keep a CA bundle"
+  # hyper-rustls is built with `native-tokio`, so it loads the OS trust store at runtime. Drop the
+  # CA bundle and HTTPS upstream proxying breaks silently — the exact failure this check exists for.
+  # Scoped to the runtime stage: a builder stage that still mentions ca-certificates must not
+  # satisfy this on behalf of a runtime stage that dropped it.
+  local f found=0
+  for f in $(dockerfiles); do
+    if ! runtime_stage "$f" | grep -qE 'ca-certificates'; then
+      fail "$(rel "$f") runtime stage has no CA bundle (breaks HTTPS upstreams)"
+      found=1
+    fi
+  done
+  [ "$found" -eq 0 ] && ok "every image's runtime stage keeps a CA bundle"
+}
+
+# --- 5. the static image installs no OS packages ----------------------------
+check_static_has_no_os_packages() {
+  echo "[5] the static image installs no OS packages"
+  local f="$ROOT/crates/rift-http-proxy/Dockerfile.static"
+  if [ ! -f "$f" ]; then
+    fail "crates/rift-http-proxy/Dockerfile.static is missing"
+    return
+  fi
+  # The whole point of the flavor: no package manager ran, so a scanner finds no OS packages.
+  local final_from
+  final_from=$(uncommented "$f" | grep -E '^FROM[[:space:]]' | tail -1)
+  if ! echo "$final_from" | grep -qE '^FROM[[:space:]]+(scratch|gcr\.io/distroless)'; then
+    fail "Dockerfile.static runtime stage is not scratch/distroless -> $final_from"
+    return
+  fi
+  if runtime_stage "$f" | grep -qE '(apt-get|apk|yum|dnf)[[:space:]]+(install|add|update)'; then
+    fail "Dockerfile.static runtime stage installs OS packages"
+    return
+  fi
+  ok "static runtime stage is scratch/distroless with no package installs"
+}
+
+# --- 6. no compose healthcheck shells out to curl ---------------------------
+check_compose_probes() {
+  echo "[6] no compose healthcheck shells out to curl"
+  local f found=0
+  for f in $(compose_files); do
+    if grep -nE '^[[:space:]]*test:' "$f" | grep -q 'curl'; then
+      fail "$(rel "$f") healthchecks with curl (image no longer ships it)"
+      found=1
+    fi
+  done
+  [ "$found" -eq 0 ] && ok "all compose healthchecks use the built-in probe"
+}
+
+# --- 7. published images get SBOM + provenance + cosign ---------------------
+check_publish_attestations() {
+  echo "[7] published images get SBOM + provenance + a signature"
+  local f="$ROOT/.github/workflows/docker-publish.yml"
+  if [ ! -f "$f" ]; then
+    fail "docker-publish.yml is missing"
+    return
+  fi
+  # `provenance: false` is the old setting this issue reverses.
+  if grep -qE '^[[:space:]]*provenance:[[:space:]]*false' "$f"; then
+    fail "docker-publish.yml still sets provenance: false"
+  else
+    ok "no provenance: false"
+  fi
+
+  # Counted, not just present-somewhere. A file-wide `grep -q` is satisfied by the OTHER jobs'
+  # settings, so adding a fourth image job with no attestations would pass — which is exactly the
+  # copy-paste regression this check exists to stop. Every build step must carry both attestations.
+  local builds sbom prov
+  builds=$(grep -cE '^[[:space:]]*uses:[[:space:]]*docker/build-push-action' "$f" || true)
+  sbom=$(grep -cE '^[[:space:]]*sbom:[[:space:]]*true' "$f" || true)
+  prov=$(grep -cE '^[[:space:]]*provenance:[[:space:]]*mode=max' "$f" || true)
+
+  [ "$builds" -gt 0 ] \
+    || fail "docker-publish.yml has no build-push-action steps — this check would pass vacuously"
+  [ "$sbom" -ge "$builds" ] \
+    && ok "sbom: true on all $builds build step(s)" \
+    || fail "only $sbom of $builds build step(s) request an SBOM"
+  [ "$prov" -ge "$builds" ] \
+    && ok "provenance: mode=max on all $builds build step(s)" \
+    || fail "only $prov of $builds build step(s) request max provenance"
+
+  # Every job that pushes must also sign, and keyless signing needs its own OIDC token.
+  local pushers signers tokens
+  pushers=$(grep -cE '^[[:space:]]*uses:[[:space:]]*docker/login-action' "$f" || true)
+  signers=$(grep -cE '^[[:space:]]*uses:[[:space:]]*sigstore/cosign-installer' "$f" || true)
+  tokens=$(grep -cE '^[[:space:]]*id-token:[[:space:]]*write' "$f" || true)
+  [ "$signers" -ge "$pushers" ] \
+    && ok "cosign present in all $pushers publishing job(s)" \
+    || fail "only $signers of $pushers publishing job(s) install cosign"
+  [ "$tokens" -ge "$pushers" ] \
+    && ok "id-token: write in all $pushers publishing job(s)" \
+    || fail "only $tokens of $pushers publishing job(s) grant id-token: write (cosign keyless needs it)"
+}
+
+# --- 8. dependabot watches the docker ecosystem -----------------------------
+check_dependabot_docker() {
+  echo "[8] dependabot watches the docker ecosystem"
+  local f="$ROOT/.github/dependabot.yml"
+  if [ ! -f "$f" ]; then
+    fail ".github/dependabot.yml is missing (digest pins would never get bumped)"
+    return
+  fi
+  if grep -qE 'package-ecosystem:[[:space:]]*"?docker"?' "$f"; then
+    ok "dependabot covers docker"
+  else
+    fail "dependabot.yml does not cover the docker ecosystem"
+  fi
+}
+
+# A gate that inspects nothing passes everything. If discovery comes back empty — wrong ROOT, a
+# renamed directory, a `find` quirk — every per-file check below would loop zero times and report
+# `ok`. Fail closed instead: no inputs is a broken checker, not a clean repo.
+check_discovery_is_not_empty() {
+  echo "[0] the checker actually found something to check"
+  local n_docker n_compose
+  n_docker=$(dockerfiles | grep -c . || true)
+  n_compose=$(compose_files | grep -c . || true)
+  [ "$n_docker" -ge 2 ] \
+    && ok "found $n_docker Dockerfiles" \
+    || fail "found only $n_docker Dockerfile(s) under $ROOT/crates — checks 1-4 would pass vacuously"
+  [ "$n_compose" -ge 2 ] \
+    && ok "found $n_compose compose sources" \
+    || fail "found only $n_compose compose source(s) — check 6 would pass vacuously"
+}
+
+run_checks() {
+  FAILURES=0
+  check_discovery_is_not_empty
+  check_no_curl_installed
+  check_healthcheck_builtin
+  check_from_digest_pinned
+  check_ca_certificates
+  check_static_has_no_os_packages
+  check_compose_probes
+  check_publish_attestations
+  check_dependabot_docker
+  return $FAILURES
+}
+
+# --- self-test --------------------------------------------------------------
+# A checker that cannot fail is a checker that proves nothing. Plant one violation per check in a
+# throwaway copy of the tree and assert the check actually catches it.
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  local planted=0 caught=0 broken=0
+
+  # Copy only what the checks read; copying the repo would drag in target/. `cp --parents` is a GNU
+  # extension, so build the tree explicitly rather than relying on it.
+  seed_tree() {
+    rm -rf "$tmp/tree"
+    mkdir -p "$tmp/tree/crates/rift-http-proxy" "$tmp/tree/crates/rift-lint" \
+             "$tmp/tree/docs" "$tmp/tree/.github/workflows"
+    cp "$ROOT"/crates/rift-http-proxy/Dockerfile* "$tmp/tree/crates/rift-http-proxy/"
+    cp "$ROOT"/crates/rift-lint/Dockerfile* "$tmp/tree/crates/rift-lint/"
+    cp -R "$ROOT/docs/demo" "$tmp/tree/docs/demo"
+    cp -R "$ROOT/tests" "$tmp/tree/tests"
+    cp "$ROOT/.github/workflows/docker-publish.yml" "$tmp/tree/.github/workflows/"
+    cp "$ROOT/.github/dependabot.yml" "$tmp/tree/.github/"
+  }
+
+  # A planted violation that doesn't actually change the file proves nothing, and would quietly
+  # report "not caught" as though the *check* were broken. Assert the mutation bit.
+  #
+  # `expect` is the substring the RESPONSIBLE check must emit. Asserting only "run_checks failed"
+  # is too weak: several plants trip more than one check (injecting `RUN apt-get install -y curl`
+  # into the static image violates both the no-curl rule and the no-OS-packages rule), so the
+  # intended check could rot into a no-op while the suite still went red on the other one — the one
+  # failure mode a self-test exists to rule out.
+  plant() {
+    local name="$1" target="$2" expect="$3" mutate="$4"
+    seed_tree
+    # A plant may legitimately delete its target, so absence is a state, not an error.
+    fingerprint() {
+      [ -f "$1" ] && cksum < "$1" || echo missing
+    }
+
+    local before after out
+    before=$(fingerprint "$tmp/tree/$target")
+    ( cd "$tmp/tree" && eval "$mutate" )
+    after=$(fingerprint "$tmp/tree/$target")
+    planted=$((planted + 1))
+    if [ "$before" = "$after" ]; then
+      echo "  SELF-TEST BROKEN: '$name' mutated nothing (stale pattern for $target)" >&2
+      broken=$((broken + 1))
+      return
+    fi
+    out=$(ROOT="$tmp/tree" run_checks 2>&1)
+    if echo "$out" | grep -q "FAIL: .*${expect}"; then
+      echo "  ok: '$name' is caught"
+      caught=$((caught + 1))
+    elif [ -n "$out" ] && ! ROOT="$tmp/tree" run_checks >/dev/null 2>&1; then
+      echo "  SELF-TEST FAIL: '$name' tripped some other check, not the one under test" >&2
+      echo "                  (expected a failure mentioning: ${expect})" >&2
+    else
+      echo "  SELF-TEST FAIL: '$name' was not caught" >&2
+    fi
+  }
+
+  echo "self-test: planting one violation per check"
+  plant "curl reinstalled" "crates/rift-http-proxy/Dockerfile.prebuilt" "installs curl" \
+    "sed -i.bak 's/ca-certificates \&\& \\\\/ca-certificates curl \&\& \\\\/' crates/rift-http-proxy/Dockerfile.prebuilt"
+  plant "HEALTHCHECK back to curl" "crates/rift-http-proxy/Dockerfile.prebuilt" "HEALTHCHECK still shells out to curl" \
+    "sed -i.bak 's|CMD \[\"/usr/local/bin/rift\", \"healthcheck\"\]|CMD curl -fsS http://localhost:2525/ \|\| exit 1|' crates/rift-http-proxy/Dockerfile.prebuilt"
+  plant "FROM unpinned" "crates/rift-http-proxy/Dockerfile.prebuilt" "unpinned base" \
+    "sed -i.bak 's|^FROM debian:bookworm-slim@sha256:[a-f0-9]*|FROM debian:bookworm-slim|' crates/rift-http-proxy/Dockerfile.prebuilt"
+  plant "CA bundle dropped" "crates/rift-http-proxy/Dockerfile.prebuilt" "has no CA bundle" \
+    "sed -i.bak '/ca-certificates/d' crates/rift-http-proxy/Dockerfile.prebuilt"
+  # Multi-stage: drop it from the RUNTIME stage only, leaving the builder's mention in place. A
+  # file-wide grep would be satisfied by the builder and miss this entirely.
+  plant "CA bundle dropped from runtime stage only" "crates/rift-http-proxy/Dockerfile" "has no CA bundle" \
+    "awk '/^FROM debian/ { rt = 1 } { if (rt && /ca-certificates/) next; print }' crates/rift-http-proxy/Dockerfile > t && mv t crates/rift-http-proxy/Dockerfile"
+  plant "static image installs packages" "crates/rift-http-proxy/Dockerfile.static" "runtime stage installs OS packages" \
+    "sed -i.bak 's|^FROM scratch|FROM scratch\nRUN apt-get install -y make|' crates/rift-http-proxy/Dockerfile.static"
+  plant "compose probes with curl" "docs/demo/docker-compose.yml" "healthchecks with curl" \
+    "sed -i.bak 's|test: \[\"CMD\", \"rift\", \"healthcheck\"\]|test: [\"CMD\", \"curl\", \"-f\", \"http://localhost:2525/\"]|' docs/demo/docker-compose.yml"
+  plant "provenance disabled" ".github/workflows/docker-publish.yml" "still sets provenance: false" \
+    "sed -i.bak 's|provenance: mode=max|provenance: false|' .github/workflows/docker-publish.yml"
+  # One unattested build step among several attested ones — the copy-paste regression.
+  plant "one build step drops its SBOM" ".github/workflows/docker-publish.yml" "request an SBOM" \
+    "perl -0pi -e 's/          sbom: true\n//' .github/workflows/docker-publish.yml"
+  plant "one build step drops max provenance" ".github/workflows/docker-publish.yml" "request max provenance" \
+    "perl -0pi -e 's/          provenance: mode=max\n//' .github/workflows/docker-publish.yml"
+  plant "a publishing job drops cosign" ".github/workflows/docker-publish.yml" "install cosign" \
+    "perl -0pi -e 's/        uses: sigstore\/cosign-installer\@v3\n//' .github/workflows/docker-publish.yml"
+  plant "a publishing job drops id-token" ".github/workflows/docker-publish.yml" "id-token: write" \
+    "perl -0pi -e 's/      id-token: write\n//' .github/workflows/docker-publish.yml"
+  plant "dependabot file removed" ".github/dependabot.yml" "dependabot.yml is missing" \
+    "rm -f .github/dependabot.yml"
+  # The file exists but stops watching docker — the branch `rm` never reaches.
+  plant "dependabot stops watching docker" ".github/dependabot.yml" "does not cover the docker ecosystem" \
+    "sed -i.bak 's|package-ecosystem: \"docker\"|package-ecosystem: \"npm\"|' .github/dependabot.yml"
+
+  echo
+  if [ "$broken" -gt 0 ]; then
+    echo "self-test FAILED: $broken plant(s) mutated nothing — fix the pattern, not the check" >&2
+    exit 1
+  fi
+  if [ "$caught" -ne "$planted" ]; then
+    echo "self-test FAILED: $caught/$planted violations caught" >&2
+    exit 1
+  fi
+  echo "self-test passed: $caught/$planted planted violations caught"
+  exit 0
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") ;;
+  *) echo "usage: $0 [--self-test]" >&2; exit 64 ;;
+esac
+
+echo "verify-image-hardening: checking $ROOT"
+if run_checks; then
+  echo
+  echo "image hardening OK"
+  exit 0
+else
+  echo
+  echo "image hardening FAILED: $FAILURES check(s) failed" >&2
+  exit 1
+fi

--- a/tests/compatibility/docker-compose.yml
+++ b/tests/compatibility/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:2525/"]
+      test: ["CMD", "rift", "healthcheck"]
       interval: 5s
       timeout: 10s
       retries: 15


### PR DESCRIPTION
## Summary

This PR implements three related improvements to rift's container images:

1. **Built-in healthcheck + curl removal**: Replaced the external `curl` binary (which was only used for HEALTHCHECK) with a built-in `rift healthcheck` subcommand. This removes a CVE-2025-10148 advisory (medium-severity) from runtime images.

2. **Static FROM scratch image**: Added a `-static` flavor built from musl release binaries already produced by the release workflow. Since rift's TLS uses pure rustls/ring, the binaries are genuinely static. The image contains only the binary, a CA bundle, and a passwd entry—no package manager, so OS scanners find zero CVE-exposed packages.

3. **Supply-chain hardening**: Added SBOM + maximal provenance attestation, cosign keyless signatures, and digest-pinned base images with Dependabot to auto-bump them.

## Implementation

- New `rift healthcheck` subcommand wired into the HEALTHCHECK line of all runtime Dockerfiles.
- New `Dockerfile.static` builds a FROM-scratch image for the `-static` variant.
- New `scripts/verify-image-hardening.sh` gates provide 8 checks (SBOM presence, provenance fields, cosign signatures, digest pins, no curl, no shell in static, etc.). Self-test mode proves all 8 checks catch planted violations.
- New CI job `static-image` cross-builds for musl, builds the scratch image, runs it, polls docker health, execs the probe, curls the admin API, and trivy-scans for OS CVEs.
- Dependabot auto-update config for digest pins in docker-publish.yml.

## Verification

- 258 unit/integration tests pass.
- Clippy clean under -D warnings.
- End-to-end runs against a real server prove MB_PORT/MB_HOST=0.0.0.0 work and that a healthcheck probe doesn't clobber the running server's PID file.
- All 8 image-hardening checks pass CI.
- Static image builds, runs, reports healthy, and answers admin API requests.

## Notes for reviewers

- The `-static` flavor has no shell (can't exec into it) and no mimalloc allocator (documented in docs/deployment/docker.md).
- docs/deployment/docker.md previously showed users running `docker exec rift curl ...` to query the admin API; this now demonstrates using `curl` from the host instead, since the container provides no curl.

Milestone: none (standalone)

Closes #664