### PR TITLE
fix(ci): grant id-token to the docker-publish caller so releases can start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -660,6 +660,10 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     permissions:
       contents: read
+      # docker-publish.yml signs with cosign keyless (#664), whose jobs request id-token: write.
+      # A called workflow cannot exceed its caller's grant, and that is validated at STARTUP --
+      # so without this the whole release run dies before any job starts, on a tag push too.
+      id-token: write
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}


### PR DESCRIPTION
Pushing the `v0.14.0` tag would currently **fail the entire release workflow at startup** — no job runs, nothing builds, nothing publishes.

## Root cause

#664 added cosign keyless signing to `docker-publish.yml`, so two of its jobs now request `id-token: write`. `release.yml` calls that workflow but still grants only:

```yaml
  publish-docker:
    permissions:
      contents: read          # <- docker-publish.yml needs id-token: write
    uses: ./.github/workflows/docker-publish.yml
```

A called workflow may not exceed its caller's permission grant, and GitHub validates that **when the run starts — before any job's `if` is evaluated**. So the whole run is rejected. (That ordering is also why a `dry_run`, which skips `publish-docker` entirely, still fails: the `if` never gets a chance to matter.)

## Evidence

Dispatched `release.yml` with `dry_run=true` at three refs:

| ref | result |
|---|---|
| `v0.13.6` (pre-#664) | **starts** — 7 jobs |
| `master` (today) | **`startup_failure`** — 0 jobs |
| this branch | **starts** — 7 jobs |

`release.yml` itself has not changed since v0.13.6; `docker-publish.yml` gained +262 lines in #668. The permissions it declares went from `contents: read` only (v0.13.6) to `contents: read` + `id-token: write` (master).

## Why CI said nothing

`release.yml` only ever runs on `push: tags: v*`. It never runs on a pull request, so #664's green checks were green over a workflow they never executed. The failure was scheduled to surface for the first time on the `v0.14.0` tag push.

This is worth noting beyond this fix: the same blind spot applies to the pending dependabot bumps of `actions/upload-artifact` (#675) and `actions/download-artifact` (#673), which change `release.yml` and are likewise green on checks that never run it. `download-artifact@v8` in particular stops unconditionally unzipping, and `release.yml` globs extracted files (`artifacts/**/*.tar.gz`, `*.zip`, `*.sha256`, `*.so`) — so they should be verified via `workflow_dispatch` + `dry_run` (which works once this lands), not merged on a green check.

## Verification

`workflow_dispatch` + `dry_run=true` on this branch starts and runs the real build -> upload -> download -> ffi-manifest chain; `dry_run` gates only the publishing steps (crates.io, the GitHub Release, docker, homebrew), so nothing is published.

Found while investigating whether the artifact-action bumps were safe to merge before the 0.14.0 cut.