### PR TITLE
fix(docs): drop the retry demo's timestamp, which was never a timestamp

### DIFF
--- a/docs/demo/docker-compose-retry-proxy.yml
+++ b/docs/demo/docker-compose-retry-proxy.yml
@@ -21,6 +21,13 @@ services:
   # Simple upstream service that returns success
   upstream:
     image: hashicorp/http-echo:latest
-    command: ["-text", "{\"status\":\"success\",\"message\":\"Request reached upstream service\",\"timestamp\":\"$(date -Iseconds)\"}"]
+    # http-echo serves one fixed string. It runs no shell and cannot template, and compose escapes
+    # `$(` to `$$(` anyway, so a `$(date -Iseconds)` here was echoed to the client verbatim rather
+    # than as a time (issue #676). Dropping the field rather than freezing it: this demo has you
+    # send the same request several times, and `test-retry-proxy.sh` prints every response — an
+    # identical timestamp on each one would read as a cached reply, which is the opposite of what a
+    # retry demo is teaching. That the retried request reached the upstream at all is the point, and
+    # `message` already says so.
+    command: ["-text", "{\"status\":\"success\",\"message\":\"Request reached upstream service\"}"]
     ports:
       - "8080:5678"


### PR DESCRIPTION
The retry demo's `upstream` service advertised a `timestamp` field:

```
command: ["-text", "{... ,\"timestamp\":\"$(date -Iseconds)\"}"]
```

`hashicorp/http-echo` serves one fixed string — it runs no shell, so `$(date -Iseconds)` was never
expanded, and compose escapes `$(` to `$$(` anyway. The demo echoed the literal string back on every
run. It went unnoticed for so long because the output is still **valid JSON**: structurally fine, just
untrue.

**Verified, not assumed** — booted the `upstream` service both ways:

| | body on the wire |
|---|---|
| before | `{"status":"success","message":"Request reached upstream service","timestamp":"$(date -Iseconds)"}` |
| after | `{"status":"success","message":"Request reached upstream service"}` |

**Why drop the field rather than freeze it to a static ISO string** (the issue offered three options):
this demo has you send the same request several times, and `docs/demo/test-retry-proxy.sh` prints every
response — an identical timestamp on each would read as a *cached* reply, which is precisely the wrong
lesson for a retry demo. Swapping in a templating image would add a dependency to a demo whose value is
that it is minimal. That the retried request reached the upstream at all is the point, and `message`
already says exactly that.

No CHANGELOG entry: the changelog omits docs-only changes by policy (same as #663, the last docs-only
fix). Checked the other five demo compose files — none has an unexpanded `$(...)` in an exec-form
command, so this was the only instance. The demo README documents no response body, so nothing else
needed updating.

Closes #676
