### PR TITLE
build(ci): bump setup-buildx-action to v4 in the demo-compose gate

### DIFF
--- a/.github/workflows/demo-compose.yml
+++ b/.github/workflows/demo-compose.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Build once; every demo but retry-proxy pins this tag.
       - name: Build rift image


### PR DESCRIPTION
Last `docker/setup-buildx-action@v3` in the repo.

#671 bumped it 3 -> 4 across every workflow that existed when dependabot opened that PR. `demo-compose.yml` landed in #678 shortly after, so it kept v3 and became the only holdout — dependabot would file a follow-up saying exactly this, so it is folded in here instead of costing another CI round.

After this, all six usages are on v4:

```
ci.yml:486                       v4
demo-compose.yml:59              v4   <- this PR
docker-publish-benchmark.yml:38  v4
docker-publish.yml:78,240,381    v4
```

**Verification**: this change is inside `demo-compose.yml`s own `paths:` filter, so the gate this PR edits runs on this PR — booting all six demo compose files under buildx v4. The bump verifies itself.