### PR TITLE
fix(imposter): stop hand-building error JSON, which broke on any quoted message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,24 @@ record.
   failure answering in two shapes depending on which door the request came through. Status and the
   `x-rift-imposter` / `x-rift-proxy-error` / `x-rift-default-forward-error` markers are unchanged.
 
+- **Every remaining imposter error body is valid JSON, in the one standard envelope.** A script that
+  failed with a quote in its message — `throw new Error('expected "ready", got "pending"')`, which is
+  how error messages ordinarily read — produced a **body the client could not decode**. Ten doors
+  built their JSON by interpolating the message into a string literal, so the quote closed the string
+  early: the reply was a 500 whose payload died in the caller's parser, replacing a legible script
+  error with a JSON syntax error. They all now go through the same builder the rest of the crate
+  uses, which escapes via serde. The doors: script execution (500) and its timeout (504), template
+  rendering, the three `strictBehaviors` failures (decorate, shellTransform, binary decode), a
+  disabled imposter (503), an over-size request body (413), an unresolved `file:`/`ref:` script, and
+  the debug-response serialize fallback. **The body shape changes** from `{"error": "..."}` to
+  `{"errors":[{"code":"<status>","message":"..."}]}` — the same move the previous entry made for the
+  proxy doors, finishing the class: no imposter door hand-builds JSON now. Statuses and every marker
+  header (`x-rift-script-error`, `x-rift-script-timeout`, `x-rift-decorate-error`,
+  `x-rift-template-error`, `x-rift-imposter-disabled`) are untouched, and each envelope's `code` is
+  its own response's status — including the decorate door, whose status varies with whether it timed
+  out. As with the proxy doors, the client still gets only the error's outermost context; the cause
+  chain stays in the server log.
+
 ### Security
 
 - **`POST /intercept/rules` now obeys `--allowInjection`.** An intercept rule's predicates are

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -253,7 +253,7 @@ async fn handle_request_inner(
         return Ok(build_response_with_headers(
             StatusCode::SERVICE_UNAVAILABLE,
             [("x-rift-imposter-disabled", "true")],
-            r#"{"error": "Imposter is disabled"}"#,
+            crate::response::error_body(StatusCode::SERVICE_UNAVAILABLE, "Imposter is disabled"),
         ));
     }
 
@@ -312,8 +312,9 @@ async fn handle_request_inner(
             return Ok(build_response_with_headers(
                 StatusCode::PAYLOAD_TOO_LARGE,
                 [("x-rift-imposter", "true")],
-                format!(
-                    r#"{{"error": "Request body exceeds maximum size of {MAX_REQUEST_BODY_SIZE} bytes"}}"#
+                crate::response::error_body(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    &format!("Request body exceeds maximum size of {MAX_REQUEST_BODY_SIZE} bytes"),
                 ),
             ));
         }
@@ -618,7 +619,10 @@ async fn handle_request_inner(
                 return Ok(build_response_with_headers(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
-                    r#"{"error": "script not resolved: `file:`/`ref:` sources must be resolved before serving"}"#,
+                    crate::response::error_body(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "script not resolved: `file:`/`ref:` sources must be resolved before serving",
+                    ),
                 ));
             };
             let engine = script_config
@@ -833,12 +837,18 @@ async fn handle_request_inner(
                     let (status, body) = if timed_out {
                         (
                             StatusCode::GATEWAY_TIMEOUT,
-                            format!(r#"{{"error": "Script timeout: {e}"}}"#),
+                            crate::response::error_body(
+                                StatusCode::GATEWAY_TIMEOUT,
+                                &format!("Script timeout: {e}"),
+                            ),
                         )
                     } else {
                         (
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            format!(r#"{{"error": "Script error: {e}"}}"#),
+                            crate::response::error_body(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                &format!("Script error: {e}"),
+                            ),
                         )
                     };
                     return Ok(build_response_with_headers(status, headers, body));
@@ -942,7 +952,10 @@ async fn handle_request_inner(
                             ("x-rift-imposter", "true"),
                             ("x-rift-template-error", "true"),
                         ],
-                        format!(r#"{{"error": "template rendering failed: {e}"}}"#),
+                        crate::response::error_body(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            &format!("template rendering failed: {e}"),
+                        ),
                     ));
                 }
             }
@@ -1115,8 +1128,9 @@ async fn handle_request_inner(
                                 return Ok(build_response_with_headers(
                                     status,
                                     hdrs,
-                                    format!(
-                                        r#"{{"error": "decorate failed (strictBehaviors): {e}"}}"#
+                                    crate::response::error_body(
+                                        status,
+                                        &format!("decorate failed (strictBehaviors): {e}"),
                                     ),
                                 ));
                             }
@@ -1168,8 +1182,9 @@ async fn handle_request_inner(
                                         ("x-rift-imposter", "true"),
                                         ("x-rift-shelltransform-error", "true"),
                                     ],
-                                    format!(
-                                        r#"{{"error": "shellTransform failed (strictBehaviors): {e}"}}"#
+                                    crate::response::error_body(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        &format!("shellTransform failed (strictBehaviors): {e}"),
                                     ),
                                 ));
                             }
@@ -1207,8 +1222,11 @@ async fn handle_request_inner(
                                 return Ok(build_response_with_headers(
                                     StatusCode::INTERNAL_SERVER_ERROR,
                                     [("x-rift-imposter", "true"), ("x-rift-binary-error", "true")],
-                                    format!(
-                                        r#"{{"error": "binary base64 decode failed (strictBehaviors): {e}"}}"#
+                                    crate::response::error_body(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        &format!(
+                                            "binary base64 decode failed (strictBehaviors): {e}"
+                                        ),
                                     ),
                                 ));
                             }
@@ -1453,7 +1471,10 @@ fn debug_serialize_or_500<T: serde::Serialize>(payload: &T) -> (StatusCode, Stri
             tracing::error!(error = %e, "failed to serialize debug response");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                r#"{"error": "Failed to serialize debug response"}"#.to_string(),
+                crate::response::error_body(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to serialize debug response",
+                ),
             )
         }
     }
@@ -1691,12 +1712,15 @@ mod debug_serialize_tests {
     // the #606 shape one endpoint over. It is a server fault and must be a 500.
     #[test]
     fn debug_serialize_failure_maps_to_500() {
-        let (status, _body) = debug_serialize_or_500(&Unserializable);
+        let (status, body) = debug_serialize_or_500(&Unserializable);
         assert_eq!(
             status,
             StatusCode::INTERNAL_SERVER_ERROR,
             "a serialize failure must be a 500, not a 200 carrying an error string"
         );
+        // Issue #682: the body is the canonical envelope now, not a hand-built `{"error"}` literal.
+        let v: serde_json::Value = serde_json::from_str(&body).expect("body must be valid JSON");
+        assert_eq!(v["errors"][0]["code"], "500", "envelope code is the status");
     }
 
     #[test]

--- a/crates/rift-mock-core/tests/handler_error_responses.rs
+++ b/crates/rift-mock-core/tests/handler_error_responses.rs
@@ -305,3 +305,198 @@ async fn decorate_timeout_strict_returns_504() {
 
     let _ = manager.delete_imposter(19764).await;
 }
+
+// ---------------------------------------------------------------------------
+// Issue #682: these doors hand-built their JSON by interpolating the error into a string literal,
+// so a message holding a `"` produced a body the client could not decode (the #611 class), in a
+// legacy `{"error"}` shape that 0.13.6/#681 had unified everywhere else. Assert the envelope AND
+// that a quoted message survives — a script's error text is user JavaScript, so quotes are ordinary.
+// ---------------------------------------------------------------------------
+
+/// The canonical envelope, parsed. Panics with the raw body when it is not valid JSON — which is
+/// exactly the pre-#682 failure for a quoted message.
+fn envelope(body: &str) -> serde_json::Value {
+    serde_json::from_str(body)
+        .unwrap_or_else(|e| panic!("body must be valid JSON ({e}), got: {body}"))
+}
+
+// A rhai script whose error message carries quotes, the way real user code reads:
+//   throw new Error('expected "ready", got "pending"')
+#[tokio::test]
+async fn script_error_with_quotes_yields_valid_json_envelope() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19771, "protocol": "http",
+            "stubs": [
+                { "responses": [{ "_rift": { "script": { "engine": "rhai",
+                  "code": r#"fn respond(ctx) { throw `expected "ready", got "pending"`; }"# } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19771).await;
+    assert_eq!(resp.status(), 500, "a broken script is a 500");
+    assert!(resp.headers().contains_key("x-rift-script-error"));
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500", "envelope code is the status");
+    let msg = v["errors"][0]["message"]
+        .as_str()
+        .expect("message is a string");
+    assert!(
+        msg.contains("Script error:"),
+        "message keeps its prefix, got: {msg}"
+    );
+    assert!(
+        msg.contains(r#""ready""#),
+        "the quoted text must survive escaping intact, got: {msg}"
+    );
+    assert!(v.get("error").is_none(), "the legacy shape must be gone");
+
+    let _ = manager.delete_imposter(19771).await;
+}
+
+#[tokio::test]
+async fn script_timeout_body_is_the_canonical_envelope() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19772, "protocol": "http",
+            "_rift": { "scriptEngine": { "timeoutMs": 50 } },
+            "stubs": [
+                { "responses": [{ "_rift": { "script": { "engine": "rhai", "code": "let i = 0; loop { i += 1; }" } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19772).await;
+    assert_eq!(resp.status(), 504, "a deadline miss stays a 504");
+    // The markers are the contract #499 established — the envelope change must not disturb them.
+    assert!(resp.headers().contains_key("x-rift-script-error"));
+    assert!(resp.headers().contains_key("x-rift-script-timeout"));
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "504", "envelope code is the status");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("Script timeout"),
+        "the 504 must still name the timeout: {body}"
+    );
+
+    let _ = manager.delete_imposter(19772).await;
+}
+
+#[tokio::test]
+async fn strict_decorate_error_body_is_the_canonical_envelope() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19773, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "decorate": "function (request, response) { throw new Error('boom-decorate'); }" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19773).await;
+    assert_eq!(resp.status(), 500);
+    assert!(resp.headers().contains_key("x-rift-decorate-error"));
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("decorate failed"),
+        "the strict failure must still be named: {body}"
+    );
+
+    let _ = manager.delete_imposter(19773).await;
+}
+
+// A static body (no error interpolated) — always valid JSON before and after, so this covers only
+// the shape half of the change. Note this door's marker is `x-rift-imposter-disabled`, NOT the
+// usual `x-rift-imposter`; the envelope change must not quietly normalise it.
+#[tokio::test]
+async fn disabled_imposter_body_is_the_canonical_envelope() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19774, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "never served" } }] }
+            ]
+        }),
+    )
+    .await;
+    manager
+        .get_imposter(19774)
+        .expect("imposter exists")
+        .set_enabled(false);
+
+    let resp = get(19774).await;
+    assert_eq!(resp.status(), 503);
+    assert!(resp.headers().contains_key("x-rift-imposter-disabled"));
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "503");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("disabled"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19774).await;
+}
+
+// The decorate door is the only one whose status is a VARIABLE (500 when the script throws, 504
+// when it misses the deadline), and the same variable feeds the envelope's `code`. That coupling is
+// what the CHANGELOG claims, so it gets pinned: its two neighbours (shellTransform, binary decode)
+// pass a hardcoded 500, and "harmonising" this site to match them would ship a 504 whose body says
+// `"code": "500"` — with every other test still green.
+#[tokio::test]
+async fn strict_decorate_timeout_envelope_code_follows_the_504() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19775, "protocol": "http", "strictBehaviors": true,
+            "_rift": { "scriptEngine": { "timeoutMs": 5 } },
+            "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "decorate": SLOW_RHAI_LOOP } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19775).await;
+    assert_eq!(resp.status(), 504, "a strict decorate timeout is a 504");
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(
+        v["errors"][0]["code"], "504",
+        "the envelope code must track the door's OWN status, not a hardcoded 500: {body}"
+    );
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("decorate failed"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19775).await;
+}


### PR DESCRIPTION
Ten imposter error doors built their JSON by interpolating a message into a string literal:

    format!(r#"{{"error": "Script error: {e}"}}"#)

So any message containing a `"` closed the string early and the client got a body its JSON decoder
rejected. **Reproduced** — a rhai script throwing `expected "ready", got "pending"` yielded:

    {"error": "Script error: ... Runtime error: expected "ready", got "pending" ..."}

which fails to parse. A user's script error text is exactly where quotes are ordinary, so this is the
common case, not the exotic one. This is the defect class #611 swept elsewhere.

All ten now call the crate's canonical `error_body`, which serialises via serde.

**The ten doors:** script execution (500) and its timeout (504), template rendering, the three
`strictBehaviors` failures (decorate / shellTransform / binary decode), a disabled imposter (503), an
over-size request body (413), an unresolved `file:`/`ref:` script, and the debug-serialize fallback.

**Behaviour change (declared in the CHANGELOG):** the body shape moves from `{"error": "..."}` to
`{"errors":[{"code":"<status>","message":"..."}]}` — the same move #681 made for the proxy doors,
finishing the class. Statuses and every marker header (`x-rift-script-error`, `x-rift-script-timeout`,
`x-rift-decorate-error`, `x-rift-template-error`, `x-rift-imposter-disabled`) are unchanged.

**Deliberately out of scope:** the inject arm (already emits the envelope via serde — #355/#499), and
`proxy/handler.rs`'s `{"error": "Connection reset by peer"}` bodies, which are *injected fault
payloads* (`x-rift-fault: tcp`) — the chaos-engineering product surface a client under test is
supposed to receive, not error reporting.

**Tests:** 5 new e2e + 1 extended, in the existing `handler_error_responses` harness. 4 fail red
against the pre-fix code. The decorate door is the only one whose status is a variable (500 throw /
504 timeout) feeding the envelope's `code`, so it gets its own guard — I mutation-tested it by
hardcoding 500 at that site: only that test failed, the other 11 stayed green.

Full suite 1970 pass, clippy `-D warnings` clean, `--no-default-features` compiles. Nothing in-repo,
in rift-conformance, or in sdk-conformance pins the old shapes (rift-conformance asserts marker
headers and success bodies, both preserved).

Closes #682
