### PR TITLE
fix(imposter): error doors missing Content-Type: application/json header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,21 @@ record.
   out. As with the proxy doors, the client still gets only the error's outermost context; the cause
   chain stays in the server log.
 
+- **Every imposter error door that serves the JSON envelope now declares `Content-Type:
+  application/json`.** The previous two
+  entries unified what these doors *say*; they left the same envelope typed on one path and untyped
+  on another. The proxy doors and the admin plane announced `application/json`, while every imposter
+  door omitted it — so a client branching on content-type, or a strict proxy or logging middleware
+  that requires it, treated one shape as two depending on which door answered. The doors: the
+  response and predicate `inject` errors (400) **and their timeouts (504)**, script execution (500)
+  and its timeout (504), template rendering, the three `strictBehaviors` failures (decorate,
+  shellTransform, binary decode), a disabled imposter (503), an over-size request body (413), and an
+  unresolved `file:`/`ref:` script. Statuses, bodies and every marker header are unchanged — this
+  adds a header and nothing else. Doors that do **not** serve the envelope keep their typing — the
+  empty-body 502 fault passthrough, and the plain-text replies (`Unknown fault`, the debug-matching
+  failures), are untouched, since labelling any of them `application/json` would be a lie a client
+  would act on.
+
 ### Security
 
 - **`POST /intercept/rules` now obeys `--allowInjection`.** An intercept rule's predicates are

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -72,8 +72,28 @@ fn inject_timeout_response(code: &str, message: &str) -> Response<Full<Bytes>> {
             ("x-rift-imposter", "true"),
             ("x-rift-inject-error", "true"),
             (SCRIPT_TIMEOUT_HEADER, "true"),
+            ("content-type", "application/json"),
         ],
         body,
+    )
+}
+
+/// Build the 500 for a failed `{{ }}` render (issue #359). Split out from the request path — as
+/// `debug_serialize_or_500` was for #611 — so this door can be pinned by a test: it fires only
+/// under `RIFT_DEBUG`, a process-global a shared-process test cannot set without racing its
+/// siblings, so end-to-end coverage is not available to it.
+fn template_error_response(e: &str) -> Response<Full<Bytes>> {
+    build_response_with_headers(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [
+            ("x-rift-imposter", "true"),
+            ("x-rift-template-error", "true"),
+            ("content-type", "application/json"),
+        ],
+        crate::response::error_body(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("template rendering failed: {e}"),
+        ),
     )
 }
 
@@ -150,7 +170,11 @@ fn matcher_error_response(e: &anyhow::Error) -> Response<Full<Bytes>> {
             .to_string();
             return build_response_with_headers(
                 StatusCode::BAD_REQUEST,
-                [("x-rift-imposter", "true"), ("x-rift-inject-error", "true")],
+                [
+                    ("x-rift-imposter", "true"),
+                    ("x-rift-inject-error", "true"),
+                    ("content-type", "application/json"),
+                ],
                 body,
             );
         }
@@ -252,7 +276,10 @@ async fn handle_request_inner(
     if !imposter.is_enabled() {
         return Ok(build_response_with_headers(
             StatusCode::SERVICE_UNAVAILABLE,
-            [("x-rift-imposter-disabled", "true")],
+            [
+                ("x-rift-imposter-disabled", "true"),
+                ("content-type", "application/json"),
+            ],
             crate::response::error_body(StatusCode::SERVICE_UNAVAILABLE, "Imposter is disabled"),
         ));
     }
@@ -311,7 +338,10 @@ async fn handle_request_inner(
         Err(_) => {
             return Ok(build_response_with_headers(
                 StatusCode::PAYLOAD_TOO_LARGE,
-                [("x-rift-imposter", "true")],
+                [
+                    ("x-rift-imposter", "true"),
+                    ("content-type", "application/json"),
+                ],
                 crate::response::error_body(
                     StatusCode::PAYLOAD_TOO_LARGE,
                     &format!("Request body exceeds maximum size of {MAX_REQUEST_BODY_SIZE} bytes"),
@@ -601,7 +631,11 @@ async fn handle_request_inner(
                     .to_string();
                     return Ok(build_response_with_headers(
                         StatusCode::BAD_REQUEST,
-                        [("x-rift-imposter", "true"), ("x-rift-inject-error", "true")],
+                        [
+                            ("x-rift-imposter", "true"),
+                            ("x-rift-inject-error", "true"),
+                            ("content-type", "application/json"),
+                        ],
                         body,
                     ));
                 }
@@ -618,7 +652,11 @@ async fn handle_request_inner(
             let Some(code) = script_config.code.clone() else {
                 return Ok(build_response_with_headers(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    [("x-rift-imposter", "true"), ("x-rift-script-error", "true")],
+                    [
+                        ("x-rift-imposter", "true"),
+                        ("x-rift-script-error", "true"),
+                        ("content-type", "application/json"),
+                    ],
                     crate::response::error_body(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "script not resolved: `file:`/`ref:` sources must be resolved before serving",
@@ -834,6 +872,7 @@ async fn handle_request_inner(
                     if let Some(trace) = trace_header {
                         headers.push(("x-rift-script-trace".to_string(), trace));
                     }
+                    headers.push(("content-type".to_string(), "application/json".to_string()));
                     let (status, body) = if timed_out {
                         (
                             StatusCode::GATEWAY_TIMEOUT,
@@ -946,17 +985,7 @@ async fn handle_request_inner(
                 });
                 if let Some(e) = template_error {
                     warn!("Response template rendering failed: {e}");
-                    return Ok(build_response_with_headers(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        [
-                            ("x-rift-imposter", "true"),
-                            ("x-rift-template-error", "true"),
-                        ],
-                        crate::response::error_body(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            &format!("template rendering failed: {e}"),
-                        ),
-                    ));
+                    return Ok(template_error_response(&e));
                 }
             }
 
@@ -1121,6 +1150,7 @@ async fn handle_request_inner(
                                 let mut hdrs = vec![
                                     ("x-rift-imposter", "true"),
                                     ("x-rift-decorate-error", "true"),
+                                    ("content-type", "application/json"),
                                 ];
                                 if timed_out {
                                     hdrs.push((SCRIPT_TIMEOUT_HEADER, "true"));
@@ -1181,6 +1211,7 @@ async fn handle_request_inner(
                                     [
                                         ("x-rift-imposter", "true"),
                                         ("x-rift-shelltransform-error", "true"),
+                                        ("content-type", "application/json"),
                                     ],
                                     crate::response::error_body(
                                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -1221,7 +1252,11 @@ async fn handle_request_inner(
                                 );
                                 return Ok(build_response_with_headers(
                                     StatusCode::INTERNAL_SERVER_ERROR,
-                                    [("x-rift-imposter", "true"), ("x-rift-binary-error", "true")],
+                                    [
+                                        ("x-rift-imposter", "true"),
+                                        ("x-rift-binary-error", "true"),
+                                        ("content-type", "application/json"),
+                                    ],
                                     crate::response::error_body(
                                         StatusCode::INTERNAL_SERVER_ERROR,
                                         &format!(
@@ -1635,6 +1670,14 @@ mod matcher_error_response_tests {
             resp.headers().contains_key("x-rift-script-timeout"),
             "the timeout marker distinguishes a deadline miss from a broken inject"
         );
+        // Issue #687: this door's 400 sibling (`matcher_error_response`) declares the envelope it
+        // serves, so the 504 must too — the two are one contract, reached by one predicate failing
+        // two different ways.
+        assert_eq!(
+            resp.headers()["content-type"],
+            "application/json",
+            "the inject-timeout 504 serves the JSON envelope, so it must declare it"
+        );
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let body = String::from_utf8(bytes.to_vec()).expect("utf8");
         assert!(
@@ -1688,6 +1731,37 @@ mod matcher_error_response_tests {
         assert!(
             resp.headers().contains_key("x-rift-inject-error"),
             "a predicate-inject timeout keeps the inject-error marker"
+        );
+    }
+}
+
+#[cfg(test)]
+mod template_error_tests {
+    use super::template_error_response;
+    use http_body_util::BodyExt;
+    use hyper::StatusCode;
+
+    // Issue #687: the template door fires only under `RIFT_DEBUG` (a process-global this binary's
+    // parallel tests cannot toggle safely), so its contract is pinned here instead of end-to-end.
+    #[tokio::test]
+    async fn template_error_response_is_500_with_marker_and_json_envelope() {
+        let resp = template_error_response("template error in `{{ nope }}`: unknown token");
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(resp.headers().contains_key("x-rift-template-error"));
+        assert_eq!(
+            resp.headers()["content-type"],
+            "application/json",
+            "the template door serves the JSON envelope, so it must declare it"
+        );
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let body = String::from_utf8(bytes.to_vec()).expect("utf8");
+        let v: serde_json::Value = serde_json::from_str(&body).expect("body must be valid JSON");
+        assert_eq!(v["errors"][0]["code"], "500", "envelope code is the status");
+        assert!(
+            v["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("template rendering failed")),
+            "the 500 must name the render failure, got: {body}"
         );
     }
 }

--- a/crates/rift-mock-core/tests/handler_error_responses.rs
+++ b/crates/rift-mock-core/tests/handler_error_responses.rs
@@ -34,6 +34,20 @@ async fn get(port: u16) -> reqwest::Response {
         .expect("send")
 }
 
+/// Issue #687: a door that serves the canonical JSON envelope must also declare it. The proxy doors
+/// (#681) and the admin plane already did, so the same `{"errors":[...]}` envelope reached clients
+/// typed on one path and untyped on another. Asserted per door rather than once, so a door added
+/// later that forgets the header fails here rather than shipping the inconsistency again.
+fn assert_json_content_type(resp: &reqwest::Response, door: &str) {
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json"),
+        "the {door} door serves the JSON error envelope, so it must declare content-type"
+    );
+}
+
 // Contract 1: a throwing response `inject` → 400 Mountebank error body + inject-error header.
 #[tokio::test]
 async fn throwing_inject_response_returns_400() {
@@ -55,6 +69,7 @@ async fn throwing_inject_response_returns_400() {
         resp.headers().contains_key("x-rift-inject-error"),
         "the inject-error marker header must be present"
     );
+    assert_json_content_type(&resp, "response inject error");
     let body: serde_json::Value = resp.json().await.expect("json body");
     assert_eq!(body["errors"][0]["code"], "invalid injection");
     assert!(
@@ -122,6 +137,7 @@ async fn decorate_error_strict_returns_500() {
     let resp = get(19752).await;
     let status = resp.status();
     let has_header = resp.headers().contains_key("x-rift-decorate-error");
+    assert_json_content_type(&resp, "strict decorate error");
     let body = resp.text().await.expect("body");
     assert_eq!(status, 500, "strict decorate failure fails loud with 500");
     assert!(has_header, "the 500 must still carry x-rift-decorate-error");
@@ -158,6 +174,7 @@ async fn predicate_inject_error_returns_400() {
     let resp = get(19753).await;
     assert_eq!(resp.status(), 400, "a throwing predicate inject is a 400");
     assert!(resp.headers().contains_key("x-rift-inject-error"));
+    assert_json_content_type(&resp, "predicate inject error");
     let body: serde_json::Value = resp.json().await.expect("json body");
     assert_eq!(
         body["errors"][0]["code"], "invalid predicate injection",
@@ -217,6 +234,7 @@ async fn rift_script_timeout_returns_504() {
     );
     assert!(resp.headers().contains_key("x-rift-script-error"));
     assert!(resp.headers().contains_key("x-rift-script-timeout"));
+    assert_json_content_type(&resp, "script timeout");
     let body = resp.text().await.expect("body");
     assert!(
         body.contains("Script timeout"),
@@ -291,6 +309,7 @@ async fn decorate_timeout_strict_returns_504() {
     let status = resp.status();
     let has_decorate_err = resp.headers().contains_key("x-rift-decorate-error");
     let has_timeout = resp.headers().contains_key("x-rift-script-timeout");
+    assert_json_content_type(&resp, "strict decorate timeout");
     let body = resp.text().await.expect("body");
     assert_eq!(
         status, 504,
@@ -340,6 +359,7 @@ async fn script_error_with_quotes_yields_valid_json_envelope() {
     let resp = get(19771).await;
     assert_eq!(resp.status(), 500, "a broken script is a 500");
     assert!(resp.headers().contains_key("x-rift-script-error"));
+    assert_json_content_type(&resp, "script error");
     let body = resp.text().await.expect("body");
     let v = envelope(&body);
     assert_eq!(v["errors"][0]["code"], "500", "envelope code is the status");
@@ -379,6 +399,7 @@ async fn script_timeout_body_is_the_canonical_envelope() {
     // The markers are the contract #499 established — the envelope change must not disturb them.
     assert!(resp.headers().contains_key("x-rift-script-error"));
     assert!(resp.headers().contains_key("x-rift-script-timeout"));
+    assert_json_content_type(&resp, "script timeout");
     let body = resp.text().await.expect("body");
     let v = envelope(&body);
     assert_eq!(v["errors"][0]["code"], "504", "envelope code is the status");
@@ -410,6 +431,7 @@ async fn strict_decorate_error_body_is_the_canonical_envelope() {
     let resp = get(19773).await;
     assert_eq!(resp.status(), 500);
     assert!(resp.headers().contains_key("x-rift-decorate-error"));
+    assert_json_content_type(&resp, "strict decorate error");
     let body = resp.text().await.expect("body");
     let v = envelope(&body);
     assert_eq!(v["errors"][0]["code"], "500");
@@ -447,6 +469,7 @@ async fn disabled_imposter_body_is_the_canonical_envelope() {
     let resp = get(19774).await;
     assert_eq!(resp.status(), 503);
     assert!(resp.headers().contains_key("x-rift-imposter-disabled"));
+    assert_json_content_type(&resp, "disabled imposter");
     let body = resp.text().await.expect("body");
     let v = envelope(&body);
     assert_eq!(v["errors"][0]["code"], "503");
@@ -484,6 +507,7 @@ async fn strict_decorate_timeout_envelope_code_follows_the_504() {
 
     let resp = get(19775).await;
     assert_eq!(resp.status(), 504, "a strict decorate timeout is a 504");
+    assert_json_content_type(&resp, "strict decorate timeout");
     let body = resp.text().await.expect("body");
     let v = envelope(&body);
     assert_eq!(
@@ -499,4 +523,180 @@ async fn strict_decorate_timeout_envelope_code_follows_the_504() {
     );
 
     let _ = manager.delete_imposter(19775).await;
+}
+
+// ---------------------------------------------------------------------------
+// Issue #687: the remaining envelope doors, which had no end-to-end coverage at all — so the
+// content-type they now declare is pinned here rather than assumed. One door is not reachable from
+// here: the template door fires only under `RIFT_DEBUG`, a process-global these parallel tests
+// cannot toggle without racing each other, so it is pinned by a unit test instead
+// (`handler::template_error_tests`).
+// ---------------------------------------------------------------------------
+
+// The over-size door is reached before any stub matching, by exceeding the handler's 10 MiB
+// `MAX_REQUEST_BODY_SIZE`.
+#[tokio::test]
+async fn oversize_request_body_door_declares_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19776, "protocol": "http", "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "never served" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .post("http://127.0.0.1:19776/x")
+        .body(vec![b'x'; 11 * 1024 * 1024])
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 413, "an over-size body is a 413");
+    assert_json_content_type(&resp, "over-size request body");
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "413");
+
+    let _ = manager.delete_imposter(19776).await;
+}
+
+#[tokio::test]
+async fn strict_shelltransform_door_declares_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19777, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "original" },
+                  "_behaviors": { "shellTransform": ["rift-no-such-command-687"] } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19777).await;
+    assert_eq!(
+        resp.status(),
+        500,
+        "a strict shellTransform failure is a 500"
+    );
+    assert!(resp.headers().contains_key("x-rift-shelltransform-error"));
+    assert_json_content_type(&resp, "strict shellTransform error");
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("shellTransform failed"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19777).await;
+}
+
+#[tokio::test]
+async fn strict_binary_decode_door_declares_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19778, "protocol": "http", "strictBehaviors": true, "stubs": [
+                { "responses": [{ "is": { "statusCode": 200, "body": "not!valid!base64", "_mode": "binary" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19778).await;
+    assert_eq!(
+        resp.status(),
+        500,
+        "a strict base64 decode failure is a 500"
+    );
+    assert!(resp.headers().contains_key("x-rift-binary-error"));
+    assert_json_content_type(&resp, "strict binary decode error");
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("binary base64 decode failed"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19778).await;
+}
+
+// The unresolved-script door. `file:`/`ref:` sources are populated by the config-time resolve pass,
+// which lives in rift-http-proxy — `ImposterManager::create_imposter` (what `create()` calls here,
+// and what an embedded/FFI host calls) never runs it. So a stub declaring `file:` arrives with
+// `code: None` and takes this door, rather than silently serving an empty script.
+#[tokio::test]
+async fn unresolved_script_door_declares_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19780, "protocol": "http", "stubs": [
+                { "responses": [{ "_rift": { "script": { "engine": "rhai",
+                  "file": "never-resolved-687.rhai" } } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19780).await;
+    assert_eq!(resp.status(), 500, "an unresolved script source is a 500");
+    assert!(resp.headers().contains_key("x-rift-script-error"));
+    assert_json_content_type(&resp, "unresolved file:/ref: script");
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("script not resolved"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19780).await;
+}
+
+// The counter-case: an unrecognised `fault` serves a PLAIN-TEXT body, so the sweep that added
+// content-type to the envelope doors must not have labelled it `application/json` — which would be
+// a lie a client would act on. Pins the boundary of the #687 change, not the change itself.
+#[tokio::test]
+async fn unknown_fault_door_is_not_labelled_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19779, "protocol": "http", "stubs": [
+                { "responses": [{ "fault": "NOT_A_REAL_FAULT" }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19779).await;
+    assert_eq!(resp.status(), 500);
+    assert_ne!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json"),
+        "this door serves plain text; claiming JSON would be a lie"
+    );
+    let body = resp.text().await.expect("body");
+    assert!(body.contains("Unknown fault"), "got: {body}");
+
+    let _ = manager.delete_imposter(19779).await;
 }


### PR DESCRIPTION
Nine of the ten imposter error doors served the canonical JSON error envelope without declaring `Content-Type: application/json`, while the proxy doors (#681) and the admin plane did — the same envelope reached clients typed on one path and untyped on another.

**The count was wrong, twice.** The file actually holds **thirteen** envelope doors: **11 fixed here**, plus `upstream_error_response` (#681) and the debug door, which already declared it.

- The issue listed nine — the doors routing through `crate::response::error_body`. It missed two hand-rolled `serde_json::json!` injection-error doors building the identical envelope.
- Review then found a **twelfth**: `inject_timeout_response`. Without it the predicate-inject **400** would declare JSON while its **504** sibling three lines away did not — the very split this issue exists to close.

Both emitter shapes (`error_body` call sites *and* hand-rolled `json!({"errors":...})` builders) were enumerated exhaustively and independently re-derived in review: 13 doors, 13 content-type declarations, no orphans.

**Deliberately excluded** — these do not serve the envelope, and labelling them `application/json` would be a lie a client would act on:
- the empty-body 502 fault passthroughs (`Bytes::new()`)
- the plain-text `Unknown fault` reply, and the plain-text debug-matching failures

`unknown_fault_door_is_not_labelled_json` pins that boundary, so a future blanket "add the header everywhere" sweep fails loudly.

### Doors → coverage

All 11 fixed doors are covered. Four E2E tests are new (over-size body, strict shellTransform, strict binary decode, unresolved `file:`/`ref:` script); the rest gained a per-door `assert_json_content_type`.

One door is genuinely not reachable end-to-end: the template door only errors under `RIFT_DEBUG`, a process-global that would race the sibling tests in this shared-process binary. It is extracted into `template_error_response` and pinned by a unit test — the same technique #611 used for `debug_serialize_or_500`.

### Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero
- `cargo clippy -p rift-mock-core -p rift-ffi --all-targets --no-default-features -- -D warnings` — zero (two doors are `cfg(javascript)`)
- `cargo test --workspace --all-features --lib` — 1534 passed
- `cargo test --workspace --all-features --tests` — 51 suites, 0 failed
- `handler_error_responses` — 17 passed (13 failed first, all on the missing header)

Statuses, bodies and every marker header are unchanged: this adds a header and nothing else.

Closes #687