### PR TITLE
observability: Display-formatted log sites drop anyhow cause chains across rift-mock-core, rift-http-proxy, and rift-ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,6 +3296,7 @@ dependencies = [
 name = "rift-ffi"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "parking_lot",
  "rcgen",
  "reqwest",
@@ -3306,6 +3307,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -20,6 +20,9 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
+# Renders the whole cause chain of an engine-side anyhow::Error before it collapses into a C
+# sentinel (issue #683) — see `warn_anyhow_failure`.
+anyhow.workspace = true
 # Features are forwarded (not hard-coded) so the per-platform cdylib build can drop optional
 # features that can't cross-compile for a given target — issue #205.
 rift-mock-core = { path = "../rift-mock-core", default-features = false }
@@ -43,6 +46,8 @@ reqwest.workspace = true
 rcgen = "0.13"
 # Write imposter config files on disk for the `configFile` allowInjection gate tests (issue #616).
 tempfile = "3.8"
+# Assert `warn_anyhow_failure` renders the whole cause chain, not just its outermost context (#683).
+tracing-test = "0.2"
 
 [features]
 default = ["redis-backend", "javascript"]

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -56,6 +56,20 @@ use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
 use tracing::warn;
 
+/// Log an `anyhow`-typed failure from an FFI entry point, whole chain included (issue #683).
+///
+/// `{e}` renders only the outermost context, so a `flow_set` that failed on a Redis timeout and one
+/// that failed on a bad URL logged the same line. These callers all take the same shape — an
+/// `anyhow::Error` from `rift_mock_core::imposter::core`, plus the port — so they share one format
+/// specifier here rather than repeating `%format_args!("{e:#}")` eight times and drifting apart.
+/// `%format_args!` avoids the `format!` allocation the field style would otherwise cost.
+///
+/// The `ImposterManager`-level calls do NOT belong here: they return `ImposterError`, whose
+/// `Backend` variant already renders its wrapped chain via `#[error("backend error: {0:#}")]`.
+fn warn_anyhow_failure(e: &anyhow::Error, port: u16, what: &str) {
+    warn!(error = %format_args!("{e:#}"), port, "{what}");
+}
+
 /// Run an FFI body under a panic guard (issue #484): a Rust panic must never unwind across the
 /// `extern "C"` boundary (that is undefined behaviour). A caught panic records its message in
 /// [`rift_last_error`], emits a `tracing` event, and returns the function's `$sentinel`
@@ -495,7 +509,7 @@ pub unsafe extern "C" fn rift_verify(
             Ok(o) => o,
             Err(e) => {
                 set_last_error(format!("rift_verify: {e}"));
-                warn!(error = %e, port, "rift_verify: predicate evaluation failed");
+                warn_anyhow_failure(&e, port, "rift_verify: predicate evaluation failed");
                 return std::ptr::null_mut();
             }
         };
@@ -890,7 +904,7 @@ pub unsafe extern "C" fn rift_clear_recorded(h: *mut RiftHandle, port: u16) -> i
             Ok(()) => 0,
             Err(e) => {
                 set_last_error(format!("rift_clear_recorded: {e}"));
-                warn!(error = %e, port, "rift_clear_recorded failed");
+                warn_anyhow_failure(&e, port, "rift_clear_recorded failed");
                 -1
             }
         }
@@ -986,7 +1000,7 @@ pub unsafe extern "C" fn rift_scenarios(
                 Ok(state) => scenarios.push(json!({ "name": name, "state": state })),
                 Err(e) => {
                     set_last_error(format!("rift_scenarios: {e}"));
-                    warn!(error = %e, port, "rift_scenarios failed");
+                    warn_anyhow_failure(&e, port, "rift_scenarios failed");
                     return std::ptr::null_mut();
                 }
             }
@@ -1042,7 +1056,7 @@ pub unsafe extern "C" fn rift_set_scenario_state(
             Ok(()) => 0,
             Err(e) => {
                 set_last_error(format!("rift_set_scenario_state: {e}"));
-                warn!(error = %e, port, "rift_set_scenario_state failed");
+                warn_anyhow_failure(&e, port, "rift_set_scenario_state failed");
                 -1
             }
         }
@@ -1079,7 +1093,7 @@ pub unsafe extern "C" fn rift_reset_scenarios(
         for name in imposter.scenario_names() {
             if let Err(e) = imposter.delete_scenario_state(&flow, &name) {
                 set_last_error(format!("rift_reset_scenarios: {e}"));
-                warn!(error = %e, port, "rift_reset_scenarios failed");
+                warn_anyhow_failure(&e, port, "rift_reset_scenarios failed");
                 return -1;
             }
         }
@@ -1130,7 +1144,7 @@ pub unsafe extern "C" fn rift_flow_state_get(
             ),
             Err(e) => {
                 set_last_error(format!("rift_flow_state_get: {e}"));
-                warn!(error = %e, port, "rift_flow_state_get failed");
+                warn_anyhow_failure(&e, port, "rift_flow_state_get failed");
                 std::ptr::null_mut()
             }
         }
@@ -1176,7 +1190,7 @@ pub unsafe extern "C" fn rift_flow_state_put(
             Ok(()) => 0,
             Err(e) => {
                 set_last_error(format!("rift_flow_state_put: {e}"));
-                warn!(error = %e, port, "rift_flow_state_put failed");
+                warn_anyhow_failure(&e, port, "rift_flow_state_put failed");
                 -1
             }
         }
@@ -1212,7 +1226,7 @@ pub unsafe extern "C" fn rift_flow_state_delete(
             Ok(()) => 0,
             Err(e) => {
                 set_last_error(format!("rift_flow_state_delete: {e}"));
-                warn!(error = %e, port, "rift_flow_state_delete failed");
+                warn_anyhow_failure(&e, port, "rift_flow_state_delete failed");
                 -1
             }
         }
@@ -2090,6 +2104,54 @@ pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
             handle.manager.shutdown().await;
         });
     })
+}
+
+#[cfg(test)]
+mod anyhow_chain_log_tests {
+    use super::warn_anyhow_failure;
+    use tracing_test::traced_test;
+
+    /// The shape #683 exists for: the outermost context names *what* failed, the causes name *why*.
+    fn chained_error() -> anyhow::Error {
+        anyhow::anyhow!("connection refused (os error 61)")
+            .context("redis flow store unreachable")
+            .context("flow_set failed")
+    }
+
+    #[traced_test]
+    #[test]
+    fn warn_anyhow_failure_names_the_whole_chain() {
+        warn_anyhow_failure(&chained_error(), 4545, "rift_flow_state_put failed");
+        assert!(
+            logs_contain("rift_flow_state_put failed"),
+            "message survives"
+        );
+        assert!(
+            logs_contain("redis flow store unreachable"),
+            "the log must name the CAUSE — the whole point of #683"
+        );
+        assert!(
+            logs_contain("connection refused"),
+            "the log must reach the ROOT cause, not stop one level down"
+        );
+    }
+
+    // Documents the defect #683 fixes, so the sibling test above reads as a real assertion and not
+    // a tautology: plain Display — what every one of these sites used before #683 — renders ONLY the
+    // outermost context, and `{:#}` is what recovers the chain.
+    #[test]
+    fn plain_display_drops_the_chain() {
+        let rendered = format!("{}", chained_error());
+        assert_eq!(rendered, "flow_set failed");
+        assert!(
+            !rendered.contains("connection refused"),
+            "plain Display must NOT reach the root cause; if it did, #683 would be a non-issue"
+        );
+        assert!(
+            format!("{:#}", chained_error()).contains("connection refused"),
+            "the alternate form is what recovers the chain"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -119,7 +119,7 @@ impl AdminApiServer {
             // Log an accept-loop failure so it is observable even for an embedder that holds
             // the handle and never calls join() (join() still returns it for run()/RunningServer).
             if let Err(ref e) = result {
-                tracing::error!("Admin API server error: {}", e);
+                tracing::error!("Admin API server error: {e:#}");
             }
             result
         });

--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -236,7 +236,7 @@ async fn handle_connection(
     match action {
         Some(InterceptAction::Serve(stub)) => {
             if let Err(e) = write_stub_response(&mut tls_stream, &stub).await {
-                tracing::warn!(%target, error = %e, "failed to render intercept stub response");
+                tracing::warn!(%target, error = %format_args!("{e:#}"), "failed to render intercept stub response");
             }
         }
         Some(InterceptAction::Forward(forward)) => {
@@ -252,7 +252,7 @@ async fn handle_connection(
             )
             .await;
             if let Err(e) = forward_result {
-                tracing::warn!(%target, port = forward.port, error = %e, "intercept forward failed");
+                tracing::warn!(%target, port = forward.port, error = %format_args!("{e:#}"), "intercept forward failed");
                 let _ = write_bad_gateway(&mut tls_stream).await;
             }
         }

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -17,6 +17,17 @@ use crate::intercept_rules::{InterceptRule, InterceptRules, InterceptState, Rule
 use rift_mock_core::proxy::intercept_ca::{CaSource, CertificateAuthority, SniCertResolver};
 use serde::Serialize;
 
+/// Log an `anyhow`-typed intercept-start failure with its whole cause chain (issue #683).
+///
+/// `{e}` renders only the outermost context, so "CA setup failed" read identically whether the PEM
+/// was malformed, the key mismatched, or the file was unreadable. The `&anyhow::Error` parameter is
+/// load-bearing: it makes the type rule compile-enforced, so the sibling `rule seeding failed` site
+/// — whose error is a concrete `RulesAtCapacity` with no chain to render — cannot be routed through
+/// here by mistake.
+fn warn_intercept_start_failure(e: &anyhow::Error, what: &str) {
+    tracing::warn!(error = %format_args!("{e:#}"), "intercept start: {what}");
+}
+
 /// A running intercept plane: the listener plus the control-plane [`InterceptState`] (rule store +
 /// CA) the admin routes and FFI mutate/export.
 pub struct InterceptPlane {
@@ -213,7 +224,7 @@ impl InterceptControl {
             opts.ca_key_pem,
         )
         .map_err(|e| {
-            tracing::warn!(error = %e, "intercept start: invalid CA options");
+            warn_intercept_start_failure(&e, "invalid CA options");
             InterceptStartError::Ca(e)
         })?;
 
@@ -228,7 +239,7 @@ impl InterceptControl {
         }
 
         let ca = Arc::new(CertificateAuthority::from_source(&source).map_err(|e| {
-            tracing::warn!(error = %e, "intercept start: CA setup failed");
+            warn_intercept_start_failure(&e, "CA setup failed");
             InterceptStartError::Ca(e)
         })?);
         let ca_export = return_ca_key.then(|| (ca.ca_cert_pem().to_string(), ca.ca_key_pem()));
@@ -248,7 +259,7 @@ impl InterceptControl {
         let listener = InterceptListener::bind(addr, resolver, rules.clone())
             .await
             .map_err(|e| {
-                tracing::warn!(error = %e, "intercept start: bind failed");
+                warn_intercept_start_failure(&e, "bind failed");
                 InterceptStartError::Bind(e)
             })?;
         let bound = listener.local_addr();
@@ -291,6 +302,48 @@ impl InterceptControl {
     /// Cheap: `InterceptState` is `Arc`-backed rules + an `Arc` CA.
     pub fn state(&self) -> Option<InterceptState> {
         self.lock().as_ref().map(|p| p.state.clone())
+    }
+}
+
+#[cfg(test)]
+mod anyhow_chain_log_tests {
+    use super::warn_intercept_start_failure;
+    use tracing_test::traced_test;
+
+    fn chained_error() -> anyhow::Error {
+        anyhow::anyhow!("PEM section is not a private key")
+            .context("failed to read CA key")
+            .context("CA setup failed")
+    }
+
+    #[traced_test]
+    #[test]
+    fn warn_intercept_start_failure_names_the_whole_chain() {
+        warn_intercept_start_failure(&chained_error(), "CA setup failed");
+        assert!(
+            logs_contain("intercept start: CA setup failed"),
+            "message survives"
+        );
+        assert!(
+            logs_contain("failed to read CA key"),
+            "the log must name the CAUSE — the whole point of #683"
+        );
+        assert!(
+            logs_contain("PEM section is not a private key"),
+            "the log must reach the ROOT cause, not stop one level down"
+        );
+    }
+
+    // Documents the defect #683 fixes, so the sibling test above reads as a real assertion and not
+    // a tautology: plain Display stops at the outermost context, and `{:#}` is what recovers the rest.
+    #[test]
+    fn plain_display_drops_the_chain() {
+        let rendered = format!("{}", chained_error());
+        assert_eq!(rendered, "CA setup failed");
+        assert!(
+            !rendered.contains("PEM section"),
+            "plain Display must NOT reach the root cause; if it did, #683 would be a non-issue"
+        );
     }
 }
 

--- a/crates/rift-http-proxy/src/intercept_rules.rs
+++ b/crates/rift-http-proxy/src/intercept_rules.rs
@@ -161,7 +161,7 @@ impl InterceptRules {
                         // matching) — log and treat the rule as non-matching rather than panic the
                         // intercept listener on a bad script.
                         .unwrap_or_else(|e| {
-                            tracing::warn!(error = %e, "intercept rule predicate match failed");
+                            tracing::warn!(error = %format_args!("{e:#}"), "intercept rule predicate match failed");
                             false
                         }))
             })

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -378,7 +378,7 @@ impl ServerBuilder {
         let metrics = match bind_metrics_server(metrics_addr).await {
             Ok(running) => Some(running),
             Err(e) => {
-                error!("Metrics server error: {}", e);
+                error!("Metrics server error: {e:#}");
                 None
             }
         };
@@ -563,7 +563,7 @@ pub async fn bind_metrics_server(addr: SocketAddr) -> anyhow::Result<RunningMetr
         // Preserve the pre-#342 behavior: an accept-loop failure is logged. Otherwise it would
         // only surface via join(), which RunningServer does not call for the metrics task.
         if let Err(ref e) = result {
-            error!("Metrics server error: {}", e);
+            error!("Metrics server error: {e:#}");
         }
         result
     });

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -478,12 +478,12 @@ impl Imposter {
         // clean teardown while stale recorded requests or scenario state persist in the backend.
         let mut first_err = None;
         if let Err(e) = self.journal.clear_flow(self.journal_port(), space) {
-            warn!("space teardown: failed to clear recorded requests for '{space}': {e}");
+            warn!("space teardown: failed to clear recorded requests for '{space}': {e:#}");
             first_err.get_or_insert(e);
         }
         for scenario in scenarios {
             if let Err(e) = self.delete_scenario_state(space, &scenario) {
-                warn!("space teardown: failed to reset scenario '{scenario}' for '{space}': {e}");
+                warn!("space teardown: failed to reset scenario '{scenario}' for '{space}': {e:#}");
                 first_err.get_or_insert(e);
             }
         }

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -501,7 +501,7 @@ impl Imposter {
                     Ok(Arc::new(store))
                 }
                 Err(e) => {
-                    error!("Failed to create Redis FlowStore: {}", e);
+                    error!("Failed to create Redis FlowStore: {e:#}");
                     anyhow::bail!("failed to build the Redis flow store: {e}");
                 }
             }

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -628,7 +628,7 @@ impl ImposterManager {
             // GC clear is best-effort: a failed backend clear must not fail the delete, but it
             // is logged rather than dropped (issue #330).
             if let Err(e) = journal.clear(port) {
-                warn!("failed to clear request journal for deleted imposter on port {port}: {e}");
+                warn!("failed to clear request journal for deleted imposter on port {port}: {e:#}");
             }
         }
         // Reclaim the shared proxy store's port slice so a later imposter reusing the port

--- a/crates/rift-mock-core/src/proxy/intercept_ca.rs
+++ b/crates/rift-mock-core/src/proxy/intercept_ca.rs
@@ -321,7 +321,7 @@ impl ResolvesServerCert for SniCertResolver {
             Err(e) => {
                 // resolve() must return Option; log before dropping so a failed MITM handshake
                 // is diagnosable instead of a silent generic TLS abort.
-                tracing::warn!(host, error = %e, "intercept TLS: failed to mint leaf certificate");
+                tracing::warn!(host, error = %format_args!("{e:#}"), "intercept TLS: failed to mint leaf certificate");
                 None
             }
         }

--- a/crates/rift-mock-core/src/scripting/js_engine.rs
+++ b/crates/rift-mock-core/src/scripting/js_engine.rs
@@ -1970,7 +1970,7 @@ fn execute_predicate_inject_in(
     let request_obj = match create_mountebank_request_object(&mut *context, request) {
         Ok(obj) => obj,
         Err(e) => {
-            tracing::warn!("inject predicate: failed to build request object: {e}");
+            tracing::warn!("inject predicate: failed to build request object: {e:#}");
             return Err(
                 PredicateInjectionError(format!("failed to build request object: {e}")).into(),
             );
@@ -1986,7 +1986,7 @@ fn execute_predicate_inject_in(
     let state_obj = match json_to_js(&mut *context, &Value::Object(state_map)) {
         Ok(obj) => obj,
         Err(e) => {
-            tracing::warn!("inject predicate: failed to build state object: {e}");
+            tracing::warn!("inject predicate: failed to build state object: {e:#}");
             return Err(
                 PredicateInjectionError(format!("failed to build state object: {e}")).into(),
             );
@@ -1999,7 +1999,7 @@ fn execute_predicate_inject_in(
     let logger_obj = match create_script_logger_object(&mut *context, imposter_port, None) {
         Ok(obj) => obj,
         Err(e) => {
-            tracing::warn!("inject predicate: failed to build logger object: {e}");
+            tracing::warn!("inject predicate: failed to build logger object: {e:#}");
             return Err(
                 PredicateInjectionError(format!("failed to build logger object: {e}")).into(),
             );


### PR DESCRIPTION
`warn!`/`error!` sites logging an `anyhow::Error` via plain Display drop the entire cause chain — `{}` renders only the outermost `.context(...)`. During 0.14.0 validation a proxy 502 logged `Failed to send proxy request to https://example.com/` with no way to tell a DNS failure from a TLS rejection. This renders the full chain on one line (`{e:#}` / `error = %format_args!("{e:#}")`).

### Design (per the issue's accepted rulings)

- **R1 — classify by TYPE, not call style.** Convert only where the logged value is an `anyhow::Error`. Concrete single-level errors (`http::Error`, `serde_json::Error`, `io::Error`, a `thiserror` enum, `String`) have no chain and are left alone — converting them is scope creep.
- **R2** — field style keeps its field: `error = %e` → `error = %format_args!("{e:#}")` (`%format_args!` avoids a `format!` allocation).
- **R3** — a per-module helper where ≥2 same-shape sites cluster; inline `{e:#}` for singletons.
- **R4** — no new CI gate (the "is this anyhow" property is type info grep can't see). Verification = clippy `-D warnings` + tests + one `#[traced_test]` per helper.

### Result: 25 of 89 candidate sites converted

| crate | converted | left (concrete / not-an-error) |
|---|---|---|
| rift-mock-core | 8 | ~62 concrete + ~34 not-an-error |
| rift-http-proxy | 9 | 6 concrete + ~15 not-an-error |
| rift-ffi | 8 | 25 concrete (16 `ImposterError`, 8 `serde_json::Error`, 1 `io::Error`) + 4 not-an-error |

**Converted (rift-mock-core, 8):** `core/mod.rs` Redis FlowStore create; `core/matching.rs` space-teardown journal clear + scenario reset; `manager.rs` journal clear on delete; `scripting/js_engine.rs` inject-predicate request/state/logger object build (×3); `proxy/intercept_ca.rs` mint leaf certificate.

**Converted (rift-http-proxy, 9):** `intercept_control.rs` invalid CA options / CA setup / bind (×3, via `warn_intercept_start_failure`); `intercept.rs` render stub response + forward (×2); `intercept_rules.rs` predicate match; `server.rs` metrics server (×2); `admin_api/server.rs` admin API server.

**Converted (rift-ffi, 8):** `rift_verify`, `rift_clear_recorded`, `rift_scenarios`, `rift_set_scenario_state`, `rift_reset_scenarios`, `rift_flow_state_get/put/delete` — all via `warn_anyhow_failure`. These log the `Err` of a `rift_mock_core::imposter::core` call, which returns `anyhow::Result` directly.

### Deliberately NOT converted (the judgment R5 asks review to check)

- **`server.rs:862` "Failed to create imposter"** — `create_imposter → Result<u16, ImposterError>`. Concrete enum.
- **`intercept_control.rs` "rule seeding failed"** — `RulesAtCapacity`, a single-level `thiserror` struct. The `&anyhow::Error` helper parameter makes routing it through the helper a compile error.
- **~16 rift-ffi `ImposterError` sites** — `ImposterError::Backend(anyhow::Error)` is declared `#[error("backend error: {0:#}")]`, so its own Display already renders the wrapped chain. Converting the log site would gain nothing.
- **`serde_json::Error` / `io::Error` / `hyper::Error` / `JoinError` sites throughout** — concrete, single-level, no chain.

One correction to the issue's own sample: `server.rs:381/566` (metrics server), guessed there as "std::io-ish → leave", are actually `bind_metrics_server → anyhow::Result` and `metrics_accept_loop → anyhow::Result`, so they convert. R1 is decided by the signature, not the guess.

### Helpers

`warn_anyhow_failure(e: &anyhow::Error, port: u16, what: &str)` and `warn_intercept_start_failure(e: &anyhow::Error, what: &str)` each carry a `#[traced_test]` asserting the root cause reaches the log, plus a companion test documenting that plain Display stops at the outermost context. The gate is proven non-vacuous: regressing a helper back to `{e}` makes its traced test fail.

`rift-ffi` gains `anyhow` as a direct dependency (the helper names `&anyhow::Error`) and `tracing-test` as a dev-dependency.

### Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero
- `cargo clippy -p rift-mock-core -p rift-ffi --all-targets --no-default-features -- -D warnings` — zero
- `cargo test --workspace --all-features --lib` — 1537 passed (4 new gate tests)
- `cargo test --workspace --all-features --tests` — 51 suites, 0 failed

Log-only: no control flow changes, no error message reaches a response body (the C-ABI last-error strings that still flatten to a `String` are issue #688's class, untouched here).

Closes #683