### PR TITLE
observability: error-handler signatures discard anyhow cause chains in five locations

### DIFF
--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -32,6 +32,7 @@
 //! (error or caught panic) returns its sentinel, records the reason in [`rift_last_error`], and
 //! emits a `tracing` event.
 
+use anyhow::Context;
 use parking_lot::Mutex;
 use rift_http_proxy::admin_api::{
     AdminApiServer, RunningAdminApi, filter_proxy_responses, filter_proxy_stubs,
@@ -1740,8 +1741,8 @@ pub unsafe extern "C" fn rift_serve_admin(
                 into_c_string(response)
             }
             Err(e) => {
-                set_last_error(format!("rift_serve_admin: {e}"));
-                warn!(error = %e, "rift_serve_admin failed");
+                set_last_error(format!("rift_serve_admin: {e:#}"));
+                warn!(error = %format_args!("{e:#}"), "rift_serve_admin failed");
                 std::ptr::null_mut()
             }
         }
@@ -1813,7 +1814,8 @@ fn gated_intercept_rules_error(
 }
 
 /// Bind the admin (and optional metrics) plane per `opts`, returning the plane plus the JSON
-/// response body. Errors are `String`s (mapped to `last_error` by the caller).
+/// response body. Errors are `anyhow::Error` (issue #688) so a failing step's whole cause chain
+/// survives to `last_error`, which the caller renders with `{e:#}`.
 ///
 /// A `configFile` `intercept` block binds a listener partway through (issue #655), so a later
 /// failure must not leave it running: the handle survives a failed `rift_serve_admin`, and an
@@ -1823,7 +1825,7 @@ fn gated_intercept_rules_error(
 async fn build_admin_plane(
     handle: &RiftHandle,
     opts: &ServeOptions,
-) -> Result<(AdminPlane, String), String> {
+) -> anyhow::Result<(AdminPlane, String)> {
     let mut started_intercept = false;
     let result = build_admin_plane_inner(handle, opts, &mut started_intercept).await;
     if result.is_err() && started_intercept {
@@ -1836,7 +1838,7 @@ async fn build_admin_plane_inner(
     handle: &RiftHandle,
     opts: &ServeOptions,
     started_intercept: &mut bool,
-) -> Result<(AdminPlane, String), String> {
+) -> anyhow::Result<(AdminPlane, String)> {
     let host = opts.host.as_deref().unwrap_or("127.0.0.1");
     let port = opts.port.unwrap_or(0);
     let api_key = opts.api_key.clone();
@@ -1845,12 +1847,12 @@ async fn build_admin_plane_inner(
     // Parse both addresses up front, before any side effects (imposter creation / binding).
     let addr: SocketAddr = format!("{host}:{port}")
         .parse()
-        .map_err(|e| format!("invalid host/port `{host}:{port}`: {e}"))?;
+        .with_context(|| format!("invalid host/port `{host}:{port}`"))?;
     let metrics_addr: Option<SocketAddr> = match opts.metrics_port {
         Some(mp) => Some(
             format!("{host}:{mp}")
                 .parse()
-                .map_err(|e| format!("invalid metrics addr `{host}:{mp}`: {e}"))?,
+                .with_context(|| format!("invalid metrics addr `{host}:{mp}`"))?,
         ),
         None => None,
     };
@@ -1866,10 +1868,9 @@ async fn build_admin_plane_inner(
                 path: PathBuf::from(path),
                 no_parse: false,
             };
-            let loaded = config_loader::load_configs_full(&source)
-                .map_err(|e| format!("configFile load: {e}"))?;
+            let loaded = config_loader::load_configs_full(&source).context("configFile load")?;
             if let Some(err) = gated_config_file_error(&loaded.imposters, allow_injection) {
-                return Err(err);
+                return Err(anyhow::anyhow!(err));
             }
             // The file's `intercept` block (issue #655) gives an embedded host the same
             // declarative listener the CLI gets — started before the imposters are applied so a
@@ -1877,20 +1878,20 @@ async fn build_admin_plane_inner(
             // Gated identically to the imposters around it: the file crossed the same boundary.
             if let Some(block) = loaded.intercept {
                 if let Some(err) = gated_intercept_rules_error(&block.rules, allow_injection) {
-                    return Err(err);
+                    return Err(anyhow::anyhow!(err));
                 }
                 handle
                     .intercept
                     .start(block)
                     .await
-                    .map_err(|e| format!("configFile intercept: {e}"))?;
+                    .context("configFile intercept")?;
                 *started_intercept = true;
             }
             let report = handle
                 .manager
                 .apply_config(loaded.imposters)
                 .await
-                .map_err(|e| format!("configFile apply: {e}"))?;
+                .context("configFile apply")?;
             warn_failed(&report, "configFile");
             Some(source)
         }
@@ -1899,23 +1900,19 @@ async fn build_admin_plane_inner(
 
     // Inline config is the desired state applied via apply_config (reconcile), mirroring reload.
     if let Some(cfg) = opts.config.as_ref().filter(|v| !v.is_null()) {
-        let configs = parse_imposter_configs(cfg)?;
+        let configs = parse_imposter_configs(cfg).map_err(anyhow::Error::msg)?;
         let report = handle
             .manager
             .apply_config(configs)
             .await
-            .map_err(|e| format!("inline config apply: {e}"))?;
+            .context("inline config apply")?;
         warn_failed(&report, "inline config");
     }
 
     // Bind metrics first (optional), then admin — so if the second bind fails, the first
     // listener is explicitly shut down rather than orphaned holding its port.
     let metrics = match metrics_addr {
-        Some(maddr) => Some(
-            bind_metrics_server(maddr)
-                .await
-                .map_err(|e| format!("metrics bind: {e}"))?,
-        ),
+        Some(maddr) => Some(bind_metrics_server(maddr).await.context("metrics bind")?),
         None => None,
     };
 
@@ -1935,7 +1932,7 @@ async fn build_admin_plane_inner(
             if let Some(metrics) = metrics {
                 metrics.shutdown().await;
             }
-            return Err(format!("admin bind: {e}"));
+            return Err(e.context("admin bind"));
         }
     };
     let admin_addr = admin.local_addr();
@@ -2104,6 +2101,82 @@ pub unsafe extern "C" fn rift_stop(h: *mut RiftHandle) {
             handle.manager.shutdown().await;
         });
     })
+}
+
+#[cfg(test)]
+mod build_admin_plane_chain_tests {
+    use super::*;
+
+    fn test_handle() -> RiftHandle {
+        RiftHandle {
+            runtime: Runtime::new().expect("runtime"),
+            manager: Arc::new(ImposterManager::new()),
+            admin: Mutex::new(None),
+            intercept: InterceptControl::default(),
+        }
+    }
+
+    // Issue #688: build_admin_plane returns `anyhow::Result` now, not `Result<_, String>`, so a
+    // failing step's cause chain (here: a configFile that cannot be read) reaches `rift_last_error`
+    // through `{e:#}` instead of being flattened at the boundary. `.chain()` is an `anyhow::Error`
+    // method — this test does not compile against the old `String` return, which is the point.
+    #[test]
+    fn build_admin_plane_surfaces_the_load_error_as_an_anyhow_chain() {
+        let handle = test_handle();
+        let opts = ServeOptions {
+            host: None,
+            port: Some(0),
+            api_key: None,
+            metrics_port: None,
+            config_file: Some("/nonexistent/rift-688/does-not-exist.json".to_string()),
+            config: None,
+            allow_injection: None,
+        };
+        let Err(err) = handle.runtime.block_on(build_admin_plane(&handle, &opts)) else {
+            panic!("a missing configFile must fail the admin build");
+        };
+        assert!(err.chain().next().is_some(), "carries an anyhow chain");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("configFile load"),
+            "the boundary context is preserved: {rendered}"
+        );
+        assert!(
+            rendered.contains("No such file") || rendered.contains("os error"),
+            "the OS-level cause survives to the sink: {rendered}"
+        );
+    }
+
+    // AC3(c) end-to-end: the literal sink named by the issue. A failing `rift_serve_admin` must
+    // leave the whole chain in `rift_last_error`, not just the outermost frame — the string all four
+    // SDKs surface in their exceptions.
+    #[test]
+    fn rift_serve_admin_leaves_the_whole_chain_in_last_error() {
+        let handle = rift_start();
+        assert!(!handle.is_null(), "rift_start returns a handle");
+        let opts =
+            std::ffi::CString::new(r#"{"configFile":"/nonexistent/rift-688/does-not-exist.json"}"#)
+                .expect("no interior NUL");
+
+        let served = unsafe { rift_serve_admin(handle, opts.as_ptr()) };
+        assert!(served.is_null(), "a missing configFile must fail the serve");
+
+        let err_ptr = rift_last_error();
+        assert!(!err_ptr.is_null(), "the failure recorded a last-error");
+        let rendered = unsafe { CStr::from_ptr(err_ptr) }
+            .to_str()
+            .expect("utf8")
+            .to_string();
+        unsafe { rift_free(err_ptr) };
+        unsafe { rift_stop(handle) };
+
+        assert!(rendered.starts_with("rift_serve_admin: "), "{rendered}");
+        assert!(rendered.contains("configFile load"), "{rendered}");
+        assert!(
+            rendered.contains("No such file") || rendered.contains("os error"),
+            "the OS-level cause must reach rift_last_error, not just the outermost frame: {rendered}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rift-mock-core/src/extensions/template_fn.rs
+++ b/crates/rift-mock-core/src/extensions/template_fn.rs
@@ -279,7 +279,7 @@ fn eval_base(head: &str, args: &[String], ctx: &TemplateContext<'_>) -> Result<S
                 let found = ctx
                     .flow_store
                     .get(ctx.flow_id, key)
-                    .map_err(|e| format!("state.{key}: flow store error: {e}"))?;
+                    .map_err(|e| format!("state.{key}: flow store error: {e:#}"))?;
                 return found
                     .map(|v| value_to_string(&v))
                     .ok_or_else(|| format!("no such state key: '{key}'"));

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -375,13 +375,15 @@ impl ImposterManager {
                 // immediately after the previous imposter's listener is torn down.
                 let addr = (bind_host, p)
                     .to_socket_addrs()
-                    .map_err(|e| ImposterError::BindError(p, e.to_string()))?
+                    .map_err(|e| ImposterError::BindError(p, anyhow::Error::new(e)))?
                     .next()
-                    .ok_or_else(|| ImposterError::BindError(p, "no socket address".to_string()))?;
+                    .ok_or_else(|| {
+                        ImposterError::BindError(p, anyhow::anyhow!("no socket address"))
+                    })?;
                 (
                     p,
                     crate::proxy::network::create_reusable_listener(addr)
-                        .map_err(|e| ImposterError::BindError(p, e.to_string()))?,
+                        .map_err(|e| ImposterError::BindError(p, anyhow::Error::new(e)))?,
                 )
             }
             _ => {
@@ -564,7 +566,7 @@ impl ImposterManager {
 
         Err(ImposterError::BindError(
             0,
-            "No available ports in range 49152-65535".to_string(),
+            anyhow::anyhow!("No available ports in range 49152-65535"),
         ))
     }
 
@@ -1007,10 +1009,15 @@ impl ImposterManager {
         snapshot.stubs = imposter.get_stubs();
         let path = datadir.join(format!("{port}.json"));
         let json = serde_json::to_string_pretty(&snapshot).map_err(|e| {
-            ImposterError::PersistError(format!("Failed to serialize imposter {port}: {e}"))
+            ImposterError::PersistError(
+                anyhow::Error::new(e).context(format!("Failed to serialize imposter {port}")),
+            )
         })?;
         tokio::fs::write(&path, json).await.map_err(|e| {
-            ImposterError::PersistError(format!("Failed to write imposter {port} to {path:?}: {e}"))
+            ImposterError::PersistError(
+                anyhow::Error::new(e)
+                    .context(format!("Failed to write imposter {port} to {path:?}")),
+            )
         })
     }
 

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -1276,8 +1276,8 @@ pub enum ImposterError {
     PortInUse(u16),
     #[error("Imposter not found on port {0}")]
     NotFound(u16),
-    #[error("Failed to bind port {0}: {1}")]
-    BindError(u16, String),
+    #[error("Failed to bind port {0}: {1:#}")]
+    BindError(u16, anyhow::Error),
     #[error("Invalid protocol: {0}")]
     InvalidProtocol(String),
     #[error("Stub index {0} out of bounds")]
@@ -1286,14 +1286,83 @@ pub enum ImposterError {
     StubNotFound(String),
     #[error("A stub with id '{0}' already exists")]
     StubIdConflict(String),
-    #[error("Failed to persist imposter: {0}")]
-    PersistError(String),
+    #[error("Failed to persist imposter: {0:#}")]
+    PersistError(anyhow::Error),
     #[error("TLS configuration error: {0}")]
     Tls(String),
     #[error("flow store configuration error: {0}")]
     FlowStoreConfig(String),
     #[error("backend error: {0:#}")]
     Backend(anyhow::Error),
+}
+
+#[cfg(test)]
+mod imposter_error_chain_tests {
+    use super::ImposterError;
+
+    // Issue #688: BindError/PersistError carry an anyhow::Error now, not a flattened String, so a
+    // chain-bearing source reaches the sink intact. Displayed with `{:#}`, the whole chain renders.
+    #[test]
+    fn bind_error_display_renders_the_whole_chain() {
+        let source = anyhow::anyhow!("address already in use (os error 48)")
+            .context("SO_REUSEADDR bind of 0.0.0.0:8080");
+        let rendered = format!("{}", ImposterError::BindError(8080, source));
+        assert!(
+            rendered.starts_with("Failed to bind port 8080: "),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("SO_REUSEADDR bind of 0.0.0.0:8080"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("address already in use"),
+            "the root cause must survive to the sink: {rendered}"
+        );
+    }
+
+    #[test]
+    fn persist_error_display_renders_the_whole_chain() {
+        let source = anyhow::Error::new(std::io::Error::other("no space left on device"))
+            .context("write imposter 8080 to \"/data/8080.json\"");
+        let rendered = format!("{}", ImposterError::PersistError(source));
+        assert!(
+            rendered.starts_with("Failed to persist imposter: "),
+            "{rendered}"
+        );
+        assert!(rendered.contains("write imposter 8080"), "{rendered}");
+        assert!(
+            rendered.contains("no space left on device"),
+            "the root cause must survive to the sink: {rendered}"
+        );
+    }
+
+    // AC2: for a single-level (leaf) source — every construction that exists today — `{:#}` renders
+    // exactly what the old `String` field did, so admin `failed[].error` and the hot-reload body are
+    // byte-identical. These pin that the type change did not perturb the current messages.
+    #[test]
+    fn bind_error_leaf_display_is_byte_identical_to_the_old_string() {
+        let err = ImposterError::BindError(8080, anyhow::anyhow!("no socket address"));
+        assert_eq!(
+            format!("{err}"),
+            "Failed to bind port 8080: no socket address"
+        );
+    }
+
+    #[test]
+    fn persist_error_leaf_display_is_byte_identical_to_the_old_string() {
+        // Mirror the exact shape manager.rs builds — `Error::new(io).context("...")`, a 2-level
+        // chain — so this pins the real construction, not a degenerate single-level stand-in. Under
+        // `{0:#}` it must render what the old `PersistError(format!("...: {e}"))` String produced.
+        let io = std::io::Error::other("no space left on device");
+        let err = ImposterError::PersistError(
+            anyhow::Error::new(io).context("Failed to serialize imposter 8080"),
+        );
+        assert_eq!(
+            format!("{err}"),
+            "Failed to persist imposter: Failed to serialize imposter 8080: no space left on device"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rift-mock-core/src/proxy/handler.rs
+++ b/crates/rift-mock-core/src/proxy/handler.rs
@@ -305,21 +305,22 @@ async fn handle_script_rules(
     };
 
     RuleHandlingResult::Response(
-        handle_script_result(
-            ctx,
-            result.map_err(|e| e.to_string()),
-            compiled_rule,
-            &forwarding_ctx,
-            script_duration,
-        )
-        .await,
+        handle_script_result(ctx, result, compiled_rule, &forwarding_ctx, script_duration).await,
     )
+}
+
+/// Log a failed proxy script execution with its whole cause chain (issue #688). The value arrives as
+/// `anyhow::Error` — no longer flattened to a `String` before this sink — so `{e:#}` renders the
+/// engine/pool/timeout causes an operator needs, not just the outermost frame. Split out so the
+/// rendering is pinned by a `#[traced_test]` rather than only reachable through the full handler.
+fn log_script_execution_error(rule_id: &str, e: &anyhow::Error) {
+    error!("Script execution error for rule {rule_id}: {e:#}");
 }
 
 /// Handle the result of a script execution.
 async fn handle_script_result(
     ctx: &RequestHandlerContext<'_>,
-    result: Result<ScriptFaultDecision, String>,
+    result: Result<ScriptFaultDecision, anyhow::Error>,
     compiled_rule: &CompiledRule,
     forwarding_ctx: &ForwardingContext,
     script_duration: f64,
@@ -467,10 +468,7 @@ async fn handle_script_result(
             response.into_boxed()
         }
         Err(e) => {
-            error!(
-                "Script execution error for rule {}: {}",
-                compiled_rule.id, e
-            );
+            log_script_execution_error(&compiled_rule.id, &e);
             metrics::record_script_execution(&compiled_rule.id, script_duration, "error");
             metrics::record_script_error(&compiled_rule.id, "runtime");
 
@@ -790,6 +788,33 @@ pub fn rule_applies_to_upstream(
         (Some(_), None) => true,
         // Both specified - must match
         (Some(rule_upstream), Some(selected)) => rule_upstream == selected,
+    }
+}
+
+#[cfg(test)]
+mod script_error_log_tests {
+    use super::log_script_execution_error;
+    use tracing_test::traced_test;
+
+    // Issue #688: the script-pool result is no longer flattened to a String before this log site, so
+    // a context-chained execution error (engine eval → pool queue → timeout) reaches the operator's
+    // log in full instead of only its outermost frame.
+    #[traced_test]
+    #[test]
+    fn script_execution_error_log_names_the_whole_chain() {
+        let e = anyhow::anyhow!("deadline exceeded after 5s")
+            .context("boa evaluate")
+            .context("script pool execute");
+        log_script_execution_error("rule-7", &e);
+        assert!(logs_contain("rule-7"), "the rule id must be present");
+        assert!(
+            logs_contain("script pool execute"),
+            "outermost context survives"
+        );
+        assert!(
+            logs_contain("deadline exceeded after 5s"),
+            "the root cause must reach the log — the whole point of #688"
+        );
     }
 }
 

--- a/crates/rift-mock-core/src/response/mod.rs
+++ b/crates/rift-mock-core/src/response/mod.rs
@@ -56,10 +56,10 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 &format!("Imposter not found on port {p}"),
             ),
             ImposterError::BindError(p, e) => {
-                tracing::error!(port = p, error = %e, "failed to bind imposter port");
+                tracing::error!(port = p, error = %format_args!("{e:#}"), "failed to bind imposter port");
                 error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("Failed to bind port {p}: {e}"),
+                    &format!("Failed to bind port {p}: {e:#}"),
                 )
             }
             ImposterError::InvalidProtocol(p) => {
@@ -76,10 +76,10 @@ impl From<ImposterError> for Response<Full<Bytes>> {
                 &format!("A stub with id '{id}' already exists"),
             ),
             ImposterError::PersistError(msg) => {
-                tracing::error!(error = %msg, "failed to persist imposter state");
+                tracing::error!(error = %format_args!("{msg:#}"), "failed to persist imposter state");
                 error_response(
                     StatusCode::SERVICE_UNAVAILABLE,
-                    &format!("Persistence error: {msg}"),
+                    &format!("Persistence error: {msg:#}"),
                 )
             }
             ImposterError::Tls(msg) => error_response(


### PR DESCRIPTION
Five error-handling paths flattened an `anyhow::Error` to a `String` **before** it reached any log or response sink — `.map_err(|e| e.to_string())`, `format!("{e}")`, and `Result<_, String>` signatures. Once flattened, the cause chain is gone, so #683's `{e:#}` convention had nothing left to render. This keeps the value typed as `anyhow::Error` until the sink, which renders `{e:#}`.

### The five sites

1. **proxy script hot path** — `handle_script_result`'s param was `Result<_, String>` (flattened at the call site). Now `Result<_, anyhow::Error>`; the Err-arm log renders `{e:#}` (extracted into `log_script_execution_error` so a `#[traced_test]` pins it).
2. **template flow-store** — one interpolation of a `FlowStore` (anyhow) error rendered `{e}`; now `{e:#}`. The module's ~40 other `Result<_, String>` sites are leaf messages with no chain and are left untouched.
3–4. **`ImposterError::BindError`/`PersistError`** — carried a `String`; now carry `anyhow::Error` with `#[error("… {…:#}")]`, mirroring the existing `Backend(anyhow::Error)` variant. `anyhow::Error` (not `#[source] io::Error`) because two `BindError` constructions have no source error at all.
5. **`build_admin_plane`** — returned `Result<_, String>` with every step `format!`-flattened; now `anyhow::Result`, each step keeping `.context(…)`. This enriches the `rift_last_error` string all four SDKs surface in exceptions — message content only, no ABI or JSON-shape change.

### Byte-identical today, richer tomorrow

Every construction that exists today wraps a **single leaf error**, and a single-level anyhow under `{:#}` renders exactly what the old `String` did. So admin `failed[].error` strings and the hot-reload response body are unchanged now; the chain only grows the message when a genuinely multi-level source appears. This is pinned by dedicated leaf byte-identity tests (one mirrors the real 2-level `Error::new(source).context(msg)` construction), and the existing manager persist tests pass unmodified (they match on the variant, not the message).

### Tests (chain survival, per site)

- `imposter_error_chain_tests` — BindError/PersistError render the whole chain, and leaf renderings stay byte-identical.
- `script_error_log_tests` — a 3-level context chain reaches the proxy Err-arm log in full.
- `build_admin_plane_chain_tests` — a failing `configFile` load surfaces its OS-level cause through `build_admin_plane`, and end-to-end through `rift_serve_admin` into `rift_last_error`.

The gate is proven non-vacuous: reverting a `{0:#}` back to `{0}` drops the root cause and fails the chain test.

### Downstream

No wire or ABI change. Checked `rift-conformance` and the in-repo `sdk-conformance` corpus for assertions on `Failed to bind port` / `Persistence error` / `Failed to persist` — none — so no consumer is affected; no SDK code change is needed.

### Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero
- `cargo clippy -p rift-mock-core -p rift-ffi --all-targets --no-default-features -- -D warnings` — zero
- `cargo test --workspace --all-features --lib` — 1545 passed
- `cargo test --workspace --all-features --tests` — 51 suites, 0 failed

Closes #688