### PR TITLE
fix(ci): stop cosign signing a doubled image digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,13 +147,16 @@ jobs:
           # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
           # list, the loop signs nothing, and the step still exits 0 — a publish that reports
           # success having signed nothing. The signed-count assertion is the backstop.
+          # `{{println}}` (not bare `{{.Manifest.Digest}}`) matters just as much: `--format` emits no
+          # trailing newline, so two tags resolving to the same digest concatenated into one
+          # `sha256:X...sha256:X...` line that `sort -u` could not dedupe and cosign could not parse.
           set -euo pipefail
           VERSION="${{ steps.vars.outputs.VERSION }}"
           REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy"
 
           DIGESTS=$(for TAG in "${VERSION}" latest; do
             docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
-              --format '{{.Manifest.Digest}}'
+              --format '{{println .Manifest.Digest}}'
           done | sort -u)
 
           [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }
@@ -297,13 +300,16 @@ jobs:
           # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
           # list, the loop signs nothing, and the step still exits 0 — a publish that reports
           # success having signed nothing. The signed-count assertion is the backstop.
+          # `{{println}}` (not bare `{{.Manifest.Digest}}`) matters just as much: `--format` emits no
+          # trailing newline, so two tags resolving to the same digest concatenated into one
+          # `sha256:X...sha256:X...` line that `sort -u` could not dedupe and cosign could not parse.
           set -euo pipefail
           VERSION="${{ steps.vars.outputs.VERSION }}"
           REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-proxy"
 
           DIGESTS=$(for TAG in "${VERSION}-static" latest-static; do
             docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
-              --format '{{.Manifest.Digest}}'
+              --format '{{println .Manifest.Digest}}'
           done | sort -u)
 
           [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }
@@ -448,13 +454,16 @@ jobs:
           # pipefail matters here: without it a failing `imagetools inspect` yields an empty digest
           # list, the loop signs nothing, and the step still exits 0 — a publish that reports
           # success having signed nothing. The signed-count assertion is the backstop.
+          # `{{println}}` (not bare `{{.Manifest.Digest}}`) matters just as much: `--format` emits no
+          # trailing newline, so two tags resolving to the same digest concatenated into one
+          # `sha256:X...sha256:X...` line that `sort -u` could not dedupe and cosign could not parse.
           set -euo pipefail
           VERSION="${{ steps.vars.outputs.VERSION }}"
           REPO="${{ secrets.DOCKERHUB_USERNAME }}/rift-lint"
 
           DIGESTS=$(for TAG in "${VERSION}" latest; do
             docker buildx imagetools inspect "${{ env.REGISTRY }}/${REPO}:${TAG}" \
-              --format '{{.Manifest.Digest}}'
+              --format '{{println .Manifest.Digest}}'
           done | sort -u)
 
           [ -n "$DIGESTS" ] || { echo "::error::resolved no digests to sign for ${REPO}"; exit 1; }


### PR DESCRIPTION
The release image-signing step (`docker-publish.yml`) collected digests with `imagetools inspect --format '{{.Manifest.Digest}}'`, which emits **no trailing newline**. At release the version tag and `latest` resolve to the same image, so the two inspects concatenated onto one line — `sha256:X…sha256:X…` — which `sort -u` couldn't dedupe and `cosign` couldn't parse. Every Docker publish job (rift-proxy, static, rift-lint) failed on the **0.14.0 release**, the first to use keyless signing.

Fix: `{{println .Manifest.Digest}}` newline-terminates each digest. Applied to all three signing jobs; the SBOM/provenance `inspect` format is untouched.

After merge, the 0.14.0 images will be re-published+signed via `docker-publish.yml` `workflow_dispatch` (tag `v0.14.0`) — no npm/crates/GitHub-release re-run.

Refs the failed run: https://github.com/EtaCassiopeia/rift/actions/runs/29499544901