### PR TITLE
fix(imposter): debug-matching error doors serve plain-text bodies, not the canonical JSON envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ record.
   body" (the client's transmission, not a server fault) and its cause is logged. Mirrors the
   admin-plane body reader (issue #546), which already drew this line.
 
+- **The last imposter error doors that served plain text now serve the standard JSON envelope.** Nine
+  doors — a debug-matching task panic and its timeout, plus the seven "Response build error"
+  fallbacks that fire when a stub/inject/script/upstream header value is one the HTTP layer rejects —
+  answered a bare string instead of the `{"errors":[{"code","message"}]}` envelope every other door
+  uses (issues #682/#686/#687). They now serve the envelope with `Content-Type: application/json`,
+  finishing that unification. **The debug-matching timeout also changes status from `500` to `504`**
+  and gains the `x-rift-script-timeout` marker: it is a miss of the same `_rift.scriptEngine.timeoutMs`
+  budget every other script deadline maps to `504` (issues #476/#499), so `500` contradicted that
+  contract. Two doors stay plain text by design — the `Unknown fault` config diagnostic and the
+  minimal internal-error last resort — since neither answers the envelope's audience.
+
 ## [0.14.0] - 2026-07-16
 
 ### Added

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -26,7 +26,7 @@ use crate::scripting::{
 };
 #[cfg(feature = "javascript")]
 use crate::scripting::{MountebankRequest, execute_mountebank_inject_bounded};
-use crate::util::{build_response, build_response_with_headers};
+use crate::util::build_response_with_headers;
 use base64::Engine;
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full, Limited};
@@ -146,6 +146,57 @@ fn template_error_response(e: &str) -> Response<Full<Bytes>> {
             StatusCode::INTERNAL_SERVER_ERROR,
             &format!("template rendering failed: {e}"),
         ),
+    )
+}
+
+// The debug-endpoint doors (issue #695). The debug success path answers JSON (`X-Rift-Debug-Response`),
+// so these error paths do too — plain text here was the same-endpoint gap #687 closed elsewhere.
+// Split out from the match arms so each can be pinned by a test: neither is safely provokable
+// end-to-end (a task panic must be injected; a timeout needs a busy-loop that starves the shared
+// script pool). The caller keeps its own `warn!` — these build the response only.
+
+/// A `_rift`-debug matching task that panicked → 500, canonical envelope.
+fn debug_matching_error_response() -> Response<Full<Bytes>> {
+    build_response_with_headers(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [
+            ("x-rift-imposter", "true"),
+            ("content-type", "application/json"),
+        ],
+        crate::response::error_body(StatusCode::INTERNAL_SERVER_ERROR, "Debug matching failed"),
+    )
+}
+
+/// A debug matching run that missed the `_rift.scriptEngine.timeoutMs` deadline → 504 + the timeout
+/// marker (issues #476/#499), like every other script deadline. It was a 500 before #695, which
+/// contradicted that transient-vs-permanent contract.
+fn debug_matching_timeout_response() -> Response<Full<Bytes>> {
+    build_response_with_headers(
+        StatusCode::GATEWAY_TIMEOUT,
+        [
+            ("x-rift-imposter", "true"),
+            (SCRIPT_TIMEOUT_HEADER, "true"),
+            ("content-type", "application/json"),
+        ],
+        crate::response::error_body(StatusCode::GATEWAY_TIMEOUT, "Debug matching timed out"),
+    )
+}
+
+/// The terminal 500 for a response whose own header/body hyper rejected (issue #695) — a bad
+/// upstream/inject/script/stub header value that fails `.body(...)`. Serves the canonical envelope
+/// so the last-resort door matches every other imposter error door instead of a bare string, and
+/// logs the caller's `what` context so the failing door is named. Safe as a terminal fallback:
+/// `error_body` is infallible by construction and `build_response_with_headers` with literal headers
+/// falls back to `internal_error_fallback` — the chain cannot itself panic.
+fn build_failure_response(e: &hyper::http::Error, log_context: &str) -> Response<Full<Bytes>> {
+    warn!("{log_context}: {e}");
+    build_response_with_headers(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [
+            ("x-rift-imposter", "true"),
+            ("content-type", "application/json"),
+        ],
+        crate::response::error_body(StatusCode::INTERNAL_SERVER_ERROR, "Response build error"),
     )
 }
 
@@ -498,20 +549,14 @@ async fn handle_request_inner(
             Ok(Ok(response)) => response,
             Ok(Err(join_err)) => {
                 warn!("debug matching task panicked: {join_err}");
-                Ok(build_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Debug matching failed",
-                ))
+                Ok(debug_matching_error_response())
             }
             Err(_elapsed) => {
                 warn!(
                     "debug matching timed out after {}ms",
                     script_timeout.as_millis()
                 );
-                Ok(build_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Debug matching timed out",
-                ))
+                Ok(debug_matching_timeout_response())
             }
         };
     }
@@ -606,10 +651,9 @@ async fn handle_request_inner(
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
                         .unwrap_or_else(|e| {
-                            warn!("proxy response build failed (bad upstream header?): {e}");
-                            build_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "Response build error",
+                            build_failure_response(
+                                &e,
+                                "proxy response build failed (bad upstream header?)",
                             )
                         }));
                 }
@@ -663,10 +707,9 @@ async fn handle_request_inner(
                     return Ok(response
                         .body(Full::new(Bytes::from(inject_response.body)))
                         .unwrap_or_else(|e| {
-                            warn!("inject response build failed (bad injected header?): {e}");
-                            build_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "Response build error",
+                            build_failure_response(
+                                &e,
+                                "inject response build failed (bad injected header?)",
                             )
                         }));
                 }
@@ -855,10 +898,9 @@ async fn handle_request_inner(
                     return Ok(response
                         .body(Full::new(Bytes::from(body)))
                         .unwrap_or_else(|e| {
-                            warn!("script response build failed (bad script header?): {e}");
-                            build_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "Response build error",
+                            build_failure_response(
+                                &e,
+                                "script response build failed (bad script header?)",
                             )
                         }));
                 }
@@ -1339,8 +1381,7 @@ async fn handle_request_inner(
             }
 
             return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|e| {
-                warn!("stub response build failed (bad stub header?): {e}");
-                build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+                build_failure_response(&e, "stub response build failed (bad stub header?)")
             }));
         }
     }
@@ -1377,8 +1418,10 @@ async fn handle_request_inner(
                 Ok(response
                     .body(Full::new(Bytes::from(body)))
                     .unwrap_or_else(|e| {
-                        warn!("defaultForward response build failed (bad upstream header?): {e}");
-                        build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+                        build_failure_response(
+                            &e,
+                            "defaultForward response build failed (bad upstream header?)",
+                        )
                     }))
             }
             Err(e) => Ok(upstream_error_response(
@@ -1435,8 +1478,7 @@ async fn handle_request_inner(
         response = response.header("x-rift-default-response", "true");
 
         return Ok(response.body(Full::new(body_bytes)).unwrap_or_else(|e| {
-            warn!("defaultResponse build failed (bad default header?): {e}");
-            build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+            build_failure_response(&e, "defaultResponse build failed (bad default header?)")
         }));
     }
 
@@ -1695,8 +1737,10 @@ async fn apply_rift_fault(
             response
                 .body(Full::new(Bytes::from(error_body)))
                 .unwrap_or_else(|e| {
-                    warn!("error-fault response build failed (bad fault header?): {e}");
-                    build_response(StatusCode::INTERNAL_SERVER_ERROR, "Response build error")
+                    build_failure_response(
+                        &e,
+                        "error-fault response build failed (bad fault header?)",
+                    )
                 }),
         );
     }
@@ -1923,6 +1967,98 @@ mod body_collect_tests {
         assert!(
             logs_contain("truncated chunked body"),
             "the previously-silent read failure must now be logged with its cause"
+        );
+    }
+}
+
+#[cfg(test)]
+mod plaintext_door_tests {
+    use super::{
+        SCRIPT_TIMEOUT_HEADER, build_failure_response, debug_matching_error_response,
+        debug_matching_timeout_response,
+    };
+    use http_body_util::BodyExt;
+    use hyper::StatusCode;
+    use tracing_test::traced_test;
+
+    async fn envelope(
+        resp: hyper::Response<http_body_util::Full<bytes::Bytes>>,
+    ) -> serde_json::Value {
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        serde_json::from_slice(&bytes).expect("body must be the canonical JSON envelope")
+    }
+
+    // Issue #695: the debug endpoint's success path already answers JSON (`X-Rift-Debug-Response`),
+    // so its error path must too — plain text was the same-endpoint gap #687 closed elsewhere.
+    #[tokio::test]
+    async fn debug_matching_error_door_is_500_envelope() {
+        let resp = debug_matching_error_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.headers()["content-type"], "application/json");
+        assert!(resp.headers().contains_key("x-rift-imposter"));
+        let v = envelope(resp).await;
+        assert_eq!(v["errors"][0]["code"], "500");
+        assert!(
+            v["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("Debug matching failed")),
+            "got: {v}"
+        );
+    }
+
+    // The timeout door is a miss of the same `_rift.scriptEngine.timeoutMs` budget every other
+    // script deadline maps to 504 + the timeout marker (#499/#476) — not the 500 it used to answer.
+    #[tokio::test]
+    async fn debug_matching_timeout_door_is_504_with_timeout_marker() {
+        let resp = debug_matching_timeout_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::GATEWAY_TIMEOUT,
+            "a debug-matching deadline miss is a 504, like every other script timeout"
+        );
+        assert!(
+            resp.headers().contains_key(SCRIPT_TIMEOUT_HEADER),
+            "the timeout marker distinguishes a deadline miss from a permanent failure"
+        );
+        assert_eq!(resp.headers()["content-type"], "application/json");
+        assert!(resp.headers().contains_key("x-rift-imposter"));
+        let v = envelope(resp).await;
+        assert_eq!(
+            v["errors"][0]["code"], "504",
+            "envelope code tracks the status"
+        );
+        assert!(
+            v["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("Debug matching timed out")),
+            "got: {v}"
+        );
+    }
+
+    // The terminal fallback shared by all seven response-build sites: it must answer the canonical
+    // envelope (not a bare string) and still log the caller's context so the failing door is named.
+    #[traced_test]
+    #[tokio::test]
+    async fn build_failure_response_is_500_envelope_and_logs_context() {
+        let e = hyper::Response::builder()
+            .header("x-bad", "line1\nline2")
+            .body(())
+            .expect_err("an invalid header value must be a build error");
+        let resp = build_failure_response(&e, "stub response build failed (bad stub header?)");
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(resp.headers()["content-type"], "application/json");
+        assert!(resp.headers().contains_key("x-rift-imposter"));
+        let v = envelope(resp).await;
+        assert_eq!(v["errors"][0]["code"], "500");
+        assert!(
+            v["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("Response build error")),
+            "got: {v}"
+        );
+        assert!(
+            logs_contain("stub response build failed"),
+            "the failing door's context must still be logged"
         );
     }
 }

--- a/crates/rift-mock-core/tests/handler_error_responses.rs
+++ b/crates/rift-mock-core/tests/handler_error_responses.rs
@@ -700,3 +700,51 @@ async fn unknown_fault_door_is_not_labelled_json() {
 
     let _ = manager.delete_imposter(19779).await;
 }
+
+// Issue #695: the terminal "Response build error" door — reached when a stub's own header value is
+// one hyper rejects (here a newline), so building the response fails — now serves the canonical
+// envelope like every other imposter error door, not a bare plain-text string. Drives a live door
+// end-to-end, proving the config path actually routes through the shared fallback.
+#[tokio::test]
+async fn response_build_error_door_declares_json() {
+    let manager = ImposterManager::new();
+    create(
+        &manager,
+        serde_json::json!({
+            "port": 19781, "protocol": "http", "stubs": [
+                { "responses": [{ "is": {
+                    "statusCode": 200,
+                    "headers": { "X-Bad": "line1\nline2" },
+                    "body": "unreached"
+                } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let resp = get(19781).await;
+    assert_eq!(
+        resp.status(),
+        500,
+        "a response that cannot be built is a 500"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json"),
+        "the build-error door serves the JSON envelope now"
+    );
+    let body = resp.text().await.expect("body");
+    let v = envelope(&body);
+    assert_eq!(v["errors"][0]["code"], "500");
+    assert!(
+        v["errors"][0]["message"]
+            .as_str()
+            .expect("string")
+            .contains("Response build error"),
+        "got: {body}"
+    );
+
+    let _ = manager.delete_imposter(19781).await;
+}


### PR DESCRIPTION
Nine imposter error doors still served **plain text** instead of the canonical `{"errors":[{"code","message"}]}` JSON envelope every other door has used since #682/#686/#687. (The issue named two; triage corrected the census to nine.)

### The nine doors

- **2 debug-matching doors** — a task panic and a deadline miss.
- **7 "Response build error" fallbacks** — the terminal `.unwrap_or_else(|e| ...)` that fires when a stub/inject/script/upstream header value is one hyper rejects, so `.body()` fails.

### What changed

- The debug doors are extracted into `debug_matching_error_response()` (500) and `debug_matching_timeout_response()`, each serving the envelope + `x-rift-imposter` + `content-type`. The match-arm `warn!`s stay at the call site (they carry `join_err` / the duration).
- **The debug-matching timeout moves from `500` to `504`** and gains `x-rift-script-timeout`: it is a miss of the same `_rift.scriptEngine.timeoutMs` budget every other script deadline maps to 504 + the timeout marker (#476/#499), so 500 contradicted that contract. The debug endpoint's *success* path already answers JSON, so its error path matching is the consistent state.
- The 7 fallbacks route through one `build_failure_response(e, log_context)` helper (envelope + 2 headers), each caller passing its original warn context. Safe as a terminal fallback: `error_body` is infallible by construction and the header builder falls back to `internal_error_fallback` — the chain cannot itself panic.
- **Deliberately unchanged:** the plain-text `Unknown fault` config diagnostic (the pinned counter-case in #687's `unknown_fault_door_is_not_labelled_json`) and `internal_error_fallback` — neither answers the envelope's audience. The now-unused `build_response` import was removed.

### Tests

- `handler.rs::plaintext_door_tests` — unit tests pinning each extracted door's status, markers, envelope code, and message (+ a `#[traced_test]` confirming `build_failure_response` preserves the caller's log context). The debug doors aren't safely provokable over a listener (a panic must be injected; a timeout needs a pool-starving busy-loop), so they're unit-tested per the file's established extraction pattern.
- `tests/handler_error_responses.rs::response_build_error_door_declares_json` — a live E2E: a stub whose `is` header value contains a newline (hyper rejects it) drives the real build-error door and asserts 500 + `content-type` + envelope.
- #687's `unknown_fault_door_is_not_labelled_json` stays green (the plain-text boundary holds). Gate proven non-vacuous: regressing the timeout door to 500 fails the 504 test.

### Verification

- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` zero; `cargo clippy -p rift-mock-core -p rift-ffi --all-targets --no-default-features -- -D warnings` zero
- `cargo test --workspace --all-features --lib` — 1553 passed; `--tests` — 51 suites, 0 failed (handler_error_responses: 18)

Closes #695