### PR TITLE
ci(perf): re-enable the benchmark regression gate as a side-job

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,19 +9,26 @@ name: Performance
 # Gated benches (BENCH_TARGETS below): the imposter matcher, the scripting decision cache, and the
 # proxy rule scan.
 
-# TEMPORARILY manual-only (issue #692). The per-PR bench run is the slowest check on shared runners
-# and was gating release turnaround, so it is off the PR hot path for now. Re-enable it as a side-job
-# (nightly schedule on master, or a label-gated / non-blocking PR lane) per #692. The original
-# trigger, restore verbatim:
-#   pull_request:
-#     # Only when code that can affect benched performance changes (keeps the job off doc/CI-only PRs).
-#     paths:
-#       - "crates/rift-mock-core/**"
-#       - "crates/rift-http-proxy/**"
-#       - "crates/rift-types/**"
-#       - ".github/workflows/perf.yml"
+# Label-gated side-job (issue #692). The bench run is the slowest check on shared runners, so it is
+# off the PR hot path: it triggers only on a PR that touches benched code AND carries the existing
+# `performance` label (the job's `if:` below). Everything else — an unlabeled PR — sees the job as
+# *skipped*, so it neither blocks the merge nor spends the wall-clock. `labeled` is in `types` on
+# purpose: the default pull_request activity types omit it, so without it, adding `performance` to an
+# already-open PR would not start a run; with it, labeling an open PR kicks off the benches. The
+# `performance` label already exists in the repo, so no new label needs managing. `workflow_dispatch` is kept only so
+# the workflow stays manually listable — the job itself diffs a PR's base against its head, so a bare
+# dispatch (no PR) has nothing to compare and its `if:` guard skips it; a functional on-demand/nightly
+# lane would need the non-PR baseline redesign that #692 deliberately scoped out.
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    # Only when code that can affect benched performance changes (keeps the job off doc/CI-only PRs).
+    paths:
+      - "crates/rift-mock-core/**"
+      - "crates/rift-http-proxy/**"
+      - "crates/rift-types/**"
+      - ".github/workflows/perf.yml"
 
 # One in-flight run per PR; a new push cancels the previous (benches are expensive).
 concurrency:
@@ -54,6 +61,10 @@ env:
 jobs:
   bench-regression:
     name: Benchmark regression gate
+    # Opt-in (issue #692): only a PR carrying the `performance` label runs the benches; an unlabeled
+    # PR (or a bare workflow_dispatch, which carries no PR labels) skips this job entirely rather than
+    # pending on it, keeping it off the merge hot path.
+    if: contains(github.event.pull_request.labels.*.name, 'performance')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for base/head)


### PR DESCRIPTION
The `Performance` workflow was disabled to `workflow_dispatch`-only (#693) to keep the ~slowest check off the release hot path. This re-enables it as a **label-gated side-job**.

### Change (perf.yml only)

- Restores the `pull_request` trigger (the benched-crate `paths:` list), keeping `workflow_dispatch`.
- Adds `labeled` to `types: [opened, synchronize, reopened, labeled]` — the default activity types omit it, so without it, labelling an already-open PR would not start a run.
- Guards the `bench-regression` job with `if: contains(github.event.pull_request.labels.*.name, 'performance')`.

### Behaviour

- An **unlabelled** PR (even one touching benched crates) → the job is **skipped**: green, non-blocking, zero bench wall-clock. Off the hot path.
- A PR labelled **`performance`** (the existing repo label — no new label to manage) that touches a benched crate → the base-vs-head criterion comparison runs, exactly as before.
- `paths:` still filters, so a `performance`-labelled docs-only PR runs nothing.
- The `REGRESSION_THRESHOLD` / best-of-N sampling / `BENCH_TARGETS` / concurrency / base-vs-head runner script are all **unchanged** (issues #298/#446 tuning intact).

### Notes for the reviewer

- `workflow_dispatch` is now vestigial: the job diffs a PR base vs head, so a bare dispatch (no PR) has nothing to compare and its `if:` guard skips it. Kept only so the workflow stays listable; a functional on-demand/nightly lane would need the non-PR baseline redesign this issue deliberately scoped out.
- This job must **not** be made a *required* status check: a `paths`-filtered workflow never reports a status on a PR it filtered out, which would hang such a PR forever. It is safe today — `protect-master` has no required status checks. The design is non-blocking (skipped), so this only matters if someone flips it to required.

### Verification

- `actionlint .github/workflows/perf.yml` — clean
- Structural check: `on:` has `pull_request` (with `labeled` in types + the paths list) and `workflow_dispatch`; the job carries the `performance`-label guard; tuning/env/runner untouched.

Closes #692