### PR TITLE
feat(admin): extend match= clause grammar with method= and path= exact-equality filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **The `match=` filter grammar on recorded traffic gains `method=` and `path=` exact-equality
+  clauses.** Alongside `header:<Name>=<Value>` and `flow_id=<Value>`, `GET`/`DELETE
+  /imposters/{port}/savedRequests` and the SSE streams (`GET /events`,
+  `GET /imposters/{port}/savedRequests/stream`) now accept `match=method=<Verb>` (case-sensitive)
+  and `match=path=<Path>` (the bare path; the query string is not compared). Clauses AND together
+  and compose with `since=`. This unblocks downstream SDKs filtering a cursor tail server-side by
+  method/path (rift-java#148, rift-scala#37). The grammar stays closed and exact — query-param and
+  body predicates remain out of scope. **Contract note:** the `400` body for an unknown clause now
+  enumerates the new forms (`unsupported match clause '…' (expected header:<Name>=<Value>,
+  flow_id=<Value>, method=<Verb> or path=<Path>)`). Older engines still fail closed with a clear
+  `400` on the new clauses, so SDKs gate on a minimum engine version rather than sniffing.
+
 ### Fixed
 
 - **A request whose body fails mid-read now answers `400`, not `413`, and is no longer silent.** The

--- a/crates/rift-http-proxy/src/admin_api/handlers/events.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/events.rs
@@ -272,6 +272,8 @@ fn event_matches(
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case(name))
             .is_some_and(|(_, values)| values.iter().any(|v| v == value)),
+        MatchClause::Method(value) => request.method == *value,
+        MatchClause::Path(value) => request.path == *value,
     })
 }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1270,9 +1270,108 @@ mod requests_filter_tests {
     #[tokio::test]
     async fn get_requests_malformed_match_400() {
         let m = manager_with(19738, None, &[rec("A", None)]).await;
-        let resp = handle_get_requests(19738, Some("match=path=/foo"), m.clone()).await;
+        let resp = handle_get_requests(19738, Some("match=query=a"), m.clone()).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let _ = m.delete_imposter(19738).await;
+    }
+
+    fn rec_mp(method: &str, path: &str, space: &str) -> RecordedRequest {
+        let mut r = rec(space, None);
+        r.method = method.to_string();
+        r.path = path.to_string();
+        r
+    }
+
+    // #700: `method=`/`path=` filter GET, compose with header/flow_id/since, and (like every other
+    // clause) advance the cursor past rejected entries so a filtered tail never re-scans.
+    #[tokio::test]
+    async fn get_requests_filters_by_method_and_path() {
+        let m = manager_with(
+            19759,
+            Some("header:X-Mock-Space"),
+            &[
+                rec_mp("GET", "/orders", "alice"),
+                rec_mp("POST", "/orders", "alice"),
+                rec_mp("POST", "/orders", "bob"),
+                rec_mp("POST", "/items", "alice"),
+            ],
+        )
+        .await;
+
+        // method= alone
+        let got =
+            requests(handle_get_requests(19759, Some("match=method=POST"), m.clone()).await).await;
+        assert_eq!(got.len(), 3, "three POSTs");
+
+        // path= alone
+        let got =
+            requests(handle_get_requests(19759, Some("match=path=/orders"), m.clone()).await).await;
+        assert_eq!(got.len(), 3, "three /orders");
+
+        // method + path + flow_id, AND-ed
+        let resp = handle_get_requests(
+            19759,
+            Some("match=flow_id=alice&match=method=POST&match=path=/orders"),
+            m.clone(),
+        )
+        .await;
+        let got = requests(resp).await;
+        assert_eq!(got.len(), 1, "only alice's POST /orders");
+        assert_eq!(got[0].method, "POST");
+        assert_eq!(got[0].path, "/orders");
+
+        let _ = m.delete_imposter(19759).await;
+    }
+
+    // #700 (AC4): a `since` window filtered by method/path still advances the cursor across every
+    // scanned entry, even the ones the filter rejects.
+    #[tokio::test]
+    async fn get_requests_since_composes_with_method_path() {
+        let m = manager_with(
+            19760,
+            None,
+            &[
+                rec_mp("GET", "/a", "A"),
+                rec_mp("POST", "/b", "A"),
+                rec_mp("GET", "/c", "A"),
+                rec_mp("POST", "/d", "A"),
+            ],
+        )
+        .await;
+
+        // since=2 cuts to entries 3 & 4 (/c GET, /d POST); the method filter rejects /c but the
+        // cursor still advances past it to 4, so a filtered tail never re-scans the window.
+        let resp = handle_get_requests(19760, Some("since=2&match=method=POST"), m.clone()).await;
+        assert_eq!(next_index(&resp), Some("4"), "cursor spans scanned entries");
+        let got = requests(resp).await;
+        assert_eq!(
+            got.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            vec!["/d"],
+            "cut at 2, then keep only POST"
+        );
+
+        let _ = m.delete_imposter(19760).await;
+    }
+
+    // #700: `method=`/`path=` scope a targeted DELETE too — both surfaces share the parser.
+    #[tokio::test]
+    async fn delete_requests_targeted_clear_by_method() {
+        let m = manager_with(
+            19761,
+            None,
+            &[
+                rec_mp("GET", "/x", "A"),
+                rec_mp("POST", "/x", "A"),
+                rec_mp("GET", "/y", "A"),
+            ],
+        )
+        .await;
+        let base = "http://localhost:2525";
+        handle_clear_requests(19761, Some("match=method=POST"), base, m.clone()).await;
+        let remaining = requests(handle_get_requests(19761, None, m.clone()).await).await;
+        assert_eq!(remaining.len(), 2, "only the POST was cleared");
+        assert!(remaining.iter().all(|r| r.method == "GET"));
+        let _ = m.delete_imposter(19761).await;
     }
 
     #[tokio::test]
@@ -1360,7 +1459,7 @@ mod requests_filter_tests {
     async fn delete_requests_malformed_match_400() {
         let m = manager_with(19741, None, &[rec("A", None)]).await;
         let base = "http://localhost:2525";
-        let resp = handle_clear_requests(19741, Some("match=path=/foo"), base, m.clone()).await;
+        let resp = handle_clear_requests(19741, Some("match=query=a"), base, m.clone()).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         // a rejected clear must leave the buffer untouched
         let remaining = requests(handle_get_requests(19741, None, m.clone()).await).await;

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -1,7 +1,8 @@
 //! Server-side filtering of recorded requests by `match=` query clauses.
 //!
-//! Supports `header:<Name>=<Value>` and `flow_id=<Value>` (the latter resolved
-//! via the imposter's `flow_id_source`). Multiple clauses are AND'd together.
+//! Supports `header:<Name>=<Value>`, `flow_id=<Value>` (the latter resolved via
+//! the imposter's `flow_id_source`), `method=<Verb>`, and `path=<Path>` — the last
+//! two exact-equality against the recorded request. Multiple clauses are AND'd together.
 
 use crate::imposter::RecordedRequest;
 
@@ -13,7 +14,9 @@ pub(crate) enum MatchClauseError {
     MissingHeaderValue(String),
     #[error("invalid match clause '{0}' (empty header name)")]
     EmptyHeaderName(String),
-    #[error("unsupported match clause '{0}' (expected header:<Name>=<Value> or flow_id=<Value>)")]
+    #[error(
+        "unsupported match clause '{0}' (expected header:<Name>=<Value>, flow_id=<Value>, method=<Verb> or path=<Path>)"
+    )]
     Unsupported(String),
 }
 
@@ -24,13 +27,17 @@ pub(crate) enum MatchClause {
     Header { name: String, value: String },
     /// Match the request's resolved `flow_id`.
     FlowId(String),
+    /// Match the request's method by exact, case-sensitive equality.
+    Method(String),
+    /// Match the request's bare path by exact equality (`query` is a separate field).
+    Path(String),
 }
 
 /// Parse every `match=` query parameter into clauses.
 ///
-/// Returns `Err` for a `match` value that is neither `header:<Name>=<Value>` nor
-/// `flow_id=<Value>`: a malformed filter must not silently fall back to returning
-/// every request, which would cross-contaminate correlated scenarios.
+/// Returns `Err` for a `match` value outside the closed grammar (`header:<Name>=<Value>`,
+/// `flow_id=<Value>`, `method=<Verb>`, `path=<Path>`): a malformed filter must not silently
+/// fall back to returning every request, which would cross-contaminate correlated scenarios.
 pub(crate) fn parse_match_clauses(
     query: Option<&str>,
 ) -> Result<Vec<MatchClause>, MatchClauseError> {
@@ -91,6 +98,10 @@ fn parse_one(value: &str) -> Result<MatchClause, MatchClauseError> {
         })
     } else if let Some(flow_id) = value.strip_prefix("flow_id=") {
         Ok(MatchClause::FlowId(flow_id.to_string()))
+    } else if let Some(method) = value.strip_prefix("method=") {
+        Ok(MatchClause::Method(method.to_string()))
+    } else if let Some(path) = value.strip_prefix("path=") {
+        Ok(MatchClause::Path(path.to_string()))
     } else {
         Err(MatchClauseError::Unsupported(value.to_string()))
     }
@@ -132,6 +143,8 @@ pub(crate) fn request_matches(
         MatchClause::FlowId(value) => {
             resolve_flow_id(req, flow_id_source, port).as_deref() == Some(value.as_str())
         }
+        MatchClause::Method(value) => req.method == *value,
+        MatchClause::Path(value) => req.path == *value,
     })
 }
 
@@ -192,8 +205,106 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_clause() {
-        assert!(parse_match_clauses(Some("match=path=/foo")).is_err());
+        // `query=`/`body=` are deliberately outside the closed grammar.
+        assert!(parse_match_clauses(Some("match=query=a=b")).is_err());
+        assert!(parse_match_clauses(Some("match=body=x")).is_err());
         assert!(parse_match_clauses(Some("match=header:X-Name")).is_err());
+    }
+
+    #[test]
+    fn unsupported_clause_message_enumerates_the_grammar() {
+        // The Display text is served verbatim as the 400 body, so it is part of the admin API
+        // contract — assert it exactly.
+        let err = parse_match_clauses(Some("match=query=a")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "unsupported match clause 'query=a' (expected header:<Name>=<Value>, flow_id=<Value>, method=<Verb> or path=<Path>)"
+        );
+    }
+
+    #[test]
+    fn parses_method_and_path_clauses() {
+        let clauses = parse_match_clauses(Some("match=method=POST&match=path=/orders")).unwrap();
+        assert_eq!(
+            clauses,
+            vec![
+                MatchClause::Method("POST".to_string()),
+                MatchClause::Path("/orders".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_url_encoded_method_and_path() {
+        // A path carrying structural `=`/spaces survives one level of percent-decoding intact.
+        let clauses = parse_match_clauses(Some("match=path%3D%2Ffoo%20bar")).unwrap();
+        assert_eq!(clauses, vec![MatchClause::Path("/foo bar".to_string())]);
+        let clauses = parse_match_clauses(Some("match=path%3D%2Fa%3Db")).unwrap();
+        assert_eq!(clauses, vec![MatchClause::Path("/a=b".to_string())]);
+    }
+
+    #[test]
+    fn method_match_is_case_sensitive() {
+        let mut req = req_with_header("X-Mock-Space", "abc");
+        req.method = "GET".to_string();
+        assert!(request_matches(
+            &req,
+            &[MatchClause::Method("GET".to_string())],
+            "imposter_port",
+            4545
+        ));
+        assert!(
+            !request_matches(
+                &req,
+                &[MatchClause::Method("get".to_string())],
+                "imposter_port",
+                4545
+            ),
+            "method comparison is case-sensitive"
+        );
+    }
+
+    #[test]
+    fn path_match_is_exact_not_prefix() {
+        let mut req = req_with_header("X-Mock-Space", "abc");
+        req.path = "/foo".to_string();
+        assert!(request_matches(
+            &req,
+            &[MatchClause::Path("/foo".to_string())],
+            "imposter_port",
+            4545
+        ));
+        assert!(
+            !request_matches(
+                &req,
+                &[MatchClause::Path("/foo/bar".to_string())],
+                "imposter_port",
+                4545
+            ),
+            "path comparison is exact, not a prefix"
+        );
+    }
+
+    #[test]
+    fn method_path_and_header_and_together() {
+        let mut req = req_with_header("X-Mock-Space", "abc");
+        req.method = "POST".to_string();
+        req.path = "/orders".to_string();
+        let clauses = vec![
+            MatchClause::Method("POST".to_string()),
+            MatchClause::Path("/orders".to_string()),
+            MatchClause::Header {
+                name: "X-Mock-Space".to_string(),
+                value: "abc".to_string(),
+            },
+        ];
+        assert!(request_matches(&req, &clauses, "imposter_port", 4545));
+        // One mismatched clause fails the whole AND.
+        let clauses = vec![
+            MatchClause::Method("GET".to_string()),
+            MatchClause::Path("/orders".to_string()),
+        ];
+        assert!(!request_matches(&req, &clauses, "imposter_port", 4545));
     }
 
     #[test]

--- a/crates/rift-http-proxy/tests/admin_sse.rs
+++ b/crates/rift-http-proxy/tests/admin_sse.rs
@@ -399,6 +399,52 @@ async fn match_flow_id_filter_scopes_request_events() {
 }
 
 #[tokio::test]
+async fn match_method_and_path_filter_scopes_request_events() {
+    // #700: `method=`/`path=` filter the SSE request stream, AND-ed like every other clause.
+    let (addr, mgr, running) = start_server(None).await;
+    let iport = create(
+        &mgr,
+        serde_json::json!({"port":18815,"protocol":"http","recordRequests":true,
+            "stubs":[{"responses":[{"is":{"statusCode":200}}]}]}),
+    )
+    .await;
+    let (mut sse, _s) = Sse::connect(
+        addr,
+        "/events?types=requests&match=method%3DPOST&match=path%3D%2Forders",
+        None,
+    )
+    .await;
+    sse.wait_for("hello", Duration::from_secs(5))
+        .await
+        .expect("hello");
+
+    let client = reqwest::Client::new();
+    // Rejected: right path, wrong method.
+    client
+        .get(format!("http://127.0.0.1:{iport}/orders"))
+        .send()
+        .await
+        .expect("get /orders");
+    // Accepted: POST /orders.
+    client
+        .post(format!("http://127.0.0.1:{iport}/orders"))
+        .send()
+        .await
+        .expect("post /orders");
+    let ev = sse
+        .wait_for("request", Duration::from_secs(5))
+        .await
+        .expect("request event");
+    assert_eq!(json(&ev)["request"]["method"], "POST");
+    assert_eq!(
+        json(&ev)["request"]["path"],
+        "/orders",
+        "must skip the GET /orders request"
+    );
+    running.shutdown().await;
+}
+
+#[tokio::test]
 async fn unauthorized_without_api_key() {
     let (addr, _mgr, running) = start_server(Some("s3cret")).await;
     let (_sse, status) = Sse::connect(addr, "/events", None).await;

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -364,6 +364,8 @@ Get recorded requests (if `recordRequests: true`). Also available under the alia
 **Query Parameters:**
 - `match=header:<Name>=<Value>` — keep only requests carrying a matching header
 - `match=flow_id=<Value>` — keep only requests whose resolved flow id matches
+- `match=method=<Verb>` — keep only requests whose method matches exactly (case-sensitive)
+- `match=path=<Path>` — keep only requests whose bare path matches exactly (the query string is not compared)
 - `since=<index>` — keep only requests newer than a cursor (see [Tailing with a cursor](#tailing-with-a-cursor))
 
 Multiple `match` clauses are AND-ed together. `since` is applied first, then the `match` clauses.
@@ -511,11 +513,12 @@ falls back to polling.
 **Query parameters:**
 - `types=requests,lifecycle` — which event families to stream (default: both).
 - `port=<port>` — restrict to one imposter.
-- `match=header:<Name>=<Value>` / `match=flow_id=<Value>` — filter **request** events (AND-ed).
-  `flow_id=` compares the request's record-time resolved flow id (per the imposter's
-  `flow_id_source`); a `header:`-source imposter whose request lacks that header falls back to the
-  port, which `GET /savedRequests?match=flow_id=` treats as "no match" instead — the only edge where
-  the two disagree.
+- `match=header:<Name>=<Value>` / `match=flow_id=<Value>` / `match=method=<Verb>` /
+  `match=path=<Path>` — filter **request** events (AND-ed). `method=`/`path=` are exact-equality
+  against the recorded request. `flow_id=` compares the request's record-time resolved flow id (per
+  the imposter's `flow_id_source`); a `header:`-source imposter whose request lacks that header falls
+  back to the port, which `GET /savedRequests?match=flow_id=` treats as "no match" instead — the only
+  edge where the two disagree.
 
 **Event stream** (`Content-Type: text/event-stream`):
 ```


### PR DESCRIPTION
## Summary

Extended match= clause grammar with two new exact-equality filters:
- `method=<Verb>` (case-sensitive): filter savedRequests GET/DELETE and SSE streams by HTTP method
- `path=<Path>` (bare path): filter by request path

New clauses are closed-grammar validated and AND-compose with existing header/flow_id/since clauses. Updated 400 error response to enumerate valid clause forms (admin API contract change).

Closes #700

**Adoption note:** Standalone admin-API extension; no milestone epic. Downstream SDKs (rift-java#148, rift-scala#37) adopt post-release.