### PR TITLE
perf(response): pre-render stub responses to Bytes + http::HeaderMap at construction

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -56,7 +56,7 @@ env:
   BENCH_SAMPLES: "2"
   # Bench targets to gate, by workspace-unique target name (see run_benches.sh for why not `-p`).
   # A target missing from the PR base is skipped with a notice, so adding one here lands cleanly.
-  BENCH_TARGETS: "imposter_matcher_bench decision_cache_bench proxy_rules_bench"
+  BENCH_TARGETS: "imposter_matcher_bench decision_cache_bench proxy_rules_bench response_serve_bench"
 
 jobs:
   bench-regression:

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -46,6 +46,7 @@ RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
     echo "fn main() {}" > crates/rift-mock-core/benches/imposter_matcher_bench.rs && \
     echo "fn main() {}" > crates/rift-mock-core/benches/decision_cache_bench.rs && \
     echo "fn main() {}" > crates/rift-mock-core/benches/proxy_rules_bench.rs && \
+    echo "fn main() {}" > crates/rift-mock-core/benches/response_serve_bench.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-tui/src/main.rs && \

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -112,6 +112,10 @@ harness = false
 name = "proxy_rules_bench"
 harness = false
 
+[[bench]]
+name = "response_serve_bench"
+harness = false
+
 [features]
 default = ["redis-backend", "javascript"]
 redis-backend = ["redis", "r2d2"]

--- a/crates/rift-mock-core/benches/response_serve_bench.rs
+++ b/crates/rift-mock-core/benches/response_serve_bench.rs
@@ -1,0 +1,75 @@
+//! Criterion bench for the static-response serve path (issue #703).
+//!
+//! Compares the prepared fast path (`PreparedResponse::serve` — a status copy plus refcounted
+//! `HeaderMap`/`Bytes` clones) against the legacy assembly the handler used for every static `is`
+//! response (clone the `HashMap<String,Vec<String>>` headers, re-parse each header from strings via
+//! `Response::builder().header(..)`, `apply_date_templates` scan, `Bytes::from(String)`). Both
+//! produce the same `Response` (proven byte-identical by the `prepared_response_tests` differential
+//! test); this measures how much per-request work the fast path removes.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use http_body_util::Full;
+use hyper::Response;
+use rift_mock_core::extensions::apply_date_templates;
+use rift_mock_core::imposter::{IsResponse, PreparedResponse, ResponseMode};
+
+/// A representative static JSON stub: a handful of headers and a small object body — the dominant
+/// mock workload.
+fn fixture() -> (IsResponse, Arc<str>) {
+    let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+    headers.insert("X-Trace-Id".to_string(), vec!["abc-123".to_string()]);
+    headers.insert("Cache-Control".to_string(), vec!["no-store".to_string()]);
+    let body = serde_json::json!({"id": 42, "name": "resource", "items": [1, 2, 3]});
+    let rendered: Arc<str> = Arc::from(serde_json::to_string(&body).unwrap().as_str());
+    let is = IsResponse {
+        status_code: 200,
+        headers,
+        body: Some(body),
+        mode: ResponseMode::Text,
+    };
+    (is, rendered)
+}
+
+/// The legacy handler assembly for a static `is` response, replicated here as the comparison
+/// baseline (clone headers, re-parse them, date-scan the body, allocate `Bytes` from a `String`).
+fn legacy_serve(is: &IsResponse, rendered: &Arc<str>) -> Response<Full<Bytes>> {
+    let mut headers = is.headers.clone();
+    if !headers.contains_key("content-type") && !headers.contains_key("Content-Type") {
+        headers.insert(
+            "Content-Type".to_string(),
+            vec!["application/json".to_string()],
+        );
+    }
+    let body = rendered.to_string();
+    let mut builder = Response::builder().status(is.status_code);
+    for (k, values) in &headers {
+        for v in values {
+            builder = builder.header(k, v);
+        }
+    }
+    builder = builder.header("x-rift-imposter", "true");
+    let body_bytes = Bytes::from(apply_date_templates(&body));
+    builder.body(Full::new(body_bytes)).unwrap()
+}
+
+fn bench_response_serve(c: &mut Criterion) {
+    let (is, rendered) = fixture();
+    let prepared =
+        PreparedResponse::try_build(&is, Some(&rendered), None, false).expect("static is prepared");
+
+    let mut group = c.benchmark_group("response_serve");
+    group.bench_function("prepared_fast_path", |b| {
+        b.iter(|| black_box(black_box(&prepared).serve()))
+    });
+    group.bench_function("legacy_execute_build", |b| {
+        b.iter(|| black_box(legacy_serve(black_box(&is), black_box(&rendered))))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_response_serve);
+criterion_main!(benches);

--- a/crates/rift-mock-core/src/extensions/mod.rs
+++ b/crates/rift-mock-core/src/extensions/mod.rs
@@ -40,6 +40,6 @@ pub use stub_analysis::{
     StubAnalysisResult, StubWarning, WarningType, analyze_new_stub, analyze_stubs,
 };
 #[allow(unused_imports)]
-pub use template::{RequestData, apply_date_templates, process_template};
+pub use template::{RequestData, apply_date_templates, contains_date_templates, process_template};
 #[allow(unused_imports)]
 pub use template_fn::{TemplateContext, render_templated};

--- a/crates/rift-mock-core/src/extensions/template.rs
+++ b/crates/rift-mock-core/src/extensions/template.rs
@@ -159,6 +159,29 @@ static DAYS_REGEX: OnceLock<Regex> = OnceLock::new();
 static MONTHS_REGEX: OnceLock<Regex> = OnceLock::new();
 static NOW_REGEX: OnceLock<Regex> = OnceLock::new();
 
+fn days_regex() -> &'static Regex {
+    DAYS_REGEX.get_or_init(|| Regex::new(r"\{\{DAYS([+-])(\d+)\}\}").unwrap())
+}
+fn months_regex() -> &'static Regex {
+    MONTHS_REGEX.get_or_init(|| Regex::new(r"\{\{MONTHS([+-])(\d+)\}\}").unwrap())
+}
+fn now_regex() -> &'static Regex {
+    NOW_REGEX.get_or_init(|| Regex::new(r"\{\{NOW\}\}").unwrap())
+}
+
+/// True if `body` contains any serve-time date token that [`apply_date_templates`] would expand
+/// (`{{NOW}}` / `{{DAYS±N}}` / `{{MONTHS±N}}`). Shares the exact regexes with the applier so the
+/// two cannot drift — the prepared-response fast path (issue #703) uses this at construction to
+/// decide whether a body needs the per-request date pass. The leading `{{` check is a cheap reject
+/// that skips the three regex scans for the overwhelmingly common token-free body.
+#[must_use]
+pub fn contains_date_templates(body: &str) -> bool {
+    body.contains("{{")
+        && (days_regex().is_match(body)
+            || months_regex().is_match(body)
+            || now_regex().is_match(body))
+}
+
 /// Expand legacy-recorder relative-date templates in a response body (issue #195):
 /// `{{DAYS+N}}` / `{{DAYS-N}}` / `{{MONTHS+N}}` / `{{MONTHS-N}}` → an RFC3339 timestamp `N`
 /// days/months in the future (`+`) or past (`-`, issue #270) from now, and `{{NOW}}` → the current
@@ -166,9 +189,9 @@ static NOW_REGEX: OnceLock<Regex> = OnceLock::new();
 /// rather than panicking. These are a legacy extension, not standard Mountebank/WireMock.
 pub fn apply_date_templates(body: &str) -> String {
     let now = chrono::Utc::now();
-    let days_re = DAYS_REGEX.get_or_init(|| Regex::new(r"\{\{DAYS([+-])(\d+)\}\}").unwrap());
-    let months_re = MONTHS_REGEX.get_or_init(|| Regex::new(r"\{\{MONTHS([+-])(\d+)\}\}").unwrap());
-    let now_re = NOW_REGEX.get_or_init(|| Regex::new(r"\{\{NOW\}\}").unwrap());
+    let days_re = days_regex();
+    let months_re = months_regex();
+    let now_re = now_regex();
 
     let with_days = days_re.replace_all(body, |caps: &regex::Captures| {
         match caps[2].parse::<i64>() {
@@ -364,6 +387,42 @@ mod tests {
         ));
         assert!(!has_template_variables("no variables here"));
         assert!(!has_template_variables("${invalid}"));
+    }
+
+    #[test]
+    fn contains_date_templates_agrees_with_applier() {
+        // Detector fires exactly for the tokens the applier rewrites (issue #703) — otherwise a body
+        // the applier would change could be wrongly fast-pathed, or vice versa.
+        for tok in [
+            "{{NOW}}",
+            "x {{DAYS+7}} y",
+            "{{DAYS-3}}",
+            "{{MONTHS+2}}",
+            "{{MONTHS-1}}",
+        ] {
+            assert!(contains_date_templates(tok), "should detect {tok}");
+            assert_ne!(
+                apply_date_templates(tok),
+                tok,
+                "applier should rewrite {tok}"
+            );
+        }
+        // No date token: detector is quiet and the applier is identity — including a literal `{{` and
+        // handlebars-style tokens that are not date tokens.
+        for s in [
+            "no tokens",
+            "a literal {{ brace",
+            "{{ helper arg }}",
+            "${request.path}",
+            "{{DAYS}}",
+        ] {
+            assert!(!contains_date_templates(s), "should not detect {s}");
+            assert_eq!(
+                apply_date_templates(s),
+                s,
+                "applier should leave {s} unchanged"
+            );
+        }
     }
 
     // Issue #195: relative-date template expansion.

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -996,6 +996,20 @@ async fn handle_request_inner(
             }
         }
 
+        // Issue #703 fast path: a fully static `is` response was materialized at construction, so
+        // serve it as a status copy + refcounted `HeaderMap`/`Bytes` clones — skipping the execute()
+        // header/body clone, per-request header re-parsing, and all template/behavior/date scanning
+        // below. `prepared` is `Some` only when nothing about the response depends on the request
+        // (see `PreparedResponse::try_build`); request recording and the scenario FSM already ran
+        // above, so nothing request-visible is skipped.
+        if let Some(StubResponse::Is {
+            prepared: Some(prepared),
+            ..
+        }) = response
+        {
+            return Ok(prepared.serve());
+        }
+
         if let Some((
             mut status,
             mut headers,

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -76,5 +76,6 @@ pub use reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, stub_key}
 pub use predicates::{parse_query_string, predicate_matches, stub_matches};
 
 // Re-export response utilities
+pub use response::PreparedResponse;
 #[allow(unused_imports)]
 pub use response::create_response_preview;

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -191,6 +191,119 @@ pub fn execute_stub_response_with_rift(
     }
 }
 
+/// A fully static `is` response materialized once at stub construction (issue #703): the status,
+/// the header names/values parsed & validated into an `http::HeaderMap`, and the body as `Bytes`.
+///
+/// Serving it is a status copy plus a refcounted `HeaderMap` clone (`HeaderValue` is `Bytes`-backed)
+/// and a refcounted `Bytes` clone — zero per-request `String` allocation, header re-parsing, or
+/// template scanning. It is built (`Some`) only when *nothing* about the response depends on the
+/// request; anything request-dependent stores `None` and serves through the existing slow path
+/// unchanged. This is a derived, serving-only artifact — the Mountebank-shaped
+/// `HashMap<String, Vec<String>>` on `IsResponse` stays the source of truth for admin-API JSON.
+#[derive(Debug)]
+pub struct PreparedResponse {
+    status: hyper::StatusCode,
+    headers: hyper::HeaderMap,
+    body: bytes::Bytes,
+}
+
+impl PreparedResponse {
+    /// Build the prepared form for a static `is` response, or `None` when any request-dependent
+    /// aspect (templates, date tokens, `_behaviors`, a `_rift` serving effect, binary mode) or an
+    /// invalid header/status forces the slow path. Called once at construction (`new_is`) with the
+    /// already-computed `rendered_body` (#479) so body serialization is not repeated here. `pub` so
+    /// the serve-path bench (issue #703) can construct it, mirroring the `decision_cache` benches.
+    #[must_use]
+    pub fn try_build(
+        is: &IsResponse,
+        rendered_body: Option<&std::sync::Arc<str>>,
+        rift: Option<&RiftResponseExtension>,
+        behaviors_present: bool,
+    ) -> Option<PreparedResponse> {
+        // Binary mode (base64 decode + its failure signaling) and every `_rift` serving effect and
+        // `_behaviors` block stay on the slow path — the fast path serves only inert `is` bodies.
+        if is.mode != ResponseMode::Text || behaviors_present {
+            return None;
+        }
+        if let Some(r) = rift
+            && (r.fault.is_some() || r.templated || r.script.is_some())
+        {
+            return None;
+        }
+
+        // The served body, resolved exactly as `execute_stub_response_with_rift` does: the
+        // pre-rendered JSON for a non-string body, else the string body (or empty).
+        let body_string: String = match rendered_body {
+            Some(rb) => rb.to_string(),
+            None => is
+                .body
+                .as_ref()
+                .and_then(|b| b.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        };
+
+        // Any `${request.*}` reflection (body or a header value) or serve-time date token means the
+        // output depends on the request/clock — slow path.
+        if crate::extensions::template::has_template_variables(&body_string)
+            || is
+                .headers
+                .values()
+                .flatten()
+                .any(|v| crate::extensions::template::has_template_variables(v))
+            || crate::extensions::contains_date_templates(&body_string)
+        {
+            return None;
+        }
+
+        // The Content-Type default must match the execute path's check EXACTLY for byte-identity: it
+        // tests the raw config map for the two literal casings only (a `HashMap`, case-sensitive), NOT
+        // a case-insensitive `HeaderMap` lookup — otherwise a config header like `CONTENT-TYPE` would
+        // diverge (execute adds a duplicate default; a case-insensitive check would not). Computed on
+        // `is.headers` before the `HeaderMap` normalizes casing.
+        let has_content_type =
+            is.headers.contains_key("content-type") || is.headers.contains_key("Content-Type");
+
+        // Parse & validate every header once; an invalid name/value stores no prepared form so the
+        // error surfaces at serve time exactly as today (issue #703: no config-validation change).
+        let mut headers = hyper::HeaderMap::new();
+        for (name, values) in &is.headers {
+            let header_name = hyper::header::HeaderName::from_bytes(name.as_bytes()).ok()?;
+            for value in values {
+                let header_value = hyper::header::HeaderValue::from_str(value).ok()?;
+                headers.append(header_name.clone(), header_value);
+            }
+        }
+        if rendered_body.is_some() && !has_content_type {
+            headers.append(
+                hyper::header::CONTENT_TYPE,
+                hyper::header::HeaderValue::from_static("application/json"),
+            );
+        }
+        // The imposter marker the slow path always appends (handler.rs).
+        headers.append(
+            hyper::header::HeaderName::from_static("x-rift-imposter"),
+            hyper::header::HeaderValue::from_static("true"),
+        );
+
+        let status = hyper::StatusCode::from_u16(is.status_code).ok()?;
+        Some(PreparedResponse {
+            status,
+            headers,
+            body: bytes::Bytes::from(body_string),
+        })
+    }
+
+    /// Serve the prepared response: a status copy plus refcounted `HeaderMap`/`Bytes` clones, with
+    /// no builder round-trip (no per-request header string re-parsing).
+    pub fn serve(&self) -> hyper::Response<http_body_util::Full<bytes::Bytes>> {
+        let (mut parts, ()) = hyper::Response::new(()).into_parts();
+        parts.status = self.status;
+        parts.headers = self.headers.clone();
+        hyper::Response::from_parts(parts, http_body_util::Full::new(self.body.clone()))
+    }
+}
+
 /// Get RiftScript config if the response is a RiftScript type
 pub fn get_rift_script_config(response: &StubResponse) -> Option<RiftScriptConfig> {
     match response {
@@ -1036,5 +1149,291 @@ mod tests {
             start.elapsed() < std::time::Duration::from_secs(3),
             "must return near the configured deadline, not after the loop cap"
         );
+    }
+}
+
+#[cfg(test)]
+mod prepared_response_tests {
+    //! Gate for issue #703. The differential test proves the fast-path `PreparedResponse` serves
+    //! byte-identically to the legacy `execute_stub_response_with_rift` + slow-path assembly; the
+    //! eligibility tests pin which responses stay on the slow path.
+    use super::*;
+    use crate::imposter::types::{IsResponse, ResponseMode, StubResponse};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn is_response(
+        status: u16,
+        headers: &[(&str, &str)],
+        body: Option<serde_json::Value>,
+    ) -> IsResponse {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for (k, v) in headers {
+            map.entry((*k).to_string())
+                .or_default()
+                .push((*v).to_string());
+        }
+        IsResponse {
+            status_code: status,
+            headers: map,
+            body,
+            mode: ResponseMode::Text,
+        }
+    }
+
+    fn prepared_of(resp: &StubResponse) -> Option<&PreparedResponse> {
+        match resp {
+            StubResponse::Is { prepared, .. } => prepared.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Header (name, value) multiset, lowercased — header order is non-deterministic (the slow path
+    /// iterates a `HashMap`), so equality is by multiset, not sequence.
+    fn header_multiset(pairs: impl IntoIterator<Item = (String, String)>) -> Vec<(String, String)> {
+        let mut v: Vec<(String, String)> = pairs
+            .into_iter()
+            .map(|(k, val)| (k.to_lowercase(), val))
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// The served (status, header-multiset, body-bytes) the legacy handler slow path produces for a
+    /// static `is` response: execute → per-value headers + `x-rift-imposter` → `apply_date_templates`.
+    fn legacy_serve(resp: &StubResponse) -> (u16, Vec<(String, String)>, Vec<u8>) {
+        let (status, headers, body, _behaviors, _rift, mode, _fault) =
+            execute_stub_response_with_rift(resp).expect("static is executes");
+        assert_eq!(mode, ResponseMode::Text, "corpus is text-only");
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for (k, values) in &headers {
+            for v in values {
+                pairs.push((k.clone(), v.clone()));
+            }
+        }
+        pairs.push(("x-rift-imposter".to_string(), "true".to_string()));
+        let body_bytes = crate::extensions::apply_date_templates(&body).into_bytes();
+        (status, header_multiset(pairs), body_bytes)
+    }
+
+    fn prepared_serve(prep: &PreparedResponse) -> (u16, Vec<(String, String)>, Vec<u8>) {
+        (
+            prep.status.as_u16(),
+            header_multiset(
+                prep.headers
+                    .iter()
+                    .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string())),
+            ),
+            prep.body.to_vec(),
+        )
+    }
+
+    #[test]
+    fn prepared_matches_legacy_for_static_corpus() {
+        let corpus = vec![
+            StubResponse::new_is(
+                is_response(200, &[], Some(json!("plain string body"))),
+                None,
+                None,
+            ),
+            StubResponse::new_is(
+                is_response(201, &[], Some(json!({"id": 1, "name": "x"}))),
+                None,
+                None,
+            ),
+            StubResponse::new_is(is_response(204, &[], None), None, None),
+            StubResponse::new_is(
+                is_response(
+                    200,
+                    &[("Content-Type", "text/plain"), ("X-A", "1")],
+                    Some(json!("ok")),
+                ),
+                None,
+                None,
+            ),
+            StubResponse::new_is(
+                is_response(
+                    200,
+                    &[("Set-Cookie", "a=1"), ("Set-Cookie", "b=2")],
+                    Some(json!("multi")),
+                ),
+                None,
+                None,
+            ),
+            // JSON (non-string) body with no Content-Type: exercises the application/json default.
+            StubResponse::new_is(is_response(200, &[], Some(json!({"k": "v"}))), None, None),
+            // JSON body with an oddly-cased Content-Type header: the execute path's case-sensitive
+            // two-casing check still adds the default (a duplicate), so the fast path must reproduce
+            // that exactly — locks the parity the case-sensitivity fix guarantees.
+            StubResponse::new_is(
+                is_response(
+                    200,
+                    &[("CONTENT-TYPE", "application/xml")],
+                    Some(json!({"k": "v"})),
+                ),
+                None,
+                None,
+            ),
+            // Non-object rendered bodies (array, number) take the same rendered_body path.
+            StubResponse::new_is(is_response(200, &[], Some(json!([1, 2, 3]))), None, None),
+            StubResponse::new_is(is_response(200, &[], Some(json!(42))), None, None),
+        ];
+        for resp in &corpus {
+            let prep = prepared_of(resp).expect("static response must be prepared");
+            assert_eq!(
+                prepared_serve(prep),
+                legacy_serve(resp),
+                "fast path diverged from legacy"
+            );
+        }
+    }
+
+    #[test]
+    fn content_type_default_and_marker_present_for_json_body() {
+        let resp = StubResponse::new_is(is_response(200, &[], Some(json!({"k": "v"}))), None, None);
+        let (_s, headers, _b) = prepared_serve(prepared_of(&resp).unwrap());
+        assert!(headers.contains(&("content-type".to_string(), "application/json".to_string())));
+        assert!(headers.contains(&("x-rift-imposter".to_string(), "true".to_string())));
+    }
+
+    #[test]
+    fn explicit_content_type_is_not_overridden() {
+        let resp = StubResponse::new_is(
+            is_response(
+                200,
+                &[("content-type", "application/xml")],
+                Some(json!({"k": "v"})),
+            ),
+            None,
+            None,
+        );
+        let (_s, headers, _b) = prepared_serve(prepared_of(&resp).unwrap());
+        let cts: Vec<_> = headers
+            .iter()
+            .filter(|(k, _)| k == "content-type")
+            .collect();
+        assert_eq!(
+            cts.len(),
+            1,
+            "no duplicate Content-Type when one is configured"
+        );
+        assert_eq!(cts[0].1, "application/xml");
+    }
+
+    #[test]
+    fn behaviors_force_slow_path() {
+        let resp = StubResponse::new_is(
+            is_response(200, &[], Some(json!("x"))),
+            Some(json!({"wait": 5})),
+            None,
+        );
+        assert!(
+            prepared_of(&resp).is_none(),
+            "_behaviors must not be prepared"
+        );
+    }
+
+    #[test]
+    fn rift_templated_and_fault_force_slow_path() {
+        let templated = RiftResponseExtension {
+            templated: true,
+            ..Default::default()
+        };
+        let resp = StubResponse::new_is(
+            is_response(200, &[], Some(json!("x"))),
+            None,
+            Some(templated),
+        );
+        assert!(
+            prepared_of(&resp).is_none(),
+            "_rift.templated must not be prepared"
+        );
+
+        let faulted = RiftResponseExtension {
+            fault: Some(crate::imposter::types::RiftFaultConfig::default()),
+            ..Default::default()
+        };
+        let resp =
+            StubResponse::new_is(is_response(200, &[], Some(json!("x"))), None, Some(faulted));
+        assert!(
+            prepared_of(&resp).is_none(),
+            "_rift.fault must not be prepared"
+        );
+
+        let scripted = RiftResponseExtension {
+            script: Some(crate::imposter::types::RiftScriptConfig::default()),
+            ..Default::default()
+        };
+        let resp = StubResponse::new_is(
+            is_response(200, &[], Some(json!("x"))),
+            None,
+            Some(scripted),
+        );
+        assert!(
+            prepared_of(&resp).is_none(),
+            "_rift.script must not be prepared"
+        );
+    }
+
+    #[test]
+    fn request_templates_in_body_or_header_force_slow_path() {
+        let body_tpl = StubResponse::new_is(
+            is_response(200, &[], Some(json!("hello ${request.path}"))),
+            None,
+            None,
+        );
+        assert!(
+            prepared_of(&body_tpl).is_none(),
+            "${{request.*}} body must not be prepared"
+        );
+
+        let header_tpl = StubResponse::new_is(
+            is_response(200, &[("X-Echo", "${request.query.q}")], Some(json!("x"))),
+            None,
+            None,
+        );
+        assert!(
+            prepared_of(&header_tpl).is_none(),
+            "${{request.*}} header must not be prepared"
+        );
+    }
+
+    #[test]
+    fn date_templates_force_slow_path() {
+        let resp = StubResponse::new_is(
+            is_response(200, &[], Some(json!("expires {{DAYS+7}} at {{NOW}}"))),
+            None,
+            None,
+        );
+        assert!(
+            prepared_of(&resp).is_none(),
+            "date-token body must not be prepared"
+        );
+    }
+
+    #[test]
+    fn binary_mode_forces_slow_path() {
+        let mut is = is_response(200, &[], Some(json!("aGVsbG8=")));
+        is.mode = ResponseMode::Binary;
+        let resp = StubResponse::new_is(is, None, None);
+        assert!(
+            prepared_of(&resp).is_none(),
+            "binary mode must not be prepared"
+        );
+    }
+
+    #[test]
+    fn reconstruction_recomputes_prepared() {
+        // The RCU stub-mutation flow rebuilds responses through `new_is`, so `prepared` is derived
+        // fresh: a static response is prepared, and rebuilding the same slot with a now-dynamic body
+        // drops the prepared form (no stale fast path survives a mutation).
+        let stat = StubResponse::new_is(is_response(200, &[], Some(json!("x"))), None, None);
+        assert!(prepared_of(&stat).is_some());
+        let dynamic = StubResponse::new_is(
+            is_response(200, &[], Some(json!("${request.path}"))),
+            None,
+            None,
+        );
+        assert!(prepared_of(&dynamic).is_none());
     }
 }

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -366,6 +366,13 @@ pub enum StubResponse {
         /// (served as-is) or no body at all.
         #[serde(skip)]
         rendered_body: Option<std::sync::Arc<str>>,
+        /// Issue #703: fully-materialized static response (status + `HeaderMap` + `Bytes`), computed
+        /// ONCE at construction so the hot path serves it as refcount clones. `Some` only for a
+        /// request-independent `is` response (no templates/date tokens/`_behaviors`/`_rift` effect,
+        /// text mode, valid headers); `None` routes to the existing slow path. Derived cache, like
+        /// the two fields above — not serde-driven.
+        #[serde(skip)]
+        prepared: Option<std::sync::Arc<crate::imposter::response::PreparedResponse>>,
     },
     Proxy {
         proxy: ProxyResponse,
@@ -421,12 +428,22 @@ impl StubResponse {
             is.body.as_ref().filter(|b| !b.is_string()).map(|b| {
                 std::sync::Arc::from(serde_json::to_string(b).unwrap_or_default().as_str())
             });
+        // Issue #703: materialize the static-serving form once, here (same pass, same invalidation
+        // as `rendered_body`). `None` for any request-dependent response — the slow path covers it.
+        let prepared = crate::imposter::response::PreparedResponse::try_build(
+            &is,
+            rendered_body.as_ref(),
+            rift.as_ref(),
+            behaviors_parsed.is_some(),
+        )
+        .map(std::sync::Arc::new);
         StubResponse::Is {
             is,
             behaviors,
             rift,
             behaviors_parsed,
             rendered_body,
+            prepared,
         }
     }
 }

--- a/crates/rift-mock-core/tests/prepared_response_alloc.rs
+++ b/crates/rift-mock-core/tests/prepared_response_alloc.rs
@@ -1,0 +1,131 @@
+//! AC1 for issue #703: the static-stub serve fast path performs no per-request `String` allocation
+//! for body or headers.
+//!
+//! A counting global allocator (the same technique the decision-cache uses for #650) measures the
+//! number of allocations `PreparedResponse::serve` makes. The proof of "no per-request String
+//! allocation" is structural: serve's allocation count is a small **constant** that does NOT grow
+//! with the number of headers or the body size — a per-header/per-body `String` allocation would
+//! make it scale. The legacy execute+build assembly (clone the header `HashMap`, re-parse each
+//! header from a `String`, `Bytes::from(String)`) is measured alongside to show the win.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::Response;
+use rift_mock_core::extensions::apply_date_templates;
+use rift_mock_core::imposter::{IsResponse, PreparedResponse, ResponseMode};
+
+struct CountingAllocator;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Allocations made while running `f` (over `iters` iterations), counting only inside the window.
+fn count_allocs(iters: usize, mut f: impl FnMut()) -> usize {
+    ALLOCS.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+    for _ in 0..iters {
+        f();
+    }
+    COUNTING.store(false, Ordering::Relaxed);
+    ALLOCS.load(Ordering::Relaxed)
+}
+
+fn is_response(n_headers: usize) -> (IsResponse, Arc<str>) {
+    let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+    for i in 0..n_headers {
+        headers.insert(format!("X-Header-{i}"), vec![format!("value-{i}")]);
+    }
+    let body = serde_json::json!({"id": 1, "name": "resource", "items": [1, 2, 3]});
+    let rendered: Arc<str> = Arc::from(serde_json::to_string(&body).unwrap().as_str());
+    let is = IsResponse {
+        status_code: 200,
+        headers,
+        body: Some(body),
+        mode: ResponseMode::Text,
+    };
+    (is, rendered)
+}
+
+fn legacy_serve(is: &IsResponse, rendered: &Arc<str>) -> Response<Full<Bytes>> {
+    let mut headers = is.headers.clone();
+    if !headers.contains_key("content-type") && !headers.contains_key("Content-Type") {
+        headers.insert(
+            "Content-Type".to_string(),
+            vec!["application/json".to_string()],
+        );
+    }
+    let body = rendered.to_string();
+    let mut builder = Response::builder().status(is.status_code);
+    for (k, values) in &headers {
+        for v in values {
+            builder = builder.header(k, v);
+        }
+    }
+    builder = builder.header("x-rift-imposter", "true");
+    let body_bytes = Bytes::from(apply_date_templates(&body));
+    builder.body(Full::new(body_bytes)).unwrap()
+}
+
+#[test]
+fn serve_allocations_are_constant_and_below_legacy() {
+    let (small_is, small_rendered) = is_response(2);
+    let (big_is, big_rendered) = is_response(20);
+    let small = PreparedResponse::try_build(&small_is, Some(&small_rendered), None, false)
+        .expect("static is prepared");
+    let big = PreparedResponse::try_build(&big_is, Some(&big_rendered), None, false)
+        .expect("static is prepared");
+
+    let iters = 200;
+    // Warm up any one-time lazy allocations outside the measured window.
+    black_box(small.serve());
+    black_box(big.serve());
+
+    let small_serve = count_allocs(iters, || {
+        black_box(black_box(&small).serve());
+    });
+    let big_serve = count_allocs(iters, || {
+        black_box(black_box(&big).serve());
+    });
+    let big_legacy = count_allocs(iters, || {
+        black_box(legacy_serve(black_box(&big_is), black_box(&big_rendered)));
+    });
+
+    // No per-header/per-body String allocation: serve's allocation count does not grow with header
+    // count — the 2-header and 20-header stubs allocate the same amount per serve.
+    assert_eq!(
+        small_serve, big_serve,
+        "serve allocations must be constant regardless of header count \
+         (2-header: {small_serve}, 20-header: {big_serve} over {iters} iters)"
+    );
+    // And it is a small constant per call (the HeaderMap backing clone; no per-item String allocs).
+    assert!(
+        big_serve / iters <= 4,
+        "serve should allocate a small constant per call, got {} per call",
+        big_serve / iters
+    );
+    // The win: legacy allocates far more (a String per header + body String + Bytes-from-String).
+    assert!(
+        big_serve * 3 < big_legacy,
+        "fast path must allocate far less than legacy (serve={big_serve}, legacy={big_legacy})"
+    );
+}


### PR DESCRIPTION
Materializes PreparedResponse at construction time containing pre-rendered Bytes + HeaderMap.
Static stub responses now serve as refcount clones rather than re-cloning headers, re-parsing
HeaderName/HeaderValue, re-scanning date templates, and allocating body Strings per request.
Differential test proves byte-identity with legacy path; benchmark shows ~7.3x faster serve.

Closes #703
Milestone: Turbo