### PR TITLE
perf(core): adopt foldhash for request-scoped and index maps (FastMap alias)

### DIFF
--- a/crates/rift-mock-core/src/extensions/template.rs
+++ b/crates/rift-mock-core/src/extensions/template.rs
@@ -22,6 +22,7 @@
 //! ```
 
 use crate::predicate::parse_query_string;
+use crate::util::FastMap;
 use regex::Regex;
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -43,12 +44,15 @@ pub struct RequestData {
     pub method: String,
     /// Request path (without query string)
     pub path: String,
-    /// Query parameters parsed from the URL
+    /// Query parameters parsed from the URL. Kept as the std-hasher map (issue #704): its source,
+    /// the legacy `crate::predicate::parse_query_string`, already returns one, so a `FastMap` here
+    /// would re-hash the whole map for a request-scoped map that is only `.get()`-probed a few times.
     pub query: HashMap<String, String>,
-    /// Request headers (keys lowercased)
-    pub headers: HashMap<String, String>,
-    /// Path parameters extracted from route patterns (e.g., /users/:id)
-    pub path_params: HashMap<String, String>,
+    /// Request headers (keys lowercased). Request-scoped — `FastMap` (issue #704).
+    pub headers: FastMap<String, String>,
+    /// Path parameters extracted from route patterns (e.g., /users/:id). Request-scoped —
+    /// `FastMap` (issue #704).
+    pub path_params: FastMap<String, String>,
     /// Raw request body
     pub body: String,
 }
@@ -62,8 +66,9 @@ impl RequestData {
         headers: &hyper::HeaderMap,
         body: Option<&str>,
     ) -> Self {
+        // Zero-copy: the legacy parser already returns a std-hasher map (see the `query` field).
         let query = parse_query_string(query_string);
-        let headers_map = headers
+        let headers_map: FastMap<String, String> = headers
             .iter()
             .filter_map(|(k, v)| {
                 v.to_str()
@@ -77,7 +82,7 @@ impl RequestData {
             path: path.to_string(),
             query,
             headers: headers_map,
-            path_params: HashMap::new(),
+            path_params: FastMap::default(),
             body: body.unwrap_or("").to_string(),
         }
     }
@@ -111,8 +116,9 @@ impl RequestData {
 
 /// Extract path parameters from a route `pattern` (`:name` segments) and the actual request
 /// `path`. Returns an empty map when the segment counts differ or a literal segment doesn't match.
-pub(crate) fn extract_path_params(pattern: &str, path: &str) -> HashMap<String, String> {
-    let mut params = HashMap::new();
+/// Request-scoped — `FastMap` (issue #704).
+pub(crate) fn extract_path_params(pattern: &str, path: &str) -> FastMap<String, String> {
+    let mut params = FastMap::default();
 
     let pattern_parts: Vec<&str> = pattern.split('/').collect();
     let path_parts: Vec<&str> = path.split('/').collect();
@@ -126,7 +132,7 @@ pub(crate) fn extract_path_params(pattern: &str, path: &str) -> HashMap<String, 
             params.insert(param_name.to_string(), path_part.to_string());
         } else if pattern_part != path_part {
             // Pattern doesn't match
-            return HashMap::new();
+            return FastMap::default();
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -3,6 +3,8 @@
 //! Part of the `Imposter` implementation; see `core/mod.rs` for the struct definition.
 
 use super::*;
+use crate::util::FastMap;
+use std::hash::BuildHasher;
 
 impl Imposter {
     /// Find a matching stub for a request and return a cloned copy with its index.
@@ -25,16 +27,19 @@ impl Imposter {
 
     /// Find a matching stub with client address information (for requestFrom/ip predicates)
     #[allow(clippy::too_many_arguments)]
-    pub fn find_matching_stub_with_client(
+    pub fn find_matching_stub_with_client<SH>(
         &self,
         method: &str,
         path: &str,
-        headers_map: &HashMap<String, String>,
+        headers_map: &HashMap<String, String, SH>,
         query: Option<&str>,
         body: Option<&str>,
         request_from: Option<&str>,
         client_ip: Option<&str>,
-    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
+    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>>
+    where
+        SH: BuildHasher,
+    {
         // Stage 1 (issue #292): the index embeds its stub snapshot, so `stubs` and the candidate
         // set are always consistent. Non-anchored stubs sit in its fallback bucket, so `candidates`
         // is a superset of the true matches, ascending — Stage-2 first-match-wins is unchanged.
@@ -112,17 +117,22 @@ impl Imposter {
     /// No abort flag: Boa has no per-instruction interrupt, so after a timeout the loop-iteration
     /// cap (issue #327) is what eventually frees the blocking thread.
     #[allow(clippy::too_many_arguments)]
-    pub async fn find_matching_stub_with_client_bounded(
+    pub async fn find_matching_stub_with_client_bounded<SH>(
         self: &Arc<Self>,
         method: &str,
         path: &str,
-        headers_map: &HashMap<String, String>,
+        headers_map: &HashMap<String, String, SH>,
         query: Option<&str>,
         body: Option<&str>,
         request_from: Option<&str>,
         client_ip: Option<&str>,
         timeout: std::time::Duration,
-    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
+    ) -> anyhow::Result<Option<(Arc<StubState>, usize)>>
+    where
+        // `Clone + Send + 'static`: the `spawn_blocking` offload below clones `headers_map` into a
+        // `'static` worker closure when the snapshot needs offloading (inject/scenario-gate).
+        SH: BuildHasher + Clone + Send + 'static,
+    {
         let snapshot = self.stub_index.load();
         let has_inject = snapshot.has_inject();
         // A scenario-gated stub reads flow state inside the matching pass; on a blocking backend
@@ -260,7 +270,10 @@ impl Imposter {
     /// Resolve the correlation `flow_id` for a request, partitioning scenario state.
     /// `"header:<Name>"` uses that (case-insensitive) header; `"imposter_port"` (the default,
     /// and the fallback when the header is absent) uses the imposter port.
-    pub fn resolve_flow_id(&self, headers: &HashMap<String, String>) -> String {
+    pub fn resolve_flow_id<SH: BuildHasher>(
+        &self,
+        headers: &HashMap<String, String, SH>,
+    ) -> String {
         // Live path uses the single-value header view (`headers_clone`); kept separate from the
         // multi-value `flow_id_for` (used over recorded requests) to avoid a per-request alloc.
         let port = self.config.port.unwrap_or(0);
@@ -493,11 +506,13 @@ impl Imposter {
         }
     }
 
-    /// Parse form-urlencoded data from body if Content-Type matches
-    pub(crate) fn parse_form_data(
-        headers: &HashMap<String, String>,
+    /// Parse form-urlencoded data from body if Content-Type matches. Request-scoped and rebuilt
+    /// per request, so the return is `FastMap` (issue #704) regardless of the input header map's
+    /// hasher.
+    pub(crate) fn parse_form_data<SH: BuildHasher>(
+        headers: &HashMap<String, String, SH>,
         body: Option<&str>,
-    ) -> Option<HashMap<String, String>> {
+    ) -> Option<FastMap<String, String>> {
         // Header keys are Title-Case in the pre-built map, so match Content-Type case-insensitively
         // (HeaderMap lookups were case-insensitive; preserve that).
         let content_type = headers
@@ -509,7 +524,7 @@ impl Imposter {
         if content_type.contains("application/x-www-form-urlencoded")
             && let Some(body_str) = body
         {
-            let mut map = HashMap::new();
+            let mut map = FastMap::default();
             for pair in body_str.split('&').filter(|s| !s.is_empty()) {
                 let mut parts = pair.splitn(2, '=');
                 if let Some(raw_key) = parts.next() {

--- a/crates/rift-mock-core/src/imposter/core/proxy.rs
+++ b/crates/rift-mock-core/src/imposter/core/proxy.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use crate::imposter::predicates::regex_cache::cached_regex;
+use std::hash::BuildHasher;
 
 /// Parts read from a successful upstream proxy response, before recording:
 /// `(status, headers, body, latency_ms)`.
@@ -15,12 +16,12 @@ impl Imposter {
     /// Returns `Err` when an `inject` generator could not produce predicates (script/pool/output
     /// failure) so the caller can skip auto-stub creation instead of silently recording a match-all
     /// stub (issue #498). An `Ok(empty)` list means the generators legitimately produced nothing.
-    pub(crate) fn generate_predicates_from_request(
+    pub(crate) fn generate_predicates_from_request<SH: BuildHasher>(
         &self,
         generators: &[serde_json::Value],
         method: &str,
         path: &str,
-        headers: &HashMap<String, String>,
+        headers: &HashMap<String, String, SH>,
         body: Option<&str>,
         query: Option<&str>,
     ) -> Result<Vec<serde_json::Value>, crate::scripting::PredicateGeneratorError> {
@@ -30,11 +31,11 @@ impl Imposter {
     /// [`Self::generate_predicates_from_request`] without `&self`, so the proxy-recording path
     /// can run it on `spawn_blocking` (issue #476) — a `predicateGenerators.inject` script must
     /// not execute (and block on the MB script pool) on a tokio async worker.
-    fn generate_predicates_impl(
+    fn generate_predicates_impl<SH: BuildHasher>(
         generators: &[serde_json::Value],
         method: &str,
         path: &str,
-        headers: &HashMap<String, String>,
+        headers: &HashMap<String, String, SH>,
         body: Option<&str>,
         query: Option<&str>,
     ) -> Result<Vec<serde_json::Value>, crate::scripting::PredicateGeneratorError> {
@@ -57,8 +58,13 @@ impl Imposter {
                     let mb_request = MountebankRequest {
                         method: method.to_string(),
                         path: path.to_string(),
-                        query: query_map,
-                        headers: headers.clone(),
+                        query: query_map.into_iter().collect(),
+                        // `MountebankRequest.headers` is the fixed std-hasher scripting boundary
+                        // (out of scope for #704), so a hasher-changing map is copied across.
+                        headers: headers
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
                         // `body` is already the classified string from the caller (base64 for a
                         // binary request body, issue #636); this path doesn't thread the mode
                         // flag through separately, so default to `Text`.
@@ -292,14 +298,19 @@ impl Imposter {
     }
 
     /// Forward a request through proxy and optionally record the response
-    pub async fn handle_proxy_request(
+    pub async fn handle_proxy_request<SH>(
         &self,
         proxy_config: &ProxyResponse,
         method: &str,
         uri: &hyper::Uri,
-        headers: &HashMap<String, String>,
+        headers: &HashMap<String, String, SH>,
         body: Option<&str>,
-    ) -> anyhow::Result<(u16, Vec<(String, String)>, Vec<u8>, Option<u64>)> {
+    ) -> anyhow::Result<(u16, Vec<(String, String)>, Vec<u8>, Option<u64>)>
+    where
+        // `Clone + Send + 'static`: an inject predicateGenerator clones `headers` into a
+        // `spawn_blocking` `'static` closure below.
+        SH: BuildHasher + Clone + Send + 'static,
+    {
         let client = get_http_client();
 
         info!(

--- a/crates/rift-mock-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-mock-core/src/imposter/core/stub_index.rs
@@ -17,6 +17,7 @@
 
 use super::StubState;
 use crate::imposter::types::Stub;
+use crate::util::FastMap;
 use rift_types::predicate::{Predicate, PredicateOperation};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -62,7 +63,9 @@ fn classify(stub: &Stub) -> Option<PathAnchor> {
 /// that loads the index gets a self-consistent (stubs, candidates) pair.
 pub(crate) struct StubIndex {
     stubs: Arc<Vec<Arc<StubState>>>,
-    exact: HashMap<String, Vec<usize>>,
+    // Rebuilt on every stub-set replace/mutation (issue #704); its keys come from operator stub
+    // config, not request traffic — see `crate::util::fastmap` doc for the HashDoS policy.
+    exact: FastMap<String, Vec<usize>>,
     prefix: Vec<(String, Vec<usize>)>,
     contains: Vec<(String, Vec<usize>)>,
     fallback: Vec<usize>,
@@ -93,9 +96,9 @@ impl StubIndex {
     /// Classify every stub in `stubs` into its path-anchor bucket (or fallback), preserving
     /// ascending stub index within each bucket.
     pub(crate) fn build(stubs: Arc<Vec<Arc<StubState>>>) -> Self {
-        let mut exact: HashMap<String, Vec<usize>> = HashMap::new();
-        let mut prefix: HashMap<String, Vec<usize>> = HashMap::new();
-        let mut contains: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut exact: FastMap<String, Vec<usize>> = FastMap::default();
+        let mut prefix: FastMap<String, Vec<usize>> = FastMap::default();
+        let mut contains: FastMap<String, Vec<usize>> = FastMap::default();
         let mut fallback: Vec<usize> = Vec::new();
 
         for (i, state) in stubs.iter().enumerate() {

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -116,6 +116,14 @@ impl Imposter {
             .as_deref()
             .and_then(|b| serde_json::from_str::<Value>(b).ok());
         let client_ip = client_ip_of(req);
+        // `RecordedRequest.query` is the fixed std-hasher journal/serde boundary (out of scope for
+        // #704); `stub_matches_inner`'s `query_map` parameter is concretely `FastMap` (it is always
+        // sourced from `parse_query`/`parse_query_string` elsewhere), so copy across here.
+        let query_map: crate::util::FastMap<String, String> = req
+            .query
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         stub_matches_inner(
             predicates,
             &req.method,
@@ -128,7 +136,7 @@ impl Imposter {
             form.as_ref(),
             self.script_state_key(),
             body_json.as_ref(),
-            Some(&req.query),
+            Some(&query_map),
         )
     }
 

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -33,6 +33,7 @@ use http_body_util::{BodyExt, Full, Limited};
 use hyper::body::Incoming;
 use hyper::{Request, Response, StatusCode};
 
+use crate::util::FastMap;
 use rand::Rng;
 use std::cell::OnceCell;
 use std::collections::HashMap;
@@ -397,7 +398,9 @@ async fn handle_request_inner(
     let method = parts.method.to_string();
     let uri = parts.uri;
     let headers_for_context = parts.headers;
-    let headers_clone: HashMap<String, String> = headers_for_context
+    // Request-scoped, built from a single request and dropped at response — a `FastMap` (issue
+    // #704); see `crate::util::fastmap` for the HashDoS policy.
+    let headers_clone: FastMap<String, String> = headers_for_context
         .iter()
         .map(|(k, v)| {
             (
@@ -408,15 +411,17 @@ async fn handle_request_inner(
         .collect();
     // Capture ALL values per header for the recorded request (issue #238) — hyper's HeaderMap
     // yields one entry per value, so a header sent twice is preserved here (headers_clone above
-    // collapses to one value and stays the single-value view used for matching/context).
+    // collapses to one value and stays the single-value view used for matching/context). The
+    // building loop uses `FastMap` (issue #704); `RecordedRequest.headers` is the fixed std-hasher
+    // journal/serde boundary, so the finished map is converted at the end.
     let headers_multi: HashMap<String, Vec<String>> = if imposter.config.record_requests {
-        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        let mut map: FastMap<String, Vec<String>> = FastMap::default();
         for (k, v) in headers_for_context.iter() {
             map.entry(header_to_title_case(k.as_str()))
                 .or_default()
                 .push(v.to_str().unwrap_or("").to_string());
         }
-        map
+        map.into_iter().collect()
     } else {
         HashMap::new()
     };
@@ -491,7 +496,9 @@ async fn handle_request_inner(
             request_from: client_addr.to_string(),
             method: method.clone(),
             path: path.clone(),
-            query: parse_query_string(&query_str),
+            // `RecordedRequest.query` is the fixed std-hasher journal/serde boundary (out of scope
+            // for #704); `parse_query_string` returns `FastMap`, so convert at this edge.
+            query: parse_query_string(&query_str).into_iter().collect(),
             headers: headers_multi,
             body: body_string.as_deref().map(str::to_string),
             mode: body_mode.clone(),
@@ -677,8 +684,13 @@ async fn handle_request_inner(
             let mb_request = MountebankRequest {
                 method: method.clone(),
                 path: path.clone(),
-                query: parse_query_string(&query_str),
-                headers: headers_clone.clone(),
+                // `MountebankRequest`'s fields are the fixed std-hasher scripting boundary (out of
+                // scope for #704), so the `FastMap`-backed maps are copied across here.
+                query: parse_query_string(&query_str).into_iter().collect(),
+                headers: headers_clone
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
                 // Owned boundary (issue #561): the inject job is submitted to a `'static` worker
                 // closure, so `body_string`'s borrow can't cross it.
                 body: body_string.as_deref().map(str::to_string),
@@ -791,13 +803,19 @@ async fn handle_request_inner(
                     .as_deref()
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or(serde_json::Value::Null),
-                query: parse_query_string(&query_str),
+                // `ScriptRequest`'s fields are the fixed std-hasher scripting boundary (out of
+                // scope for #704), so the `FastMap`-backed maps are copied across here.
+                query: parse_query_string(&query_str).into_iter().collect(),
                 // Issue #433: populate path params from the matched stub's route pattern, if any.
                 path_params: stub_state
                     .stub
                     .route_pattern
                     .as_deref()
-                    .map(|pattern| crate::extensions::template::extract_path_params(pattern, &path))
+                    .map(|pattern| {
+                        crate::extensions::template::extract_path_params(pattern, &path)
+                            .into_iter()
+                            .collect()
+                    })
                     .unwrap_or_default(),
             };
 
@@ -1511,7 +1529,9 @@ fn handle_debug_request(
     method: &str,
     path: &str,
     query_str: &str,
-    headers_clone: &HashMap<String, String>,
+    // Private helper, single call site (the debug-mode `spawn_blocking` job below), which always
+    // passes the request-scoped `FastMap` header view (issue #704).
+    headers_clone: &FastMap<String, String>,
     body_string: &Option<String>,
     client_addr: SocketAddr,
 ) -> Result<Response<Full<Bytes>>, Infallible> {

--- a/crates/rift-mock-core/src/imposter/predicates/fields.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/fields.rs
@@ -3,24 +3,28 @@
 
 use super::json::compare_json_recursive;
 use super::regex_cache::cached_regex;
+use crate::util::FastMap;
 use std::collections::HashMap;
+use std::hash::BuildHasher;
 
 /// Check predicate fields against request values
 /// Supports: method, path, body, query, headers, requestFrom, ip, form
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn check_predicate_fields<F>(
+pub(crate) fn check_predicate_fields<F, SH>(
     obj: &HashMap<String, serde_json::Value>,
     method: &str,
     path: &str,
-    query: &HashMap<String, String>,
-    headers: &HashMap<String, String>,
+    // Concretely `FastMap` — always sourced from `parse_query`/`parse_query_string` (issue #704).
+    query: &FastMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: &str,
     apply_except: &impl for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>,
     compare: F,
     deep_equals: bool,
     request_from: Option<&str>,
     client_ip: Option<&str>,
-    form: Option<&HashMap<String, String>>,
+    // Concretely `FastMap` — see `predicate_matches_inner`.
+    form: Option<&FastMap<String, String>>,
     key_case_sensitive: bool,
     // Request body already parsed once per request (issue #290); `Some` only for a
     // no-selector predicate whose `body` field then equals this parse.
@@ -28,6 +32,7 @@ pub(crate) fn check_predicate_fields<F>(
 ) -> bool
 where
     F: Fn(&str, &str) -> bool,
+    SH: BuildHasher,
 {
     // Helper for key comparison based on keyCaseSensitive
     let key_matches = |expected_key: &str, actual_key: &str| -> bool {
@@ -195,22 +200,27 @@ where
 /// Check predicate fields with regex matching
 /// Supports: method, path, body, query, headers, requestFrom, ip, form
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn check_predicate_fields_regex(
+pub(crate) fn check_predicate_fields_regex<SH>(
     obj: &HashMap<String, serde_json::Value>,
     method: &str,
     path: &str,
-    query: &HashMap<String, String>,
-    headers: &HashMap<String, String>,
+    // Concretely `FastMap` — see `check_predicate_fields`.
+    query: &FastMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: &str,
     apply_except: &impl for<'a> Fn(&'a str) -> std::borrow::Cow<'a, str>,
     case_sensitive: bool,
     request_from: Option<&str>,
     client_ip: Option<&str>,
-    form: Option<&HashMap<String, String>>,
+    // Concretely `FastMap` — see `check_predicate_fields`.
+    form: Option<&FastMap<String, String>>,
     key_case_sensitive: bool,
     // Request body already parsed once per request (issue #290); see `check_predicate_fields`.
     body_json: Option<&serde_json::Value>,
-) -> bool {
+) -> bool
+where
+    SH: BuildHasher,
+{
     // Compile-once, cached regex keyed on (pattern, case_insensitive). Returns `None` for an
     // unparseable pattern, which callers treat as "no match" — same as the previous per-request
     // `Regex::new` returning `Err`.

--- a/crates/rift-mock-core/src/imposter/predicates/json.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/json.rs
@@ -1,7 +1,9 @@
 //! JSON-shaped predicate helpers: value stringification, recursive `exists` checks,
 //! and recursive JSON comparison used by the `equals`/`deepEquals`/`matches` operators.
 
+use crate::util::FastMap;
 use std::collections::HashMap;
+use std::hash::BuildHasher;
 
 /// Convert a JSON value to its string representation for predicate comparison.
 /// Strings are unwrapped (no quotes), other primitives use their natural representation.
@@ -75,18 +77,23 @@ fn check_exists_json_recursive(expected: &serde_json::Value, actual_str: &str) -
 /// When a field's value is an object (not a boolean), parse the actual value as JSON
 /// and recursively check field existence within it (Mountebank compatible).
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn check_exists_predicate(
+pub(crate) fn check_exists_predicate<SH>(
     obj: &HashMap<String, serde_json::Value>,
     method: &str,
     path: &str,
-    query: &HashMap<String, String>,
-    headers: &HashMap<String, String>,
+    // Concretely `FastMap` — always sourced from `parse_query`/`parse_query_string` (issue #704).
+    query: &FastMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: &str,
     request_from: Option<&str>,
     client_ip: Option<&str>,
-    form: Option<&HashMap<String, String>>,
+    // Concretely `FastMap` — see `check_predicate_fields`.
+    form: Option<&FastMap<String, String>>,
     key_case_sensitive: bool,
-) -> bool {
+) -> bool
+where
+    SH: BuildHasher,
+{
     // Helper for key comparison based on keyCaseSensitive
     let key_matches = |expected_key: &str, actual_key: &str| -> bool {
         if key_case_sensitive {

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -5,7 +5,9 @@
 
 use crate::behaviors::{extract_jsonpath, extract_xpath_with_ns};
 use crate::imposter::types::{Predicate, PredicateOperation, PredicateSelector};
+use crate::util::FastMap;
 use std::collections::HashMap;
+use std::hash::BuildHasher;
 
 /// Check if a stub matches a request based on its predicates.
 ///
@@ -14,22 +16,31 @@ use std::collections::HashMap;
 /// predicate as non-matching, so callers must surface the error rather than swallow it into
 /// `false`. Every other predicate op is infallible.
 #[allow(clippy::too_many_arguments)]
-pub fn stub_matches(
+pub fn stub_matches<SH>(
     predicates: &[Predicate],
     method: &str,
     path: &str,
     query: Option<&str>,
-    headers: &HashMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: Option<&str>,
     request_from: Option<&str>,
     client_ip: Option<&str>,
+    // Kept as the plain std-hasher map (unlike `headers`): a bare `None` here — the overwhelming
+    // majority of calls — can't be threaded through a generic hasher parameter (nothing at the
+    // call site would pin the type down), so `stub_matches`/`predicate_matches` keep this
+    // parameter exactly as before and convert once at the `stub_matches_inner` boundary below.
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<bool>
+where
+    SH: BuildHasher,
+{
     // Parse the body and query once for standalone callers; the request hot path parses each once
     // per request (before the stub scan) and calls `stub_matches_inner` directly (issues #290, #480).
     let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
     let query_map = parse_query(query);
+    let form_fast: Option<FastMap<String, String>> =
+        form.map(|f| f.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
     stub_matches_inner(
         predicates,
         method,
@@ -39,7 +50,7 @@ pub fn stub_matches(
         body,
         request_from,
         client_ip,
-        form,
+        form_fast.as_ref(),
         imposter_port,
         body_json.as_ref(),
         Some(&query_map),
@@ -51,20 +62,27 @@ pub fn stub_matches(
 ///
 /// See [`stub_matches`] for the `Err` contract (issue #440).
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn stub_matches_inner(
+pub(crate) fn stub_matches_inner<SH>(
     predicates: &[Predicate],
     method: &str,
     path: &str,
     query: Option<&str>,
-    headers: &HashMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: Option<&str>,
     request_from: Option<&str>,
     client_ip: Option<&str>,
-    form: Option<&HashMap<String, String>>,
+    // Concretely `FastMap` — always sourced from `Imposter::parse_form_data` (issue #704) on the
+    // request hot path; unlike `headers`, this can't be generic (a bare `None` form argument, the
+    // common non-form-predicate case, gives type inference nothing to pin the hasher to).
+    form: Option<&FastMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
-    query_map: Option<&HashMap<String, String>>,
-) -> anyhow::Result<bool> {
+    // Always sourced from `parse_query`/`parse_query_string` (issue #704); same reasoning as `form`.
+    query_map: Option<&FastMap<String, String>>,
+) -> anyhow::Result<bool>
+where
+    SH: BuildHasher,
+{
     // If no predicates, match everything
     if predicates.is_empty() {
         return Ok(true);
@@ -93,8 +111,8 @@ pub(crate) fn stub_matches_inner(
 }
 
 /// Parse query string for predicate matching, URL-decoding both keys and values
-pub fn parse_query(query: Option<&str>) -> HashMap<String, String> {
-    query.map_or_else(HashMap::new, parse_query_string)
+pub fn parse_query(query: Option<&str>) -> FastMap<String, String> {
+    query.map_or_else(FastMap::default, parse_query_string)
 }
 
 // Allocation-free ASCII case-insensitive string tests (issue #480). The previous
@@ -130,22 +148,28 @@ fn ends_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 /// `Err` propagates a predicate-`inject` failure (issue #440) — see [`stub_matches`] for the
 /// full contract. Every other predicate op is infallible.
 #[allow(clippy::too_many_arguments)]
-pub fn predicate_matches(
+pub fn predicate_matches<SH>(
     predicate: &Predicate,
     method: &str,
     path: &str,
     query: Option<&str>,
-    headers: &HashMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: Option<&str>,
     request_from: Option<&str>,
     client_ip: Option<&str>,
+    // See `stub_matches` for why this stays the plain std-hasher map.
     form: Option<&HashMap<String, String>>,
     imposter_port: u16,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<bool>
+where
+    SH: BuildHasher,
+{
     // Standalone callers parse the body and query here; the request hot path parses each once per
     // request and calls `predicate_matches_inner` directly with the shared parses (issues #290, #480).
     let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
     let query_map = parse_query(query);
+    let form_fast: Option<FastMap<String, String>> =
+        form.map(|f| f.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
     predicate_matches_inner(
         predicate,
         method,
@@ -155,7 +179,7 @@ pub fn predicate_matches(
         body,
         request_from,
         client_ip,
-        form,
+        form_fast.as_ref(),
         imposter_port,
         body_json.as_ref(),
         Some(&query_map),
@@ -172,20 +196,25 @@ pub fn predicate_matches(
 // (issue #599); without that feature the arm doesn't use it, so it's only threaded through the
 // recursive And/Or descent — a false positive for this build only.
 #[cfg_attr(not(feature = "javascript"), allow(clippy::only_used_in_recursion))]
-pub(crate) fn predicate_matches_inner(
+pub(crate) fn predicate_matches_inner<SH>(
     predicate: &Predicate,
     method: &str,
     path: &str,
     query: Option<&str>,
-    headers: &HashMap<String, String>,
+    headers: &HashMap<String, String, SH>,
     body: Option<&str>,
     request_from: Option<&str>,
     client_ip: Option<&str>,
-    form: Option<&HashMap<String, String>>,
+    // Concretely `FastMap` — see `stub_matches_inner`.
+    form: Option<&FastMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
-    query_map: Option<&HashMap<String, String>>,
-) -> anyhow::Result<bool> {
+    // Concretely `FastMap` — see `stub_matches_inner`.
+    query_map: Option<&FastMap<String, String>>,
+) -> anyhow::Result<bool>
+where
+    SH: BuildHasher,
+{
     // Get predicate options
     let case_sensitive = predicate.parameters.case_sensitive.unwrap_or(false);
 
@@ -250,7 +279,7 @@ pub(crate) fn predicate_matches_inner(
     // Build request context for field access. Use the once-per-request parse when the caller
     // threaded it (hot path / standalone wrappers); only parse locally as a fallback (issue #480).
     let parsed_query;
-    let query_map: &HashMap<String, String> = match query_map {
+    let query_map: &FastMap<String, String> = match query_map {
         Some(q) => q,
         None => {
             parsed_query = parse_query(query);
@@ -462,8 +491,17 @@ pub(crate) fn predicate_matches_inner(
                     method: method.to_string(),
                     path: path.to_string(),
                     // Reuse the once-per-request query map instead of re-parsing (issue #480).
-                    query: query_map.clone(),
-                    headers: headers.clone(),
+                    // `MountebankRequest`'s fields are the fixed std-hasher scripting boundary
+                    // (out of scope for #704), so a hasher-changing map is copied across rather
+                    // than moved.
+                    query: query_map
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    headers: headers
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
                     // `body` is already the classified string from the caller (base64 for a
                     // binary request body, issue #636); this predicate-inject path doesn't thread
                     // the mode flag through separately, so default to `Text` — the script still
@@ -496,8 +534,8 @@ use regex_cache::cached_regex;
 /// URL-decodes both keys and values to properly handle encoded characters.
 /// Bare params without `=` (e.g. `?flag`) are treated as key with empty value.
 /// Duplicate keys are joined with commas (Mountebank `stringify` behavior).
-pub fn parse_query_string(query: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
+pub fn parse_query_string(query: &str) -> FastMap<String, String> {
+    let mut map = FastMap::default();
     for pair in query.split('&').filter(|s| !s.is_empty()) {
         let (key, value) = match pair.split_once('=') {
             Some((k, v)) => (k, v),

--- a/crates/rift-mock-core/src/lib.rs
+++ b/crates/rift-mock-core/src/lib.rs
@@ -25,6 +25,8 @@ pub use extensions::template;
 
 // Shared utilities
 pub mod util;
+// Embedded-Rust consumers name the aliases as `rift_mock_core::FastMap` (issue #704).
+pub use util::{FastMap, FastSet};
 
 // Backends (pub for integration tests)
 pub mod backends;

--- a/crates/rift-mock-core/src/util.rs
+++ b/crates/rift-mock-core/src/util.rs
@@ -7,6 +7,32 @@ use hyper::{Response, StatusCode};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Fast, non-cryptographic hash maps for the imposter hot path (issue #704).
+///
+/// [`FastMap`]/[`FastSet`] swap SipHash for [`foldhash`], which is ~2–4× faster on the short string
+/// keys the request path deals in. `foldhash::fast::RandomState` is seeded per-process, so it is not
+/// a fixed-seed map an attacker can precompute against, but it is only *minimally* HashDoS-resistant.
+///
+/// # When to use which
+///
+/// - **`FastMap`/`FastSet` — request-scoped maps** built from a single request and dropped at
+///   response (headers, query, form, per-request template context). Keys come from one request with
+///   bounded entry counts (header/query caps), so an attacker cannot accumulate collisions across
+///   requests. Also **stub-index maps** rebuilt on stub mutation, whose keys come from operator
+///   stub config, not request traffic.
+/// - **Keep `std::collections::HashMap` (SipHash)** for any *long-lived* map keyed by *unbounded,
+///   request-derived* input, where an attacker could grow a colliding key set over many requests.
+///   None exist on the hot path today (the request journal keys by port, not request content).
+pub mod fastmap {
+    /// A `HashMap` using the fast, non-cryptographic `foldhash` hasher. See the [module docs](self)
+    /// for the HashDoS policy governing when this is appropriate.
+    pub type FastMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+    /// A `HashSet` using the fast, non-cryptographic `foldhash` hasher. See the [module docs](self).
+    pub type FastSet<K> = std::collections::HashSet<K, foldhash::fast::RandomState>;
+}
+
+pub use fastmap::{FastMap, FastSet};
+
 /// Whether HTTP/2 auto-negotiation should be force-disabled on the serve listeners, read once from
 /// the `RIFT_DISABLE_HTTP2` env var (issue #378). An operational escape hatch: the listeners
 /// auto-negotiate HTTP/1 and HTTP/2 by default (#295); set this (`1`/`true`/`yes`/`on`) to serve
@@ -169,10 +195,26 @@ pub fn unix_timestamp() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_response, build_response_with_headers, http2_disabled_from, rift_debug_from,
-        strict_behaviors_from,
+        FastMap, FastSet, build_response, build_response_with_headers, http2_disabled_from,
+        rift_debug_from, strict_behaviors_from,
     };
     use hyper::StatusCode;
+
+    #[test]
+    fn fastmap_is_foldhash_backed_and_default_constructible() {
+        // The alias must resolve to a foldhash-hashed map, and `Default` must construct it (so
+        // migrations can swap `HashMap::new()` for `FastMap::default()` mechanically).
+        fn assert_foldhash<K, V>(_: &std::collections::HashMap<K, V, foldhash::fast::RandomState>) {
+        }
+        let mut map: FastMap<String, i32> = FastMap::default();
+        assert_foldhash(&map);
+        map.insert("k".to_string(), 1);
+        assert_eq!(map.get("k"), Some(&1));
+
+        let mut set: FastSet<String> = FastSet::default();
+        set.insert("a".to_string());
+        assert!(set.contains("a"));
+    }
 
     // Issue #611: the terminal builder fallback must not answer 200. A response-builder failure is
     // a server fault, and `Response::new` defaults to 200 — the same 200-masking shape #606 fixed


### PR DESCRIPTION
Introduce `FastMap`/`FastSet` foldhash aliases (`rift_mock_core::FastMap`, with a HashDoS policy doc)
and migrate the imposter hot-path request-scoped + index maps off SipHash. Pure hasher swap —
behavior-transparent (full `cargo test --workspace --all-features` green, clippy -D warnings clean).

Classification audit:
| Map | File | Category |
|---|---|---|
| headers_clone + recorded multi-value map | handler.rs | request-scoped |
| parse_query_string / parse_query | predicates/mod.rs | request-scoped |
| parse_form_data (form) | core/matching.rs | request-scoped |
| StubIndex.exact (+ build-time prefix/contains) | core/stub_index.rs | index |
| RequestData.headers, .path_params, extract_path_params | extensions/template.rs | template-context |
| RequestData.query | extensions/template.rs | left std (legacy parser returns std; a FastMap would double-hash) |

Predicate-matching consumers thread a `<SH: BuildHasher>` generic for the `headers` param; the
`form`/`query` maps are converted once at the public API boundary (off the hot path). Serde/admin
boundary structs (RecordedRequest, MountebankRequest, ScriptRequest, DebugRequest) stay std, converted
at the edge.

Closes #704
Milestone: Turbo