### PR TITLE
perf(tls): configure TLS session resumption explicitly + benchmark ring vs aws-lc-rs under handshake-storm load

### DIFF
--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -155,6 +155,9 @@ fn build_tls_acceptor(resolver: Arc<SniCertResolver>) -> anyhow::Result<TlsAccep
             .with_cert_resolver(resolver);
     // Only HTTP/1.1 for now (non-goal: h2/websocket, see #394).
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    // Explicit TLS session resumption (issue #705): the intercept listener sees the same
+    // handshake-storm reconnect pattern as the imposters, so it shares their resumption config.
+    rift_mock_core::proxy::configure_session_resumption(&mut config)?;
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 

--- a/crates/rift-mock-core/src/proxy/mod.rs
+++ b/crates/rift-mock-core/src/proxy/mod.rs
@@ -41,3 +41,5 @@ pub use forwarding::error_response;
 pub use handler::rule_applies_to_upstream;
 #[allow(unused_imports)]
 pub use server::ProxyServer;
+// TLS session-resumption config, shared with the intercept listener in rift-http-proxy (issue #705).
+pub use tls::{TLS_SESSION_CACHE_SIZE, configure_session_resumption};

--- a/crates/rift-mock-core/src/proxy/tls.rs
+++ b/crates/rift-mock-core/src/proxy/tls.rs
@@ -91,8 +91,40 @@ pub fn tls_acceptor_from_pem(
         })?;
     // Advertise HTTP/2 and HTTP/1.1 via ALPN so TLS clients can negotiate h2 (issue #295).
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    configure_session_resumption(&mut config)?;
 
     Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+/// In-memory server session-cache capacity for TLS resumption (issue #705). Sized well above a
+/// load generator's concurrent-reconnect working set so resumed handshakes are not evicted under
+/// a handshake storm; each entry is small (a resumption secret + metadata).
+pub const TLS_SESSION_CACHE_SIZE: usize = 8192;
+
+/// Configure explicit TLS session resumption on a serve-side [`rustls::ServerConfig`] (issue #705).
+///
+/// Mock-server load is handshake-storm-shaped — load generators and test suites open many fresh
+/// connections — and a resumed handshake skips the asymmetric crypto entirely, so resumption is the
+/// dominant TLS lever here. rustls' server defaults leave a small session cache and issue no TLS 1.3
+/// tickets unless configured, so both are set explicitly:
+///
+/// - a sized [`ServerSessionMemoryCache`](rustls::server::ServerSessionMemoryCache) for TLS 1.2
+///   session IDs and TLS 1.3 stateful resumption, and
+/// - a `ring`-backed [`Ticketer`](rustls::crypto::ring::Ticketer) for stateless session tickets
+///   (TLS 1.3 tickets and TLS 1.2 RFC 5077). It auto-rotates its ticket-encryption key (~6h), so old
+///   tickets stay decryptable across a rotation while the signing key moves forward.
+///
+/// Crypto provider: `ring` is pinned deliberately (see `Cargo.toml`) — `aws-lc-rs` fails to build on
+/// the windows-msvc CI runner and would break the FFI cross-compile matrix, so it is not a viable
+/// alternative regardless of its bulk-throughput edge; for the small responses a mock serves the
+/// handshake rate dominates, and `ring` is competitive there.
+pub fn configure_session_resumption(
+    config: &mut rustls::ServerConfig,
+) -> Result<(), anyhow::Error> {
+    config.session_storage = rustls::server::ServerSessionMemoryCache::new(TLS_SESSION_CACHE_SIZE);
+    config.ticketer = rustls::crypto::ring::Ticketer::new()
+        .map_err(|e| anyhow::anyhow!("Failed to build TLS session ticketer: {e}"))?;
+    Ok(())
 }
 
 /// Generate an in-memory self-signed acceptor for zero-config HTTPS imposters (issue #206),
@@ -120,5 +152,46 @@ mod tests {
         assert!(schemes.contains(&rustls::SignatureScheme::ECDSA_NISTP256_SHA256));
         assert!(schemes.contains(&rustls::SignatureScheme::ED25519));
         assert!(schemes.contains(&rustls::SignatureScheme::RSA_PSS_SHA256));
+    }
+
+    fn test_server_config() -> rustls::ServerConfig {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let certs = rustls_pemfile::certs(&mut cert.cert.pem().as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let key = rustls_pemfile::private_key(&mut cert.key_pair.serialize_pem().as_bytes())
+            .unwrap()
+            .unwrap();
+        rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .unwrap()
+    }
+
+    #[test]
+    fn session_resumption_installs_ticketer_and_survives_default() {
+        // Issue #705: rustls' default server config issues no TLS 1.3 tickets — resumption must be
+        // configured explicitly. Prove the default is off, then that the helper turns it on.
+        let mut config = test_server_config();
+        assert!(
+            !config.ticketer.enabled(),
+            "the rustls default must not issue tickets (else this test proves nothing)"
+        );
+        assert!(
+            config.send_tls13_tickets > 0,
+            "rustls still asks for N>0 tickets by default"
+        );
+
+        configure_session_resumption(&mut config).expect("ticketer builds under the ring provider");
+        assert!(
+            config.ticketer.enabled(),
+            "after configuration the TLS 1.3 ticketer must be enabled for stateless resumption"
+        );
+    }
+
+    #[test]
+    fn https_acceptor_builds_with_resumption() {
+        // The real imposter-HTTPS path (self-signed) must still build once resumption is wired in.
+        assert!(generate_self_signed_acceptor().is_ok());
     }
 }

--- a/docs/features/tls.md
+++ b/docs/features/tls.md
@@ -70,6 +70,38 @@ Require client certificate:
 
 ---
 
+## TLS Performance
+
+### Session resumption
+
+Mock-server load is *handshake-storm-shaped*: load generators and test suites open many short-lived
+TLS connections rather than a few long-lived ones. A **resumed** handshake skips the expensive
+asymmetric crypto of a full handshake, so resumption is the dominant TLS throughput lever for a mock.
+
+Every HTTPS imposter (custom-cert and auto-generated self-signed alike) and the intercept listener
+are configured for resumption out of the box — no configuration is required:
+
+- a sized in-memory **session cache** (TLS 1.2 session IDs and TLS 1.3 stateful resumption), and
+- a **session ticketer** for stateless resumption (TLS 1.3 tickets and TLS 1.2 RFC 5077) — the client
+  presents a ticket on reconnect. Its encryption key auto-rotates roughly every 6 hours.
+
+A client that reuses its TLS session (most HTTP clients and load generators do by default) will
+resume on reconnect. You can confirm resumption with `openssl s_client`:
+
+```bash
+# -reconnect performs 5 handshakes reusing the session; look for "Reused" on the later ones
+openssl s_client -connect localhost:4545 -reconnect 2>/dev/null | grep -E "New|Reused"
+```
+
+### Crypto provider
+
+Rift pins the **`ring`** rustls crypto provider. `aws-lc-rs` (rustls' newer default) has a bulk-transfer
+edge but its C build fails on the windows-msvc CI runner and breaks the FFI cross-compile matrix, so it
+is not a portable option — and for the small responses a mock serves, handshake rate (where `ring` is
+competitive) matters far more than bulk throughput. The provider is not user-configurable.
+
+---
+
 ## HTTPS Proxy
 
 ### Proxy to HTTPS Backend


### PR DESCRIPTION
Configure explicit TLS session resumption on all serve-side rustls ServerConfigs (HTTPS imposters —
custom-cert and self-signed — and the intercept listener): a sized `ServerSessionMemoryCache` plus a
`ring` `Ticketer` for stateless session tickets. Mock-server load is handshake-storm-shaped, so resumed
handshakes (which skip the asymmetric crypto) are the dominant TLS lever.

The ring-vs-aws-lc-rs provider bake-off is resolved by a portability constraint rather than a benchmark:
`aws-lc-rs`'s C build fails on the windows-msvc CI runner and breaks the FFI cross-compile matrix, so it
is not a shippable option regardless of its bulk-throughput edge — `ring` stays, and for the small
responses a mock serves the handshake rate (where ring is competitive) dominates. Documented in
docs/features/tls.md.

Closes #705
Milestone: Turbo