### PR TITLE
perf(core): hot-path drop-ins — itoa, memchr Finders, compile out trace-level logging in release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lru",
+ "memchr",
  "num_cpus",
  "p12",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 anyhow = "1.0"
 thiserror = "2.0"
 
-# Logging
-tracing = "0.1"
+# Logging. `release_max_level_debug` compiles `trace!` out of release builds entirely (issue #706),
+# so per-request `trace!` sites cost nothing in production — not even the cached-interest atomic load.
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Time
@@ -72,6 +73,8 @@ chrono = { version = "0.4", features = ["serde"] }
 # Misc utilities
 futures = "0.3"
 bytes = "1.7"
+# SIMD substring search for fixed literals probed per request (issue #706).
+memchr = "2.7"
 uuid = { version = "1.8", features = ["v4", "serde"] }
 rand = "0.8"
 

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -68,6 +68,7 @@ bytes.workspace = true
 base64 = "0.22"
 chrono.workspace = true
 regex = "1.11"
+memchr.workspace = true
 rand.workspace = true
 urlencoding = "2.1"
 similar = "2.6"

--- a/crates/rift-mock-core/src/extensions/template.rs
+++ b/crates/rift-mock-core/src/extensions/template.rs
@@ -182,11 +182,17 @@ fn now_regex() -> &'static Regex {
 /// that skips the three regex scans for the overwhelmingly common token-free body.
 #[must_use]
 pub fn contains_date_templates(body: &str) -> bool {
-    body.contains("{{")
+    DOUBLE_BRACE_FINDER.find(body.as_bytes()).is_some()
         && (days_regex().is_match(body)
             || months_regex().is_match(body)
             || now_regex().is_match(body))
 }
+
+/// Prebuilt SIMD substring searcher for the `{{` marker probed on every candidate response body
+/// (issue #706). Building the `Finder` once amortizes its setup; `str::contains` rebuilds its search
+/// state on each call.
+static DOUBLE_BRACE_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> =
+    std::sync::LazyLock::new(|| memchr::memmem::Finder::new(b"{{"));
 
 /// Expand legacy-recorder relative-date templates in a response body (issue #195):
 /// `{{DAYS+N}}` / `{{DAYS-N}}` / `{{MONTHS+N}}` / `{{MONTHS-N}}` → an RFC3339 timestamp `N`

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -41,7 +41,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 /// Maximum allowed request body size (10 MB)
 const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -628,7 +628,9 @@ async fn handle_request_inner(
             proxy: proxy_config,
         }) = response
         {
-            debug!("Handling proxy request to {}", proxy_config.to);
+            // Per-request entry announcement — `trace!` so it compiles out of release (issue #706);
+            // the outcome (status/latency) is captured by metrics and the response's x-rift-* headers.
+            trace!("Handling proxy request to {}", proxy_config.to);
             match imposter
                 .handle_proxy_request(
                     proxy_config,
@@ -678,7 +680,7 @@ async fn handle_request_inner(
         // Check if this is an inject response (JavaScript function)
         #[cfg(feature = "javascript")]
         if let Some(StubResponse::Inject { inject: inject_fn }) = response {
-            debug!("Handling inject response");
+            trace!("Handling inject response");
 
             // Build request for inject function
             let mb_request = MountebankRequest {
@@ -781,7 +783,7 @@ async fn handle_request_inner(
                 .engine
                 .clone()
                 .unwrap_or_else(|| "rhai".to_string());
-            debug!("Handling Rift script response (engine: {})", engine);
+            trace!("Handling Rift script response (engine: {})", engine);
 
             // Build script request. Expose headers with lowercase keys so scripts can read
             // them case-insensitively (e.g. `request.headers["x-flow-id"]`) regardless of the


### PR DESCRIPTION
Three hot-path drop-ins from issue #706, scoped honestly against what #703 (the prepared-response fast path) already removed from the hot path:

- **Compile out trace logging in release**: set `tracing`'s `release_max_level_debug` feature, so `trace!` is compiled out of release builds entirely (not even the cached-interest atomic load remains).
- **Demote per-request entry-announcement logs** (proxy / inject / script "Handling X") from `debug!` to `trace!` — their outcomes are already captured by metrics and the response's `x-rift-*` headers.
- **memchr Finder for the `{{` probe**: a prebuilt `memmem::Finder` replaces the per-call `str::contains` in the date-token detector (`contains_date_templates`).

**itoa was assessed and not adopted**: Content-Length is assembled by hyper (not Rift), and the remaining integer-format sites (latency headers) are cold, so per the issue's own "do not chase cold sites" there is no hot itoa site. Behavior-transparent — full `cargo test --workspace --all-features` green, clippy -D clean.

Closes #706
Milestone: Turbo