### PR TITLE
perf(matching): unified StubSnapshot + per-dimension candidate bitsets (LBV framework) with method dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ record.
 
 ### Fixed
 
+- **A path-anchored stub could silently stop matching when its anchor contained non-ASCII text.**
+  The Stage-1 path prefilter folded case with Unicode `to_lowercase`, while predicate evaluation
+  folds with ASCII (`eq_ignore_ascii_case`). Unicode folding is length-changing and
+  context-sensitive, so for `startsWith`/`contains` anchors the two disagreed: a stub with
+  `startsWith: {"path": "/ΟΣ"}` was pruned from the candidate set for a request to `/ΟΣΑ` — which
+  evaluation *would* have matched — and the request fell through to a later stub or to no match at
+  all. The prefilter now folds exactly as the evaluator does, so the index and evaluation can no
+  longer diverge. Only stubs whose path anchor contained non-ASCII characters were affected.
+
 - **A request whose body fails mid-read now answers `400`, not `413`, and is no longer silent.** The
   imposter body reader funneled the size-cap breach and a genuine transport failure — a connection
   reset, a truncated chunked body — through one error arm that always answered `413` "Request body
@@ -91,6 +100,22 @@ record.
   reloaded file carries an `intercept` block, so an edit to it never looks applied when it wasn't.
 
 ### Changed
+
+- **Stub matching prunes candidates on request *method*, not just path.** The Stage-1 prefilter is
+  now a multi-dimensional candidate-bitset index (the Lucent Bit Vector technique from packet
+  classification): each dimension answers which stubs a request attribute cannot rule out, and the
+  per-dimension bitsets are intersected. A `POST`-anchored stub is therefore no longer a candidate
+  for every `GET`. On a 1000-stub corpus sharing one path and partitioned 6 ways by method,
+  matching went from ~33.4 µs to ~12.9 µs per request (~2.6x). Matching *semantics* are unchanged:
+  the index only ever over-approximates, and full predicate evaluation remains the single source of
+  truth (a randomized differential test asserts the indexed path returns exactly what an
+  exhaustive linear scan does).
+
+- **`Imposter::stubs` is no longer a public field.** It and the internal `stub_index` were merged
+  into one atomically-swapped snapshot so the match hot path takes a single wait-free load and a
+  torn (stubs *N*, index *N+1*) read is unrepresentable. The stub-reading API is unchanged —
+  `get_stubs`, `get_stub`, `get_stub_by_id`, `stub_count` and the admin/FFI surfaces all behave
+  exactly as before; only direct field access by an embedding Rust consumer is affected.
 
 - **Every image base is now digest-pinned** (`image:tag@sha256:...`), with Dependabot owning the
   bumps. `rustlang/rust:nightly` floats daily, so builds of the same commit were not reproducible.

--- a/crates/rift-mock-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-mock-core/benches/imposter_matcher_bench.rs
@@ -185,5 +185,76 @@ fn bench_find_matching_stub(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, bench_stub_matches, bench_find_matching_stub);
+const METHODS: [&str; 6] = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"];
+
+/// Issue #707: what the method dimension buys, isolated from the path index.
+///
+/// Every stub shares ONE path, so the path dimension resolves *all* of them as candidates and can
+/// prune nothing — pre-#707 that meant a full predicate evaluation of every stub on every request,
+/// because the index could not see the method at all. Stubs are distinguished by method (6-way) and
+/// by a body, and the request targets the *last* stub, so nothing short-circuits early.
+///
+/// The method dimension collapses the candidate set to the ~1/6 of stubs sharing the request's
+/// method, so this should scale at ~1/6 the per-stub work — and the collapse itself is asserted
+/// exactly (not just timed) by `method_dimension_collapses_candidates` in `stub_index.rs`.
+fn bench_method_dimension(c: &mut Criterion) {
+    let headers: HashMap<String, String> = HashMap::new();
+    let mut group = c.benchmark_group("find_matching_stub_method_disjoint");
+
+    for count in [10usize, 100, 1000] {
+        let imposter = imposter_with_stubs(count, &|i| {
+            json!({ "equals": {
+                "method": METHODS[i % METHODS.len()],
+                "path": "/api/shared",
+                "body": format!("req{i}"),
+            }})
+        });
+        // Target the last stub: its method, its body.
+        let last = count - 1;
+        let method = METHODS[last % METHODS.len()];
+        let body = format!("req{last}");
+
+        // A fixture that stops matching would silently measure the no-match path instead. Pin it.
+        assert!(
+            imposter
+                .find_matching_stub_with_client(
+                    method,
+                    "/api/shared",
+                    &headers,
+                    None,
+                    Some(&body),
+                    None,
+                    None
+                )
+                .expect("matching must not error")
+                .is_some(),
+            "method_disjoint/{count}: fixture no longer matches its target stub",
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                imposter
+                    .find_matching_stub_with_client(
+                        black_box(method),
+                        black_box("/api/shared"),
+                        black_box(&headers),
+                        None,
+                        black_box(Some(body.as_str())),
+                        None,
+                        None,
+                    )
+                    .expect("matching must not error")
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_stub_matches,
+    bench_find_matching_stub,
+    bench_method_dimension
+);
 criterion_main!(benches);

--- a/crates/rift-mock-core/src/imposter/core/bitset.rs
+++ b/crates/rift-mock-core/src/imposter/core/bitset.rs
@@ -1,0 +1,209 @@
+//! Dense candidate bitsets for the matching index (issue #707).
+//!
+//! Stub ids are positions in the snapshot's stub vector — dense, ascending, declaration-ordered —
+//! so a candidate set is naturally a fixed-width bitset rather than a `Vec<usize>`. The matching
+//! index ANDs one bitset per dimension and then walks the surviving bits in ascending order, which
+//! is exactly Mountebank's first-match-wins order.
+//!
+//! Hand-rolled over a `fixedbitset`/`roaring` dependency on purpose: the operations needed are
+//! intersect, union, and ascending iteration; the design point is ≤ a few thousand stubs (4096
+//! stubs = 512 B), where a dense word vector is both smaller and faster than a compressed
+//! representation, and the word-wise AND autovectorizes.
+
+/// Bits per backing word.
+const WORD: usize = u64::BITS as usize;
+
+/// A dense set of stub ids in `0..len`.
+///
+/// Bits at or above `len` are always zero — every constructor and mutator maintains this, so
+/// [`Self::iter`] and [`Self::count`] can never report a phantom id past the end of the stub
+/// vector.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CandidateBits {
+    words: Vec<u64>,
+    len: usize,
+}
+
+impl CandidateBits {
+    /// An empty set over `0..len`.
+    #[must_use]
+    pub(crate) fn zeros(len: usize) -> Self {
+        Self {
+            words: vec![0; len.div_ceil(WORD)],
+            len,
+        }
+    }
+
+    /// The full set `0..len` — the identity for [`Self::intersect_with`], and what a dimension's
+    /// `always_bits` degenerates to when it can index nothing.
+    #[must_use]
+    pub(crate) fn all(len: usize) -> Self {
+        let mut bits = Self {
+            words: vec![u64::MAX; len.div_ceil(WORD)],
+            len,
+        };
+        bits.mask_tail();
+        bits
+    }
+
+    /// Clear the bits above `len` in the final word. `u64::MAX` fills whole words, so a `len` that
+    /// isn't a word multiple would otherwise leave phantom ids set.
+    fn mask_tail(&mut self) {
+        let rem = self.len % WORD;
+        if rem != 0
+            && let Some(last) = self.words.last_mut()
+        {
+            *last &= (1u64 << rem) - 1;
+        }
+    }
+
+    /// Add `id` to the set. Ids at or above `len` are not representable and are ignored.
+    pub(crate) fn set(&mut self, id: usize) {
+        if id < self.len {
+            self.words[id / WORD] |= 1u64 << (id % WORD);
+        }
+    }
+
+    /// Whether `id` is in the set.
+    #[must_use]
+    pub(crate) fn contains(&self, id: usize) -> bool {
+        id < self.len && self.words[id / WORD] & (1u64 << (id % WORD)) != 0
+    }
+
+    /// Overwrite this set with `other`, reusing the existing allocation. Lets the match loop keep
+    /// one scratch bitset per request instead of allocating per dimension.
+    pub(crate) fn copy_from(&mut self, other: &Self) {
+        debug_assert_eq!(self.len, other.len, "bitsets span different id spaces");
+        self.words.copy_from_slice(&other.words);
+    }
+
+    /// Intersect in place (`self &= other`) — the dimension-combining operation.
+    pub(crate) fn intersect_with(&mut self, other: &Self) {
+        debug_assert_eq!(self.len, other.len, "bitsets span different id spaces");
+        for (a, b) in self.words.iter_mut().zip(&other.words) {
+            *a &= *b;
+        }
+    }
+
+    /// Whether no id is set — lets the match loop bail before the remaining dimensions.
+    ///
+    /// Note this is emptiness of the *set*, not of the id space: `zeros(10).is_empty()` is true.
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.words.iter().all(|w| *w == 0)
+    }
+
+    /// How many ids are in the set.
+    #[must_use]
+    pub(crate) fn count(&self) -> usize {
+        self.words.iter().map(|w| w.count_ones() as usize).sum()
+    }
+
+    /// The ids in the set, ascending — i.e. in stub declaration order, which is what makes
+    /// first-match-wins fall out of iteration.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.words.iter().enumerate().flat_map(|(w, word)| {
+            let mut rest = *word;
+            std::iter::from_fn(move || {
+                if rest == 0 {
+                    return None;
+                }
+                let bit = rest.trailing_zeros() as usize;
+                rest &= rest - 1;
+                Some(w * WORD + bit)
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zeros_is_empty_and_all_is_full() {
+        let z = CandidateBits::zeros(10);
+        assert!(z.is_empty());
+        assert_eq!(z.count(), 0);
+
+        let a = CandidateBits::all(10);
+        assert!(!a.is_empty());
+        assert_eq!(a.count(), 10);
+        assert_eq!(a.iter().collect::<Vec<_>>(), (0..10).collect::<Vec<_>>());
+    }
+
+    // The tail-masking invariant: `all()` fills whole u64 words, so a non-word-multiple `len` must
+    // still not report ids past the end — otherwise the match loop would index out of bounds.
+    #[test]
+    fn all_masks_bits_past_len() {
+        for len in [0usize, 1, 63, 64, 65, 127, 128, 129, 200] {
+            let a = CandidateBits::all(len);
+            assert_eq!(a.count(), len, "all({len}) must contain exactly len ids");
+            assert_eq!(a.iter().max(), len.checked_sub(1), "no phantom id past len");
+            assert!(!a.contains(len), "all({len}) must not contain id len");
+        }
+    }
+
+    #[test]
+    fn set_and_contains_across_word_boundaries() {
+        let mut b = CandidateBits::zeros(200);
+        for id in [0usize, 1, 63, 64, 65, 127, 128, 199] {
+            b.set(id);
+        }
+        assert_eq!(
+            b.iter().collect::<Vec<_>>(),
+            vec![0, 1, 63, 64, 65, 127, 128, 199]
+        );
+        assert!(b.contains(64) && !b.contains(66));
+        assert_eq!(b.count(), 8);
+    }
+
+    // Out-of-range ids are ignored rather than panicking or corrupting a neighbouring word.
+    #[test]
+    fn set_ignores_out_of_range_ids() {
+        let mut b = CandidateBits::zeros(64);
+        b.set(64);
+        b.set(1000);
+        assert!(b.is_empty());
+        assert!(!b.contains(64));
+    }
+
+    #[test]
+    fn intersect_keeps_only_common_ids() {
+        let mut a = CandidateBits::zeros(128);
+        [1usize, 5, 70].iter().for_each(|i| a.set(*i));
+        let mut b = CandidateBits::zeros(128);
+        [5usize, 70, 100].iter().for_each(|i| b.set(*i));
+
+        a.intersect_with(&b);
+        assert_eq!(a.iter().collect::<Vec<_>>(), vec![5, 70]);
+    }
+
+    // `all()` is the identity for intersection — the match loop seeds the accumulator with it.
+    #[test]
+    fn all_is_the_intersection_identity() {
+        let mut b = CandidateBits::zeros(70);
+        [3usize, 69].iter().for_each(|i| b.set(*i));
+        let mut acc = CandidateBits::all(70);
+        acc.intersect_with(&b);
+        assert_eq!(acc, b);
+    }
+
+    #[test]
+    fn copy_from_overwrites_in_place() {
+        let mut src = CandidateBits::zeros(70);
+        src.set(9);
+        let mut dst = CandidateBits::all(70);
+        dst.copy_from(&src);
+        assert_eq!(dst, src);
+        assert_eq!(dst.iter().collect::<Vec<_>>(), vec![9]);
+    }
+
+    #[test]
+    fn empty_id_space_is_degenerate_but_sound() {
+        let a = CandidateBits::all(0);
+        assert!(a.is_empty());
+        assert_eq!(a.count(), 0);
+        assert_eq!(a.iter().next(), None);
+    }
+}

--- a/crates/rift-mock-core/src/imposter/core/lifecycle.rs
+++ b/crates/rift-mock-core/src/imposter/core/lifecycle.rs
@@ -87,8 +87,8 @@ impl Imposter {
 
     /// Get a clone of the stub with `id`, if present.
     pub fn get_stub_by_id(&self, id: &str) -> Option<Stub> {
-        self.stubs
-            .load()
+        self.snapshot()
+            .stubs()
             .iter()
             .find(|s| s.stub.id.as_deref() == Some(id))
             .map(|s| s.stub.clone())
@@ -119,8 +119,8 @@ impl Imposter {
 
     /// Get all stubs
     pub fn get_stubs(&self) -> Vec<Stub> {
-        self.stubs
-            .load()
+        self.snapshot()
+            .stubs()
             .iter()
             .map(|stub_state| stub_state.stub.clone())
             .collect()
@@ -128,12 +128,13 @@ impl Imposter {
 
     /// Number of stubs, without cloning them (list/summary endpoints poll this on a tick).
     pub fn stub_count(&self) -> usize {
-        self.stubs.load().len()
+        self.snapshot().stubs().len()
     }
 
     /// Get a specific stub by index
     pub fn get_stub(&self, index: usize) -> Option<Stub> {
-        let stubs = self.stubs.load();
+        let snapshot = self.snapshot();
+        let stubs = snapshot.stubs();
         stubs.get(index).map(|stub_state| stub_state.stub.clone())
     }
 

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -40,13 +40,14 @@ impl Imposter {
     where
         SH: BuildHasher,
     {
-        // Stage 1 (issue #292): the index embeds its stub snapshot, so `stubs` and the candidate
-        // set are always consistent. Non-anchored stubs sit in its fallback bucket, so `candidates`
-        // is a superset of the true matches, ascending — Stage-2 first-match-wins is unchanged.
-        // Note: a path-anchored stub whose anchor doesn't match the request is no longer visited, so
-        // its `required_scenario_state` backend read (which could `Err`, #318) is skipped for that
+        // Stage 1 (issues #292, #707): one wait-free load yields the stubs and the index built over
+        // those exact stubs, so they are consistent by construction. Every dimension over-
+        // approximates (stubs it can't index sit in its always-bits), so `candidates` is a superset
+        // of the true matches, ascending — Stage-2 first-match-wins is unchanged.
+        // Note: a stub some dimension rules out is no longer visited, so its
+        // `required_scenario_state` backend read (which could `Err`, #318) is skipped for that
         // request — correct, since a stub that provably can't match should not be consulted.
-        let snapshot = self.stub_index.load();
+        let snapshot = self.snapshot();
         let stubs = snapshot.stubs();
         // `headers_map` is the single-value, Title-Case header view already built once by the
         // caller (#288) — no re-conversion from `HeaderMap` here.
@@ -60,7 +61,7 @@ impl Imposter {
         let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
         // Likewise parse the query string once per request rather than per predicate (issue #480).
         let query_map = crate::imposter::predicates::parse_query(query);
-        for stub_idx in snapshot.candidates(path) {
+        for stub_idx in snapshot.candidates(method, path).iter() {
             let stub_state = &stubs[stub_idx];
             let stub = &stub_state.stub;
             // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only
@@ -133,7 +134,7 @@ impl Imposter {
         // `'static` worker closure when the snapshot needs offloading (inject/scenario-gate).
         SH: BuildHasher + Clone + Send + 'static,
     {
-        let snapshot = self.stub_index.load();
+        let snapshot = self.snapshot();
         let has_inject = snapshot.has_inject();
         // A scenario-gated stub reads flow state inside the matching pass; on a blocking backend
         // (Redis) that read must not run on the tokio worker either (issue #475). A scenario-free
@@ -217,7 +218,8 @@ impl Imposter {
         request_from: Option<&str>,
         client_ip: Option<&str>,
     ) -> anyhow::Result<Option<(Arc<StubState>, usize)>> {
-        let stubs = self.stubs.load();
+        let snapshot = self.snapshot();
+        let stubs = snapshot.stubs();
         let form = Self::parse_form_data(headers_map, body);
         let imposter_port = self.script_state_key();
         let flow_id = self.resolve_flow_id(headers_map);
@@ -459,8 +461,8 @@ impl Imposter {
     /// Distinct scenario names declared by this imposter's stubs (sorted).
     pub fn scenario_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self
-            .stubs
-            .load()
+            .snapshot()
+            .stubs()
             .iter()
             .filter_map(|s| s.stub.scenario_name.clone())
             .collect();
@@ -471,8 +473,8 @@ impl Imposter {
 
     /// Stubs scoped to a given correlation space (issue #223).
     pub fn space_stubs(&self, space: &str) -> Vec<Stub> {
-        self.stubs
-            .load()
+        self.snapshot()
+            .stubs()
             .iter()
             .filter(|s| s.stub.space.as_deref() == Some(space))
             .map(|s| s.stub.clone())
@@ -779,7 +781,7 @@ mod bounded_matching_tests {
             }]),
             Arc::new(BlockingProbeStore::new()),
         );
-        assert!(imp.stub_index.load().has_scenario_gate());
+        assert!(imp.snapshot().has_scenario_gate());
         assert!(imp.flow_store.is_blocking());
 
         let matched = imp
@@ -896,7 +898,7 @@ mod bounded_matching_tests {
             "responses": [{ "is": { "statusCode": 200 } }]
         }]));
         assert!(
-            !imp.stub_index.load().has_inject(),
+            !imp.snapshot().has_inject(),
             "a scriptless stub set must not set the has_inject gate"
         );
         let matched = imp

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -116,16 +116,17 @@ impl StubState {
 /// Runtime state of an imposter
 pub struct Imposter {
     pub config: ImposterConfig,
-    /// Mutable stubs (can be modified at runtime). Stored behind `Arc` so a matched request
-    /// takes a refcount bump instead of deep-cloning the whole `StubState` (issue #287), and
-    /// behind `ArcSwap` so the match hot path reads wait-free (`load()`, no lock) while a
-    /// mutation atomically swaps in a fresh snapshot (issue #291). Serialize *writers* through
-    /// [`Self::mutate_stubs`] / `stubs_write`; never `store()` this field directly.
-    pub stubs: ArcSwap<Vec<Arc<StubState>>>,
-    /// Stage-1 path-anchor prefilter over the current `stubs` snapshot (issue #292). Rebuilt in
-    /// [`Self::mutate_stubs`] alongside `stubs`; the match hot path loads it wait-free and uses the
-    /// snapshot it embeds for both candidate selection and evaluation (so no torn read).
-    stub_index: ArcSwap<StubIndex>,
+    /// The stubs, the Stage-1 candidate index over those exact stubs, and the snapshot-wide
+    /// matching gates — one unit (issue #707).
+    ///
+    /// Each `StubState` sits behind `Arc` so a matched request takes a refcount bump instead of
+    /// deep-cloning it (issue #287), and the whole snapshot behind `ArcSwap` so the match hot path
+    /// reads wait-free (one `load()`, no lock) while a mutation atomically swaps in a fresh
+    /// snapshot (issue #291). Bundling the stubs with their index (previously two `ArcSwap`s kept
+    /// in sync by convention) makes a torn (stubs N, index N+1) read unrepresentable and halves the
+    /// hot path's atomic loads. Serialize *writers* through [`Self::mutate_stubs`] /
+    /// `stubs_write`; never `store()` this field directly.
+    stubs_snapshot: ArcSwap<StubSnapshot>,
     /// Serializes stub *writers* so a read-copy-update (clone snapshot → mutate → store) can't
     /// lose a concurrent update (issue #291). Off the request hot path — held only by admin /
     /// reload / proxy-record mutations, never by readers.
@@ -209,11 +210,6 @@ impl Imposter {
             .iter()
             .map(|stub| Arc::new(StubState::new(stub.clone())))
             .collect();
-        // Share the exact snapshot with the Stage-1 index so a reader that loads the index gets a
-        // self-consistent (stubs, candidates) pair (issue #292).
-        let stubs_arc = Arc::new(stubs);
-        let stub_index = ArcSwap::from_pointee(StubIndex::build(Arc::clone(&stubs_arc)));
-
         // Extract proxy mode from stubs (use first proxy response's mode)
         let proxy_mode = Self::extract_proxy_mode(&config.stubs);
 
@@ -223,8 +219,7 @@ impl Imposter {
 
         Ok(Self {
             config,
-            stubs: ArcSwap::new(stubs_arc),
-            stub_index,
+            stubs_snapshot: ArcSwap::from_pointee(StubSnapshot::build(stubs)),
             stubs_write: Mutex::new(()),
             proxy_store: Arc::new(LocalProxyStore::new(proxy_mode)),
             event_bus: None,
@@ -241,7 +236,13 @@ impl Imposter {
         })
     }
 
-    /// Read-copy-update the stub vector (issue #291). Reads stay wait-free (`self.stubs.load()`);
+    /// The current stub snapshot: stubs, the index over them, and the matching gates, from a single
+    /// wait-free load (issue #707). The match hot path calls this exactly once per request.
+    pub(crate) fn snapshot(&self) -> arc_swap::Guard<Arc<StubSnapshot>> {
+        self.stubs_snapshot.load()
+    }
+
+    /// Read-copy-update the stub vector (issue #291). Reads stay wait-free (`self.snapshot()`);
     /// a mutation takes the `stubs_write` mutex (serializing writers so no update is lost), clones
     /// the current snapshot, applies `f`, then atomically swaps the new snapshot in. `f`'s return
     /// value is passed back to the caller. Mutations are off the request hot path.
@@ -253,13 +254,12 @@ impl Imposter {
     /// vector and then return an error/no-op, or the partial change would be committed silently.
     pub(crate) fn mutate_stubs<R>(&self, f: impl FnOnce(&mut Vec<Arc<StubState>>) -> R) -> R {
         let _writer = self.stubs_write.lock();
-        let mut next: Vec<Arc<StubState>> = self.stubs.load_full().as_ref().clone();
+        let mut next: Vec<Arc<StubState>> = self.stubs_snapshot.load().stubs().to_vec();
         let result = f(&mut next);
-        // Store the snapshot and rebuild the Stage-1 index from the *same* Arc, under the write
-        // lock, so the two never diverge (issue #292).
-        let next_arc = Arc::new(next);
-        self.stubs.store(Arc::clone(&next_arc));
-        self.stub_index.store(Arc::new(StubIndex::build(next_arc)));
+        // One store of stubs+index together (issue #707): the index is built from the very vector
+        // it is stored with, so the two cannot diverge by construction.
+        self.stubs_snapshot
+            .store(Arc::new(StubSnapshot::build(next)));
         // Invalidate the cached stub-analysis warnings (issue #423). This is O(1) — the actual
         // O(n) recompute is deferred to the next `stub_warnings()` read — so high-frequency
         // mutations (e.g. proxy recording) don't pay analysis cost on every recorded stub.
@@ -441,8 +441,8 @@ impl Imposter {
                 .and_then(|f| f.tcp.as_ref())
                 .is_some_and(|t| TcpFaultKind::parse(t.kind()).is_some())
         };
-        self.stubs
-            .load()
+        self.snapshot()
+            .stubs()
             .iter()
             .flat_map(|s| &s.stub.responses)
             .any(|resp| match resp {
@@ -534,10 +534,11 @@ impl Imposter {
     }
 }
 
+mod bitset;
 mod lifecycle;
 mod matching;
 mod stub_index;
-use stub_index::StubIndex;
+use stub_index::StubSnapshot;
 mod proxy;
 mod recording;
 mod responses;
@@ -665,7 +666,7 @@ mod tests {
             .find_matching_stub_with_client("GET", "/shared", &headers, None, None, None, None)
             .expect("store is infallible")
             .expect("request must match");
-        let stored = std::sync::Arc::clone(&imp.stubs.load()[index]);
+        let stored = std::sync::Arc::clone(&imp.snapshot().stubs()[index]);
         assert!(
             std::sync::Arc::ptr_eq(&matched, &stored),
             "matched stub must be the shared Arc, not a deep clone"
@@ -868,7 +869,7 @@ mod tests {
         }))
         .unwrap();
         let imp = Imposter::new(cfg).expect("test imposter");
-        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
+        assert_eq!(served_body(&imp.snapshot().stubs()[0]), "A"); // cursor now at index 1
         let new = serde_json::from_value(json!({
             "predicates": [{ "equals": { "path": "/c" } }],
             "responses": [
@@ -879,7 +880,7 @@ mod tests {
         .unwrap();
         imp.replace_stub(0, new).expect("index in bounds");
         assert_eq!(
-            served_body(&imp.stubs.load()[0]),
+            served_body(&imp.snapshot().stubs()[0]),
             "D",
             "cursor (index 1) preserved and content swapped"
         );
@@ -901,7 +902,7 @@ mod tests {
         }))
         .unwrap();
         let imp = Imposter::new(cfg).expect("test imposter");
-        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
+        assert_eq!(served_body(&imp.snapshot().stubs()[0]), "A"); // cursor now at index 1
         let new = serde_json::from_value(json!({
             "predicates": [{ "equals": { "path": "/c" } }],
             "responses": [
@@ -912,7 +913,7 @@ mod tests {
         .unwrap();
         assert!(imp.replace_stub_by_id("s1", new), "id exists");
         assert_eq!(
-            served_body(&imp.stubs.load()[0]),
+            served_body(&imp.snapshot().stubs()[0]),
             "D",
             "cursor (index 1) preserved and content swapped"
         );
@@ -942,13 +943,13 @@ mod tests {
         imp.insert_or_append_proxy_stub(rec, "http://upstream", "proxyAlways");
 
         let rec_index = imp
-            .stubs
-            .load()
+            .snapshot()
+            .stubs()
             .iter()
             .position(|s| !s.stub.predicates.is_empty())
             .expect("recorded stub present");
-        let slot_before = imp.stubs.load()[rec_index].slot;
-        assert_eq!(served_body(&imp.stubs.load()[rec_index]), "R1"); // cursor now at index 1
+        let slot_before = imp.snapshot().stubs()[rec_index].slot;
+        assert_eq!(served_body(&imp.snapshot().stubs()[rec_index]), "R1"); // cursor now at index 1
 
         // Second record with identical predicates → append branch: responses become [R1, R2, R3].
         let rec2 = serde_json::from_value(json!({
@@ -959,12 +960,12 @@ mod tests {
         imp.insert_or_append_proxy_stub(rec2, "http://upstream", "proxyAlways");
 
         assert_eq!(
-            imp.stubs.load()[rec_index].slot,
+            imp.snapshot().stubs()[rec_index].slot,
             slot_before,
             "append must reuse the slot token, not mint a fresh StubState"
         );
         assert_eq!(
-            served_body(&imp.stubs.load()[rec_index]),
+            served_body(&imp.snapshot().stubs()[rec_index]),
             "R2",
             "cursor (index 1) preserved across the append"
         );
@@ -1019,7 +1020,7 @@ mod tests {
         }))
         .unwrap();
         let imp = Imposter::new(cfg).expect("test imposter");
-        assert_eq!(served_body(&imp.stubs.load()[0]), "A"); // cursor now at index 1
+        assert_eq!(served_body(&imp.snapshot().stubs()[0]), "A"); // cursor now at index 1
         let other: Stub = serde_json::from_value(json!({
             "predicates": [{ "equals": { "path": "/other" } }],
             "responses": [{ "is": { "statusCode": 200, "body": "Z" } }]
@@ -1027,7 +1028,7 @@ mod tests {
         .unwrap();
         imp.add_stub(other, None);
         assert_eq!(
-            served_body(&imp.stubs.load()[0]),
+            served_body(&imp.snapshot().stubs()[0]),
             "B",
             "cursor preserved across an unrelated structural snapshot swap (Arc identity carried)"
         );

--- a/crates/rift-mock-core/src/imposter/core/responses.rs
+++ b/crates/rift-mock-core/src/imposter/core/responses.rs
@@ -71,7 +71,8 @@ impl Imposter {
 
     /// Get all stubs info for debug purposes (Rift extension)
     pub fn get_all_stubs_info(&self) -> Vec<DebugStubInfo> {
-        let stubs = self.stubs.load();
+        let snapshot = self.snapshot();
+        let stubs = snapshot.stubs();
         stubs
             .iter()
             .map(|stub_state| &stub_state.stub)
@@ -87,7 +88,8 @@ impl Imposter {
 
     /// Get imposter info for debug purposes (Rift extension)
     pub fn get_debug_imposter_info(&self) -> DebugImposter {
-        let stubs = self.stubs.load();
+        let snapshot = self.snapshot();
+        let stubs = snapshot.stubs();
         DebugImposter {
             port: self.config.port.unwrap_or(0),
             name: self.config.name.clone(),

--- a/crates/rift-mock-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-mock-core/src/imposter/core/stub_index.rs
@@ -1,26 +1,77 @@
-//! Stage-1 path-anchor prefilter for imposter stub matching (issue #292).
+//! Stage-1 candidate prefilter for imposter stub matching (issues #292, #707).
 //!
-//! The imposter match loop (`core/matching.rs`) is a linear scan that runs full Mountebank
-//! predicate evaluation on every stub. This index narrows that to a candidate set by the request
-//! path, so only stubs that *could* match are evaluated — turning O(stubs) into ~O(1)–O(k) for the
-//! common method/path-anchored cases.
+//! The imposter match loop (`core/matching.rs`) would otherwise be a linear scan running full
+//! Mountebank predicate evaluation on every stub. This index narrows that to a candidate set, so
+//! only stubs that *could* match are evaluated.
 //!
-//! **Correctness is by construction.** A stub is path-anchored (indexed) only when a *top-level*
-//! (implicitly AND-ed) predicate is a straightforward `equals`/`startsWith`/`contains` on the raw
-//! `path` field — no selector, no `except`, not case-sensitive. Such a predicate is *required* for
-//! the stub to match, so a request whose path fails it can never match the stub → safe to exclude.
-//! Every other stub (regex/exists/body/method-only predicates, `or`/`not`/`and`, selectors,
-//! `except`, `caseSensitive`, empty predicates) goes in the always-candidate `fallback` bucket.
-//! `candidates()` therefore returns a *superset* of the true matches, in ascending stub order, so
-//! Stage-2 evaluation preserves Mountebank first-match-wins exactly. The differential test below
-//! (indexed candidates ≡ linear scan over a diverse corpus) is the guardrail.
+//! # The dimension framework (issue #707)
+//!
+//! The index is a set of independent **dimensions**, one per request attribute (path, method, and
+//! — via the sibling issues built on this seam — deepEquals bodies (#708), regexes (#709), and
+//! literals (#710)). Each dimension answers one question for a request: *which stubs can this
+//! attribute not rule out?* The answers are [`CandidateBits`] — dense bitsets over stub ids, where
+//! a stub's id is its position in the snapshot's stub vector (declaration-ordered).
+//!
+//! [`StubIndex::candidates`] ANDs the per-dimension bitsets and walks the surviving bits ascending.
+//! This is the Lucent Bit Vector technique from packet classification: each dimension prunes
+//! independently, and the intersection is the candidate set. Ascending iteration *is* Mountebank's
+//! first-match-wins order, so Stage-2 evaluation order is unchanged.
+//!
+//! ## The soundness rule — the one invariant every dimension must uphold
+//!
+//! A dimension's bitset for a request is `matched_bits | always_bits`, where:
+//!
+//! * `matched_bits` — stubs whose constraint on this attribute the request *satisfies*;
+//! * `always_bits` — stubs that either do not constrain this attribute at all, or constrain it in
+//!   a shape this dimension cannot index (precomputed once at build).
+//!
+//! **A dimension may only ever exclude a stub it can prove cannot match.** Everything else must be
+//! in `always_bits`. The index is therefore a strict *over-approximation*: `candidates()` returns a
+//! superset of the true matches, and full predicate verification (`stub_matches`, unchanged) stays
+//! the single source of truth for semantics — including `and`/`or`/`not`, `except`, selectors,
+//! case flags, and `inject`. Widening a dimension's eligibility later is a pure optimization, never
+//! a semantics question.
+//!
+//! Eligibility is deliberately conservative and uniform across dimensions: a stub is indexed only
+//! when a *top-level* (implicitly AND-ed) predicate is a plain `equals`/`startsWith`/`contains` on
+//! the raw field — no `selector`, no `except`, not `caseSensitive`. Such a predicate is *required*
+//! for the stub to match, so a request failing it can never match the stub → safe to exclude.
+//!
+//! ## Adding a dimension
+//!
+//! Implement [`Dimension`], add it as a field of [`StubIndex`], build its `always_bits` from the
+//! stubs it cannot index, and AND it in [`StubIndex::candidates`]. Dimensions are concrete fields
+//! rather than `Box<dyn Dimension>` so the match loop dispatches statically and allocates nothing
+//! extra. The guardrail is `differential_index_matches_linear_oracle` below: a dimension that
+//! under-approximates fails it immediately.
 
 use super::StubState;
+use super::bitset::CandidateBits;
 use crate::imposter::types::Stub;
 use crate::util::FastMap;
 use rift_types::predicate::{Predicate, PredicateOperation};
 use std::collections::HashMap;
 use std::sync::Arc;
+
+/// The request attributes the index prunes on. Extended as sibling dimensions land.
+pub(crate) struct DimensionRequest<'a> {
+    pub(crate) method: &'a str,
+    pub(crate) path: &'a str,
+}
+
+/// One pruning dimension of the index. See the module docs for the soundness rule this contract
+/// requires: `select` must set a bit for **every** stub the request cannot rule out.
+trait Dimension {
+    /// Write `matched_bits | always_bits` for `request` into `out`, overwriting it entirely.
+    fn select(&self, request: &DimensionRequest<'_>, out: &mut CandidateBits);
+
+    /// Whether any stub is indexed on this dimension at all.
+    ///
+    /// When none is, `always_bits` is all-ones, so `select` can only ever produce all-ones and
+    /// intersecting it is a no-op — [`StubIndex::candidates`] skips the dimension entirely rather
+    /// than pay a full-width copy and intersect to learn nothing. Constant per snapshot.
+    fn prunes(&self) -> bool;
+}
 
 /// A required path constraint extracted from a stub's top-level predicates.
 enum PathAnchor {
@@ -29,20 +80,44 @@ enum PathAnchor {
     Contains(String),
 }
 
-/// The lowercased `path` value of a predicate's field map, if present and a string.
+/// The `path` value of a predicate's field map, folded for indexing, if present and a string.
 fn field_path(fields: &HashMap<String, serde_json::Value>) -> Option<String> {
     match fields.get("path") {
-        Some(serde_json::Value::String(s)) => Some(s.to_lowercase()),
+        Some(serde_json::Value::String(s)) => Some(fold(s)),
         _ => None,
     }
 }
 
+/// The case fold the index compares under.
+///
+/// This MUST be the evaluator's fold, not merely *a* fold. The default (non-`caseSensitive`)
+/// comparison in `predicates::mod` is `eq_ignore_ascii_case` / `starts_with_ignore_ascii_case` /
+/// `contains_ignore_ascii_case` — **ASCII**. Folding both sides with `to_ascii_lowercase` is
+/// exactly equivalent to those, so the path dimension neither over- nor under-approximates.
+///
+/// Unicode `to_lowercase` would be wrong here, and not merely conservative: it is length-changing
+/// and context-sensitive, so it breaks the prefix/substring relation the dimension relies on. Stub
+/// `startsWith "/ΟΣ"` vs request `/ΟΣΑ` is the counter-example — the evaluator matches (its ASCII
+/// fold leaves Greek untouched), but Unicode-lowercasing the anchor yields a final sigma (`/ος`)
+/// that `"/οσα"` does not start with, so the stub would be pruned and silently stop matching.
+fn fold(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
+/// Whether a predicate's parameters leave its field values comparable as raw request values — the
+/// soundness gate every dimension's eligibility rule shares.
+///
+/// Anything that transforms or re-scopes the compared value cannot be indexed against the raw
+/// field: `except` rewrites the value before comparison, `selector` re-scopes it, and
+/// `caseSensitive` opts out of the fold [`fold`] assumes. One home for the rule, because the
+/// dimensions added on this seam (#708-#710) must not let their copies of it drift.
+fn is_safely_indexable(p: &rift_types::predicate::PredicateParameters) -> bool {
+    p.case_sensitive != Some(true) && p.except.is_empty() && p.selector.is_none()
+}
+
 /// A single predicate's path anchor, if it is a safely-indexable required path constraint.
 fn path_anchor(pred: &Predicate) -> Option<PathAnchor> {
-    let p = &pred.parameters;
-    // Anything that transforms or re-scopes the compared value can't be indexed by the raw path.
-    // caseSensitive is opt-in; the default (None/Some(false)) is case-insensitive, so we lowercase.
-    if p.case_sensitive == Some(true) || !p.except.is_empty() || p.selector.is_some() {
+    if !is_safely_indexable(&pred.parameters) {
         return None;
     }
     match &pred.operation {
@@ -54,30 +129,201 @@ fn path_anchor(pred: &Predicate) -> Option<PathAnchor> {
 }
 
 /// The first required path anchor among a stub's top-level (AND-ed) predicates, or `None` if the
-/// stub can't be safely path-indexed (→ fallback bucket).
+/// stub can't be safely path-indexed (→ `always_bits`).
 fn classify(stub: &Stub) -> Option<PathAnchor> {
     stub.predicates.iter().find_map(path_anchor)
 }
 
-/// Path-anchor index over a specific stub snapshot. Embeds the exact `Arc` it describes so a reader
-/// that loads the index gets a self-consistent (stubs, candidates) pair.
-pub(crate) struct StubIndex {
-    stubs: Arc<Vec<Arc<StubState>>>,
+/// The path dimension (issue #292, ported onto the #707 bitset framework).
+///
+/// Buckets stay `Vec<usize>` rather than a bitset each: a bucket holds only the stubs sharing an
+/// anchor, so materializing it costs O(matched) rather than O(stubs/64), and build memory stays
+/// O(stubs) instead of O(stubs x buckets).
+///
+/// The prefix/contains buckets are walked linearly, exactly as pre-#707. Issue #710 replaces both
+/// walks with an anchored/unanchored Aho-Corasick pass behind this same `Dimension` seam.
+struct PathDimension {
     // Rebuilt on every stub-set replace/mutation (issue #704); its keys come from operator stub
     // config, not request traffic — see `crate::util::fastmap` doc for the HashDoS policy.
     exact: FastMap<String, Vec<usize>>,
     prefix: Vec<(String, Vec<usize>)>,
     contains: Vec<(String, Vec<usize>)>,
-    fallback: Vec<usize>,
-    /// Whether any stub's predicate tree contains an `inject` predicate, anywhere (including
-    /// nested under `and`/`or`/`not`). Computed once per snapshot so the request hot path can
-    /// gate the bounded (spawn_blocking) matching route on it for free (issue #476).
-    has_inject: bool,
-    /// Whether any stub is scenario-gated (`requiredScenarioState`). The eligibility gate reads
-    /// flow state during matching; on a blocking backend (Redis) that read must run off the tokio
-    /// worker, so the bounded matcher offloads only when this is set — a scenario-free snapshot
-    /// keeps the inline fast path even on a blocking backend (issue #475).
-    has_scenario_gate: bool,
+    /// Stubs with no indexable top-level path constraint — always candidates on this dimension.
+    always: CandidateBits,
+}
+
+impl Dimension for PathDimension {
+    fn select(&self, request: &DimensionRequest<'_>, out: &mut CandidateBits) {
+        out.copy_from(&self.always);
+        // Anchors were folded at build; fold the request the same way — see `fold`.
+        let p = fold(request.path);
+        if let Some(v) = self.exact.get(&p) {
+            v.iter().for_each(|i| out.set(*i));
+        }
+        for (prefix, v) in &self.prefix {
+            if p.starts_with(prefix.as_str()) {
+                v.iter().for_each(|i| out.set(*i));
+            }
+        }
+        for (sub, v) in &self.contains {
+            if p.contains(sub.as_str()) {
+                v.iter().for_each(|i| out.set(*i));
+            }
+        }
+    }
+
+    fn prunes(&self) -> bool {
+        !self.exact.is_empty() || !self.prefix.is_empty() || !self.contains.is_empty()
+    }
+}
+
+/// The fixed method slots. Any method outside the standard set (or a stub constraining an
+/// unusual one) shares `Other` — a coarser bucket is still sound, it just prunes less.
+const METHOD_SLOTS: usize = 8;
+const SLOT_OTHER: usize = METHOD_SLOTS - 1;
+
+/// The slot a method name belongs to, matched case-insensitively and without allocating.
+fn method_slot(method: &str) -> usize {
+    const NAMED: [&str; SLOT_OTHER] = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
+    NAMED
+        .iter()
+        .position(|m| method.eq_ignore_ascii_case(m))
+        .unwrap_or(SLOT_OTHER)
+}
+
+/// The method required by a single predicate, if it is a safely-indexable required constraint.
+fn method_anchor(pred: &Predicate) -> Option<&str> {
+    if !is_safely_indexable(&pred.parameters) {
+        return None;
+    }
+    match &pred.operation {
+        PredicateOperation::Equals(fields) => match fields.get("method") {
+            Some(serde_json::Value::String(s)) => Some(s.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// The method dimension (issue #707) — the cheapest possible dimension, and the proof of the
+/// framework: a POST-only stub stops being a candidate for every GET.
+struct MethodDimension {
+    slots: [Vec<usize>; METHOD_SLOTS],
+    /// Stubs with no indexable top-level method constraint — always candidates on this dimension.
+    always: CandidateBits,
+}
+
+impl Dimension for MethodDimension {
+    fn select(&self, request: &DimensionRequest<'_>, out: &mut CandidateBits) {
+        out.copy_from(&self.always);
+        self.slots[method_slot(request.method)]
+            .iter()
+            .for_each(|i| out.set(*i));
+    }
+
+    fn prunes(&self) -> bool {
+        self.slots.iter().any(|s| !s.is_empty())
+    }
+}
+
+/// The multi-dimensional candidate prefilter over a stub snapshot. See the module docs.
+pub(crate) struct StubIndex {
+    len: usize,
+    path: PathDimension,
+    method: MethodDimension,
+}
+
+impl StubIndex {
+    /// Build every dimension in one pass over the stubs, preserving ascending stub id within each
+    /// bucket (so iteration stays declaration-ordered).
+    fn build(stubs: &[Arc<StubState>]) -> Self {
+        let len = stubs.len();
+        let mut exact: FastMap<String, Vec<usize>> = FastMap::default();
+        let mut prefix: FastMap<String, Vec<usize>> = FastMap::default();
+        let mut contains: FastMap<String, Vec<usize>> = FastMap::default();
+        let mut path_always = CandidateBits::zeros(len);
+
+        let mut slots: [Vec<usize>; METHOD_SLOTS] = Default::default();
+        let mut method_always = CandidateBits::zeros(len);
+
+        for (i, state) in stubs.iter().enumerate() {
+            match classify(&state.stub) {
+                Some(PathAnchor::Exact(k)) => exact.entry(k).or_default().push(i),
+                Some(PathAnchor::Prefix(k)) => prefix.entry(k).or_default().push(i),
+                Some(PathAnchor::Contains(k)) => contains.entry(k).or_default().push(i),
+                None => path_always.set(i),
+            }
+            match state.stub.predicates.iter().find_map(method_anchor) {
+                Some(m) => slots[method_slot(m)].push(i),
+                None => method_always.set(i),
+            }
+        }
+
+        StubIndex {
+            len,
+            path: PathDimension {
+                exact,
+                prefix: prefix.into_iter().collect(),
+                contains: contains.into_iter().collect(),
+                always: path_always,
+            },
+            method: MethodDimension {
+                slots,
+                always: method_always,
+            },
+        }
+    }
+
+    /// The number of stubs this index spans.
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Candidate stub ids for a request: the intersection of every dimension's bitset. A superset
+    /// of the stubs that could match — Stage-2 does the real Mountebank evaluation on these, in the
+    /// ascending (declaration) order [`CandidateBits::iter`] yields.
+    /// Dimensions run cheapest-first, and only when they can actually prune:
+    ///
+    /// * a dimension no stub is indexed on is skipped ([`Dimension::prunes`]) — otherwise a corpus
+    ///   that never constrains the method would pay the method dimension a full-width copy and
+    ///   intersect to produce all-ones;
+    /// * the first dimension that does run seeds the accumulator directly, since `select`
+    ///   overwrites — no `all()` fill to intersect against, and no scratch buffer;
+    /// * an empty accumulator short-circuits the rest. Method runs first because it is both the
+    ///   cheapest (a slot lookup, no allocation) and, on method-partitioned corpora, the most
+    ///   selective — so the exit can skip the path dimension's fold allocation entirely.
+    ///
+    /// Sibling dimensions (#708-#710) slot in as further blocks in the same shape.
+    pub(crate) fn candidates(&self, request: &DimensionRequest<'_>) -> CandidateBits {
+        let mut acc = CandidateBits::zeros(self.len);
+        let mut seeded = false;
+
+        if self.method.prunes() {
+            self.method.select(request, &mut acc);
+            seeded = true;
+            if acc.is_empty() {
+                return acc;
+            }
+        }
+
+        if self.path.prunes() {
+            if seeded {
+                let mut scratch = CandidateBits::zeros(self.len);
+                self.path.select(request, &mut scratch);
+                acc.intersect_with(&scratch);
+            } else {
+                self.path.select(request, &mut acc);
+                seeded = true;
+            }
+        }
+
+        // No dimension indexes anything (e.g. every stub is a body regex): everyone is a candidate.
+        if seeded {
+            acc
+        } else {
+            CandidateBits::all(self.len)
+        }
+    }
 }
 
 /// Does this predicate tree contain an `inject` predicate anywhere?
@@ -92,40 +338,49 @@ fn predicate_contains_inject(pred: &Predicate) -> bool {
     }
 }
 
-impl StubIndex {
-    /// Classify every stub in `stubs` into its path-anchor bucket (or fallback), preserving
-    /// ascending stub index within each bucket.
-    pub(crate) fn build(stubs: Arc<Vec<Arc<StubState>>>) -> Self {
-        let mut exact: FastMap<String, Vec<usize>> = FastMap::default();
-        let mut prefix: FastMap<String, Vec<usize>> = FastMap::default();
-        let mut contains: FastMap<String, Vec<usize>> = FastMap::default();
-        let mut fallback: Vec<usize> = Vec::new();
+/// The unit of stub state the match hot path reads: the stubs, the index over *those exact* stubs,
+/// and the snapshot-wide precomputed gates (issue #707).
+///
+/// Held behind a single `ArcSwap` in [`Imposter`](super::Imposter), so one wait-free `load()` per
+/// request yields all of it. Before #707 the stubs and the index lived in two `ArcSwap`s kept in
+/// sync only by convention inside `mutate_stubs`; bundling them makes that invariant type-enforced
+/// — a reader cannot observe an index built for a different stub vector — and costs one atomic
+/// instead of two.
+pub(crate) struct StubSnapshot {
+    stubs: Vec<Arc<StubState>>,
+    index: StubIndex,
+    /// Whether any stub's predicate tree contains an `inject` predicate, anywhere (including
+    /// nested under `and`/`or`/`not`). Computed once per snapshot so the request hot path can
+    /// gate the bounded (spawn_blocking) matching route on it for free (issue #476).
+    has_inject: bool,
+    /// Whether any stub is scenario-gated (`requiredScenarioState`). The eligibility gate reads
+    /// flow state during matching; on a blocking backend (Redis) that read must run off the tokio
+    /// worker, so the bounded matcher offloads only when this is set — a scenario-free snapshot
+    /// keeps the inline fast path even on a blocking backend (issue #475).
+    has_scenario_gate: bool,
+}
 
-        for (i, state) in stubs.iter().enumerate() {
-            match classify(&state.stub) {
-                Some(PathAnchor::Exact(k)) => exact.entry(k).or_default().push(i),
-                Some(PathAnchor::Prefix(k)) => prefix.entry(k).or_default().push(i),
-                Some(PathAnchor::Contains(k)) => contains.entry(k).or_default().push(i),
-                None => fallback.push(i),
-            }
-        }
-
+impl StubSnapshot {
+    /// Build the index and the snapshot-wide gates for `stubs`.
+    pub(crate) fn build(stubs: Vec<Arc<StubState>>) -> Self {
+        let index = StubIndex::build(&stubs);
         let has_inject = stubs
             .iter()
             .any(|s| s.stub.predicates.iter().any(predicate_contains_inject));
         let has_scenario_gate = stubs
             .iter()
             .any(|s| s.stub.required_scenario_state.is_some());
-
-        StubIndex {
+        StubSnapshot {
             stubs,
-            exact,
-            prefix: prefix.into_iter().collect(),
-            contains: contains.into_iter().collect(),
-            fallback,
+            index,
             has_inject,
             has_scenario_gate,
         }
+    }
+
+    /// The stubs this snapshot describes, in declaration order.
+    pub(crate) fn stubs(&self) -> &[Arc<StubState>] {
+        &self.stubs
     }
 
     /// Whether any stub in this snapshot uses an `inject` predicate (issue #476).
@@ -138,33 +393,15 @@ impl StubIndex {
         self.has_scenario_gate
     }
 
-    /// The stub snapshot this index describes.
-    pub(crate) fn stubs(&self) -> &Arc<Vec<Arc<StubState>>> {
-        &self.stubs
+    /// Candidate stub ids for a request — see [`StubIndex::candidates`].
+    pub(crate) fn candidates(&self, method: &str, path: &str) -> CandidateBits {
+        self.index.candidates(&DimensionRequest { method, path })
     }
 
-    /// Candidate stub indices for a request `path`, in ascending order (deduped). A superset of the
-    /// stubs that could match — Stage-2 does the real Mountebank evaluation on these in order.
-    pub(crate) fn candidates(&self, path: &str) -> Vec<usize> {
-        let p = path.to_lowercase();
-        let mut out: Vec<usize> = Vec::new();
-        if let Some(v) = self.exact.get(&p) {
-            out.extend_from_slice(v);
-        }
-        for (prefix, v) in &self.prefix {
-            if p.starts_with(prefix.as_str()) {
-                out.extend_from_slice(v);
-            }
-        }
-        for (sub, v) in &self.contains {
-            if p.contains(sub.as_str()) {
-                out.extend_from_slice(v);
-            }
-        }
-        out.extend_from_slice(&self.fallback);
-        out.sort_unstable();
-        out.dedup();
-        out
+    /// The index over these stubs (tests assert dimension-level behaviour through it).
+    #[cfg(test)]
+    pub(crate) fn index(&self) -> &StubIndex {
+        &self.index
     }
 }
 
@@ -173,11 +410,13 @@ mod tests {
     use super::*;
     use crate::imposter::core::Imposter;
     use crate::imposter::types::ImposterConfig;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use serde_json::{Value, json};
     use std::collections::HashMap;
 
-    fn stub_states(preds: &[Value]) -> Arc<Vec<Arc<StubState>>> {
-        let states: Vec<Arc<StubState>> = preds
+    fn stub_states(preds: &[Value]) -> Vec<Arc<StubState>> {
+        preds
             .iter()
             .map(|p| {
                 let stub = serde_json::from_value(
@@ -186,8 +425,18 @@ mod tests {
                 .expect("valid stub");
                 Arc::new(StubState::new(stub))
             })
-            .collect();
-        Arc::new(states)
+            .collect()
+    }
+
+    /// A snapshot over `preds`, for dimension-level assertions.
+    fn snapshot(preds: &[Value]) -> StubSnapshot {
+        StubSnapshot::build(stub_states(preds))
+    }
+
+    /// The candidate ids for a request, ascending — the pre-#707 `candidates()` shape, so the
+    /// existing coverage/ordering assertions read unchanged.
+    fn candidate_ids(snap: &StubSnapshot, method: &str, path: &str) -> Vec<usize> {
+        snap.candidates(method, path).iter().collect()
     }
 
     fn imposter(preds: &[Value]) -> Imposter {
@@ -307,13 +556,14 @@ mod tests {
         }
     }
 
-    // AC1: the index genuinely narrows (excludes non-matching anchored stubs) yet never drops a
-    // stub the linear scan would consider (fallback + matching anchors are all present).
+    // The path dimension genuinely narrows (excludes non-matching anchored stubs) yet never drops a
+    // stub the linear scan would consider (always-bits + matching anchors are all present).
+    // Stub 6 is method-only (`equals {method: POST}`), so a GET request now prunes it on the method
+    // dimension — the #707 pruning the path dimension alone could never do.
     #[test]
     fn stub_index_narrows_and_covers() {
-        let stubs = stub_states(&corpus());
-        let index = StubIndex::build(Arc::clone(&stubs));
-        let cands = index.candidates("/exact");
+        let snap = snapshot(&corpus());
+        let cands = candidate_ids(&snap, "GET", "/exact");
 
         // Narrowing: the prefix (2) and method+path-/mp (11) anchored stubs cannot match /exact,
         // so they are excluded.
@@ -322,16 +572,21 @@ mod tests {
             !cands.contains(&11),
             "method+path /mp stub excluded for /exact"
         );
+        assert!(
+            !cands.contains(&6),
+            "POST-only stub excluded for a GET request (method dimension, #707)"
+        );
 
-        // Coverage: both exact stubs (case-insensitive collision) and every fallback stub remain.
+        // Coverage: both exact stubs (case-insensitive collision) and every stub no dimension can
+        // index remain candidates.
         assert!(
             cands.contains(&0) && cands.contains(&1),
             "exact stubs present"
         );
-        for fb in [4, 5, 6, 7, 8, 9, 10, 12] {
+        for fb in [4, 5, 7, 8, 9, 10, 12] {
             assert!(
                 cands.contains(&fb),
-                "fallback stub {fb} must always be a candidate"
+                "un-indexable stub {fb} must always be a candidate"
             );
         }
         // Ascending + deduped so Stage-2 preserves declaration order.
@@ -339,6 +594,175 @@ mod tests {
         sorted.sort_unstable();
         sorted.dedup();
         assert_eq!(cands, sorted, "candidates must be ascending and deduped");
+    }
+
+    // AC4: the method dimension collapses the candidate set — a request's method prunes every stub
+    // anchored to a different one. This is the framework's proof: before #707 all four stubs were
+    // candidates for every request, because the path dimension cannot see the method.
+    #[test]
+    fn method_dimension_collapses_candidates() {
+        let snap = snapshot(&[
+            json!([{"equals": {"method": "GET"}}]),
+            json!([{"equals": {"method": "POST"}}]),
+            json!([{"equals": {"method": "PUT"}}]),
+            json!([{"equals": {"method": "DELETE"}}]),
+        ]);
+        for (i, m) in ["GET", "POST", "PUT", "DELETE"].iter().enumerate() {
+            let c = snap.candidates(m, "/anything");
+            assert_eq!(c.count(), 1, "{m}: exactly one candidate survives");
+            assert!(c.contains(i), "{m}: the {m}-anchored stub is the survivor");
+        }
+        // A method no stub anchors prunes everything — and the early-exit path returns empty.
+        assert_eq!(snap.candidates("PATCH", "/anything").count(), 0);
+        // Case-insensitive, per Mountebank's default comparison.
+        assert!(snap.candidates("get", "/anything").contains(0));
+    }
+
+    // AC6 (the soundness rule): a stub whose method constraint the dimension cannot index must stay
+    // a candidate for EVERY method. A dimension may only exclude what it can prove cannot match —
+    // anything else belongs in always_bits.
+    #[test]
+    fn ineligible_method_shapes_are_always_candidates() {
+        let snap = snapshot(&[
+            json!([{"equals": {"method": "GET"}}]), // 0 indexable
+            json!([{"or": [{"equals": {"method": "GET"}}, {"equals": {"method": "POST"}}]}]), // 1 or
+            json!([{"not": {"equals": {"method": "GET"}}}]), // 2 not
+            json!([{"and": [{"equals": {"method": "GET"}}, {"equals": {"path": "/x"}}]}]), // 3 and
+            json!([{"equals": {"method": "GET"}, "except": "X"}]), // 4 except rewrites the value
+            json!([{"equals": {"method": "GET"}, "caseSensitive": true}]), // 5 caseSensitive
+            json!([{"matches": {"method": "^G"}}]),          // 6 regex
+            // 7: the evaluator stringifies a non-string value and compares it, so it IS a real
+            // constraint — just not one this dimension indexes.
+            json!([{"equals": {"method": 7}}]),
+            json!([{"equals": {"method": "GET"}, "jsonpath": {"selector": "$.id"}}]), // 8 selector
+            json!([]),                                                                // 9 match-all
+        ]);
+        // PATCH matches no indexable anchor, so only always-bits stubs may survive.
+        let c = snap.candidates("PATCH", "/x");
+        assert!(!c.contains(0), "the indexable GET stub must be pruned");
+        for i in [1, 2, 3, 4, 5, 6, 7, 8, 9] {
+            assert!(
+                c.contains(i),
+                "stub {i} is un-indexable → always a candidate"
+            );
+        }
+    }
+
+    // The `selector` arm of the shared `is_safely_indexable` gate, for the path dimension. Without
+    // a test, inverting or dropping that check would be an *under*-approximation — a silently
+    // pruned stub — which is the one failure mode the index must never have.
+    #[test]
+    fn selector_scoped_path_predicates_are_always_candidates() {
+        let snap = snapshot(&[
+            json!([{"equals": {"path": "/a"}, "jsonpath": {"selector": "$.id"}}]), // 0 selector
+            json!([{"equals": {"path": "/a"}, "except": "X"}]),                    // 1 except
+            json!([{"equals": {"path": "/a"}, "caseSensitive": true}]), // 2 caseSensitive
+            json!([{"equals": {"path": "/a"}}]),                        // 3 indexable
+        ]);
+        // A path no anchor matches: only stubs the dimension cannot index may survive.
+        let c = snap.candidates("GET", "/other");
+        for i in [0, 1, 2] {
+            assert!(
+                c.contains(i),
+                "stub {i} is un-indexable → always a candidate"
+            );
+        }
+        assert!(!c.contains(3), "the indexable /a stub must be pruned");
+    }
+
+    // The index must fold case EXACTLY as the evaluator does (ASCII), not merely conservatively.
+    // Unicode `to_lowercase` is length-changing and context-sensitive, so it breaks the prefix and
+    // substring relations the path dimension relies on: the evaluator matches `startsWith "/ΟΣ"`
+    // against `/ΟΣΑ` (its ASCII fold leaves Greek untouched), but a Unicode fold maps the anchor's
+    // trailing Σ to a final sigma (`/ος`) that `"/οσα"` does not start with — pruning a stub that
+    // does match. Regression test for that class of silent no-match.
+    #[test]
+    fn non_ascii_case_folding_matches_the_evaluator() {
+        let imp = imposter(&[
+            json!([{"startsWith": {"path": "/ΟΣ"}}]), // 0 Greek sigma: Unicode fold breaks the prefix
+            json!([{"contains": {"path": "ΑΣ"}}]),    // 1 the same trap via contains
+            json!([{"equals": {"path": "/İ"}}]),      // 2 dotted capital I lowercases to two chars
+        ]);
+        let no_headers: HashMap<String, String> = HashMap::new();
+        for (m, p) in [
+            ("GET", "/ΟΣΑ"),
+            ("GET", "/ΟΣ"),
+            ("GET", "/οσα"),
+            ("GET", "/xΑΣy"),
+            ("GET", "/İ"),
+            ("GET", "/i̇"),
+        ] {
+            let linear =
+                idx(imp.find_matching_stub_linear(m, p, &no_headers, None, None, None, None));
+            let indexed =
+                idx(imp.find_matching_stub_with_client(m, p, &no_headers, None, None, None, None));
+            assert_eq!(indexed, linear, "index diverged from linear for {m} {p}");
+        }
+    }
+
+    // An unusual method shares the `Other` slot with every other unusual method. That is coarser,
+    // not wrong: the dimension over-includes and verification decides. Guards against a slot scheme
+    // that silently drops methods outside the named set.
+    #[test]
+    fn unnamed_methods_share_the_other_slot_soundly() {
+        let snap = snapshot(&[
+            json!([{"equals": {"method": "TRACE"}}]),
+            json!([{"equals": {"method": "CONNECT"}}]),
+            json!([{"equals": {"method": "GET"}}]),
+        ]);
+        // Both unusual stubs are candidates for either unusual method (over-approximation)...
+        for m in ["TRACE", "CONNECT"] {
+            let c = snap.candidates(m, "/x");
+            assert!(c.contains(0) && c.contains(1), "{m}: Other-slot stubs kept");
+            assert!(!c.contains(2), "{m}: the GET stub is still pruned");
+        }
+        // ...but full verification still returns only the truly matching one.
+        let imp = imposter(&[
+            json!([{"equals": {"method": "TRACE"}}]),
+            json!([{"equals": {"method": "CONNECT"}}]),
+        ]);
+        let no_headers: HashMap<String, String> = HashMap::new();
+        assert_eq!(
+            idx(imp.find_matching_stub_with_client(
+                "CONNECT",
+                "/x",
+                &no_headers,
+                None,
+                None,
+                None,
+                None
+            )),
+            Some(1)
+        );
+    }
+
+    // AC1: one load yields the stubs and an index built over those exact stubs. The two cannot
+    // diverge — there is no second ArcSwap to tear against — and that must survive mutation.
+    #[test]
+    fn snapshot_stubs_and_index_are_one_unit() {
+        let imp = imposter(&[json!([{"equals": {"path": "/a"}}])]);
+        for n in 1..6usize {
+            let snap = imp.snapshot();
+            assert_eq!(
+                snap.stubs().len(),
+                snap.index().len(),
+                "index spans exactly the stubs it was loaded with"
+            );
+            // Every candidate id must be a valid index into the same load's stub vector.
+            let c = snap.candidates("GET", "/a");
+            assert!(c.iter().all(|i| i < snap.stubs().len()));
+            drop(snap);
+
+            let stub = serde_json::from_value(json!({
+                "predicates": [{"equals": {"path": format!("/p{n}")}}],
+                "responses": [{ "is": { "statusCode": 200 } }]
+            }))
+            .expect("valid stub");
+            imp.add_stub(stub, None);
+        }
+        let snap = imp.snapshot();
+        assert_eq!(snap.stubs().len(), 6);
+        assert_eq!(snap.index().len(), 6);
     }
 
     // AC3: rebuilding on stub reload keeps the index consistent with the new stubs.
@@ -420,6 +844,103 @@ mod tests {
         );
     }
 
+    /// A randomized stub corpus spanning every dimension the index prunes on (method, path) and
+    /// every shape it must *not* prune on (regex, body, exists, or/not/and, caseSensitive, except,
+    /// empty). Seeded, so a differential failure is reproducible from the seed alone.
+    fn random_corpus(rng: &mut StdRng, n: usize) -> Vec<Value> {
+        const METHODS: &[&str] = &["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "TRACE"];
+        const SEGS: &[&str] = &["/a", "/b", "/api/v1", "/api/v2", "/x/y", "/mid"];
+        (0..n)
+            .map(|_| {
+                let seg = SEGS[rng.gen_range(0..SEGS.len())];
+                let m = METHODS[rng.gen_range(0..METHODS.len())];
+                match rng.gen_range(0..12) {
+                    // Indexable on both dimensions (one predicate, two fields).
+                    0 => json!([{"equals": {"method": m, "path": seg}}]),
+                    // Indexable on both dimensions (two separate top-level predicates).
+                    1 => json!([{"equals": {"method": m}}, {"equals": {"path": seg}}]),
+                    // Method-only: prunable by method, always-candidate on path.
+                    2 => json!([{"equals": {"method": m}}]),
+                    // Path-only: prunable by path, always-candidate on method.
+                    3 => json!([{"equals": {"path": seg}}]),
+                    4 => json!([{"startsWith": {"path": seg}}]),
+                    5 => json!([{"contains": {"path": seg}}]),
+                    // Not indexable on either dimension — must be always-candidate.
+                    6 => json!([{"matches": {"path": format!("^{seg}[0-9]*$")}}]),
+                    7 => json!([{"or": [{"equals": {"method": m}}, {"equals": {"path": seg}}]}]),
+                    8 => json!([{"not": {"equals": {"path": seg}}}]),
+                    9 => json!([{"equals": {"method": m}, "caseSensitive": true}]),
+                    10 => json!([{"equals": {"method": m}, "except": "X"}]),
+                    _ => json!([]),
+                }
+            })
+            .collect()
+    }
+
+    // AC2 (the load-bearing correctness gate): over a randomized corpus, the indexed path must
+    // return exactly the stub the linear oracle returns — same index, same first-match-wins order —
+    // for every request. This is a *characterization* gate: it holds for the pre-#707 index too, and
+    // must keep holding through the snapshot/bitset refactor and every dimension added on top of it
+    // (#708/#709/#710). Any dimension that under-approximates (prunes a stub that could match)
+    // fails here.
+    #[test]
+    fn differential_index_matches_linear_oracle() {
+        const METHODS: &[&str] = &[
+            "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "TRACE", "get",
+        ];
+        const PATHS: &[&str] = &[
+            "/a",
+            "/b",
+            "/A",
+            "/api/v1",
+            "/api/v2",
+            "/api/v1/deep",
+            "/x/y",
+            "/x-mid-y",
+            "/mid",
+            "/zzz",
+            "/a0",
+            "/GETX",
+        ];
+        let mut rng = StdRng::seed_from_u64(0x0707_5EED);
+        let no_headers: HashMap<String, String> = HashMap::new();
+
+        // Several independent corpora, so the assertion isn't hostage to one lucky stub layout.
+        for corpus_n in 0..8 {
+            let imp = imposter(&random_corpus(&mut rng, 40));
+            for _ in 0..1250 {
+                let m = METHODS[rng.gen_range(0..METHODS.len())];
+                let p = PATHS[rng.gen_range(0..PATHS.len())];
+                let body = if rng.gen_bool(0.25) {
+                    Some("ping")
+                } else {
+                    None
+                };
+                let query = if rng.gen_bool(0.25) {
+                    Some("a=1")
+                } else {
+                    None
+                };
+
+                let linear =
+                    idx(imp.find_matching_stub_linear(m, p, &no_headers, query, body, None, None));
+                let indexed = idx(imp.find_matching_stub_with_client(
+                    m,
+                    p,
+                    &no_headers,
+                    query,
+                    body,
+                    None,
+                    None,
+                ));
+                assert_eq!(
+                    indexed, linear,
+                    "index diverged from linear oracle: corpus {corpus_n}, {m} {p} q={query:?} b={body:?}"
+                );
+            }
+        }
+    }
+
     // Issue #475: the has_scenario_gate flag — computed once at index build — detects a
     // `requiredScenarioState` stub so the bounded matcher offloads the gate's flow-store read to
     // spawn_blocking on a blocking backend, while a scenario-free set keeps the inline fast path.
@@ -436,7 +957,7 @@ mod tests {
                     ))
                 })
                 .collect();
-            StubIndex::build(Arc::new(states))
+            StubSnapshot::build(states)
         };
         let ungated = build(json!([
             { "predicates": [{"equals": {"path": "/a"}}], "responses": [{"is": {"statusCode": 200}}] }
@@ -459,24 +980,24 @@ mod tests {
     // stays false for scriptless stub sets so they keep the inline matching fast path.
     #[test]
     fn has_inject_detects_top_level_and_nested() {
-        let scriptless = StubIndex::build(stub_states(&[
+        let scriptless = StubSnapshot::build(stub_states(&[
             json!([{"equals": {"path": "/a"}}]),
             json!([{"and": [{"equals": {"path": "/b"}}, {"exists": {"query": {"q": true}}}]}]),
         ]));
         assert!(!scriptless.has_inject());
 
-        let top_level = StubIndex::build(stub_states(&[
+        let top_level = StubSnapshot::build(stub_states(&[
             json!([{"equals": {"path": "/a"}}]),
             json!([{"inject": "function (config) { return true; }"}]),
         ]));
         assert!(top_level.has_inject());
 
-        let under_and = StubIndex::build(stub_states(&[json!([
+        let under_and = StubSnapshot::build(stub_states(&[json!([
             {"and": [{"equals": {"path": "/a"}}, {"inject": "function (config) { return true; }"}]}
         ])]));
         assert!(under_and.has_inject());
 
-        let under_not_in_or = StubIndex::build(stub_states(&[json!([
+        let under_not_in_or = StubSnapshot::build(stub_states(&[json!([
             {"or": [{"equals": {"path": "/a"}}, {"not": {"inject": "function (config) { return true; }"}}]}
         ])]));
         assert!(under_not_in_or.has_inject());

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -1626,7 +1626,7 @@ mod tests {
 
         let untouched = manager.get_imposter(19410).unwrap();
         untouched.record_request(recorded("/cycled"));
-        assert_eq!(next_body(&untouched.stubs.load()[0]), "a1");
+        assert_eq!(next_body(&untouched.snapshot().stubs()[0]), "a1");
 
         let p2_changed = imposter_cfg(json!({
             "protocol": "http", "port": 19411,
@@ -1648,7 +1648,7 @@ mod tests {
         );
         assert_eq!(after.get_recorded_requests().len(), 1);
         assert_eq!(
-            next_body(&after.stubs.load()[0]),
+            next_body(&after.snapshot().stubs()[0]),
             "a2",
             "cycler position survives a sibling patch"
         );
@@ -2007,11 +2007,12 @@ mod tests {
             .await
             .expect("create");
         let imposter = manager.get_imposter(19440).unwrap();
-        assert_eq!(next_body(&imposter.stubs.load()[0]), "a1");
+        assert_eq!(next_body(&imposter.snapshot().stubs()[0]), "a1");
 
         manager.move_stub(19440, 0, 2).await.expect("move");
         {
-            let stubs = imposter.stubs.load();
+            let snap = imposter.snapshot();
+            let stubs = snap.stubs();
             let first = serde_json::to_value(&stubs[0].stub).unwrap();
             assert_eq!(first["responses"][0]["is"]["body"], "b");
             assert_eq!(
@@ -2638,7 +2639,7 @@ mod tests {
             manager.add_stub(19524, spaced, None).await.expect("add");
 
             let imposter = manager.get_imposter(19524).unwrap();
-            let stub_state = imposter.stubs.load()[0].clone();
+            let stub_state = imposter.snapshot().stubs()[0].clone();
             let _ = imposter
                 .execute_stub_with_rift(&stub_state)
                 .expect("sequencer ok");


### PR DESCRIPTION
Lands the Turbo matching tier's foundation: one atomically-swapped stub snapshot, a candidate-bitset (Lucent Bit Vector) dimension framework, and the method dimension as its first proof.

## What changed

- **Unified snapshot.** `Imposter`'s two `ArcSwap`s (`stubs`, `stub_index`) become one `ArcSwap<StubSnapshot>` holding the stubs, the index built over *those exact* stubs, and the `has_inject` / `has_scenario_gate` gates. The match hot path takes a single wait-free load, and a torn (stubs N, index N+1) read is now unrepresentable rather than prevented by convention.
- **Dimension framework** (`core/bitset.rs`, `core/stub_index.rs`). Each dimension answers "which stubs can this request attribute not rule out?" as a dense `CandidateBits` bitset; `candidates()` intersects them and walks the surviving bits ascending — which *is* first-match-wins order. Dimensions are concrete fields (static dispatch, no per-request allocation beyond the accumulator). Hand-rolled bitset, no new dependency.
- **Method dimension.** A POST-anchored stub is no longer a candidate for every GET.
- **Path dimension** ported onto the framework, faithfully — see the deviation note below.

## Soundness

The one invariant: **a dimension may only exclude a stub it can prove cannot match**; everything else lands in `always_bits`. The index stays a strict over-approximation and `stub_matches` remains the single source of truth for semantics. Guarded by `differential_index_matches_linear_oracle` — a seeded, randomized corpus (8 corpora x 1250 requests) asserting the indexed path returns exactly what the linear oracle does. The gate was written first, run green against the pre-refactor code, and **mutation-tested** (deleting the fallback bucket makes it fail immediately), so it demonstrably has teeth.

## Also fixes a latent soundness bug (present on master)

The prefilter folded case with Unicode `to_lowercase` while predicate evaluation folds ASCII (`eq_ignore_ascii_case`). Unicode folding is length-changing and context-sensitive, so for `startsWith`/`contains` the two disagreed: a stub with `startsWith: {"path": "/ΟΣ"}` was **pruned** for a request to `/ΟΣΑ` that evaluation *would* have matched — a silent no-match. The index now folds exactly as the evaluator does. Mutation-verified (reverting the fold fails `non_ascii_case_folding_matches_the_evaluator` with `index diverged from linear for GET /ΟΣΑ`). Only path anchors containing non-ASCII text were affected.

## Deviation from the issue text

The issue proposed folding the prefix/contains buckets into `always_bits` "for now", leaving #710 to tighten them. That would have been a **pruning regression** — today's `candidates()` already excludes prefix/contains anchors that can't match, and `stub_index_narrows_and_covers` asserts it. The path prefilter is instead ported faithfully (exact + prefix-walk + contains-walk → `matched_bits`, un-anchored → `always_bits`): zero behaviour change, no regression, and #710 still swaps the linear walks for Aho-Corasick behind the same `Dimension` seam.

## Benchmarks

M1 Pro, criterion, same machine, measured against `origin/master` running the identical bench file:

| corpus | master | this PR | |
|---|---|---|---|
| `indexed_exact/1000` | 146.1 ns | 149.9 ns | parity |
| `prefix_anchored/1000` | 1683 ns | 1699 ns | parity |
| `unindexed_fallback/1000` | 203.5 µs | 209.3 µs | parity (#709/#710's target) |
| `method_disjoint/100` | 3316 ns | 1303 ns | **2.54x** |
| `method_disjoint/1000` | 32.96 µs | 12.92 µs | **2.55x** |

An earlier cut regressed `indexed_exact` ~10%, because a corpus that never constrains the method still paid the method dimension a full-width copy+intersect to produce all-ones. `Dimension::prunes()` now skips inert dimensions and the first active one seeds the accumulator directly, which removed it.

## Verification

`cargo fmt` clean · `cargo clippy --all-targets -- -D warnings` **0 warnings** · `cargo test --workspace` **58/58 suites green** (1202 in `rift-mock-core`, incl. the Mountebank compatibility suite).

## Notes for reviewers

- `Imposter::stubs` is no longer a `pub` field (merged into the snapshot). Nothing outside `imposter/core` used it and the SDKs go through the C-ABI/admin API, but it is a public-API change for an embedding Rust consumer — CHANGELOG'd.
- Unblocks #708 / #709 / #710 / #714: the `Dimension` trait, the soundness rule, and "how to add a dimension" are documented in `stub_index.rs`'s module docs.

Closes #707
Milestone: Turbo (tracking #720)