### PR TITLE
perf(selectors): compile XPath/JSONPath once, parse the XML DOM once per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,18 @@ record.
 
 ### Changed
 
+- **XPath/JSONPath selectors are compiled once and the XML DOM is parsed once per request, not
+  per predicate per stub.** Rift's slowest scenario was XPath, because every XPath predicate
+  evaluation re-parsed the whole request body into a DOM and recompiled the XPath expression — so N
+  XPath stubs sharing a path cost N DOM parses + N compilations per request; JSONPath likewise
+  re-parsed both the body and the selector each time. Now the request body's XML DOM is parsed at
+  most once per request and shared across every stub/predicate that evaluates it; compiled XPath
+  expressions are cached per thread (the `sxd` XPath type is not shareable across threads) and
+  compiled JSONPath selectors in a process-wide bounded cache; and JSONPath predicate matching
+  reuses the request body already parsed once for `deepEquals` (#290). Matching semantics are
+  unchanged — the same engines against cached artifacts. The parse-/compile-once guarantees are
+  asserted directly by test counters.
+
 - **Path `startsWith`/`contains`/`endsWith` stubs are matched in a single Aho-Corasick pass, and
   `endsWith` is now indexed at all.** The Stage-1 prefilter previously walked a linear bucket per
   distinct prefix/substring literal, so the prefilter's own cost grew with the number of literal

--- a/crates/rift-mock-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-mock-core/benches/imposter_matcher_bench.rs
@@ -272,10 +272,73 @@ fn bench_method_dimension(c: &mut Criterion) {
     group.finish();
 }
 
+/// Issue #711: the XPath scenario, Rift's slowest. Each of `count` stubs carries an XPath predicate
+/// selecting a distinct node of one shared XML body; the request targets the last, so every stub's
+/// XPath predicate is evaluated. Before #711 that meant `count` XML DOM parses **and** `count` XPath
+/// compilations per request; after, one DOM parse and (warm) zero compilations. This is the
+/// before/after headline for the slowest path.
+///
+/// XPath predicates are never candidate-indexable (they sit in `always_bits`), so the bitset
+/// framework can't prune here — the win is purely the parse/compile-once change this benches.
+fn bench_xpath_heavy(c: &mut Criterion) {
+    let headers: HashMap<String, String> = HashMap::new();
+    let mut group = c.benchmark_group("find_matching_stub_xpath_heavy");
+    for count in [10usize, 100, 1000] {
+        // Each stub extracts its own node and equals-checks it against "MATCH"; only the last node
+        // holds "MATCH", so all `count` XPath predicates evaluate but only the last matches.
+        let imposter = imposter_with_stubs(count, &|i| {
+            json!({ "equals": { "body": "MATCH" },
+                    "xpath": { "selector": format!("//item[@id='{i}']") } })
+        });
+        let body = format!(
+            "<root>{}</root>",
+            (0..count)
+                .map(|i| format!(
+                    "<item id='{i}'>{}</item>",
+                    if i == count - 1 { "MATCH" } else { "x" }
+                ))
+                .collect::<String>()
+        );
+        assert!(
+            imposter
+                .find_matching_stub_with_client(
+                    "POST",
+                    "/x",
+                    &headers,
+                    None,
+                    Some(&body),
+                    None,
+                    None
+                )
+                .expect("matching must not error")
+                .is_some(),
+            "xpath_heavy/{count}: fixture no longer matches its target stub",
+        );
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                imposter
+                    .find_matching_stub_with_client(
+                        "POST",
+                        black_box("/x"),
+                        black_box(&headers),
+                        None,
+                        black_box(Some(body.as_str())),
+                        None,
+                        None,
+                    )
+                    .expect("matching must not error")
+            })
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_stub_matches,
     bench_find_matching_stub,
-    bench_method_dimension
+    bench_method_dimension,
+    bench_xpath_heavy
 );
 criterion_main!(benches);

--- a/crates/rift-mock-core/src/behaviors/extraction.rs
+++ b/crates/rift-mock-core/src/behaviors/extraction.rs
@@ -3,6 +3,61 @@
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::cell::{OnceCell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{Arc, LazyLock};
+
+/// Test-only counters proving the parse/compile-once guarantees of issue #711.
+///
+/// These are the verifier for two acceptance criteria that are, literally, "N parses become one"
+/// and "zero per-request selector compilation": there is no behavioural proxy for "the DOM was
+/// parsed exactly once", so the count is asserted directly. `#[cfg(test)]` so release builds carry
+/// neither the counters nor the increments.
+///
+/// **Thread-local, not global atomics.** `cargo test` runs the suite in parallel, and many other
+/// tests evaluate jsonpath/xpath predicates concurrently — a process-global counter would be bumped
+/// by all of them, so a `reset(); drive one request; read count` assertion would race. The counted
+/// work (DOM parse, selector compile) all runs synchronously on the thread driving the request, so a
+/// thread-local counter captures exactly that request's activity and nothing else.
+#[cfg(test)]
+pub(crate) mod counters {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// Bumped once each time an XML body is parsed into a DOM `Package`.
+        static DOM_PARSE: Cell<usize> = const { Cell::new(0) };
+        /// Bumped on an XPath compile (a thread-local cache miss).
+        static XPATH_COMPILE: Cell<usize> = const { Cell::new(0) };
+        /// Bumped on a JSONPath selector compile (a global cache miss).
+        static JSONPATH_COMPILE: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn bump_dom_parse() {
+        DOM_PARSE.with(|c| c.set(c.get() + 1));
+    }
+    pub(crate) fn bump_xpath_compile() {
+        XPATH_COMPILE.with(|c| c.set(c.get() + 1));
+    }
+    pub(crate) fn bump_jsonpath_compile() {
+        JSONPATH_COMPILE.with(|c| c.set(c.get() + 1));
+    }
+
+    pub(crate) fn reset() {
+        DOM_PARSE.with(|c| c.set(0));
+        XPATH_COMPILE.with(|c| c.set(0));
+        JSONPATH_COMPILE.with(|c| c.set(0));
+    }
+    pub(crate) fn dom_parses() -> usize {
+        DOM_PARSE.with(Cell::get)
+    }
+    pub(crate) fn xpath_compiles() -> usize {
+        XPATH_COMPILE.with(Cell::get)
+    }
+    pub(crate) fn jsonpath_compiles() -> usize {
+        JSONPATH_COMPILE.with(Cell::get)
+    }
+}
 
 /// Regex matching options (Mountebank-compatible)
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -86,17 +141,75 @@ fn normalize_jsonpath(path: &str) -> Cow<'_, str> {
     }
 }
 
+/// Process-wide cache of compiled JSONPath selectors (issue #711).
+///
+/// Every predicate/copy-behavior evaluation that uses a `jsonpath` selector recompiled it from its
+/// source string per call — for a stub set with N jsonpath-selectored stubs, one request paid N
+/// compiles even when every stub shares the same selector string across requests. `JsonPath` (unlike
+/// `sxd_xpath::XPath`, see the thread-local cache below) is `Send + Sync`, so a process-global cache
+/// mirroring [`regex_cache`](super::super::imposter::predicates::regex_cache) is sufficient — no
+/// thread-local needed.
+///
+/// Bounded for the same reason as the regex cache: it's a process-global static, so imposter churn
+/// with ever-distinct selectors must not grow it forever.
+const MAX_CACHED_JSONPATHS: usize = 1024;
+
+static JSONPATH_CACHE: LazyLock<
+    parking_lot::RwLock<HashMap<String, Arc<serde_json_path::JsonPath>>>,
+> = LazyLock::new(|| parking_lot::RwLock::new(HashMap::new()));
+
+/// Return the compiled selector for `selector`, compiling and caching it on first use. The cache key
+/// is the *normalized* (rooted) selector string, so a bare and a `$`-rooted form of the same
+/// selector share one cache entry. Returns `None` when `selector` fails to parse (callers treat this
+/// as "no extraction"), preserving today's behavior on a bad selector.
+fn cached_jsonpath(selector: &str) -> Option<Arc<serde_json_path::JsonPath>> {
+    let rooted = normalize_jsonpath(selector);
+
+    // Fast path: shared read lock, no allocation or compile on a hit.
+    {
+        let cache = JSONPATH_CACHE.read();
+        if let Some(jp) = cache.get(rooted.as_ref()) {
+            return Some(Arc::clone(jp));
+        }
+    }
+
+    // Slow path (cache miss): compile once (outside the lock), then insert under the write lock.
+    #[cfg(test)]
+    counters::bump_jsonpath_compile();
+    let compiled = Arc::new(serde_json_path::JsonPath::parse(&rooted).ok()?);
+    let mut cache = JSONPATH_CACHE.write();
+    // Another thread may have inserted this selector while we compiled — reuse its entry.
+    if let Some(jp) = cache.get(rooted.as_ref()) {
+        return Some(Arc::clone(jp));
+    }
+    if cache.len() >= MAX_CACHED_JSONPATHS {
+        cache.clear();
+    }
+    cache.insert(rooted.into_owned(), Arc::clone(&compiled));
+    Some(compiled)
+}
+
 /// Extract value using JSONPath (RFC 9535 compliant via serde_json_path)
 /// Used by copy behaviors and predicate jsonpath parameter.
 /// Supports the full JSONPath spec: wildcards, descendant segments, filters,
 /// negative indices, selector sequences, bracket notation, etc.
 /// Bare selectors (no leading `$`) are treated as root-relative for
 /// Mountebank compatibility.
+///
+/// String-only entry point for callers that only have the raw body (copy/lookup behaviors); it
+/// parses the body once and delegates to [`extract_jsonpath_value`], which is also what the matching
+/// hot path calls directly with an already-parsed `Value` to avoid a second parse (issue #711).
 pub fn extract_jsonpath(json_str: &str, path: &str) -> Option<String> {
     let json: serde_json::Value = serde_json::from_str(json_str).ok()?;
-    let rooted = normalize_jsonpath(path);
-    let json_path = serde_json_path::JsonPath::parse(&rooted).ok()?;
-    let node_list = json_path.query(&json);
+    extract_jsonpath_value(&json, path)
+}
+
+/// Extract value using JSONPath against an already-parsed JSON value. Reuses the caller's parse
+/// (the matching hot path parses the request body once per request, issue #290) and the process-wide
+/// compiled-selector cache (issue #711) instead of recompiling `path` on every call.
+pub fn extract_jsonpath_value(json: &serde_json::Value, path: &str) -> Option<String> {
+    let json_path = cached_jsonpath(path)?;
+    let node_list = json_path.query(json);
 
     // Return the first matched node as a string
     let first = node_list.first()?;
@@ -116,19 +229,99 @@ pub fn extract_xpath(xml_str: &str, path: &str) -> Option<String> {
 }
 
 /// Extract value using XPath with optional namespace prefix→URI map.
+///
+/// String-only entry point for callers that only have the raw body (copy behaviors, and any
+/// predicate caller that hasn't pre-parsed a DOM). It parses the body itself — bumping `DOM_PARSE` —
+/// then delegates to [`eval_xpath_on`], which is also what the matching hot path calls directly
+/// against a DOM shared across a whole request (issue #711).
 pub fn extract_xpath_with_ns(
     xml_str: &str,
     path: &str,
-    ns: Option<&std::collections::HashMap<String, String>>,
+    ns: Option<&HashMap<String, String>>,
 ) -> Option<String> {
     use sxd_document::parser;
-    use sxd_xpath::{Context, Factory, Value};
 
+    #[cfg(test)]
+    counters::bump_dom_parse();
     let package = parser::parse(xml_str).ok()?;
     let document = package.as_document();
+    eval_xpath_on(&document, path, ns)
+}
 
-    let factory = Factory::new();
-    let xpath = factory.build(path).ok()??;
+// Thread-local cache of compiled XPath selectors, keyed by `(selector, namespace-map key)`.
+//
+// `sxd_xpath::XPath` is `!Send`/`!Sync` (its internal AST holds `Rc`s), so it cannot live in a
+// process-global cache the way the JSONPath cache above does — every thread must compile and keep
+// its own copy. That's still a large win: the request-handling threads in the pool are long-lived,
+// so a per-thread cache amortizes the compile across every request that thread ever handles, not
+// just within one request. `Rc` (not `Arc`) mirrors the type's own `!Send` bound.
+thread_local! {
+    static XPATH_CACHE: RefCell<HashMap<(String, String), Rc<sxd_xpath::XPath>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Per-thread ceiling on distinct cached XPath selectors, mirroring [`MAX_CACHED_JSONPATHS`]/the
+/// regex cache's bound — imposter churn with ever-distinct selectors must not grow this forever.
+const MAX_CACHED_XPATHS: usize = 1024;
+
+/// Deterministic key for a namespace prefix→URI map: sorted `(prefix, uri)` pairs joined, so two
+/// equal maps (in any iteration order) always produce the same string, and an absent/empty map
+/// always produces the same fixed empty key. Part of the cache key alongside the selector string —
+/// the same selector text resolves differently under different namespace bindings.
+fn ns_key(ns: Option<&HashMap<String, String>>) -> String {
+    let Some(ns) = ns else {
+        return String::new();
+    };
+    let mut pairs: Vec<(&str, &str)> = ns.iter().map(|(p, u)| (p.as_str(), u.as_str())).collect();
+    pairs.sort_unstable();
+    pairs
+        .into_iter()
+        .map(|(p, u)| format!("{p}={u}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Return the compiled XPath for `(selector, ns)`, compiling and caching it in this thread's cache
+/// on first use. Returns `None` when `selector` fails to compile (callers treat this as "no
+/// extraction"), preserving today's behavior on a bad selector.
+///
+/// `ns` is part of the key defensively, not because compilation depends on it: `sxd_xpath` compiles
+/// a namespace-independent `XPath` and the real prefix→URI bindings are applied at *evaluation* time
+/// in [`eval_xpath_on`]. So the key's `ns_key` component can at worst duplicate an entry (or, on the
+/// theoretical `ns_key` collision where a URI contains the `,`/`=` delimiters, share one) — either
+/// way the compiled selector returned is correct, because it carries no namespace state.
+fn cached_xpath(
+    selector: &str,
+    ns: Option<&HashMap<String, String>>,
+) -> Option<Rc<sxd_xpath::XPath>> {
+    let key = (selector.to_string(), ns_key(ns));
+    XPATH_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(xpath) = cache.get(&key) {
+            return Some(Rc::clone(xpath));
+        }
+        #[cfg(test)]
+        counters::bump_xpath_compile();
+        let xpath = Rc::new(sxd_xpath::Factory::new().build(selector).ok()??);
+        if cache.len() >= MAX_CACHED_XPATHS {
+            cache.clear();
+        }
+        cache.insert(key, Rc::clone(&xpath));
+        Some(xpath)
+    })
+}
+
+/// Evaluate an XPath selector against an already-parsed DOM `Document`, using the thread-local
+/// compiled-selector cache. The matching hot path calls this directly with a `Document` shared
+/// across every predicate/stub in one request (issue #711) instead of parsing per predicate.
+pub(crate) fn eval_xpath_on(
+    document: &sxd_document::dom::Document,
+    selector: &str,
+    ns: Option<&HashMap<String, String>>,
+) -> Option<String> {
+    use sxd_xpath::{Context, Value};
+
+    let xpath = cached_xpath(selector, ns)?;
 
     let mut context = Context::new();
     if let Some(namespaces) = ns {
@@ -144,6 +337,41 @@ pub fn extract_xpath_with_ns(
         Ok(Value::Boolean(b)) => Some(b.to_string()),
         Ok(Value::Nodeset(nodes)) => nodes.iter().next().map(|n| n.string_value()),
         _ => None,
+    }
+}
+
+/// Parse-once-per-request primitive for the XML DOM (issue #711).
+///
+/// `sxd_document::Package` is `!Send`, and every borrow off it (`Document<'d>`) is lifetime-bound to
+/// it — it cannot be stored in `Arc<StubState>` or held across an `.await` point, so this type is
+/// deliberately scoped to live only for the synchronous duration of one matching pass: constructed
+/// before the stub loop, dropped when matching returns. Within that scope it memoizes the parse (and
+/// the parse failure) so N XPath predicates across N stubs in one request share a single
+/// `sxd_document::parser::parse` call instead of one each.
+pub(crate) struct LazyXmlDom<'a> {
+    body: &'a str,
+    parsed: OnceCell<Option<sxd_document::Package>>,
+}
+
+impl<'a> LazyXmlDom<'a> {
+    pub(crate) fn new(body: &'a str) -> Self {
+        Self {
+            body,
+            parsed: OnceCell::new(),
+        }
+    }
+
+    /// The parsed DOM, parsing (and bumping `DOM_PARSE`) on the first call only. `None` if the body
+    /// isn't well-formed XML — cached too, so a malformed body doesn't retry the parse per predicate.
+    pub(crate) fn document(&self) -> Option<sxd_document::dom::Document<'_>> {
+        self.parsed
+            .get_or_init(|| {
+                #[cfg(test)]
+                counters::bump_dom_parse();
+                sxd_document::parser::parse(self.body).ok()
+            })
+            .as_ref()
+            .map(sxd_document::Package::as_document)
     }
 }
 

--- a/crates/rift-mock-core/src/behaviors/mod.rs
+++ b/crates/rift-mock-core/src/behaviors/mod.rs
@@ -30,8 +30,14 @@ pub use copy::{CopyBehavior, CopySource, apply_copy_behaviors};
 pub use cycler::{HasRepeatBehavior, ResponseCycler, RuleCycler};
 
 pub mod sequencer;
+#[cfg(test)]
+pub(crate) use extraction::counters;
 #[allow(unused_imports)]
-pub use extraction::{ExtractionMethod, extract_jsonpath, extract_xpath, extract_xpath_with_ns};
+pub use extraction::{
+    ExtractionMethod, extract_jsonpath, extract_jsonpath_value, extract_xpath,
+    extract_xpath_with_ns,
+};
+pub(crate) use extraction::{LazyXmlDom, eval_xpath_on};
 #[allow(unused_imports)]
 pub use lookup::{
     CsvCache, CsvData, CsvDataSource, DataSource, LookupBehavior, LookupKey, apply_lookup_behaviors,

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -61,6 +61,10 @@ impl Imposter {
         let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
         // Likewise parse the query string once per request rather than per predicate (issue #480).
         let query_map = crate::imposter::predicates::parse_query(query);
+        // Likewise the XML DOM (issue #711): lazily parsed on first XPath predicate touched, then
+        // shared across every remaining stub in this request's scan — one parse per request, not
+        // one per XPath predicate evaluation.
+        let xml_dom = body.map(crate::behaviors::LazyXmlDom::new);
         for stub_idx in snapshot.candidates(method, path).iter() {
             let stub_state = &stubs[stub_idx];
             let stub = &stub_state.stub;
@@ -93,6 +97,7 @@ impl Imposter {
                 form.as_ref(),
                 imposter_port,
                 body_json.as_ref(),
+                xml_dom.as_ref(),
                 Some(&query_map),
             )? {
                 // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
@@ -225,6 +230,7 @@ impl Imposter {
         let flow_id = self.resolve_flow_id(headers_map);
         let body_json = body.and_then(|b| serde_json::from_str::<serde_json::Value>(b).ok());
         let query_map = crate::imposter::predicates::parse_query(query);
+        let xml_dom = body.map(crate::behaviors::LazyXmlDom::new);
         for (index, stub_state) in stubs.iter().enumerate() {
             let stub = &stub_state.stub;
             if let Some(space) = &stub.space
@@ -250,6 +256,7 @@ impl Imposter {
                 form.as_ref(),
                 imposter_port,
                 body_json.as_ref(),
+                xml_dom.as_ref(),
                 Some(&query_map),
             )? {
                 return Ok(Some((Arc::clone(stub_state), index)));
@@ -915,5 +922,217 @@ mod bounded_matching_tests {
             .await
             .expect("matcher must not error");
         assert!(matched.is_some());
+    }
+
+    // ---- issue #711: parse the XML DOM once per request, compile selectors once ----------
+
+    use crate::behaviors::counters;
+
+    // Each stub extracts a DIFFERENT node via its own XPath selector, then `equals`-checks the
+    // extracted (effective) body against the fixed string "MATCH". In the body below only item 19
+    // holds "MATCH"; items 0..18 hold "x". So every stub's XPath predicate is *evaluated* (each
+    // extracts and compares — that's the DOM touch), but only stub 19 matches. Crucially this means
+    // first-match-wins does NOT short-circuit before stub 19, so all 20 XPath evaluations run —
+    // which is what makes the DOM-parse count meaningful: 20 parses before #711, one after.
+    fn xpath_stub(i: usize) -> serde_json::Value {
+        json!({
+            "predicates": [{ "equals": { "body": "MATCH" },
+                             "xpath": { "selector": format!("//item[@id='{i}']") } }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        })
+    }
+
+    // AC1: the XML body is parsed into a DOM exactly ONCE per request, no matter how many XPath
+    // predicates/stubs evaluate it. Before #711 every XPath predicate evaluation re-parsed the body
+    // (N stubs sharing a path = N DOM parses); the whole point is one parse shared across the match.
+    #[test]
+    fn one_dom_parse_per_request_many_xpath_stubs() {
+        let stubs: Vec<serde_json::Value> = (0..20).map(xpath_stub).collect();
+        let imp = imposter(json!(stubs));
+        // Only item 19 holds "MATCH"; the rest hold "x", so stubs 0..18 evaluate their XPath (a DOM
+        // touch) but don't match, and evaluation continues to stub 19.
+        let body = format!(
+            "<root>{}</root>",
+            (0..20)
+                .map(|i| format!(
+                    "<item id='{i}'>{}</item>",
+                    if i == 19 { "MATCH" } else { "x" }
+                ))
+                .collect::<String>()
+        );
+        let headers = no_headers();
+
+        counters::reset();
+        let hit = imp
+            .find_matching_stub_with_client("POST", "/x", &headers, None, Some(&body), None, None)
+            .expect("no backend error");
+        assert_eq!(
+            hit.map(|(_, i)| i),
+            Some(19),
+            "only the last XPath stub matches; the earlier 19 evaluate their XPath but don't match"
+        );
+        assert_eq!(
+            counters::dom_parses(),
+            1,
+            "the DOM must be parsed exactly once for the whole request, not once per XPath predicate"
+        );
+    }
+
+    // AC1 boundary: a request that touches no XPath predicate must not parse a DOM at all — the
+    // parse is lazy, paid only when an XPath predicate is actually evaluated.
+    #[test]
+    fn no_dom_parse_when_no_xpath_touched() {
+        let imp = imposter(json!([
+            { "predicates": [{ "equals": { "path": "/a" } }],
+              "responses": [{ "is": { "statusCode": 200 } }] }
+        ]));
+        let headers = no_headers();
+        counters::reset();
+        let _ = imp
+            .find_matching_stub_with_client("GET", "/a", &headers, None, Some("<r/>"), None, None)
+            .expect("no backend error");
+        assert_eq!(
+            counters::dom_parses(),
+            0,
+            "no XPath predicate touched → the DOM must never be parsed"
+        );
+    }
+
+    // AC2: an XPath selector is compiled once and reused across requests — the per-request compile
+    // (Factory::build) is gone. Drive the same XPath stub through several requests; after the first
+    // warms the cache, no further compiles occur.
+    #[test]
+    fn xpath_compiled_once_across_requests() {
+        let imp = imposter(json!([xpath_stub(7)]));
+        let body = "<root><item id='7'>v7</item></root>";
+        let headers = no_headers();
+
+        counters::reset();
+        for _ in 0..5 {
+            let _ = imp
+                .find_matching_stub_with_client(
+                    "POST",
+                    "/x",
+                    &headers,
+                    None,
+                    Some(body),
+                    None,
+                    None,
+                )
+                .expect("no backend error");
+        }
+        assert!(
+            counters::xpath_compiles() <= 1,
+            "the XPath selector must be compiled at most once across 5 identical requests, not per \
+             request (saw {})",
+            counters::xpath_compiles()
+        );
+    }
+
+    // AC2: same for JSONPath — the selector string is compiled once, not re-parsed per request.
+    #[test]
+    fn jsonpath_compiled_once_across_requests() {
+        let imp = imposter(json!([
+            { "predicates": [{ "equals": { "body": "42" },
+                               "jsonpath": { "selector": "$.a.b" } }],
+              "responses": [{ "is": { "statusCode": 200 } }] }
+        ]));
+        let body = r#"{"a":{"b":42}}"#;
+        let headers = no_headers();
+
+        counters::reset();
+        for _ in 0..5 {
+            let _ = imp
+                .find_matching_stub_with_client(
+                    "POST",
+                    "/x",
+                    &headers,
+                    None,
+                    Some(body),
+                    None,
+                    None,
+                )
+                .expect("no backend error");
+        }
+        assert!(
+            counters::jsonpath_compiles() <= 1,
+            "the JSONPath selector must be compiled at most once across 5 identical requests (saw {})",
+            counters::jsonpath_compiles()
+        );
+    }
+
+    // Semantics unchanged: the parse-once / compile-once XPath path returns exactly what a
+    // per-call parse would. A namespaced selector is included because the namespace map is part of
+    // the XPath cache key — a cache that ignored it would cross-contaminate.
+    #[test]
+    fn xpath_dom_once_matches_per_call_semantics() {
+        let imp = imposter(json!([
+            { "predicates": [{ "equals": { "body": "found" },
+                               "xpath": { "selector": "//x:v", "ns": { "x": "urn:e" } } }],
+              "responses": [{ "is": { "statusCode": 200 } }] },
+            { "predicates": [{ "equals": { "body": "other" },
+                               "xpath": { "selector": "//v" } }],
+              "responses": [{ "is": { "statusCode": 200 } }] },
+        ]));
+        let headers = no_headers();
+        let ns_body = r#"<r xmlns:x="urn:e"><x:v>found</x:v></r>"#;
+        let plain_body = "<r><v>other</v></r>";
+
+        assert_eq!(
+            imp.find_matching_stub_with_client(
+                "POST",
+                "/x",
+                &headers,
+                None,
+                Some(ns_body),
+                None,
+                None
+            )
+            .expect("no error")
+            .map(|(_, i)| i),
+            Some(0),
+            "namespaced XPath resolves against its ns map"
+        );
+        assert_eq!(
+            imp.find_matching_stub_with_client(
+                "POST",
+                "/x",
+                &headers,
+                None,
+                Some(plain_body),
+                None,
+                None
+            )
+            .expect("no error")
+            .map(|(_, i)| i),
+            Some(1),
+            "plain XPath still resolves — the ns-keyed cache did not cross-contaminate"
+        );
+    }
+
+    // Fix 3: JSONPath predicate matching reuses the once-parsed request body and still returns the
+    // correct extraction. (The distinct concern — that the *effective body* after extraction is not
+    // the raw parse — stays guarded by `deep_equals_with_jsonpath_selector_uses_extracted_body_not_raw_parse`
+    // in predicates::mod.)
+    #[test]
+    fn jsonpath_reuses_parsed_body() {
+        let imp = imposter(json!([
+            { "predicates": [{ "equals": { "body": "hello" },
+                               "jsonpath": { "selector": "$.msg" } }],
+              "responses": [{ "is": { "statusCode": 200 } }] }
+        ]));
+        let headers = no_headers();
+        let hit = imp
+            .find_matching_stub_with_client(
+                "POST",
+                "/x",
+                &headers,
+                None,
+                Some(r#"{"msg":"hello"}"#),
+                None,
+                None,
+            )
+            .expect("no error");
+        assert_eq!(hit.map(|(_, i)| i), Some(0));
     }
 }

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -124,6 +124,11 @@ impl Imposter {
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // One recorded request evaluated against (possibly several, e.g. via `closest_non_match`)
+        // predicates — same parse-once-per-evaluation shape as `body_json` above, applied to the
+        // XML DOM (issue #711): an XPath predicate re-evaluated for this same request reuses one
+        // parse rather than re-parsing per predicate.
+        let xml_dom = req.body.as_deref().map(crate::behaviors::LazyXmlDom::new);
         stub_matches_inner(
             predicates,
             &req.method,
@@ -136,6 +141,7 @@ impl Imposter {
             form.as_ref(),
             self.script_state_key(),
             body_json.as_ref(),
+            xml_dom.as_ref(),
             Some(&query_map),
         )
     }

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -3,7 +3,9 @@
 //! Supports: equals, deepEquals, contains, startsWith, endsWith, matches, exists, not, or, and
 //! Also supports requestFrom, ip, and form fields.
 
-use crate::behaviors::{extract_jsonpath, extract_xpath_with_ns};
+use crate::behaviors::{
+    LazyXmlDom, eval_xpath_on, extract_jsonpath, extract_jsonpath_value, extract_xpath_with_ns,
+};
 use crate::imposter::types::{Predicate, PredicateOperation, PredicateSelector};
 use crate::util::FastMap;
 use std::collections::HashMap;
@@ -41,6 +43,9 @@ where
     let query_map = parse_query(query);
     let form_fast: Option<FastMap<String, String>> =
         form.map(|f| f.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+    // Standalone callers of this wrapper aren't a per-request hot loop, so there's no shared DOM
+    // to thread in — `None` here just means an XPath predicate falls back to its own per-call parse
+    // (correct, just not cached; see `stub_matches_inner`).
     stub_matches_inner(
         predicates,
         method,
@@ -53,6 +58,7 @@ where
         form_fast.as_ref(),
         imposter_port,
         body_json.as_ref(),
+        None,
         Some(&query_map),
     )
 }
@@ -77,6 +83,12 @@ pub(crate) fn stub_matches_inner<SH>(
     form: Option<&FastMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
+    // The once-per-request lazily-parsed XML DOM (issue #711): `Some` on the request hot path
+    // (`find_matching_stub_with_client`/`_linear`), which constructs one `LazyXmlDom` before the
+    // stub loop and shares it across every stub's XPath predicates, so the body is parsed at most
+    // once per request no matter how many XPath predicates evaluate it. `None` for standalone
+    // callers (the `stub_matches` wrapper, tests) — they fall back to a per-call parse.
+    xml_dom: Option<&LazyXmlDom<'_>>,
     // Always sourced from `parse_query`/`parse_query_string` (issue #704); same reasoning as `form`.
     query_map: Option<&FastMap<String, String>>,
 ) -> anyhow::Result<bool>
@@ -102,6 +114,7 @@ where
             form,
             imposter_port,
             body_json,
+            xml_dom,
             query_map,
         )? {
             return Ok(false);
@@ -170,6 +183,8 @@ where
     let query_map = parse_query(query);
     let form_fast: Option<FastMap<String, String>> =
         form.map(|f| f.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+    // Not the request hot loop — no shared DOM to thread in (see `stub_matches` for the same
+    // reasoning); an XPath predicate degrades to its own per-call parse.
     predicate_matches_inner(
         predicate,
         method,
@@ -182,6 +197,7 @@ where
         form_fast.as_ref(),
         imposter_port,
         body_json.as_ref(),
+        None,
         Some(&query_map),
     )
 }
@@ -209,6 +225,8 @@ pub(crate) fn predicate_matches_inner<SH>(
     form: Option<&FastMap<String, String>>,
     imposter_port: u16,
     body_json: Option<&serde_json::Value>,
+    // The once-per-request lazily-parsed XML DOM (issue #711) — see `stub_matches_inner`.
+    xml_dom: Option<&LazyXmlDom<'_>>,
     // Concretely `FastMap` — see `stub_matches_inner`.
     query_map: Option<&FastMap<String, String>>,
 ) -> anyhow::Result<bool>
@@ -292,15 +310,27 @@ where
     let extracted_body: String;
     let effective_body = match &predicate.parameters.selector {
         Some(PredicateSelector::JsonPath { selector }) => {
-            extracted_body = extract_jsonpath(body_str, selector).unwrap_or_default();
+            // Reuse the once-per-request body parse when the caller threaded it (issue #290) —
+            // `extract_jsonpath_value` also reuses the process-wide compiled-selector cache
+            // (issue #711) so this doesn't recompile `selector` per stub/predicate either way.
+            extracted_body = match body_json {
+                Some(json) => extract_jsonpath_value(json, selector),
+                None => extract_jsonpath(body_str, selector),
+            }
+            .unwrap_or_default();
             &extracted_body
         }
         Some(PredicateSelector::XPath {
             selector,
             namespaces,
         }) => {
-            extracted_body =
-                extract_xpath_with_ns(body_str, selector, namespaces.as_ref()).unwrap_or_default();
+            // Reuse the once-per-request DOM when the caller threaded it (issue #711) — the DOM is
+            // parsed at most once no matter how many XPath predicates/stubs evaluate it this request.
+            extracted_body = match xml_dom.and_then(LazyXmlDom::document) {
+                Some(document) => eval_xpath_on(&document, selector, namespaces.as_ref()),
+                None => extract_xpath_with_ns(body_str, selector, namespaces.as_ref()),
+            }
+            .unwrap_or_default();
             &extracted_body
         }
         None => body_str,
@@ -434,6 +464,7 @@ where
             form,
             imposter_port,
             body_json,
+            xml_dom,
             Some(query_map),
         )?),
         PredicateOperation::Or(children) => {
@@ -453,6 +484,7 @@ where
                     form,
                     imposter_port,
                     body_json,
+                    xml_dom,
                     Some(query_map),
                 )? {
                     return Ok(true);
@@ -476,6 +508,7 @@ where
                     form,
                     imposter_port,
                     body_json,
+                    xml_dom,
                     Some(query_map),
                 )? {
                     return Ok(false);
@@ -2331,6 +2364,7 @@ mod tests {
                 0,
                 None,
                 None,
+                None,
             )
             .is_err(),
             "an `or` must propagate a nested inject error rather than short-circuit past it"
@@ -2351,6 +2385,7 @@ mod tests {
                 0,
                 None,
                 None,
+                None,
             )
             .is_err(),
             "an `and` must propagate a nested inject error"
@@ -2369,6 +2404,7 @@ mod tests {
                 None,
                 None,
                 0,
+                None,
                 None,
                 None,
             )
@@ -2429,6 +2465,7 @@ mod tests {
             None,
             0,
             None,
+            None,
             Some(&parsed),
         )
         .unwrap();
@@ -2443,6 +2480,7 @@ mod tests {
             None,
             None,
             0,
+            None,
             None,
             None,
         )


### PR DESCRIPTION
Three coordinated fixes to selector handling on the matching path (issue #711):

1. **XML DOM parsed once per request** — a lazily-parsed `sxd_document::Package` (`LazyXmlDom`) created once per request and shared across every stub/predicate that evaluates XPath, threaded through `stub_matches_inner`/`predicate_matches_inner` alongside the once-parsed body JSON (#290). It is `!Send` and never crosses an `.await` (the bounded/`spawn_blocking` path runs the whole match in one closure).
2. **Selectors compiled once** — XPath in a `thread_local!` cache (the `sxd_xpath::XPath` type is `!Send + !Sync`, so it cannot be global or stored in the `Arc`-shared `StubState`); JSONPath in a process-wide bounded cache mirroring `regex_cache` (it is `Send + Sync`).
3. **JSONPath reuses the parsed body** — the selector is applied against the body already parsed once for `deepEquals` (#290).

## Numbers (`find_matching_stub_xpath_heavy`, N stubs over one shared XML body, all evaluated)

| stubs | before | after | speedup |
|---|---|---|---|
| 10 | 116.4 µs | 61.0 µs | 1.9x |
| 100 | 7.30 ms | 3.58 ms | 2.0x |

XPath was ~2x slower than other scenarios; this halves it. The residual is XPath *evaluation* itself (O(nodes) per eval, and XPath predicates are never candidate-indexable) — inherent and out of scope; this PR removes the per-evaluation re-parse/re-compile.

## Semantics & safety

Unchanged — same engines (`sxd_xpath`, `serde_json_path`) against cached artifacts; a bad selector or non-XML body still yields no extraction, exactly as before. The parse-once and compile-once guarantees are asserted directly by thread-local test counters (`one_dom_parse_per_request_many_xpath_stubs`, `xpath_compiled_once_across_requests`, `jsonpath_compiled_once_across_requests`), each verified to fail without its cache. The XPath cache key includes the namespace map defensively even though compilation is namespace-independent (bindings are applied at evaluation time).

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings), `cargo test --workspace`: 2048 passed / 0 failed.

Closes #711