### PR TITLE
perf(regex-cache): lock-free reads via papaya + fix the clear-on-overflow eviction cliff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ record.
 
 ### Changed
 
+- **The compiled-regex cache does lock-free reads and no longer flushes wholesale on overflow.** It
+  was a `RwLock<HashMap>` taking a shared read lock on every cache hit — a lock on the matching hot
+  path, per regex predicate per request — and on reaching its 1024-entry ceiling it `clear()`ed the
+  entire cache, so a workload cycling just over the cap recompiled everything repeatedly. It is now
+  a lock-free `papaya` map (hits are a wait-free guarded lookup, no lock) that evicts a bounded
+  batch (~a quarter of the cap) on overflow instead of clearing, so the bulk of the working set
+  stays hot across the boundary. Compile semantics and keying are unchanged.
+
 - **Path `startsWith`/`contains`/`endsWith` stubs are matched in a single Aho-Corasick pass, and
   `endsWith` is now indexed at all.** The Stage-1 prefilter previously walked a linear bucket per
   distinct prefix/substring literal, so the prefilter's own cost grew with the number of literal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3417,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "p12",
+ "papaya",
  "parking_lot",
  "prometheus",
  "r2d2",
@@ -3705,6 +3716,16 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -99,6 +99,9 @@ serde_json_path = "0.7"
 p12 = "0.6.3"
 yasna = "0.5"
 ring = "0.17"
+# Lock-free concurrent HashMap for the predicate regex cache (issue #715): reads on the imposter
+# matching hot path proceed without contending a lock.
+papaya = "0.2.4"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/rift-mock-core/src/imposter/predicates/regex_cache.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/regex_cache.rs
@@ -10,25 +10,57 @@
 //! small. The cache is nonetheless **capacity-bounded**: because it is a process-global
 //! static, repeatedly creating and deleting imposters with ever-distinct patterns would
 //! otherwise grow it for the life of the process. On reaching [`MAX_CACHED_REGEXES`] the map
-//! is reset (dropping stale entries); overflow patterns simply recompile on their next miss.
+//! evicts a **batch** of entries (roughly a quarter of the cap), not the whole map: a working
+//! set that cycles just over the cap keeps most of its previously-compiled regexes hot instead
+//! of hitting a full recompile storm every time it crosses the ceiling.
+//!
+//! Reads are lock-free: the backing store is [`papaya::HashMap`], which lets concurrent readers
+//! (the matching hot path, per request) proceed without contending on a lock. Only a cache
+//! *miss* pays for compilation and an insert; hits are a single atomic-guarded lookup.
 
-use parking_lot::RwLock;
+use papaya::HashMap as PapayaMap;
 use regex::{Regex, RegexBuilder};
-use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
 /// Per-map ceiling on distinct cached regexes. Comfortably above any realistic imposter
 /// config's pattern count; the bound only exists to cap growth under runtime imposter churn.
 const MAX_CACHED_REGEXES: usize = 1024;
 
-#[derive(Default)]
-struct RegexCache {
-    sensitive: HashMap<String, Arc<Regex>>,
-    insensitive: HashMap<String, Arc<Regex>>,
+/// How many entries a single overflow evicts. A quarter of the cap leaves the majority of the
+/// map intact, so a working set that cycles just over the cap doesn't get fully recompiled on
+/// every overflow (the defect `clear()`-on-overflow had).
+const EVICTION_BATCH: usize = MAX_CACHED_REGEXES / 4;
+
+/// `papaya`'s own map-level synchronization already makes the store lock-free; each `String` key
+/// is cheap to hash and the working set is operator/stub-derived (bounded, not attacker-supplied
+/// per request), so the extra HashDoS resistance of `papaya`'s default hasher over `foldhash`
+/// buys nothing here. `foldhash::fast::RandomState` matches the hasher already used for other
+/// hot-path maps in `crate::util`.
+type CacheMap = PapayaMap<String, Arc<Regex>, foldhash::fast::RandomState>;
+
+fn new_cache_map() -> CacheMap {
+    PapayaMap::with_hasher(foldhash::fast::RandomState::default())
 }
 
-static REGEX_CACHE: LazyLock<RwLock<RegexCache>> =
-    LazyLock::new(|| RwLock::new(RegexCache::default()));
+/// The two case classes are kept as separate maps (rather than one map keyed on
+/// `(pattern, case_insensitive)`) so each class's [`MAX_CACHED_REGEXES`] ceiling — and the batch
+/// eviction it triggers — is independent: churn in one case class can't evict the other's
+/// entries.
+struct RegexCache {
+    sensitive: CacheMap,
+    insensitive: CacheMap,
+}
+
+impl Default for RegexCache {
+    fn default() -> Self {
+        Self {
+            sensitive: new_cache_map(),
+            insensitive: new_cache_map(),
+        }
+    }
+}
+
+static REGEX_CACHE: LazyLock<RegexCache> = LazyLock::new(RegexCache::default);
 
 fn compile(pattern: &str, case_insensitive: bool) -> Result<Regex, regex::Error> {
     if case_insensitive {
@@ -45,46 +77,60 @@ fn compile(pattern: &str, case_insensitive: bool) -> Result<Regex, regex::Error>
 /// Returns `None` when `pattern` fails to compile (callers treat this as "no match"),
 /// preserving the previous per-request behavior of a failed `Regex::new`.
 pub(crate) fn cached_regex(pattern: &str, case_insensitive: bool) -> Option<Arc<Regex>> {
-    // Fast path: shared read lock, no allocation on a hit.
-    {
-        let cache = REGEX_CACHE.read();
-        let map = if case_insensitive {
-            &cache.insensitive
-        } else {
-            &cache.sensitive
-        };
-        if let Some(re) = map.get(pattern) {
-            return Some(Arc::clone(re));
+    let map = if case_insensitive {
+        &REGEX_CACHE.insensitive
+    } else {
+        &REGEX_CACHE.sensitive
+    };
+    let guard = map.pin();
+
+    // Fast path: a lock-free guarded read, no allocation on a hit.
+    if let Some(re) = guard.get(pattern) {
+        return Some(Arc::clone(re));
+    }
+
+    // Slow path (cache miss): compile outside any critical section — papaya never takes a lock,
+    // but compilation is the expensive part and has no business happening more than once per
+    // insert attempt.
+    let compiled = Arc::new(compile(pattern, case_insensitive).ok()?);
+
+    // Batch-evict on overflow instead of `clear()`-ing: drop a fixed fraction of entries so the
+    // rest of the map (the majority of the working set) stays hot across the overflow.
+    if guard.len() >= MAX_CACHED_REGEXES {
+        let victims: Vec<String> = guard.keys().take(EVICTION_BATCH).cloned().collect();
+        for victim in &victims {
+            guard.remove(victim);
         }
     }
 
-    // Slow path (cache miss): compile once (outside the lock), then insert under the write lock.
-    let compiled = Arc::new(compile(pattern, case_insensitive).ok()?);
-    let mut cache = REGEX_CACHE.write();
-    let map = if case_insensitive {
-        &mut cache.insensitive
-    } else {
-        &mut cache.sensitive
-    };
-    // Another thread may have inserted this pattern while we compiled — reuse its entry.
-    if let Some(re) = map.get(pattern) {
-        return Some(Arc::clone(re));
-    }
-    if map.len() >= MAX_CACHED_REGEXES {
-        map.clear();
-    }
-    map.insert(pattern.to_string(), Arc::clone(&compiled));
-    Some(compiled)
+    // `get_or_insert_with` double-checks atomically: if another thread inserted this exact
+    // pattern while we were compiling, we discard our copy and reuse theirs.
+    Some(Arc::clone(
+        guard.get_or_insert_with(pattern.to_string(), || compiled),
+    ))
 }
 
 #[cfg(test)]
 fn cached_len(case_insensitive: bool) -> usize {
-    let cache = REGEX_CACHE.read();
-    if case_insensitive {
-        cache.insensitive.len()
+    let map = if case_insensitive {
+        &REGEX_CACHE.insensitive
     } else {
-        cache.sensitive.len()
-    }
+        &REGEX_CACHE.sensitive
+    };
+    map.pin().len()
+}
+
+/// True iff `(pattern, case_insensitive)` is currently cached. A pure probe: unlike
+/// [`cached_regex`], it never compiles or inserts, so it can check survivorship after an eviction
+/// without perturbing the cache under test.
+#[cfg(test)]
+fn is_cached(pattern: &str, case_insensitive: bool) -> bool {
+    let map = if case_insensitive {
+        &REGEX_CACHE.insensitive
+    } else {
+        &REGEX_CACHE.sensitive
+    };
+    map.pin().contains_key(pattern)
 }
 
 #[cfg(test)]
@@ -125,14 +171,70 @@ mod tests {
 
     #[test]
     fn cache_stays_bounded_under_distinct_patterns() {
-        // Insert well past the cap with distinct patterns; the map must never exceed the
-        // ceiling (it resets on overflow), so runtime imposter churn can't grow it forever.
+        // Insert well past the cap with distinct patterns; the map must stay near the ceiling
+        // (overflow evicts a batch), so runtime imposter churn can't grow it forever. A small
+        // slack over the cap is allowed for the batch-eviction boundary (single-threaded here).
         for i in 0..(MAX_CACHED_REGEXES + 200) {
             let _ = cached_regex(&format!("bounded-probe-{i}-[a-z]+"), false);
         }
         assert!(
             cached_len(false) <= MAX_CACHED_REGEXES,
-            "sensitive cache must stay within MAX_CACHED_REGEXES"
+            "sensitive cache must stay within MAX_CACHED_REGEXES (saw {})",
+            cached_len(false)
         );
+    }
+
+    // AC (the eviction-cliff fix): overflow must NOT flush the whole cache. Fill to the cap, then
+    // push past it, and assert a large fraction of the earlier entries survive — the old
+    // clear-on-overflow would drop ALL of them, causing a recompile storm for a working set that
+    // cycles just over the cap. With batch eviction (a bounded fraction dropped per overflow), most
+    // entries remain hot.
+    #[test]
+    fn overflow_evicts_a_batch_not_the_whole_cache() {
+        // Use the insensitive map so this test is independent of others sharing the sensitive one.
+        // Fill to just under the cap.
+        let fill = MAX_CACHED_REGEXES - 1;
+        for i in 0..fill {
+            let _ = cached_regex(&format!("cliff-fill-{i}-[a-z]+"), true).expect("compiles");
+        }
+        // Push ~30% past the cap to force at least one overflow eviction.
+        let overshoot = MAX_CACHED_REGEXES / 3;
+        for i in 0..overshoot {
+            let _ = cached_regex(&format!("cliff-over-{i}-[a-z]+"), true).expect("compiles");
+        }
+        // Count how many of the ORIGINAL fill patterns are still cached. A clear() would leave 0.
+        let survivors = (0..fill)
+            .filter(|i| is_cached(&format!("cliff-fill-{i}-[a-z]+"), true))
+            .count();
+        assert!(
+            survivors > fill / 2,
+            "overflow must evict a batch, not flush the cache: only {survivors}/{fill} of the \
+             pre-overflow entries survived (clear-on-overflow would leave 0)"
+        );
+    }
+
+    // The lock-free store must be safe under concurrent hits and misses from many threads (papaya's
+    // design center). This is a smoke test that the eviction/insert logic doesn't corrupt or panic
+    // under contention; papaya provides the lock-freedom.
+    #[test]
+    fn concurrent_hits_and_misses_are_safe() {
+        use std::thread;
+        let threads: Vec<_> = (0..8)
+            .map(|t| {
+                thread::spawn(move || {
+                    for i in 0..500 {
+                        // A shared hot set (hits) plus per-thread distinct patterns (misses).
+                        let _ = cached_regex("concurrent-hot-[0-9]+", false);
+                        let _ = cached_regex(&format!("concurrent-{t}-{i}-[a-z]+"), false);
+                    }
+                })
+            })
+            .collect();
+        for h in threads {
+            h.join().expect("no panic under concurrent access");
+        }
+        // The shared hot pattern must still resolve and match.
+        let re = cached_regex("concurrent-hot-[0-9]+", false).expect("compiles");
+        assert!(re.is_match("concurrent-hot-42"));
     }
 }


### PR DESCRIPTION
Rewrites the process-global compiled-regex cache (`regex_cache.rs`) — the last lock on the matching hot path.

- **Lock-free reads**: replaces `RwLock<HashMap>` with `papaya::HashMap` (v0.2.4, first use in-tree). A cache hit is a wait-free guarded lookup plus an `Arc::clone` — no lock. Misses compile outside any critical section (as before) and insert via `get_or_insert_with`, which atomically reuses a concurrent inserter's entry.
- **Eviction-cliff fix**: the old cache `clear()`ed on reaching 1024 entries, so a working set cycling just over the cap paid a full recompile storm each time it crossed. It now evicts a bounded batch (~a quarter of the cap) on overflow, keeping the majority of the working set hot.
- Two maps kept per case class so each class's cap and eviction are independent; `foldhash` hasher (keys are operator/stub-derived regex sources, bounded and not per-request attacker-controlled).

Signature and compile semantics are unchanged (`cached_regex(pattern, case_insensitive) -> Option<Arc<Regex>>`; a bad pattern still returns `None`).

## Verification
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings), `cargo test --workspace`: 2044 passed / 0 failed.
- New tests: `overflow_evicts_a_batch_not_the_whole_cache` (verified discriminating — reverting to `clear()` leaves 0 survivors) and `concurrent_hits_and_misses_are_safe` (8-thread smoke).

Closes #715