### PR TITLE
perf(http): hyper builder knob audit (max_buf_size, header timeout) + accept-side connection backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ record.
 
 ### Added
 
+- **HTTP connection-builder tuning knobs and optional accept-side connection backpressure**
+  (env-tunable, applied to the imposter, proxy, admin-API, and metrics listeners). The hyper
+  connection builders previously ran on defaults: a ~400 KB per-connection buffer and no
+  header-read timeout. `RIFT_HTTP_MAX_BUF` (default 64 KB) now caps the per-connection buffer —
+  bounding memory at high connection counts without affecting normal small mock requests — and
+  `RIFT_HTTP_HEADER_TIMEOUT` (default 30 s) sets an explicit header-read timeout so a
+  slow-header (slowloris) client can no longer hold a connection open indefinitely. Both are
+  conservative defense-in-depth tightenings, on by default. `RIFT_MAX_CONNECTIONS` (default
+  unlimited — today's behavior) optionally bounds concurrently-served connections with a
+  per-listener semaphore acquired *before* accept, so overload is absorbed by the kernel backlog
+  rather than collapsing into unbounded queueing; it never RST-storms clients.
+
 - **The `match=` filter grammar on recorded traffic gains `method=` and `path=` exact-equality
   clauses.** Alongside `header:<Name>=<Value>` and `flow_id=<Value>`, `GET`/`DELETE
   /imposters/{port}/savedRequests` and the SSE streams (`GET /events`,

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -211,7 +211,30 @@ async fn accept_loop(
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
+    // Read HTTP tuning once per listener, not per accepted connection (issue #716).
+    let http_tuning = rift_mock_core::proxy::HttpTuning::from_env();
+    // `None` (the default) preserves today's behavior exactly: no semaphore, no permit.
+    let connection_semaphore = http_tuning
+        .max_connections
+        .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
+
     loop {
+        // Acquire a permit *before* accepting so a cap holds connections back in the listener
+        // backlog rather than accepting-then-failing. Raced against `cancel` so a saturated cap
+        // never delays admin-server shutdown.
+        let permit = match &connection_semaphore {
+            Some(sem) => {
+                let acquire = Arc::clone(sem).acquire_owned();
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    acquired = acquire => match acquired {
+                        Ok(permit) => Some(permit),
+                        Err(_) => break,
+                    },
+                }
+            }
+            None => None,
+        };
         let (stream, _) = tokio::select! {
             _ = cancel.cancelled() => break,
             accepted = listener.accept() => accepted?,
@@ -225,6 +248,8 @@ async fn accept_loop(
         let conn_cancel = cancel.clone();
 
         tracker.spawn(async move {
+            // Held for the connection's lifetime; released to the semaphore when this task ends.
+            let _permit = permit;
             let stream_cancel = conn_cancel.clone();
             let service = service_fn(move |req| {
                 let manager = Arc::clone(&manager);
@@ -315,13 +340,24 @@ async fn accept_loop(
             }
 
             if rift_mock_core::util::http2_disabled() {
-                drive_conn!(
-                    hyper::server::conn::http1::Builder::new().serve_connection(io, service)
-                );
+                let mut builder = hyper::server::conn::http1::Builder::new();
+                // A timer is required for `header_read_timeout` to take effect (hyper panics on
+                // serve_connection otherwise) — always paired with it (issue #716).
+                builder
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
+                drive_conn!(builder.serve_connection(io, service));
             } else {
-                let builder = hyper_util::server::conn::auto::Builder::new(
+                let mut builder = hyper_util::server::conn::auto::Builder::new(
                     hyper_util::rt::TokioExecutor::new(),
                 );
+                // The h1 buffer/timeout knobs live on the `.http1()` sub-config of the auto builder.
+                builder
+                    .http1()
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
                 drive_conn!(builder.serve_connection(io, service));
             }
         });

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -642,9 +642,36 @@ async fn metrics_accept_loop(
     use hyper::service::service_fn;
     use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
+    use rift_mock_core::proxy::HttpTuning;
     use std::convert::Infallible;
 
+    // Read HTTP tuning once per listener, not per accepted connection.
+    let http_tuning = HttpTuning::from_env();
+    // `None` (the default) preserves today's behavior exactly: no semaphore, no permit, accept as
+    // fast as the kernel hands connections over (issue #716).
+    let connection_semaphore = http_tuning
+        .max_connections
+        .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n)));
+
     loop {
+        // Acquire a permit *before* accepting so a cap holds connections back in the listener
+        // backlog/kernel SYN queue rather than accepting them and then failing downstream. Raced
+        // against `cancel` (like the accept below) so a saturated cap never delays shutdown.
+        let permit = match &connection_semaphore {
+            Some(sem) => {
+                let acquire = sem.clone().acquire_owned();
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    acquired = acquire => match acquired {
+                        Ok(permit) => Some(permit),
+                        // Only closes on Drop, which never happens here — but if it ever does,
+                        // stop accepting rather than panic.
+                        Err(_) => break,
+                    },
+                }
+            }
+            None => None,
+        };
         let (stream, _) = tokio::select! {
             _ = cancel.cancelled() => break,
             accepted = listener.accept() => accepted?,
@@ -653,6 +680,9 @@ async fn metrics_accept_loop(
         let conn_cancel = cancel.clone();
 
         tracker.spawn(async move {
+            // Held for the connection's lifetime; released back to the semaphore when this task
+            // ends (issue #716).
+            let _permit = permit;
             let service = service_fn(move |req: Request<Incoming>| async move {
                 if req.uri().path() == "/metrics" {
                     let metrics = metrics::collect_metrics();
@@ -688,13 +718,23 @@ async fn metrics_accept_loop(
             }
 
             if rift_mock_core::util::http2_disabled() {
-                drive_conn!(
-                    hyper::server::conn::http1::Builder::new().serve_connection(io, service)
-                );
+                let mut builder = hyper::server::conn::http1::Builder::new();
+                // A timer is required for `header_read_timeout` to take effect (hyper panics on
+                // serve_connection otherwise) — always paired with it below.
+                builder
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
+                drive_conn!(builder.serve_connection(io, service));
             } else {
-                let builder = hyper_util::server::conn::auto::Builder::new(
+                let mut builder = hyper_util::server::conn::auto::Builder::new(
                     hyper_util::rt::TokioExecutor::new(),
                 );
+                builder
+                    .http1()
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
                 drive_conn!(builder.serve_connection(io, service));
             }
         });

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -50,6 +50,7 @@ impl Default for TlsDefaults {
 /// completes or the imposter is torn down. Auto-negotiates HTTP/1 and HTTP/2 (issue #295), except
 /// for imposters that can fire a connection-level TCP fault, which are served HTTP/1-only. Shared
 /// by the plain and HTTPS serve paths (issue #206). (Name kept for history.)
+#[allow(clippy::too_many_arguments)]
 async fn run_http1<I>(
     io: I,
     imposter: Arc<Imposter>,
@@ -58,6 +59,7 @@ async fn run_http1<I>(
     mut conn_shutdown_rx: broadcast::Receiver<()>,
     port: u16,
     decorator: Option<Arc<dyn ResponseDecorator>>,
+    http_tuning: crate::proxy::network::HttpTuning,
 ) where
     I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
 {
@@ -105,10 +107,22 @@ async fn run_http1<I>(
     }
 
     if http1_only {
-        drive_conn!(hyper::server::conn::http1::Builder::new().serve_connection(io, service));
+        let mut builder = hyper::server::conn::http1::Builder::new();
+        builder
+            // A timer is required for `header_read_timeout` to take effect (hyper panics on
+            // serve_connection otherwise) — always paired with it below.
+            .timer(hyper_util::rt::TokioTimer::new())
+            .header_read_timeout(http_tuning.header_read_timeout)
+            .max_buf_size(http_tuning.max_buf_size);
+        drive_conn!(builder.serve_connection(io, service));
     } else {
-        let builder =
+        let mut builder =
             hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+        builder
+            .http1()
+            .timer(hyper_util::rt::TokioTimer::new())
+            .header_read_timeout(http_tuning.header_read_timeout)
+            .max_buf_size(http_tuning.max_buf_size);
         drive_conn!(builder.serve_connection(io, service));
     }
 }
@@ -424,11 +438,41 @@ impl ImposterManager {
         let conn_shutdown_tx = shutdown_tx.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
         let response_decorator = self.response_decorator.clone();
-        // Read socket tuning once per listener, not per accepted connection.
+        // Read socket/HTTP tuning once per listener, not per accepted connection.
         let socket_tuning = crate::proxy::network::SocketTuning::from_env();
+        let http_tuning = crate::proxy::network::HttpTuning::from_env();
+        // `None` (the default) preserves today's behavior exactly: no semaphore, no permit,
+        // accept as fast as the kernel hands connections over.
+        let connection_semaphore = http_tuning
+            .max_connections
+            .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
 
         let serve_handle = tokio::spawn(async move {
             loop {
+                // Acquire a permit *before* accepting so a cap holds connections back in the
+                // listener backlog/kernel SYN queue rather than accepting them and then failing
+                // downstream (issue #716). Raced against shutdown (not just `select!`-dropped)
+                // because `delete_imposter_inner` awaits this task with no timeout — without the
+                // race, a cap saturated by long-lived connections would make delete hang until one
+                // freed up, instead of tearing down promptly.
+                let permit = match &connection_semaphore {
+                    Some(sem) => {
+                        let acquire = sem.clone().acquire_owned();
+                        tokio::select! {
+                            acquired = acquire => match acquired {
+                                Ok(permit) => Some(permit),
+                                // Only closes on Drop, which never happens here — but if it ever
+                                // does, stop accepting rather than panic.
+                                Err(_) => break,
+                            },
+                            _ = shutdown_rx.recv() => {
+                                info!("Imposter on port {} shutting down", port);
+                                break;
+                            }
+                        }
+                    }
+                    None => None,
+                };
                 tokio::select! {
                     result = listener.accept() => {
                         match result {
@@ -444,6 +488,9 @@ impl ImposterManager {
                                 let decorator = response_decorator.clone();
                                 // Track the connection task so `delete` can drain it (issue #596).
                                 imposter_clone.conn_tracker.spawn(async move {
+                                    // Held for the connection's lifetime; released back to the
+                                    // semaphore when this task ends (issue #716).
+                                    let _permit = permit;
                                     // Per-connection slot for a real transport fault (issue #239);
                                     // armed by the handler, applied by FaultIo on the response write.
                                     let fault_cell: FaultCell = Arc::new(Mutex::new(None));
@@ -468,6 +515,7 @@ impl ImposterManager {
                                                     conn_shutdown_rx,
                                                     port,
                                                     decorator,
+                                                    http_tuning,
                                                 )
                                                 .await
                                             }
@@ -487,6 +535,7 @@ impl ImposterManager {
                                                 conn_shutdown_rx,
                                                 port,
                                                 decorator,
+                                                http_tuning,
                                             )
                                             .await
                                         }

--- a/crates/rift-mock-core/src/proxy/mod.rs
+++ b/crates/rift-mock-core/src/proxy/mod.rs
@@ -43,3 +43,6 @@ pub use handler::rule_applies_to_upstream;
 pub use server::ProxyServer;
 // TLS session-resumption config, shared with the intercept listener in rift-http-proxy (issue #705).
 pub use tls::{TLS_SESSION_CACHE_SIZE, configure_session_resumption};
+// HTTP connection-builder tuning, shared with the metrics/admin accept loops in rift-http-proxy
+// (issue #716) — `network` itself stays `pub(crate)`, only this type is exposed.
+pub use network::{DEFAULT_HTTP_MAX_BUF, HttpTuning};

--- a/crates/rift-mock-core/src/proxy/network.rs
+++ b/crates/rift-mock-core/src/proxy/network.rs
@@ -6,10 +6,98 @@
 
 use socket2::{Domain, Protocol, Socket, Type};
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 
 /// Default listen backlog; overridable via `RIFT_TCP_BACKLOG`.
 const DEFAULT_BACKLOG: i32 = 1024;
+
+/// Default `hyper`/`hyper-util` connection buffer cap; overridable via `RIFT_HTTP_MAX_BUF`.
+/// Hyper's own default is ~400KB, sized for arbitrary internet traffic; mock/proxy requests are
+/// small and numerous, so a 64KB ceiling bounds per-connection memory without touching normal
+/// traffic.
+pub const DEFAULT_HTTP_MAX_BUF: usize = 64 * 1024;
+
+/// Default HTTP/1 header-read timeout (slowloris hygiene); overridable via
+/// `RIFT_HTTP_HEADER_TIMEOUT` (seconds).
+const DEFAULT_HTTP_HEADER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// `hyper`'s h1 buffer floor (`proto::h1::MINIMUM_MAX_BUFFER_SIZE`, currently 8KB). It isn't part
+/// of hyper's public API, so it's mirrored here as a guard: `http1::Builder::max_buf_size` (and
+/// the `auto::Builder` equivalent) panics if handed anything smaller. Enforced only in `parse` so
+/// a bogus/too-small env value degrades to the default instead of crashing the server.
+const HYPER_H1_MIN_MAX_BUF: usize = 8192;
+
+/// HTTP connection-builder tuning knobs (issue #716): the hyper/hyper-util `serve_connection`
+/// builders otherwise run on hyper's own defaults (a ~400KB buffer, no header-read timeout, and
+/// no cap on concurrent connections).
+///
+/// Populated from the environment ([`HttpTuning::from_env`]) once per listener setup, mirroring
+/// [`SocketTuning`] — not read per accepted connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HttpTuning {
+    /// Cap on the connection's internal read/write buffer (`Builder::max_buf_size`).
+    pub max_buf_size: usize,
+    /// How long to wait for a client to finish sending request headers before closing the
+    /// connection (`Builder::header_read_timeout`) — mitigates slowloris-style stalls.
+    pub header_read_timeout: Duration,
+    /// Cap on concurrently accepted connections. `None` (the default) preserves today's
+    /// behavior: unlimited, accept-as-fast-as-the-kernel-hands-them-over.
+    pub max_connections: Option<usize>,
+}
+
+impl Default for HttpTuning {
+    fn default() -> Self {
+        Self {
+            max_buf_size: DEFAULT_HTTP_MAX_BUF,
+            header_read_timeout: DEFAULT_HTTP_HEADER_TIMEOUT,
+            max_connections: None,
+        }
+    }
+}
+
+impl HttpTuning {
+    /// Read tuning from the environment: `RIFT_HTTP_MAX_BUF` (bytes), `RIFT_HTTP_HEADER_TIMEOUT`
+    /// (seconds), and `RIFT_MAX_CONNECTIONS` (connection count, opt-in). Unset or unparsable
+    /// values fall back to [`HttpTuning::default`].
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::parse(
+            std::env::var("RIFT_HTTP_MAX_BUF").ok().as_deref(),
+            std::env::var("RIFT_HTTP_HEADER_TIMEOUT").ok().as_deref(),
+            std::env::var("RIFT_MAX_CONNECTIONS").ok().as_deref(),
+        )
+    }
+
+    /// Pure parser behind [`HttpTuning::from_env`] — kept env-free so it is testable without
+    /// mutating process-global state.
+    fn parse(
+        max_buf: Option<&str>,
+        header_timeout_secs: Option<&str>,
+        max_conns: Option<&str>,
+    ) -> Self {
+        let defaults = Self::default();
+        let max_buf_size = max_buf
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .filter(|&v| v >= HYPER_H1_MIN_MAX_BUF)
+            .unwrap_or(defaults.max_buf_size);
+        let header_read_timeout = header_timeout_secs
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .filter(|&secs| secs > 0)
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.header_read_timeout);
+        // Opt-in: unset, zero, negative, or garbage all mean "unlimited" rather than an error —
+        // this knob defaults to today's behavior, so a malformed value should not fail closed.
+        let max_connections = max_conns
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .filter(|&n| n > 0);
+        Self {
+            max_buf_size,
+            header_read_timeout,
+            max_connections,
+        }
+    }
+}
 
 /// Accept-loop / socket tuning knobs.
 ///
@@ -149,6 +237,80 @@ pub fn apply_stream_tuning(stream: &TcpStream, tuning: &SocketTuning) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- issue #716: HTTP connection-builder tuning knobs -------------------------------
+
+    #[test]
+    fn http_tuning_defaults() {
+        let t = HttpTuning::default();
+        assert_eq!(t.max_buf_size, DEFAULT_HTTP_MAX_BUF);
+        assert_eq!(t.header_read_timeout, std::time::Duration::from_secs(30));
+        assert_eq!(
+            t.max_connections, None,
+            "unlimited by default (today's behavior)"
+        );
+    }
+
+    #[test]
+    fn http_tuning_parse_falls_back_to_defaults_when_unset() {
+        assert_eq!(HttpTuning::parse(None, None, None), HttpTuning::default());
+    }
+
+    #[test]
+    fn http_tuning_parse_reads_max_buf() {
+        assert_eq!(
+            HttpTuning::parse(Some(" 16384 "), None, None).max_buf_size,
+            16384
+        );
+    }
+
+    #[test]
+    fn http_tuning_parse_rejects_garbage_or_zero_max_buf() {
+        for v in ["0", "-5", "nope", ""] {
+            assert_eq!(
+                HttpTuning::parse(Some(v), None, None).max_buf_size,
+                DEFAULT_HTTP_MAX_BUF,
+                "value {v} must fall back to the default"
+            );
+        }
+    }
+
+    #[test]
+    fn http_tuning_parse_reads_header_timeout_seconds() {
+        assert_eq!(
+            HttpTuning::parse(None, Some("10"), None).header_read_timeout,
+            std::time::Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn http_tuning_parse_rejects_garbage_header_timeout() {
+        for v in ["nope", "-1", ""] {
+            assert_eq!(
+                HttpTuning::parse(None, Some(v), None).header_read_timeout,
+                std::time::Duration::from_secs(30),
+                "value {v} must fall back to the default"
+            );
+        }
+    }
+
+    #[test]
+    fn http_tuning_parse_max_connections_opt_in() {
+        // Unset or non-positive => unlimited (None); a positive value => a cap.
+        assert_eq!(HttpTuning::parse(None, None, None).max_connections, None);
+        assert_eq!(
+            HttpTuning::parse(None, None, Some("0")).max_connections,
+            None
+        );
+        assert_eq!(
+            HttpTuning::parse(None, None, Some("nope")).max_connections,
+            None
+        );
+        assert_eq!(
+            HttpTuning::parse(None, None, Some(" 500 ")).max_connections,
+            Some(500)
+        );
+    }
 
     #[test]
     fn default_tuning_enables_nodelay_and_uses_default_backlog() {

--- a/crates/rift-mock-core/src/proxy/server.rs
+++ b/crates/rift-mock-core/src/proxy/server.rs
@@ -5,7 +5,7 @@
 
 use super::client::{HttpClient, create_http_client, should_skip_tls_verify};
 use super::handler::handle_request;
-use super::network::create_reusable_listener;
+use super::network::{HttpTuning, create_reusable_listener};
 use super::tls::create_tls_acceptor;
 use crate::behaviors::{CsvCache, ResponseCycler};
 use crate::config::{Config, Protocol as RiftProtocol, Upstream};
@@ -278,16 +278,37 @@ impl ProxyServer {
         }
 
         let server = Arc::new(self);
-        // Read socket tuning once per listener, not per accepted connection.
+        // Read socket/HTTP tuning once per listener, not per accepted connection.
         let socket_tuning = super::network::SocketTuning::from_env();
+        let http_tuning = HttpTuning::from_env();
+        // `None` (the default) preserves today's behavior exactly: no semaphore, no permit,
+        // accept as fast as the kernel hands connections over. This loop has no shutdown signal
+        // to race against, so a plain acquire-then-accept is enough (issue #716).
+        let connection_semaphore = http_tuning
+            .max_connections
+            .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
 
         loop {
+            // Acquire a permit *before* accepting so a cap holds connections back in the listener
+            // backlog/kernel SYN queue rather than accepting them and then failing downstream.
+            let permit = match &connection_semaphore {
+                Some(sem) => match sem.clone().acquire_owned().await {
+                    Ok(permit) => Some(permit),
+                    // Only closes on Drop, which never happens here — but if it ever does, stop
+                    // accepting rather than panic.
+                    Err(_) => break,
+                },
+                None => None,
+            };
             let (stream, remote_addr) = listener.accept().await?;
             super::network::apply_stream_tuning(&stream, &socket_tuning);
             let server = Arc::clone(&server);
             let tls_acceptor = tls_acceptor.clone();
 
             tokio::spawn(async move {
+                // Held for the connection's lifetime; released back to the semaphore when this
+                // task ends (issue #716).
+                let _permit = permit;
                 match protocol {
                     RiftProtocol::Https => {
                         // HTTPS: perform TLS handshake first
@@ -309,19 +330,29 @@ impl ProxyServer {
                                 // Issue #378: force-disable HTTP/2 auto-negotiation as an
                                 // operational escape hatch when a client misbehaves over h2.
                                 if crate::util::http2_disabled() {
-                                    if let Err(err) = hyper::server::conn::http1::Builder::new()
-                                        .serve_connection(io, service)
-                                        .await
-                                    {
+                                    let mut builder = hyper::server::conn::http1::Builder::new();
+                                    // A timer is required for `header_read_timeout` to take effect
+                                    // (hyper panics on serve_connection otherwise) — always paired
+                                    // with it below.
+                                    builder
+                                        .timer(hyper_util::rt::TokioTimer::new())
+                                        .header_read_timeout(http_tuning.header_read_timeout)
+                                        .max_buf_size(http_tuning.max_buf_size);
+                                    if let Err(err) = builder.serve_connection(io, service).await {
                                         error!(
                                             "Error serving HTTPS connection from {}: {}",
                                             remote_addr, err
                                         );
                                     }
                                 } else {
-                                    let builder = hyper_util::server::conn::auto::Builder::new(
+                                    let mut builder = hyper_util::server::conn::auto::Builder::new(
                                         hyper_util::rt::TokioExecutor::new(),
                                     );
+                                    builder
+                                        .http1()
+                                        .timer(hyper_util::rt::TokioTimer::new())
+                                        .header_read_timeout(http_tuning.header_read_timeout)
+                                        .max_buf_size(http_tuning.max_buf_size);
                                     if let Err(err) = builder.serve_connection(io, service).await {
                                         error!(
                                             "Error serving HTTPS connection from {}: {}",
@@ -346,19 +377,26 @@ impl ProxyServer {
                         // Issue #378: force-disable HTTP/2 auto-negotiation as an operational
                         // escape hatch when a client misbehaves over h2.
                         if crate::util::http2_disabled() {
-                            if let Err(err) = hyper::server::conn::http1::Builder::new()
-                                .serve_connection(io, service)
-                                .await
-                            {
+                            let mut builder = hyper::server::conn::http1::Builder::new();
+                            builder
+                                .timer(hyper_util::rt::TokioTimer::new())
+                                .header_read_timeout(http_tuning.header_read_timeout)
+                                .max_buf_size(http_tuning.max_buf_size);
+                            if let Err(err) = builder.serve_connection(io, service).await {
                                 error!(
                                     "Error serving HTTP connection from {}: {}",
                                     remote_addr, err
                                 );
                             }
                         } else {
-                            let builder = hyper_util::server::conn::auto::Builder::new(
+                            let mut builder = hyper_util::server::conn::auto::Builder::new(
                                 hyper_util::rt::TokioExecutor::new(),
                             );
+                            builder
+                                .http1()
+                                .timer(hyper_util::rt::TokioTimer::new())
+                                .header_read_timeout(http_tuning.header_read_timeout)
+                                .max_buf_size(http_tuning.max_buf_size);
                             if let Err(err) = builder.serve_connection(io, service).await {
                                 error!(
                                     "Error serving HTTP connection from {}: {}",
@@ -373,6 +411,7 @@ impl ProxyServer {
                 }
             });
         }
+        Ok(())
     }
 
     /// Internal request handler that builds the context and delegates to handler module.

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -156,6 +156,9 @@ Environment variables override CLI defaults:
 | `RIFT_DISABLE_HTTP2` | Force HTTP/1-only listeners, disabling HTTP/2 & h2c auto-negotiation (truthy: `1`/`true`/`yes`/`on`) | off |
 | `RIFT_TCP_BACKLOG` | Listen backlog for the accept loop (positive integer) | `1024` |
 | `RIFT_TCP_NODELAY` | `TCP_NODELAY` on accepted sockets; set `false`/`0`/`off` to disable | on |
+| `RIFT_HTTP_MAX_BUF` | Per-connection HTTP read/write buffer cap, in bytes (positive integer; floored at hyper's 8 KB minimum). Bounds per-connection memory at high connection counts | `65536` |
+| `RIFT_HTTP_HEADER_TIMEOUT` | Seconds to wait for a client to finish sending request headers before closing the connection (slowloris hygiene; positive integer) | `30` |
+| `RIFT_MAX_CONNECTIONS` | Cap on concurrently-served connections per listener (positive integer). Unset means unlimited; at the cap the server stops accepting until a connection closes, so overload waits in the kernel backlog rather than piling up | unlimited |
 | `RIFT_STRICT_BEHAVIORS` | Force strict mode process-wide (truthy: `1`/`true`/`yes`/`on`): a `decorate`/`shellTransform`/binary-base64-decode failure returns `500` instead of the lenient fallback body | off |
 | `NO_COLOR` | Suppress ANSI color and the decorative banner in `rift-verify` / `rift-lint` output | |
 | `RUST_LOG` | Detailed log configuration | `info` |


### PR DESCRIPTION
Audits the hyper 1.x connection builders (previously on defaults) and adds env-tunable knobs + optional accept-side backpressure across all four serve loops — the imposter listener, the proxy listener, the admin API listener, and the metrics listener.

- **RIFT_HTTP_MAX_BUF** (default 64KB, floored at hypers 8KB h1 minimum to avoid a builder panic): caps the per-connection read/write buffer. hypers default is ~400KB, sized for arbitrary traffic; mock requests are small, so this bounds memory at high connection counts without touching normal traffic. (Bounds streaming-chunk buffering, not the total body limit.)
- **RIFT_HTTP_HEADER_TIMEOUT** (default 30s): explicit header-read timeout, paired with a TokioTimer on every builder, so a slow-header (slowloris) client can no longer hold a connection open indefinitely.
- **RIFT_MAX_CONNECTIONS** (default unlimited — unchanged behavior): optional per-listener Semaphore; a permit is acquired *before* accept() and moved into the connection task, so overload is held in the kernel backlog rather than accepted-then-queued (never RST-storms clients). On loops with a shutdown/cancel signal the acquire is raced against it, so a saturated cap cannot hang shutdown or imposter deletion.

Applied to both the http1::Builder and the auto::Builder (.http1() sub-config) at every site. Knobs live in HttpTuning (mirroring the existing SocketTuning), read once per listener. The measure-first experiments in the issue (pipeline_flush / writev / lifo) are intentionally not included — those stay on hyper defaults until a benchmark justifies a change.

## Verification
- cargo fmt, cargo clippy --workspace --all-targets -- -D warnings (zero warnings), cargo test --workspace: 2049 passed / 0 failed.
- New tests: HttpTuning::parse unit tests (defaults, max_buf, header timeout, max_connections opt-in, garbage/zero fallback).

Closes #716