### PR TITLE
fix(response): execute_stub_response_with_rift adds a duplicate Content-Type for oddly-cased config headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ record.
 
 ### Fixed
 
+- **A stub whose configured `Content-Type` used a nonstandard casing (e.g. `CONTENT-TYPE`) with a
+  JSON (non-string) body emitted two `Content-Type` headers.** The default-injection gate only
+  checked the two literal casings `content-type` and `Content-Type`, so any other casing failed the
+  check and Rift appended its own `Content-Type: application/json` alongside the configured header.
+  The check is now case-insensitive (matching Mountebank, whose header handling is case-insensitive),
+  so such stubs emit a single, configured `Content-Type`. Only stubs combining a nonstandard-cased
+  `Content-Type` header with a JSON body were affected (issue #723).
+
 - **A path-anchored stub could silently stop matching when its anchor contained non-ASCII text.**
   The Stage-1 path prefilter folded case with Unicode `to_lowercase`, while predicate evaluation
   folds with ASCII (`eq_ignore_ascii_case`). Unicode folding is length-changing and

--- a/crates/rift-mock-core/src/imposter/response.rs
+++ b/crates/rift-mock-core/src/imposter/response.rs
@@ -116,6 +116,18 @@ pub fn create_response_preview(response: &StubResponse) -> DebugResponsePreview 
     }
 }
 
+/// Whether the config headers already declare a Content-Type in any casing.
+///
+/// Mountebank treats header names case-insensitively, so the `application/json` default must be
+/// injected only when no Content-Type exists in *any* casing — a case-sensitive check emits a
+/// duplicate for a header like `CONTENT-TYPE` (issue #723). Shared by the execute path and
+/// `PreparedResponse::try_build` so the two serve paths cannot drift.
+fn has_content_type(headers: &HashMap<String, Vec<String>>) -> bool {
+    headers
+        .keys()
+        .any(|k| k.eq_ignore_ascii_case("content-type"))
+}
+
 /// Execute a stub response with Rift extensions
 /// Returns (status, headers, body, behaviors, rift_extension, response_mode, is_fault)
 #[allow(clippy::type_complexity)]
@@ -146,9 +158,7 @@ pub fn execute_stub_response_with_rift(
             // request. A string body (or no body) has no `rendered_body` and is used as-is.
             let body = match rendered_body {
                 Some(rb) => {
-                    if !headers.contains_key("content-type")
-                        && !headers.contains_key("Content-Type")
-                    {
+                    if !has_content_type(&headers) {
                         headers.insert(
                             "Content-Type".to_string(),
                             vec!["application/json".to_string()],
@@ -256,13 +266,11 @@ impl PreparedResponse {
             return None;
         }
 
-        // The Content-Type default must match the execute path's check EXACTLY for byte-identity: it
-        // tests the raw config map for the two literal casings only (a `HashMap`, case-sensitive), NOT
-        // a case-insensitive `HeaderMap` lookup — otherwise a config header like `CONTENT-TYPE` would
-        // diverge (execute adds a duplicate default; a case-insensitive check would not). Computed on
-        // `is.headers` before the `HeaderMap` normalizes casing.
-        let has_content_type =
-            is.headers.contains_key("content-type") || is.headers.contains_key("Content-Type");
+        // The Content-Type default must match the execute path exactly for byte-identity, so both
+        // call the shared `has_content_type` helper (issue #723 — the invariant is now "shared
+        // helper", not a textually identical check). Computed on the raw config `is.headers` before
+        // the `HeaderMap` normalizes casing.
+        let has_content_type = has_content_type(&is.headers);
 
         // Parse & validate every header once; an invalid name/value stores no prepared form so the
         // error surfaces at serve time exactly as today (issue #703: no config-validation change).
@@ -1262,9 +1270,9 @@ mod prepared_response_tests {
             ),
             // JSON (non-string) body with no Content-Type: exercises the application/json default.
             StubResponse::new_is(is_response(200, &[], Some(json!({"k": "v"}))), None, None),
-            // JSON body with an oddly-cased Content-Type header: the execute path's case-sensitive
-            // two-casing check still adds the default (a duplicate), so the fast path must reproduce
-            // that exactly — locks the parity the case-sensitivity fix guarantees.
+            // JSON body with an oddly-cased Content-Type header: after #723 the case-insensitive
+            // check suppresses the injected default on both paths (one Content-Type, not a
+            // duplicate) — this entry locks fast/slow-path parity on that fixed behavior.
             StubResponse::new_is(
                 is_response(
                     200,
@@ -1318,6 +1326,41 @@ mod prepared_response_tests {
             "no duplicate Content-Type when one is configured"
         );
         assert_eq!(cts[0].1, "application/xml");
+    }
+
+    #[test]
+    fn oddly_cased_content_type_not_duplicated() {
+        // #723: a config header spelled in a nonstandard casing (`CONTENT-TYPE`) with a JSON body
+        // must NOT receive a second, injected `Content-Type: application/json`. Both serve paths
+        // must emit exactly one Content-Type, and it must be the configured value.
+        let resp = StubResponse::new_is(
+            is_response(
+                200,
+                &[("CONTENT-TYPE", "application/xml")],
+                Some(json!({"k": "v"})),
+            ),
+            None,
+            None,
+        );
+        for (label, served) in [
+            ("execute", legacy_serve(&resp)),
+            ("prepared", prepared_serve(prepared_of(&resp).unwrap())),
+        ] {
+            let cts: Vec<_> = served
+                .1
+                .iter()
+                .filter(|(k, _)| k == "content-type")
+                .collect();
+            assert_eq!(
+                cts.len(),
+                1,
+                "{label}: no duplicate Content-Type for an oddly-cased config header"
+            );
+            assert_eq!(
+                cts[0].1, "application/xml",
+                "{label}: keeps the configured value"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes a serve-path bug: a stub whose config Content-Type used a nonstandard casing (e.g. CONTENT-TYPE) with a JSON (non-string) body received a second, injected Content-Type: application/json — two Content-Type headers on the wire.

The default-injection gate in execute_stub_response_with_rift only checked the two literal casings; it's now a shared case-insensitive has_content_type() helper (keys().any(|k| k.eq_ignore_ascii_case("content-type"))), called from both the execute path and PreparedResponse::try_build so the fast/slow serve paths cannot drift. This matches Mountebank (case-insensitive header handling).

Gate test oddly_cased_content_type_not_duplicated asserts BOTH serve paths emit exactly one Content-Type = the configured value. Added a CHANGELOG "Fixed" entry.

Verify: clippy 0 warnings; rift-mock-core response/content_type tests green (107 + 5 + 1).

Closes #723