### PR TITLE
perf(matching): deepEquals body dimension via structural hashing (O(1) probe for exact-JSON stubs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ record.
   flow_id=<Value>, method=<Verb> or path=<Path>)`). Older engines still fail closed with a clear
   `400` on the new clauses, so SDKs gate on a minimum engine version rather than sniffing.
 
+### Changed
+
+- **`deepEquals`-on-body matching is now indexed by a structural body hash** instead of being
+  compared stub-by-stub. For the classic contract-test workload — hundreds of stubs on one
+  path/method, each asserting one exact JSON body — selecting the matching stub drops from an
+  `O(stubs × body)` scan of structural comparisons to a single `O(body)` hash probe. Matching
+  results are unchanged; this is purely a prefilter. The index applies to default-mode `deepEquals`
+  whose `body` is a JSON object or array; `caseSensitive`/`keyCaseSensitive`, a `jsonpath`/`xpath`
+  selector, an `except`, a scalar `body`, or an expected body containing a string that is itself
+  JSON all fall back to the existing full comparison (correctness is never affected, only pruning).
+
 ### Fixed
 
 - **A stub whose configured `Content-Type` used a nonstandard casing (e.g. `CONTENT-TYPE`) with a

--- a/crates/rift-mock-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-mock-core/benches/imposter_matcher_bench.rs
@@ -343,13 +343,22 @@ fn bench_deepequals_body(c: &mut Criterion) {
     let headers: HashMap<String, String> = HashMap::new();
     let mut group = c.benchmark_group("find_matching_stub_deepequals_body");
     for count in [10usize, 100, 500] {
-        let imposter = imposter_with_stubs(count, &|i| {
-            json!({ "deepEquals": { "body": { "id": i, "kind": "order", "note": "x" } } })
-        });
+        let imposter = imposter_with_stubs(
+            count,
+            &|i| json!({ "deepEquals": { "body": { "id": i, "kind": "order", "note": "x" } } }),
+        );
         let body = format!(r#"{{"id":{},"kind":"order","note":"x"}}"#, count - 1);
         assert!(
             imposter
-                .find_matching_stub_with_client("POST", "/orders", &headers, None, Some(&body), None, None)
+                .find_matching_stub_with_client(
+                    "POST",
+                    "/orders",
+                    &headers,
+                    None,
+                    Some(&body),
+                    None,
+                    None
+                )
                 .expect("matching must not error")
                 .is_some(),
             "deepequals_body/{count}: fixture no longer matches its target stub",

--- a/crates/rift-mock-core/benches/imposter_matcher_bench.rs
+++ b/crates/rift-mock-core/benches/imposter_matcher_bench.rs
@@ -334,11 +334,52 @@ fn bench_xpath_heavy(c: &mut Criterion) {
     group.finish();
 }
 
+/// Issue #708: the deepEquals-body dimension's headline. Every stub asserts one exact JSON body via
+/// `deepEquals`, all sharing one path/method so no other dimension can prune — before #708 that meant
+/// a full recursive structural comparison of every stub's body on every request (O(stubs × body)).
+/// The request body equals the *last* stub's, so nothing short-circuits early. With the body-hash
+/// dimension the candidate set collapses to ~1 via a single hash probe.
+fn bench_deepequals_body(c: &mut Criterion) {
+    let headers: HashMap<String, String> = HashMap::new();
+    let mut group = c.benchmark_group("find_matching_stub_deepequals_body");
+    for count in [10usize, 100, 500] {
+        let imposter = imposter_with_stubs(count, &|i| {
+            json!({ "deepEquals": { "body": { "id": i, "kind": "order", "note": "x" } } })
+        });
+        let body = format!(r#"{{"id":{},"kind":"order","note":"x"}}"#, count - 1);
+        assert!(
+            imposter
+                .find_matching_stub_with_client("POST", "/orders", &headers, None, Some(&body), None, None)
+                .expect("matching must not error")
+                .is_some(),
+            "deepequals_body/{count}: fixture no longer matches its target stub",
+        );
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| {
+                imposter
+                    .find_matching_stub_with_client(
+                        "POST",
+                        black_box("/orders"),
+                        black_box(&headers),
+                        None,
+                        black_box(Some(body.as_str())),
+                        None,
+                        None,
+                    )
+                    .expect("matching must not error")
+            })
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_stub_matches,
     bench_find_matching_stub,
     bench_method_dimension,
-    bench_xpath_heavy
+    bench_xpath_heavy,
+    bench_deepequals_body
 );
 criterion_main!(benches);

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -65,7 +65,10 @@ impl Imposter {
         // shared across every remaining stub in this request's scan — one parse per request, not
         // one per XPath predicate evaluation.
         let xml_dom = body.map(crate::behaviors::LazyXmlDom::new);
-        for stub_idx in snapshot.candidates(method, path).iter() {
+        for stub_idx in snapshot
+            .candidates_with_body(method, path, body_json.as_ref())
+            .iter()
+        {
             let stub_state = &stubs[stub_idx];
             let stub = &stub_state.stub;
             // Correlated-isolation gate (issue #223, runs first): a space-scoped stub only

--- a/crates/rift-mock-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-mock-core/src/imposter/core/stub_index.rs
@@ -2193,7 +2193,7 @@ mod tests {
             json!([{"deepEquals": {"body": "hello"}}]), // 3 scalar body (raw-string compare)
             json!([{"deepEquals": {"body": {"a": "{\"k\":1}"}}}]), // 4 JSON-in-string leaf in expected
             json!([{"deepEquals": {"body": {"a": 1}}, "except": "x"}]), // 5 except (rewrites the value)
-            deep_body(json!({"eligible": true})),                  // 6 ELIGIBLE (indexed)
+            deep_body(json!({"eligible": true})),                       // 6 ELIGIBLE (indexed)
         ]);
         // A body matching only stub 6: the eligible stub is hit by the probe; the six ineligible
         // stubs are `always` and must all remain — none can be hash-pruned.

--- a/crates/rift-mock-core/src/imposter/core/stub_index.rs
+++ b/crates/rift-mock-core/src/imposter/core/stub_index.rs
@@ -50,6 +50,7 @@
 
 use super::StubState;
 use super::bitset::CandidateBits;
+use crate::imposter::predicates::json::structural_hash;
 use crate::imposter::types::Stub;
 use crate::util::FastMap;
 use aho_corasick::{AhoCorasick, MatchKind as AcMatchKind};
@@ -64,6 +65,9 @@ use std::sync::Arc;
 pub(crate) struct DimensionRequest<'a> {
     pub(crate) method: &'a str,
     pub(crate) path: &'a str,
+    /// The request body parsed as JSON once per request (#290), if it parsed. `None` for a non-JSON
+    /// or absent body — the body dimension (#708) can only prune JSON request bodies.
+    pub(crate) body: Option<&'a serde_json::Value>,
 }
 
 /// One pruning dimension of the index. See the module docs for the soundness rule this contract
@@ -656,6 +660,70 @@ impl Dimension for RegexDimension {
     }
 }
 
+/// The structural hash of a stub predicate's eligible `deepEquals`-on-`body` constraint (#708).
+///
+/// Eligible (conservative first cut): a top-level `deepEquals` whose `body` field is an object or
+/// array (a scalar `body` compares against the raw request string, not the parse — `fields.rs`),
+/// that is safely indexable ([`is_safely_indexable`]: no `except`, no selector, not
+/// `caseSensitive: true`) and not `keyCaseSensitive: true`, and whose expected body has no JSON-ish
+/// string leaf ([`structural_hash`] → `Some`). Anything else → `None` → `always_bits`.
+///
+/// Other fields on the same `deepEquals`, and the stub's other predicates, are further required
+/// constraints; ignoring them here only over-approximates (Stage-2 still checks them), exactly as
+/// the path/regex/literal classifiers index only their first anchor.
+fn body_anchor(pred: &Predicate) -> Option<u64> {
+    if !is_safely_indexable(&pred.parameters) || pred.parameters.key_case_sensitive == Some(true) {
+        return None;
+    }
+    let PredicateOperation::DeepEquals(fields) = &pred.operation else {
+        return None;
+    };
+    match fields.get("body") {
+        Some(v @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) => {
+            structural_hash(v)
+        }
+        _ => None,
+    }
+}
+
+/// The deepEquals-body dimension (issue #708): collapses "which of N `deepEquals`-on-body stubs
+/// equals this request body" from O(stubs × body) structural comparisons into one hash probe.
+struct BodyHashDimension {
+    /// `structural_hash(expected body)` → the stubs sharing it. A `Vec` bucket (not a bitset) like
+    /// [`PathDimension`], since it holds only the stubs at one hash. Keyed by our own `FixedState`-
+    /// derived `u64`, so the request-scoped `FastMap` hasher just re-hashes an already-good `u64`.
+    by_hash: FastMap<u64, Vec<usize>>,
+    /// Stubs with no eligible `deepEquals` body anchor — always candidates on this dimension.
+    always: CandidateBits,
+    len: usize,
+}
+
+impl Dimension for BodyHashDimension {
+    fn select(&self, request: &DimensionRequest<'_>, out: &mut CandidateBits) {
+        match request.body {
+            // A non-JSON (or absent) body can never `deepEquals` an object/array expected body, so
+            // every indexed stub is soundly excluded — only `always` stubs survive.
+            None => out.copy_from(&self.always),
+            Some(body) => match structural_hash(body) {
+                // A JSON-ish string leaf in the request body is equivalent (both directions) to a
+                // container an indexed stub may expect, which no structural hash can reconcile — so
+                // this dimension must not prune this request. Widen to all; Stage-2 decides.
+                None => out.copy_from(&CandidateBits::all(self.len)),
+                Some(h) => {
+                    out.copy_from(&self.always);
+                    if let Some(ids) = self.by_hash.get(&h) {
+                        ids.iter().for_each(|i| out.set(*i));
+                    }
+                }
+            },
+        }
+    }
+
+    fn prunes(&self) -> bool {
+        !self.by_hash.is_empty()
+    }
+}
+
 /// The multi-dimensional candidate prefilter over a stub snapshot. See the module docs.
 pub(crate) struct StubIndex {
     len: usize,
@@ -663,6 +731,7 @@ pub(crate) struct StubIndex {
     method: MethodDimension,
     literal: LiteralDimension,
     regex: RegexDimension,
+    body: BodyHashDimension,
 }
 
 impl StubIndex {
@@ -683,6 +752,9 @@ impl StubIndex {
         let mut regex_ci: Vec<(usize, String)> = Vec::new();
         let mut regex_cs: Vec<(usize, String)> = Vec::new();
         let mut regex_always = CandidateBits::zeros(len);
+
+        let mut body_by_hash: FastMap<u64, Vec<usize>> = FastMap::default();
+        let mut body_always = CandidateBits::zeros(len);
 
         for (i, state) in stubs.iter().enumerate() {
             match classify(&state.stub) {
@@ -712,6 +784,12 @@ impl StubIndex {
                 Some(a) if a.case_sensitive => regex_cs.push((i, a.pattern.to_owned())),
                 Some(a) => regex_ci.push((i, a.pattern.to_owned())),
                 None => regex_always.set(i),
+            }
+            // Only the first eligible deepEquals-body anchor is indexed — same first-anchor rule as
+            // above; a stub's further body constraints stay required and are checked by Stage 2.
+            match state.stub.predicates.iter().find_map(body_anchor) {
+                Some(h) => body_by_hash.entry(h).or_default().push(i),
+                None => body_always.set(i),
             }
         }
 
@@ -745,12 +823,18 @@ impl StubIndex {
             sensitive,
             always: regex_always,
         };
+        let body = BodyHashDimension {
+            by_hash: body_by_hash,
+            always: body_always,
+            len,
+        };
         StubIndex {
             len,
             path,
             method,
             literal,
             regex,
+            body,
         }
     }
 
@@ -821,8 +905,11 @@ impl StubIndex {
         if Self::fold_in(&self.method, request, &mut acc, &mut seeded, self.len)
             && Self::fold_in(&self.path, request, &mut acc, &mut seeded, self.len)
             && Self::fold_in(&self.literal, request, &mut acc, &mut seeded, self.len)
+            && Self::fold_in(&self.regex, request, &mut acc, &mut seeded, self.len)
         {
-            Self::fold_in(&self.regex, request, &mut acc, &mut seeded, self.len);
+            // Body last: hashing the request body is O(body), so let the cheap path/method/automaton
+            // dimensions empty the accumulator first (short-circuiting the hash away) where they can.
+            Self::fold_in(&self.body, request, &mut acc, &mut seeded, self.len);
         }
 
         // No dimension indexes anything (e.g. every stub is a body regex): everyone is a candidate.
@@ -901,9 +988,25 @@ impl StubSnapshot {
         self.has_scenario_gate
     }
 
-    /// Candidate stub ids for a request — see [`StubIndex::candidates`].
+    /// Candidate stub ids for a request that carries no (or a non-JSON) body — see
+    /// [`StubIndex::candidates`]. The body dimension then contributes only its `always` stubs.
     pub(crate) fn candidates(&self, method: &str, path: &str) -> CandidateBits {
-        self.index.candidates(&DimensionRequest { method, path })
+        self.candidates_with_body(method, path, None)
+    }
+
+    /// Candidate stub ids for a request, threading the once-per-request parsed body (#290/#708) so
+    /// the deepEquals-body dimension can prune. `body_json` is `None` for a non-JSON/absent body.
+    pub(crate) fn candidates_with_body(
+        &self,
+        method: &str,
+        path: &str,
+        body_json: Option<&serde_json::Value>,
+    ) -> CandidateBits {
+        self.index.candidates(&DimensionRequest {
+            method,
+            path,
+            body: body_json,
+        })
     }
 
     /// The index over these stubs (tests assert dimension-level behaviour through it).
@@ -946,6 +1049,18 @@ mod tests {
     /// existing coverage/ordering assertions read unchanged.
     fn candidate_ids(snap: &StubSnapshot, method: &str, path: &str) -> Vec<usize> {
         snap.candidates(method, path).iter().collect()
+    }
+
+    /// The candidate ids for a request with a JSON body, ascending (#708 body dimension).
+    fn candidate_ids_body(
+        snap: &StubSnapshot,
+        method: &str,
+        path: &str,
+        body: &Value,
+    ) -> Vec<usize> {
+        snap.candidates_with_body(method, path, Some(body))
+            .iter()
+            .collect()
     }
 
     fn imposter(preds: &[Value]) -> Imposter {
@@ -1369,7 +1484,7 @@ mod tests {
             .map(|_| {
                 let seg = SEGS[rng.gen_range(0..SEGS.len())];
                 let m = METHODS[rng.gen_range(0..METHODS.len())];
-                match rng.gen_range(0..28) {
+                match rng.gen_range(0..32) {
                     // Indexable on both dimensions (one predicate, two fields).
                     0 => json!([{"equals": {"method": m, "path": seg}}]),
                     // Indexable on both dimensions (two separate top-level predicates).
@@ -1420,6 +1535,14 @@ mod tests {
                     // a shape that reliably produces it this oracle cannot see that whole class of
                     // under-approximation — it passed against exactly that bug during #709.
                     19 => json!([{"matches": {"path": format!("^{seg}")}}]),
+                    // deepEquals-body (#708): eligible object/array bodies the body-hash dimension
+                    // indexes, drawn from the same templates the request generator sends so they
+                    // frequently match — the shape that exercises the dimension, not just its always
+                    // set. `caseSensitive`/json-in-string are the carve-outs that must stay always.
+                    28 => json!([{"deepEquals": {"body": {"k": 1}}}]),
+                    29 => json!([{"deepEquals": {"body": [1, 2]}}]),
+                    30 => json!([{"deepEquals": {"body": {"n": {"a": 1}}}}]),
+                    31 => json!([{"deepEquals": {"body": {"k": 1}}, "caseSensitive": true}]),
                     _ => json!([]),
                 }
             })
@@ -1460,10 +1583,18 @@ mod tests {
             for _ in 0..1250 {
                 let m = METHODS[rng.gen_range(0..METHODS.len())];
                 let p = PATHS[rng.gen_range(0..PATHS.len())];
-                let body = if rng.gen_bool(0.25) {
-                    Some("ping")
-                } else {
-                    None
+                // Mix non-JSON, absent, and several JSON bodies — exact matches, a type-coercion
+                // variant, an array, a JSON-in-string leaf (the bail path), and a nested object —
+                // so the body-hash dimension (#708) is exercised against the linear oracle.
+                let body = match rng.gen_range(0..8) {
+                    0 => Some("ping"),
+                    1 => Some(r#"{"k":1}"#),
+                    2 => Some(r#"{"k":"1"}"#),
+                    3 => Some(r#"[1,2]"#),
+                    4 => Some(r#"{"n":{"a":1}}"#),
+                    5 => Some(r#"{"j":"{\"x\":1}"}"#),
+                    6 => None,
+                    _ => None,
                 };
                 let query = if rng.gen_bool(0.25) {
                     Some("a=1")
@@ -2013,5 +2144,91 @@ mod tests {
             {"or": [{"equals": {"path": "/a"}}, {"not": {"inject": "function (config) { return true; }"}}]}
         ])]));
         assert!(under_not_in_or.has_inject());
+    }
+
+    // ---- issue #708: deepEquals body-hash dimension ----
+
+    fn deep_body(expected: Value) -> Value {
+        json!([{"deepEquals": {"body": expected}}])
+    }
+
+    #[test]
+    fn body_dimension_collapses_candidates() {
+        // 500 deepEquals-body stubs, each expecting a distinct object. A request equal to one must
+        // probe down to just that stub — O(stubs) structural comparisons collapse to one hash probe.
+        let preds: Vec<Value> = (0..500)
+            .map(|i| deep_body(json!({"id": i, "kind": "order"})))
+            .collect();
+        let snap = snapshot(&preds);
+
+        let target = 437usize;
+        let ids = candidate_ids_body(&snap, "POST", "/x", &json!({"id": target, "kind": "order"}));
+        assert_eq!(ids.len(), 1, "collapses to a single candidate, got {ids:?}");
+        assert_eq!(ids, vec![target]);
+
+        // A body equal to none of them prunes the whole dimension to empty.
+        assert!(
+            candidate_ids_body(&snap, "POST", "/x", &json!({"id": 9999, "kind": "order"}))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn body_dimension_matches_across_coercion_key_order_and_case() {
+        let snap = snapshot(&[
+            deep_body(json!({"a": 1, "b": "x"})), // 0
+            deep_body(json!({"a": 2})),           // 1
+        ]);
+        // number↔string coercion, object key order, and ASCII key/value case all fold to stub 0.
+        let ids = candidate_ids_body(&snap, "POST", "/p", &json!({"B": "X", "a": "1"}));
+        assert_eq!(ids, vec![0]);
+    }
+
+    #[test]
+    fn body_dimension_ineligible_stubs_are_never_pruned() {
+        let snap = snapshot(&[
+            json!([{"deepEquals": {"body": {"a": 1}}, "caseSensitive": true}]), // 0 caseSensitive
+            json!([{"deepEquals": {"body": {"a": 1}}, "keyCaseSensitive": true}]), // 1 keyCaseSensitive
+            json!([{"deepEquals": {"body": {"a": 1}}, "jsonpath": {"selector": "$.x"}}]), // 2 selector
+            json!([{"deepEquals": {"body": "hello"}}]), // 3 scalar body (raw-string compare)
+            json!([{"deepEquals": {"body": {"a": "{\"k\":1}"}}}]), // 4 JSON-in-string leaf in expected
+            json!([{"deepEquals": {"body": {"a": 1}}, "except": "x"}]), // 5 except (rewrites the value)
+            deep_body(json!({"eligible": true})),                  // 6 ELIGIBLE (indexed)
+        ]);
+        // A body matching only stub 6: the eligible stub is hit by the probe; the six ineligible
+        // stubs are `always` and must all remain — none can be hash-pruned.
+        let hit = candidate_ids_body(&snap, "POST", "/p", &json!({"eligible": true}));
+        assert_eq!(hit, vec![0, 1, 2, 3, 4, 5, 6]);
+        // A body matching none: only the eligible stub 6 is pruned; the carve-outs stay candidates.
+        let miss = candidate_ids_body(&snap, "POST", "/p", &json!({"zzz": 0}));
+        assert_eq!(miss, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn body_dimension_non_json_body_excludes_indexed_stubs() {
+        let snap = snapshot(&[
+            deep_body(json!({"a": 1})),          // 0 indexed body stub
+            json!([{"equals": {"path": "/p"}}]), // 1 path stub
+        ]);
+        // `candidate_ids` sends no body (the non-JSON/absent case): the indexed body stub cannot
+        // match, so it is excluded; the path stub still matches /p.
+        assert_eq!(candidate_ids(&snap, "GET", "/p"), vec![1]);
+    }
+
+    #[test]
+    fn body_dimension_json_in_string_request_widens() {
+        let snap = snapshot(&[
+            deep_body(json!({"a": {"b": 1}})), // 0 expects a nested object
+            deep_body(json!({"z": 9})),        // 1
+        ]);
+        // The request body carries a JSON-ish string leaf, equivalent (both directions) to the
+        // object stub 0 expects. The dimension must not prune — it widens to every candidate so
+        // Stage-2 can confirm stub 0. (Soundness over precision: stub 1 rides along.)
+        let ids = candidate_ids_body(&snap, "POST", "/p", &json!({"a": "{\"b\":1}"}));
+        assert_eq!(
+            ids,
+            vec![0, 1],
+            "a JSON-ish string leaf disables pruning for the dimension"
+        );
     }
 }

--- a/crates/rift-mock-core/src/imposter/predicates/json.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/json.rs
@@ -491,7 +491,10 @@ mod structural_hash_tests {
         // deepEquals compares arrays element-wise (order-sensitive), so the hash must be too —
         // `[1,2]` and `[2,1]` do not deep-equal and should not collide.
         assert!(!deep_equals_default(&json!([1, 2]), &json!([2, 1])));
-        assert_ne!(structural_hash(&json!([1, 2])), structural_hash(&json!([2, 1])));
+        assert_ne!(
+            structural_hash(&json!([1, 2])),
+            structural_hash(&json!([2, 1]))
+        );
     }
 
     // A tiny deterministic LCG — a seeded, dependency-free "proptest-style" generator (the design

--- a/crates/rift-mock-core/src/imposter/predicates/json.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/json.rs
@@ -304,3 +304,326 @@ where
         }
     }
 }
+
+/// Whether a string could itself be JSON — trimmed, it starts with `{` or `[`.
+///
+/// Such a leaf is the one case a purely structural hash cannot handle: `compare_json_recursive`
+/// re-stringifies actual values and re-parses when the expected side is a container, so a string
+/// leaf `"{\"b\":1}"` is equivalent to the object `{"b":1}` (in **both** directions). See
+/// [`structural_hash`].
+fn is_jsonish_string(s: &str) -> bool {
+    let t = s.trim_start();
+    t.starts_with('{') || t.starts_with('[')
+}
+
+/// A finalizing bit-mixer (MurmurHash3 fmix64) so structurally-derived intermediate values don't
+/// collide on low bits.
+fn mix64(mut x: u64) -> u64 {
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51afd7ed558ccd);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xc4ceb9fe1a85ec53);
+    x ^= x >> 33;
+    x
+}
+
+/// Order-sensitive combine of two sub-hashes (arrays, and key↔value within an object entry).
+fn combine(a: u64, b: u64) -> u64 {
+    mix64(a ^ mix64(b).rotate_left(31))
+}
+
+/// Hash a string leaf under the comparator's default fold.
+///
+/// `FixedState` (not `RandomState`): this `u64` is *stored* in the body-index map and computed at
+/// two different times (index build vs request), so it must be stable within the process — the same
+/// reason `decision_cache::hash_body` uses it.
+fn hash_folded(s: &str) -> u64 {
+    // Default (non-`caseSensitive`) leaf comparison is `eq_ignore_ascii_case`, so folding with
+    // `to_ascii_lowercase` before hashing makes case-equal leaves hash-equal — exactly and only
+    // ASCII, matching the evaluator (Unicode folding would over-collapse; see `stub_index::fold`).
+    foldhash::fast::FixedState::default().hash_one(s.to_ascii_lowercase())
+}
+
+/// Container type tags, keeping `{}`/`[]`/leaves in distinct hash spaces. Leaves carry **no** tag,
+/// so the comparator's type coercion (`1`≡`"1"`, `true`≡`"true"`, `null`≡`""`) is preserved.
+const OBJ_TAG: u64 = 0x9e37_79b9_7f4a_7c15;
+const ARR_TAG: u64 = 0xc2b2_ae3d_27d4_eb4f;
+
+/// A structural hash of a JSON value under the **deepEquals default-mode** comparator's equivalence
+/// relation — the one the body-hash index (#708) probes with. It is derived from
+/// [`compare_json_recursive`]'s own shape, NOT from `serde_json::Value::eq`:
+///
+/// - **Leaves** hash `fold(json_value_to_string(v))`, so cross-type coercions the comparator treats
+///   as equal collapse to one bucket: `1`≡`"1"`, `true`≡`"true"`, `null`≡`""`, and ASCII-case-equal
+///   strings. Distinct stringifications stay distinct (`1.0`≢`1`).
+/// - **Objects** combine commutatively (key order is irrelevant — deepEquals matches keys
+///   case-insensitively by default) over `combine(hash(fold(key)), hash(value))`, plus a length tag
+///   (deepEquals is length-exact).
+/// - **Arrays** combine order-sensitively, plus a length tag.
+///
+/// Returns `None` when the value contains a JSON-ish string leaf (see [`is_jsonish_string`]): no
+/// structural hash can reconcile a string with the container it is equivalent to, so the caller
+/// treats `None` as "not indexable" at build time and "do not prune this dimension" at request time
+/// — both of which only ever *widen* the candidate set, so soundness is preserved.
+///
+/// Collisions are harmless: the index over-approximates and Stage-2 (`compare_json_recursive`)
+/// rejects false candidates. The one real bug class is *under*-approximation — a value equal under
+/// the comparator hashing differently — which is what the `structural_hash` property test guards.
+pub(crate) fn structural_hash(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut acc: u64 = 0;
+            for (k, v) in map {
+                let entry = combine(hash_folded(k), structural_hash(v)?);
+                // Commutative (wrapping-add) so object key order does not affect the hash, but each
+                // entry is `mix64`'d first so `{"a":"b"}` and `{"b":"a"}` do not cancel.
+                acc = acc.wrapping_add(mix64(entry));
+            }
+            Some(combine(OBJ_TAG, combine(map.len() as u64, acc)))
+        }
+        serde_json::Value::Array(arr) => {
+            let mut h = ARR_TAG;
+            for v in arr {
+                h = combine(h, structural_hash(v)?);
+            }
+            Some(combine(h, arr.len() as u64))
+        }
+        serde_json::Value::String(s) if is_jsonish_string(s) => None,
+        // String (non-JSON-ish), Number, Bool, Null: the comparator compares the *stringified* leaf,
+        // so hash that same normalization. `json_value_to_string(String)` is the raw string, so this
+        // arm treats a plain string and the scalar that stringifies to it identically.
+        _ => Some(hash_folded(&json_value_to_string(value))),
+    }
+}
+
+#[cfg(test)]
+mod structural_hash_tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    /// deepEquals in default mode (the exact relation the body index indexes): case-insensitive
+    /// leaves, case-insensitive keys, length-exact, no `except`, no selector.
+    fn deep_equals_default(expected: &Value, actual: &Value) -> bool {
+        compare_json_recursive(
+            expected,
+            &json_value_to_string(actual),
+            &|e: &str, a: &str| e.eq_ignore_ascii_case(a),
+            true,  // deep_equals
+            false, // key_case_sensitive (defaults to caseSensitive = false)
+            &|s: &str| std::borrow::Cow::Borrowed(s),
+            Some(actual),
+        )
+    }
+
+    /// The soundness contract: if two values are deepEquals-equal, either they hash the same, or one
+    /// of them is un-indexable (a JSON-ish string leaf → `None`, which makes the dimension not prune).
+    /// Anything else would be an under-approximation — a matching stub silently dropped.
+    fn assert_sound(e: &Value, a: &Value) {
+        if deep_equals_default(e, a) {
+            let (he, ha) = (structural_hash(e), structural_hash(a));
+            assert!(
+                he.is_none() || ha.is_none() || he == ha,
+                "under-approximation: deep_equals holds but hashes differ\n e={e}\n a={a}\n he={he:?} ha={ha:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn concrete_cross_type_equivalences_hash_equal() {
+        // Each pair deep-equals in default mode and must therefore hash-agree.
+        for (e, a) in [
+            (json!({"n": 1}), json!({"n": "1"})), // number ≡ its string
+            (json!({"b": true}), json!({"b": "true"})), // bool ≡ its string
+            (json!({"z": null}), json!({"z": ""})), // null ≡ empty string
+            (json!({"s": "ABC"}), json!({"s": "abc"})), // ASCII case fold
+            (json!({"a": 1, "b": 2}), json!({"b": 2, "a": 1})), // object key order
+            (json!({"Key": 1}), json!({"key": 1})), // key case (keyCaseSensitive default false)
+            (json!([1, "2", null]), json!(["1", 2, ""])), // nested array coercions
+            (json!({"o": {"x": 1}}), json!({"o": {"x": "1"}})), // nested object
+        ] {
+            assert!(
+                deep_equals_default(&e, &a),
+                "precondition: {e} deep-equals {a}"
+            );
+            assert_eq!(
+                structural_hash(&e),
+                structural_hash(&a),
+                "{e} and {a} deep-equal but hash differently"
+            );
+            assert!(structural_hash(&e).is_some());
+        }
+    }
+
+    #[test]
+    fn distinct_numbers_stay_distinct() {
+        // 1.0 and 1 stringify differently ("1.0" vs "1"), do NOT deep-equal, and must not collide.
+        assert!(!deep_equals_default(&json!({"n": 1.0}), &json!({"n": 1})));
+        assert_ne!(
+            structural_hash(&json!({"n": 1.0})),
+            structural_hash(&json!({"n": 1}))
+        );
+    }
+
+    #[test]
+    fn json_in_string_leaf_bails_both_directions() {
+        // A string leaf that could be JSON is equivalent to the container it encodes, in both
+        // directions — structural_hash must return None so the caller widens rather than prunes.
+        assert_eq!(structural_hash(&json!({"a": "{\"b\":1}"})), None);
+        assert_eq!(structural_hash(&json!({"a": " [1,2]"})), None); // leading space, still JSON-ish
+        assert_eq!(structural_hash(&json!(["{}"])), None);
+        // And the equivalence it protects really holds under the comparator:
+        assert!(deep_equals_default(
+            &json!({"a": {"b": 1}}),
+            &json!({"a": "{\"b\":1}"})
+        ));
+        // A plain string that merely contains a brace later is not JSON-ish → still indexable.
+        assert!(structural_hash(&json!({"a": "x{y"})).is_some());
+    }
+
+    #[test]
+    fn empty_container_types_are_distinct() {
+        assert_ne!(structural_hash(&json!({})), structural_hash(&json!([])));
+        assert_ne!(structural_hash(&json!({})), structural_hash(&json!("")));
+    }
+
+    #[test]
+    fn array_order_is_significant() {
+        // deepEquals compares arrays element-wise (order-sensitive), so the hash must be too —
+        // `[1,2]` and `[2,1]` do not deep-equal and should not collide.
+        assert!(!deep_equals_default(&json!([1, 2]), &json!([2, 1])));
+        assert_ne!(structural_hash(&json!([1, 2])), structural_hash(&json!([2, 1])));
+    }
+
+    // A tiny deterministic LCG — a seeded, dependency-free "proptest-style" generator (the design
+    // sign-off asked for ~10k seeded cases). Determinism matters so a failure is reproducible.
+    struct Lcg(u64);
+    impl Lcg {
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0
+        }
+        fn below(&mut self, n: u64) -> u64 {
+            self.next_u64() % n
+        }
+        fn coin(&mut self) -> bool {
+            self.next_u64() & 1 == 1
+        }
+    }
+
+    fn gen_value(rng: &mut Lcg, depth: u32) -> Value {
+        // Leaf bias grows with depth so trees terminate.
+        let leaf = depth == 0 || rng.below(100) < (40 + u64::from(depth) * 25);
+        if leaf {
+            match rng.below(7) {
+                0 => Value::Null,
+                1 => Value::Bool(rng.coin()),
+                2 => json!(rng.below(4) as i64), // small ints so "n" ≡ "\"n\"" pairs recur
+                3 => json!(rng.below(3) as f64 + 0.5), // non-integer floats
+                4 => Value::String(["a", "B", "aB", ""][rng.below(4) as usize].to_string()),
+                5 => Value::String(rng.below(4).to_string()), // digit strings ≡ numbers
+                _ => Value::String("{jsonish".to_string()),   // exercises the bail path
+            }
+        } else if rng.coin() {
+            let n = rng.below(3);
+            let mut m = serde_json::Map::new();
+            for i in 0..n {
+                let key = ["k", "K", "other"][i as usize % 3].to_string();
+                m.insert(key, gen_value(rng, depth - 1));
+            }
+            Value::Object(m)
+        } else {
+            let n = rng.below(3);
+            Value::Array((0..n).map(|_| gen_value(rng, depth - 1)).collect())
+        }
+    }
+
+    /// Produce a value that deep-equals `v` in default mode (coerce scalars across types, flip ASCII
+    /// case, permute object keys) so the property test actually exercises equality, not just the
+    /// vacuous `false` branch.
+    fn preserving_variant(rng: &mut Lcg, v: &Value) -> Value {
+        match v {
+            Value::Null => {
+                if rng.coin() {
+                    Value::String(String::new())
+                } else {
+                    Value::Null
+                }
+            }
+            Value::Bool(b) => {
+                if rng.coin() {
+                    Value::String(b.to_string())
+                } else {
+                    Value::Bool(*b)
+                }
+            }
+            Value::Number(n) => {
+                if rng.coin() {
+                    Value::String(n.to_string())
+                } else {
+                    Value::Number(n.clone())
+                }
+            }
+            Value::String(s) => {
+                // Case-flip is fold-preserving; leave JSON-ish strings untouched (both sides bail).
+                if is_jsonish_string(s) {
+                    Value::String(s.clone())
+                } else if rng.coin() {
+                    Value::String(s.to_uppercase())
+                } else {
+                    Value::String(s.to_lowercase())
+                }
+            }
+            Value::Array(a) => Value::Array(a.iter().map(|e| preserving_variant(rng, e)).collect()),
+            Value::Object(m) => {
+                // Rebuild in a different insertion order, flipping key case (default keyCaseSensitive
+                // is false). serde_json::Map preserves insertion order, so reversing exercises the
+                // commutative object combine.
+                let mut entries: Vec<(String, Value)> = m
+                    .iter()
+                    .map(|(k, val)| {
+                        let key = if rng.coin() {
+                            k.to_uppercase()
+                        } else {
+                            k.clone()
+                        };
+                        (key, preserving_variant(rng, val))
+                    })
+                    .collect();
+                entries.reverse();
+                Value::Object(entries.into_iter().collect())
+            }
+        }
+    }
+
+    #[test]
+    fn structural_hash_agrees_with_deep_equals_property() {
+        let mut rng = Lcg(0x5eed_1234_9e37_79b9);
+        let mut deep_equal_cases = 0u32;
+        let iterations = 10_000;
+        for _ in 0..iterations {
+            let a = gen_value(&mut rng, 3);
+            // Half the time compare against a comparator-preserving variant (forces frequent
+            // equality); half against a freshly generated value (mostly inequality).
+            let e = if rng.coin() {
+                preserving_variant(&mut rng, &a)
+            } else {
+                gen_value(&mut rng, 3)
+            };
+            if deep_equals_default(&e, &a) {
+                deep_equal_cases += 1;
+            }
+            assert_sound(&e, &a);
+            // Symmetric: the comparator is not symmetric in general, but the index must be sound
+            // whichever side is the indexed (expected) stub.
+            assert_sound(&a, &e);
+        }
+        assert!(
+            deep_equal_cases > iterations / 10,
+            "generator too weak: only {deep_equal_cases}/{iterations} deep-equal pairs — the \
+             soundness assertion would be near-vacuous"
+        );
+    }
+}

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -557,7 +557,7 @@ where
 }
 
 mod fields;
-mod json;
+pub(crate) mod json;
 pub(crate) mod regex_cache;
 use fields::{check_predicate_fields, check_predicate_fields_regex};
 use json::check_exists_predicate;


### PR DESCRIPTION
Turns "which of N `deepEquals`-on-body stubs equals this request body" into a single hash probe, per the owner's signed-off corrected design on the issue.

## What
- New `structural_hash(&Value) -> Option<u64>` colocated with `compare_json_recursive` (`predicates/json.rs`), derived from the **comparator's** equivalence — `fold(json_value_to_string(v))`, NOT `Value::eq` — so `1`≡`"1"`, `true`≡`"true"`, `null`≡`""`, ASCII-case- and key-order-insensitive, length-exact. Returns `None` (→ widen, never prune) for the JSON-in-string case a structural hash can't reconcile.
- New `BodyHashDimension` in the candidate-bitset framework (`stub_index.rs`): eligible default-mode `deepEquals` bodies (object/array, no `except`/selector, not `caseSensitive`/`keyCaseSensitive`, no JSON-ish string leaf) are keyed by hash; everything else stays `always`.
- Request-time: the once-parsed body (#290) is threaded into `candidates_with_body`; the dimension runs last (after the cheap path/method/automaton dims) since it's O(body).

## Soundness (the only real bug class is under-approximation)
- 10k-iteration seeded property test: `deep_equals(e,a) ⟹ hash agrees` over the **verifier**, with cross-type / case / key-order / JSON-in-string generators, both directions.
- Extended the seeded `differential_index_matches_linear_oracle` with deepEquals-body stubs + JSON request bodies (8×1250 requests, indexed == linear).
- All optional/fallible paths fail toward **widening**.

## Bench (`find_matching_stub_deepequals_body`, this machine) — flat in stub count:
- 10 stubs: 512 ns
- 100 stubs: 520 ns
- 500 stubs: 524 ns

(vs. the pre-#708 O(stubs) structural scan, which grows with stub count.)

Verify: clippy 0; full rift-mock-core lib 1247 tests green; new tests: `structural_hash_tests` (6), `body_dimension_*` (5). CHANGELOG updated (Changed).

Closes #708