### PR TITLE
build(bench): allocator bake-off tooling — jemalloc/system builds, --allocator runner, RSS sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in `jemalloc` allocator feature for the server binary** (allocator bake-off, part of
+  #717). `cargo build --release --no-default-features --features redis-backend,javascript,jemalloc`
+  builds `rift-http-proxy` with tikv-jemallocator instead of the default mimalloc; when both
+  allocator features are enabled (e.g. `--all-features`), mimalloc takes precedence. The binary
+  logs `Global allocator: <name>` at startup, and the direct benchmark harness gained
+  `--allocator {mimalloc,jemalloc,system}` — per-allocator builds, RSS sampling
+  (`rss_mb_peak`/`rss_mb_end`), and suffixed result artefacts for three-way comparison. The
+  default allocator is unchanged; any switch is gated on #717's pre-registered decision rule.
+
 ### Fixed
 
 - **Recording-path throughput collapse once the journal hit its 10,000-entry cap.** A full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -4326,6 +4327,26 @@ dependencies = [
  "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -86,6 +86,9 @@ crossbeam = "0.8"
 # Feature-gated (default-on) so FFI/cdylib and cross-compile builds can drop it;
 # it is wired only into the `rift-http-proxy` binary, never rift-mock-core/rift-ffi.
 mimalloc = { version = "0.1", optional = true }
+# Allocator bake-off candidate (issue #717): opt-in alternative to mimalloc for A/B
+# throughput/RSS comparison; never both wired as the active allocator (see [features]).
+tikv-jemallocator = { version = "0.6", optional = true }
 
 # XML/XPath support for Mountebank compatibility
 sxd-document = "0.3"
@@ -119,6 +122,10 @@ javascript = ["rift-mock-core/javascript"]
 # High-throughput global allocator for the server binary; drop it (e.g.
 # `--no-default-features`) for FFI/cross-compile builds that must not link it.
 mimalloc = ["dep:mimalloc"]
+# Opt-in bake-off allocator (#717): when both `mimalloc` and `jemalloc` are enabled
+# (e.g. CI's --all-features lanes) mimalloc wins by cfg precedence in main.rs — deliberately
+# NOT a compile_error! because CI builds --all-features.
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[bin]]
 name = "rift-verify"

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -25,6 +25,22 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// jemalloc bake-off build (issue #717): active only when `jemalloc` is enabled and
+// `mimalloc` is not — under `--all-features` (CI) mimalloc keeps precedence, so the
+// two allocator features can coexist without a compile_error.
+#[cfg(all(feature = "jemalloc", not(feature = "mimalloc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+/// Which global allocator this binary was built with — logged at startup so benchmark
+/// results are labeled by the binary itself, not by whoever invoked the build (#717).
+#[cfg(feature = "mimalloc")]
+const ACTIVE_ALLOCATOR: &str = "mimalloc";
+#[cfg(all(feature = "jemalloc", not(feature = "mimalloc")))]
+const ACTIVE_ALLOCATOR: &str = "jemalloc";
+#[cfg(not(any(feature = "mimalloc", feature = "jemalloc")))]
+const ACTIVE_ALLOCATOR: &str = "system";
+
 use clap::Parser;
 use rift_http_proxy::admin_api::DEFAULT_ADMIN_PORT;
 use rift_http_proxy::healthcheck;
@@ -150,6 +166,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Start in Mountebank mode
     info!("Starting Rift on port {}", cli.port);
+    info!("Global allocator: {}", ACTIVE_ALLOCATOR);
     run_mountebank_mode(cli)
 }
 

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -276,7 +276,17 @@ cargo build --release
 
 # Drop it (e.g. for a cross-compile or FFI build) by opting out of default features
 cargo build --release --no-default-features --features redis-backend,javascript
+
+# Or swap in jemalloc (bake-off candidate, issue #717)
+cargo build --release --no-default-features --features redis-backend,javascript,jemalloc
 ```
+
+An opt-in `jemalloc` feature builds the binary with
+[tikv-jemallocator](https://github.com/tikv/jemallocator) instead, for A/B allocator
+comparison; if both allocator features are enabled (e.g. `--all-features`), mimalloc takes
+precedence. The startup log reports which allocator is active (`Global allocator: …`), and the
+benchmark harness automates the three-way comparison — see the allocator bake-off section in
+`tests/benchmark/README.md`.
 
 Only the `rift-http-proxy` binary is affected; `rift-mock-core` and the FFI crate use the system
 allocator.

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -87,6 +87,28 @@ of `S` and only then climbs is healthy; one that climbs at 50 % points at backpr
 accept-loop contention — exactly the structural changes the Turbo Tier-3/Tier-4 issues
 target.
 
+### Allocator bake-off (issue #717, Rift-only)
+
+`--allocator {mimalloc,jemalloc,system}` benches one allocator variant: it builds the binary
+with the matching feature set into its own `target/alloc-<name>/` (so the three builds coexist;
+an explicit `--rift-bin` skips the build and is trusted verbatim), samples the engine's RSS once
+a second (`rss_mb_peak`/`rss_mb_end` CSV columns + an RSS matrix in the report), and writes
+suffixed artefacts (`direct_rift_<name>.csv`, `DIRECT_RIFT_SWEEP_REPORT_<name>.md`) so runs
+never overwrite each other:
+
+```bash
+for alloc in mimalloc jemalloc system; do
+  python3 scripts/bench_direct.py --run-all --allocator $alloc \
+      --sweep-connections 50,200 --duration 15s --warmup 2s
+done
+```
+
+The three variants differ **only** in the allocator — `redis-backend`+`javascript` stay enabled
+in all of them — and each binary logs `Global allocator: <name>` at startup, so a report can
+never mislabel its build. Decision rule and result recording live in #717 (pre-registered: a
+default switch needs ≥5% RPS or ≥20% p999/RSS on the majority of scenarios, macOS numbers are
+indicative — the decision run is Linux x86_64).
+
 Both scripts run each engine **one at a time on disjoint port ranges** (no CPU
 contention, no cross-talk), launch it in its own process group and hard-kill it by
 group + `lsof` before the next engine starts, and post **identical** imposter JSON to

--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -20,7 +20,7 @@ Run everything (launches + stops both engines, writes the report):
 Must be run OUTSIDE the CLI sandbox (via the sidecar) because `oha` needs
 macOS keychain access to initialise TLS even for plain-HTTP targets.
 """
-import argparse, csv, json, subprocess, sys, time, urllib.request, urllib.error, os, signal, shutil
+import argparse, csv, json, subprocess, sys, threading, time, urllib.request, urllib.error, os, signal, shutil
 
 RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
 
@@ -335,9 +335,92 @@ def metric(j):
         "codes": codes,
     }
 
-# ---- results CSV (extended with `connections` + `mode` + `p999_ms`, issue #702) ----
+# ---- allocator bake-off (issue #717): build-arg selection + RSS sampling ----
 
-CSV_HEADER = "scenario,connections,mode,rps,p50_ms,p90_ms,p99_ms,p999_ms,avg_ms"
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+ALLOCATORS = ("mimalloc", "jemalloc", "system")
+DEFAULT_RIFT_BIN = os.path.join(REPO_ROOT, "target", "release", "rift-http-proxy")
+
+def allocator_build_args(name):
+    """Cargo flags that swap ONLY the global allocator, keeping redis-backend+javascript on in
+    every variant so the three builds are functionally identical apart from the allocator (#717)."""
+    if name == "mimalloc":
+        return []   # default features already include mimalloc
+    if name == "jemalloc":
+        return ["--no-default-features", "--features", "redis-backend,javascript,jemalloc"]
+    if name == "system":
+        return ["--no-default-features", "--features", "redis-backend,javascript"]
+    raise ValueError(f"unknown allocator {name!r}: choose from {','.join(ALLOCATORS)}")
+
+def allocator_bin_path(name):
+    """Per-allocator binary path; a separate --target-dir per allocator so three builds can
+    coexist on disk instead of clobbering each other's `target/release` (#717)."""
+    return os.path.join(REPO_ROOT, "target", f"alloc-{name}", "release", "rift-http-proxy")
+
+def resolve_rift_bin(rift_bin_arg, allocator):
+    """Resolve (path, needs_build). An explicit --rift-bin is always trusted verbatim (no build,
+    even if --allocator is also set). No allocator selected: fall back to the default release
+    path, unchanged from pre-#717 behaviour. Allocator selected with no --rift-bin: build into
+    the per-allocator target dir."""
+    if rift_bin_arg is not None:
+        return rift_bin_arg, False
+    if allocator is None:
+        return DEFAULT_RIFT_BIN, False
+    return allocator_bin_path(allocator), True
+
+def build_allocator_binary(name):
+    """Build the bake-off binary for one allocator into target/alloc-<name>/ (#717)."""
+    print(f"building rift with allocator={name}")
+    cmd = ["cargo", "build", "--release", "-p", "rift-http-proxy",
+           "--target-dir", os.path.join("target", f"alloc-{name}")] + allocator_build_args(name)
+    out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    if out.returncode != 0:
+        tail = "\n".join((out.stdout + out.stderr).splitlines()[-40:])
+        raise SystemExit(f"build failed for allocator={name}:\n{tail}")
+    print(f"  built target/alloc-{name}/release/rift-http-proxy")
+
+def parse_rss_kb(text):
+    """Parse `ps -o rss=` output (KB); absent/garbage reads as None, never 0 (#717)."""
+    try:
+        return int(text.strip())
+    except ValueError:
+        return None
+
+class RssSampler(threading.Thread):
+    """Samples the engine's RSS (ps -o rss=, KB) once a second while a bench runs, so each
+    scenario row can report peak/end memory (#717). Daemon: never blocks harness exit."""
+
+    def __init__(self, pid):
+        super().__init__(daemon=True)
+        self.pid = pid
+        self.samples = []
+        self._stop = threading.Event()
+
+    def run(self):
+        while not self._stop.wait(1.0):
+            try:
+                out = subprocess.run(["ps", "-o", "rss=", "-p", str(self.pid)],
+                                      capture_output=True, text=True)
+                kb = parse_rss_kb(out.stdout)
+            except Exception:
+                kb = None   # engine may be restarting/gone — a missing sample is not an error
+            if kb is not None:
+                self.samples.append((time.time(), kb))
+
+    def stop(self):
+        self._stop.set()
+        self.join(timeout=2)
+
+    def window(self, since_ts):
+        """(peak_mb, end_mb) over samples with ts >= since_ts; (None, None) if none in window."""
+        kbs = [kb for ts, kb in self.samples if ts >= since_ts]
+        if not kbs:
+            return None, None
+        return round(max(kbs) / 1024, 1), round(kbs[-1] / 1024, 1)
+
+# ---- results CSV (extended with `connections` + `mode` + `p999_ms`, issue #702; +rss, #717) ----
+
+CSV_HEADER = "scenario,connections,mode,rps,p50_ms,p90_ms,p99_ms,p999_ms,avg_ms,rss_mb_peak,rss_mb_end"
 
 def _csv_num(v):
     # A percentile can be legitimately absent (oha omits a p99.9 when a point has too few samples,
@@ -346,7 +429,8 @@ def _csv_num(v):
 
 def csv_row(name, conns, mode, m):
     cells = [name, conns, mode, m["rps"], _csv_num(m["p50_ms"]), _csv_num(m["p90_ms"]),
-             _csv_num(m["p99_ms"]), _csv_num(m["p999_ms"]), m["avg_ms"]]
+             _csv_num(m["p99_ms"]), _csv_num(m["p999_ms"]), m["avg_ms"],
+             _csv_num(m.get("rss_mb_peak")), _csv_num(m.get("rss_mb_end"))]
     return ",".join(str(c) for c in cells)
 
 def write_rift_csv(path, rows):
@@ -379,7 +463,8 @@ def assert_journal_filled(engine, admin, offset):
             f"(numberOfRequests={n}, recorded={recorded}, cap={MAX_RECORDED_REQUESTS}) — aborting")
     print(f"  journal ok: numberOfRequests={n}, recorded={recorded} (cap {MAX_RECORDED_REQUESTS})")
 
-def bench(engine, admin_port, offset, duration, warmup, conn_list, rate=None, recording=False):
+def bench(engine, admin_port, offset, duration, warmup, conn_list, rate=None, recording=False,
+          pid=None, csv_suffix=""):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     admin = f"http://localhost:{admin_port}"
     if not wait_ready(admin_port):
@@ -390,23 +475,33 @@ def bench(engine, admin_port, offset, duration, warmup, conn_list, rate=None, re
     mode = mode_label(rate)
     scenarios = SCENARIOS + ([RECORDING_SCENARIO] if recording else [])
     rows = []
-    for conns in conn_list:
-        for name, base_port, method, path, body, headers in scenarios:
-            url = f"http://localhost:{base_port + offset}{path}"
-            verify_body(engine, name, method, url, body, headers)   # prove the stub matched (not fall-through)
-            run_oha(url, method, body, headers, warmup, conns)      # warmup (discarded)
-            m = metric(run_oha(url, method, body, headers, duration, conns, rate))
-            total = sum(m["codes"].values())
-            good = all(c.startswith("2") for c in m["codes"])
-            status = "ok" if good and total > 0 else f"BAD codes={m['codes']}"
-            print(f"  {name:20s} c={conns:<4d} {m['rps']:>10.1f} rps  "
-                  f"p50={m['p50_ms']}ms p99={m['p99_ms']}ms p999={m['p999_ms']}ms  {status}")
-            if not (good and total > 0):
-                raise SystemExit(f"{engine}/{name}: unexpected status distribution {m['codes']} — aborting")
-            if name == RECORDING_SCENARIO[0]:
-                assert_journal_filled(engine, admin, offset)
-            rows.append((name, conns, mode, m))
-    csv_path = os.path.join(RESULTS_DIR, f"direct_{engine}.csv")
+    sampler = RssSampler(pid) if pid is not None else None
+    if sampler is not None:
+        sampler.start()
+    try:
+        for conns in conn_list:
+            for name, base_port, method, path, body, headers in scenarios:
+                url = f"http://localhost:{base_port + offset}{path}"
+                verify_body(engine, name, method, url, body, headers)   # prove the stub matched (not fall-through)
+                run_oha(url, method, body, headers, warmup, conns)      # warmup (discarded)
+                t0 = time.time()
+                m = metric(run_oha(url, method, body, headers, duration, conns, rate))
+                if sampler is not None:
+                    m["rss_mb_peak"], m["rss_mb_end"] = sampler.window(t0)
+                total = sum(m["codes"].values())
+                good = all(c.startswith("2") for c in m["codes"])
+                status = "ok" if good and total > 0 else f"BAD codes={m['codes']}"
+                print(f"  {name:20s} c={conns:<4d} {m['rps']:>10.1f} rps  "
+                      f"p50={m['p50_ms']}ms p99={m['p99_ms']}ms p999={m['p999_ms']}ms  {status}")
+                if not (good and total > 0):
+                    raise SystemExit(f"{engine}/{name}: unexpected status distribution {m['codes']} — aborting")
+                if name == RECORDING_SCENARIO[0]:
+                    assert_journal_filled(engine, admin, offset)
+                rows.append((name, conns, mode, m))
+    finally:
+        if sampler is not None:
+            sampler.stop()
+    csv_path = os.path.join(RESULTS_DIR, f"direct_{engine}{csv_suffix}.csv")
     write_rift_csv(csv_path, rows)
     print(f"[{engine}] wrote {csv_path}")
 
@@ -458,9 +553,50 @@ def launch(cmd, logpath):
     lf = open(logpath, "w")
     return subprocess.Popen(cmd, stdout=lf, stderr=subprocess.STDOUT, start_new_session=True)
 
-def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False):
+# The binary self-reports its allocator at startup: `Global allocator: <name>` (#717). That line
+# is info-level, and bench engines run at --loglevel warn (per #718, extra logging on a measured
+# run is itself a perf distortion) — so verification is a separate one-second probe launch, not
+# part of the measured run.
+ALLOC_MARKER = "Global allocator: "
+ALLOC_PROBE_PORT = 3525
+
+def extract_allocator_marker(text):
+    """Pull the self-reported allocator name out of an engine log, or None if absent."""
+    for line in text.splitlines():
+        if ALLOC_MARKER in line:
+            return line.split(ALLOC_MARKER, 1)[1].strip()
+    return None
+
+def verify_allocator_marker(rift_bin, expected):
+    """Probe-launch the binary (info level, scratch admin port) and require its self-reported
+    allocator to equal the requested one. Without this, a stale/wrong --rift-bin — or a
+    mis-featured build — would stamp a whole sweep with the wrong label and feed #717's
+    pre-registered decision rule bogus data, silently."""
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    free_ports([ALLOC_PROBE_PORT])
+    logpath = os.path.join(RESULTS_DIR, "allocator-probe.log")
+    proc = launch([rift_bin, "--port", str(ALLOC_PROBE_PORT), "--loglevel", "info"], logpath)
+    try:
+        name = None
+        for _ in range(40):
+            time.sleep(0.25)
+            with open(logpath) as f:
+                name = extract_allocator_marker(f.read())
+            if name is not None:
+                break
+        if name != expected:
+            raise SystemExit(
+                f"allocator probe: binary reports {name!r}, expected {expected!r} ({rift_bin}) "
+                f"— aborting so the sweep is not mislabeled")
+        print(f"  allocator probe ok: {name}")
+    finally:
+        stop(proc, [ALLOC_PROBE_PORT])
+
+def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False,
+            allocator=None):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     node = shutil.which("node") or "node"
+    csv_suffix = f"_{allocator}" if allocator else ""
     full_plan = [
         ("rift", 0,   [rift_bin, "--port", str(admin_port_for(0)), "--allow-injection", "--loglevel", "warn"]),
         ("mb",   100, [node, mb_bin, "start", "--port", str(admin_port_for(100)), "--allowInjection", "--loglevel", "warn"]),
@@ -475,8 +611,10 @@ def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, r
         proc = launch(cmd, os.path.join(RESULTS_DIR, f"{engine}-engine.log"))
         try:
             # recording_on only applies to Rift's journal write path; MB never records here.
+            # RSS sampling (#717) likewise only makes sense for the rift process itself.
             bench(engine, admin_port_for(offset), offset, duration, warmup, conn_list,
-                  rate=rate, recording=recording and engine == "rift")
+                  rate=rate, recording=recording and engine == "rift",
+                  pid=proc.pid if engine == "rift" else None, csv_suffix=csv_suffix)
         finally:
             stop(proc, ports)
     rift_ver = subprocess.run([rift_bin, "--version"], capture_output=True, text=True).stdout.strip() or "local"
@@ -484,17 +622,19 @@ def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, r
         mb_ver = subprocess.run([node, mb_bin, "--version"], capture_output=True, text=True).stdout.strip() or "2.9.1"
         report(rift_ver, mb_ver, duration, conn_list[0])
     elif engines == ["rift"]:
-        rift_only_report(rift_ver, duration, conn_list, rate, recording)
+        rift_only_report(rift_ver, duration, conn_list, rate, recording,
+                          allocator=allocator, csv_suffix=csv_suffix)
     else:
         # engines == ["mb"]: no comparison possible (needs Rift too) and no Rift-only report to write.
         print(f"[report] engines={engines}: benched only Mountebank; no report written "
               f"(the comparison needs both rift and mb)")
 
-def rift_only_report(rift_ver, duration, conn_list, rate, recording):
+def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=None, csv_suffix=""):
     """Rift-only sweep / open-loop report: scenario × (connections, mode) matrices of RPS and p999.
     The MB-comparison report is deliberately untouched so its historical single-point numbers stay
-    comparable; this is the extra artefact the Turbo round consumes."""
-    path = os.path.join(RESULTS_DIR, "direct_rift.csv")
+    comparable; this is the extra artefact the Turbo round consumes. Allocator bake-off runs (#717)
+    keep their own suffixed CSV/report so mimalloc/jemalloc/system results never overwrite each other."""
+    path = os.path.join(RESULTS_DIR, f"direct_rift{csv_suffix}.csv")
     with open(path) as f:
         rows = load_rift_csv(f)
     cols = list(dict.fromkeys((int(r["connections"]), r["mode"]) for r in rows))
@@ -512,10 +652,13 @@ def rift_only_report(rift_ver, duration, conn_list, rate, recording):
             mark = " **(recording)**" if name == RECORDING_SCENARIO[0] else ""
             f.write(f"| {name}{mark} | " + " | ".join(cells) + " |\n")
     lat = lambda v: "n/a" if v in (None, "") else v   # an absent percentile renders n/a, not blank
-    out = os.path.join(RESULTS_DIR, "DIRECT_RIFT_SWEEP_REPORT.md")
+    has_rss = any(r.get("rss_mb_peak", "") != "" for r in rows)
+    out = os.path.join(RESULTS_DIR, f"DIRECT_RIFT_SWEEP_REPORT{csv_suffix}.md")
     with open(out, "w") as f:
         f.write("# Rift — Concurrency Sweep / Open-Loop (issue #702)\n\n")
         f.write(f"- **Date:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n- **Rift:** {rift_ver}\n")
+        if allocator:
+            f.write(f"- **Allocator:** {allocator}\n")
         f.write(f"- **Load generator:** oha, {duration} per point (after warmup)\n")
         f.write(f"- **Connections:** {','.join(str(c) for c in conn_list)}\n")
         if rate is not None:
@@ -528,6 +671,8 @@ def rift_only_report(rift_ver, duration, conn_list, rate, recording):
         matrix(f, "Latency p50 (ms, lower is better)", "p50_ms", lat)
         matrix(f, "Latency p99 (ms, lower is better)", "p99_ms", lat)
         matrix(f, "Tail latency p999 (ms, lower is better)", "p999_ms", lat)
+        if has_rss:
+            matrix(f, "RSS peak (MB, during measurement)", "rss_mb_peak", lat)
     print(f"wrote {out}")
 
 def report(rift_ver, mb_ver, duration, conns):
@@ -578,10 +723,16 @@ if __name__ == "__main__":
                          "Rift-only and override this to rift.")
     ap.add_argument("--run-all", action="store_true")
     ap.add_argument("--report", action="store_true")
-    ap.add_argument("--rift-bin", default=os.path.join(os.path.dirname(__file__), "..", "..", "..", "target", "release", "rift-http-proxy"))
+    ap.add_argument("--rift-bin", default=None,
+                    help="path to a prebuilt rift-http-proxy binary; overrides --allocator's "
+                         "own build (default: target/release/rift-http-proxy, or "
+                         "target/alloc-<name>/release/rift-http-proxy when --allocator is set)")
     ap.add_argument("--mb-bin", default=os.path.expanduser("~/bench-mb/node_modules/mountebank/bin/mb"))
     ap.add_argument("--rift-version", default="local")
     ap.add_argument("--mb-version", default="2.9.1")
+    ap.add_argument("--allocator", choices=list(ALLOCATORS),
+                    help="build+bench one allocator variant (Rift-only; #717 bake-off). Builds "
+                         "into target/alloc-<name>/ unless --rift-bin is given.")
     a = ap.parse_args()
     if a.run_all:
         try:
@@ -590,10 +741,19 @@ if __name__ == "__main__":
         except ValueError as e:
             raise SystemExit(str(e))
         requested = [e.strip() for e in a.engines.split(",") if e.strip()]
+        if a.allocator and engines != ["rift"]:
+            engines = ["rift"]
         if engines != requested:
-            print("note: sweep/open-loop is Rift-only; running --engines rift")
-        run_all(a.duration, a.warmup, conn_list, a.rift_bin, a.mb_bin, engines,
-                rate=rate, recording=recording)
+            print("note: sweep/open-loop/allocator is Rift-only; running --engines rift")
+        rift_bin, needs_build = resolve_rift_bin(a.rift_bin, a.allocator)
+        if needs_build:
+            build_allocator_binary(a.allocator)
+        if a.allocator:
+            # Applies to explicit --rift-bin AND harness-built binaries alike: the label on the
+            # results must come from the binary itself, never from the invocation.
+            verify_allocator_marker(rift_bin, a.allocator)
+        run_all(a.duration, a.warmup, conn_list, rift_bin, a.mb_bin, engines,
+                rate=rate, recording=recording, allocator=a.allocator)
     elif a.report:
         report(a.rift_version, a.mb_version, a.duration, a.connections)
     else:

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -230,5 +230,104 @@ class DefaultRunUnchanged(unittest.TestCase):
         self.assertEqual(names[-1], "query_last")
 
 
+class AllocatorBuildArgs(unittest.TestCase):
+    """Issue #717: each allocator maps to cargo flags that swap ONLY the allocator, keeping the
+    functional feature set (redis-backend, javascript) identical so the comparison is fair."""
+
+    def test_mimalloc_is_the_default_build(self):
+        self.assertEqual(bd.allocator_build_args("mimalloc"), [])
+
+    def test_jemalloc_swaps_allocator_only(self):
+        self.assertEqual(
+            bd.allocator_build_args("jemalloc"),
+            ["--no-default-features", "--features", "redis-backend,javascript,jemalloc"],
+        )
+
+    def test_system_drops_the_allocator_only(self):
+        self.assertEqual(
+            bd.allocator_build_args("system"),
+            ["--no-default-features", "--features", "redis-backend,javascript"],
+        )
+
+    def test_rejects_unknown_allocator(self):
+        with self.assertRaises(ValueError):
+            bd.allocator_build_args("tcmalloc")
+
+
+class ResolveRiftBin(unittest.TestCase):
+    """Issue #717: --allocator builds its own binary into a per-allocator target dir unless the
+    caller supplied an explicit --rift-bin (then it is trusted verbatim, no build)."""
+
+    def test_no_allocator_uses_default_path(self):
+        path, build = bd.resolve_rift_bin(None, None)
+        self.assertEqual(path, bd.DEFAULT_RIFT_BIN)
+        self.assertFalse(build)
+
+    def test_explicit_bin_is_used_verbatim_even_with_allocator(self):
+        path, build = bd.resolve_rift_bin("/tmp/custom-rift", "jemalloc")
+        self.assertEqual(path, "/tmp/custom-rift")
+        self.assertFalse(build)
+
+    def test_allocator_without_bin_builds_into_per_allocator_target(self):
+        path, build = bd.resolve_rift_bin(None, "jemalloc")
+        self.assertIn("alloc-jemalloc", path)
+        self.assertTrue(build)
+
+
+class ParseRssKb(unittest.TestCase):
+    """Issue #717: `ps -o rss=` output (KB) parsing; absent/garbage reads as None, never 0."""
+
+    def test_parses_ps_output(self):
+        self.assertEqual(bd.parse_rss_kb(" 123456\n"), 123456)
+
+    def test_empty_is_none(self):
+        self.assertIsNone(bd.parse_rss_kb(""))
+
+    def test_garbage_is_none(self):
+        self.assertIsNone(bd.parse_rss_kb("abc"))
+
+
+class CsvRssColumns(unittest.TestCase):
+    """Issue #717: the CSV grows rss_mb_peak/rss_mb_end; rows without RSS keep empty cells so
+    DictReader consumers and pre-#717 rows stay compatible."""
+
+    _BASE = {"rps": 1000, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+             "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}}
+
+    def test_header_gains_rss_columns(self):
+        cols = bd.CSV_HEADER.split(",")
+        self.assertIn("rss_mb_peak", cols)
+        self.assertIn("rss_mb_end", cols)
+
+    def test_rows_without_rss_have_empty_cells(self):
+        row = bd.csv_row("api_middle", 50, "closed", dict(self._BASE))
+        parsed = bd.load_rift_csv(io.StringIO(bd.CSV_HEADER + "\n" + row + "\n"))[0]
+        self.assertEqual(parsed["rss_mb_peak"], "")
+        self.assertEqual(parsed["rss_mb_end"], "")
+
+    def test_rss_round_trips(self):
+        m = dict(self._BASE, rss_mb_peak=61.2, rss_mb_end=58.9)
+        row = bd.csv_row("api_middle", 50, "closed", m)
+        parsed = bd.load_rift_csv(io.StringIO(bd.CSV_HEADER + "\n" + row + "\n"))[0]
+        self.assertEqual(float(parsed["rss_mb_peak"]), 61.2)
+        self.assertEqual(float(parsed["rss_mb_end"]), 58.9)
+
+
+class AllocatorMarker(unittest.TestCase):
+    """Issue #717: the results label must come from the binary's own startup self-report
+    (`Global allocator: <name>`), so a wrong --rift-bin can never silently mislabel a sweep."""
+
+    def test_extracts_name_from_log(self):
+        log = ("2026-07-17T00:00:00Z  INFO rift: Starting Rift on port 3525\n"
+               "2026-07-17T00:00:00Z  INFO rift: Global allocator: jemalloc\n")
+        self.assertEqual(bd.extract_allocator_marker(log), "jemalloc")
+
+    def test_absent_marker_is_none(self):
+        self.assertIsNone(bd.extract_allocator_marker("INFO rift: Starting Rift on port 3525\n"))
+
+    def test_empty_log_is_none(self):
+        self.assertIsNone(bd.extract_allocator_marker(""))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Enabling tooling for the allocator bake-off (part of #717 — the issue stays open: the decision run is the Linux x86_64 matrix per its pre-registered rule; macOS indicative numbers are being recorded on the issue).

- Opt-in `jemalloc` feature on `rift-http-proxy` (tikv-jemallocator). Mutual exclusion with mimalloc is **cfg precedence** (mimalloc wins), deliberately not a `compile_error!` — five CI lanes build `--all-features` and must keep compiling. The binary logs `Global allocator: <name>` at startup so results are labeled by the binary itself.
- `bench_direct.py --allocator {mimalloc,jemalloc,system}`: per-allocator builds into `target/alloc-<name>/` (functionally identical feature sets, only the allocator differs), a **probe launch that asserts the binary's self-reported allocator matches before any measurement** (a wrong `--rift-bin` can no longer silently mislabel a sweep), 1 Hz RSS sampling (`rss_mb_peak`/`rss_mb_end` columns + an RSS matrix in the sweep report), and suffixed artefacts (`direct_rift_<name>.csv`, `DIRECT_RIFT_SWEEP_REPORT_<name>.md`).
- Docs: `docs/performance/index.md` allocator section, `tests/benchmark/README.md` bake-off usage, CHANGELOG (Added).
- Gate: 16 new unittest cases (45 total green), three feature-combo builds compile, `clippy --all-features -D warnings` clean, live smoke: `allocator probe ok: jemalloc`.

Part of #717

Milestone: none (turbo round)