### PR TITLE
feat(bench): per-worker accept counters + --runtime topology bench support (RFC-712 gate, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ record.
 
 ### Added
 
+- **Per-worker accept counters + runtime-topology bench support** (part of the RFC-712 gate,
+  #746). `rift_accepted_connections_total{worker=…}` counts accepted connections per
+  accept-loop slot — under `--runtime per-core` that is the worker index, so SO_REUSEPORT
+  4-tuple skew is observable in production rather than inferred. The direct benchmark harness
+  gained `--runtime {work-stealing,per-core}` with a topology self-report probe (a per-core
+  request on macOS aborts instead of benching the fallback under a wrong label) and
+  suffix-composed artefacts alongside `--allocator`.
+
 - **Per-core topology now serves imposter traffic (experimental, RFC-712).** Under
   `--runtime per-core[=N]` every imposter port binds one SO_REUSEPORT listener per worker
   runtime and each accept loop runs pinned to its worker; the kernel spreads connections by

--- a/crates/rift-mock-core/src/extensions/metrics.rs
+++ b/crates/rift-mock-core/src/extensions/metrics.rs
@@ -18,6 +18,18 @@ lazy_static! {
     )
     .unwrap();
 
+    /// Connections accepted per accept-loop slot (issue #746). Under `--runtime per-core`
+    /// the slot index IS the worker index, which makes SO_REUSEPORT 4-tuple skew observable
+    /// in production instead of inferred; in the default topology every accept lands on
+    /// slot 0. Resolved to a plain Counter once per accept loop, so the hot path pays one
+    /// atomic inc per accepted connection and no label lookup.
+    pub static ref ACCEPTED_CONNECTIONS_TOTAL: CounterVec = register_counter_vec!(
+        "rift_accepted_connections_total",
+        "Connections accepted, labeled by accept-loop worker slot (RFC-712 skew observability)",
+        &["worker"]
+    )
+    .unwrap();
+
     /// Total number of faults injected
     pub static ref FAULTS_INJECTED_TOTAL: CounterVec = register_counter_vec!(
         "rift_faults_injected_total",

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -598,6 +598,10 @@ impl ImposterManager {
 
         let mut serve_handles = Vec::with_capacity(listeners.len());
         for (index, listener) in listeners.into_iter().enumerate() {
+            // Resolved once per loop: `inc()` on the returned Counter is a bare atomic add,
+            // so the accept path pays no label lookup or allocation (issue #746).
+            let accept_counter = crate::extensions::metrics::ACCEPTED_CONNECTIONS_TOTAL
+                .with_label_values(&[index.to_string().as_str()]);
             let loop_future = Self::run_accept_loop(
                 listener,
                 Arc::clone(&imposter),
@@ -609,6 +613,7 @@ impl ImposterManager {
                 socket_tuning,
                 http_tuning,
                 port,
+                accept_counter,
             );
             serve_handles.push(match &self.accept_runtimes {
                 Some(runtimes) => runtimes[index].spawn(loop_future),
@@ -666,6 +671,7 @@ impl ImposterManager {
         socket_tuning: crate::proxy::network::SocketTuning,
         http_tuning: crate::proxy::network::HttpTuning,
         port: u16,
+        accept_counter: prometheus::Counter,
     ) {
         loop {
             // Acquire a permit *before* accepting so a cap holds connections back in the
@@ -696,6 +702,7 @@ impl ImposterManager {
                 result = listener.accept() => {
                     match result {
                         Ok((stream, addr)) => {
+                            accept_counter.inc();
                             crate::proxy::network::apply_stream_tuning(&stream, &socket_tuning);
                             let imposter = Arc::clone(&imposter_clone);
                             // Each connection watches the shutdown signal so existing

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -57,6 +57,7 @@ Histogram metrics expand into the usual `_bucket{le="…"}`, `_sum`, and `_count
 | `rift_active_flows` | gauge | `backend` | Currently-tracked flows, by backend. |
 | `rift_proxy_request_duration_ms` | histogram | `method`, `fault_applied` | Proxy handling time, in milliseconds. |
 | `rift_upstream_request_duration_ms` | histogram | `method`, `status` | Upstream (proxied) request time, in milliseconds. |
+| `rift_accepted_connections_total` | counter | `worker` | Connections accepted per accept-loop worker slot. Under `--runtime per-core` the slot is the worker index, making SO_REUSEPORT skew observable; in the default topology everything lands on slot `0`. |
 
 Example scrape output:
 

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -109,6 +109,22 @@ never mislabel its build. Decision rule and result recording live in #717 (pre-r
 default switch needs ≥5% RPS or ≥20% p999/RSS on the majority of scenarios, macOS numbers are
 indicative — the decision run is Linux x86_64).
 
+### Runtime topology sweep (issue #746, Rift-only, Linux)
+
+`--runtime {work-stealing,per-core}` benches one topology and composes with `--allocator`
+(artefacts get a combined suffix, e.g. `direct_rift_per-core.csv`). A probe launch checks the
+binary's `Runtime topology:` self-report first — on macOS a requested `per-core` falls back to
+work-stealing by design (RFC-712 D5), so the probe **aborts rather than mislabel the sweep**;
+run per-core sweeps on Linux. Per-worker accept counts are exported as
+`rift_accepted_connections_total{worker=…}` for skew evidence:
+
+```bash
+for rt in work-stealing per-core; do
+  python3 scripts/bench_direct.py --run-all --runtime $rt \
+      --sweep-connections 1,64,256,512 --duration 15s --warmup 2s
+done
+```
+
 Both scripts run each engine **one at a time on disjoint port ranges** (no CPU
 contention, no cross-talk), launch it in its own process group and hard-kill it by
 group + `lsof` before the next engine starts, and post **identical** imposter JSON to

--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -592,13 +592,76 @@ def verify_allocator_marker(rift_bin, expected):
     finally:
         stop(proc, [ALLOC_PROBE_PORT])
 
+# ---- runtime topology pass-through (issue #746): same discipline as --allocator ----
+
+RUNTIME_MODES = ("work-stealing", "per-core")
+TOPOLOGY_MARKER = "Runtime topology: "
+TOPOLOGY_PROBE_PORT = 3526
+
+def runtime_launch_args(mode):
+    """Engine flags for the requested topology; None = engine default (today's work-stealing)."""
+    if mode is None:
+        return []
+    if mode in RUNTIME_MODES:
+        return ["--runtime", mode]
+    raise ValueError(f"unknown runtime mode {mode!r}: choose from {','.join(RUNTIME_MODES)}")
+
+def extract_topology_marker(text):
+    """Pull the self-reported EFFECTIVE topology out of an engine log, or None if absent."""
+    for line in text.splitlines():
+        if TOPOLOGY_MARKER in line:
+            return line.split(TOPOLOGY_MARKER, 1)[1].strip()
+    return None
+
+def topology_matches(reported, requested):
+    """`per-core` self-reports as `per-core xN`; work-stealing reports itself verbatim."""
+    return reported == requested or reported.startswith(requested + " ")
+
+def verify_runtime_marker(rift_bin, mode, extra_args):
+    """Probe-launch and require the binary's self-reported topology to match the request.
+    This is what refuses a mislabeled sweep on macOS, where a requested per-core falls back
+    to work-stealing with a warning (RFC-712 D5) — the fallback is correct engine behavior,
+    but benching it under a per-core label would poison the #746 decision data."""
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    free_ports([TOPOLOGY_PROBE_PORT])
+    logpath = os.path.join(RESULTS_DIR, "topology-probe.log")
+    proc = launch(
+        [rift_bin, "--port", str(TOPOLOGY_PROBE_PORT), "--loglevel", "info"] + extra_args,
+        logpath,
+    )
+    try:
+        reported = None
+        for _ in range(40):
+            time.sleep(0.25)
+            with open(logpath) as f:
+                reported = extract_topology_marker(f.read())
+            if reported is not None:
+                break
+        if reported is None or not topology_matches(reported, mode):
+            raise SystemExit(
+                f"topology probe: binary reports {reported!r}, requested {mode!r} ({rift_bin}) "
+                f"— aborting so the sweep is not mislabeled (on macOS per-core falls back to "
+                f"work-stealing by design; run the per-core sweep on Linux)")
+        print(f"  topology probe ok: {reported}")
+    finally:
+        stop(proc, [TOPOLOGY_PROBE_PORT])
+
+def result_suffix(allocator, runtime_mode):
+    """Allocator and runtime dimensions compose into one artefact suffix so no combination
+    overwrites another's CSV/report (#717, #746)."""
+    suffix = f"_{allocator}" if allocator else ""
+    if runtime_mode:
+        suffix += f"_{runtime_mode}"
+    return suffix
+
 def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False,
-            allocator=None):
+            allocator=None, runtime=None):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     node = shutil.which("node") or "node"
-    csv_suffix = f"_{allocator}" if allocator else ""
+    csv_suffix = result_suffix(allocator, runtime)
     full_plan = [
-        ("rift", 0,   [rift_bin, "--port", str(admin_port_for(0)), "--allow-injection", "--loglevel", "warn"]),
+        ("rift", 0,   [rift_bin, "--port", str(admin_port_for(0)), "--allow-injection", "--loglevel", "warn"]
+                      + runtime_launch_args(runtime)),
         ("mb",   100, [node, mb_bin, "start", "--port", str(admin_port_for(100)), "--allowInjection", "--loglevel", "warn"]),
     ]
     plan = [p for p in full_plan if p[0] in engines]
@@ -623,13 +686,14 @@ def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, r
         report(rift_ver, mb_ver, duration, conn_list[0])
     elif engines == ["rift"]:
         rift_only_report(rift_ver, duration, conn_list, rate, recording,
-                          allocator=allocator, csv_suffix=csv_suffix)
+                          allocator=allocator, runtime=runtime, csv_suffix=csv_suffix)
     else:
         # engines == ["mb"]: no comparison possible (needs Rift too) and no Rift-only report to write.
         print(f"[report] engines={engines}: benched only Mountebank; no report written "
               f"(the comparison needs both rift and mb)")
 
-def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=None, csv_suffix=""):
+def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=None,
+                     runtime=None, csv_suffix=""):
     """Rift-only sweep / open-loop report: scenario × (connections, mode) matrices of RPS and p999.
     The MB-comparison report is deliberately untouched so its historical single-point numbers stay
     comparable; this is the extra artefact the Turbo round consumes. Allocator bake-off runs (#717)
@@ -659,6 +723,8 @@ def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=N
         f.write(f"- **Date:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n- **Rift:** {rift_ver}\n")
         if allocator:
             f.write(f"- **Allocator:** {allocator}\n")
+        if runtime:
+            f.write(f"- **Runtime:** {runtime}\n")
         f.write(f"- **Load generator:** oha, {duration} per point (after warmup)\n")
         f.write(f"- **Connections:** {','.join(str(c) for c in conn_list)}\n")
         if rate is not None:
@@ -733,6 +799,10 @@ if __name__ == "__main__":
     ap.add_argument("--allocator", choices=list(ALLOCATORS),
                     help="build+bench one allocator variant (Rift-only; #717 bake-off). Builds "
                          "into target/alloc-<name>/ unless --rift-bin is given.")
+    ap.add_argument("--runtime", choices=list(RUNTIME_MODES),
+                    help="bench one runtime topology (Rift-only; #746 RFC-712 gate). The probe "
+                         "verifies the binary's Runtime-topology self-report, so a per-core "
+                         "request on macOS (which falls back) aborts instead of mislabeling.")
     a = ap.parse_args()
     if a.run_all:
         try:
@@ -741,7 +811,7 @@ if __name__ == "__main__":
         except ValueError as e:
             raise SystemExit(str(e))
         requested = [e.strip() for e in a.engines.split(",") if e.strip()]
-        if a.allocator and engines != ["rift"]:
+        if (a.allocator or a.runtime) and engines != ["rift"]:
             engines = ["rift"]
         if engines != requested:
             print("note: sweep/open-loop/allocator is Rift-only; running --engines rift")
@@ -752,8 +822,10 @@ if __name__ == "__main__":
             # Applies to explicit --rift-bin AND harness-built binaries alike: the label on the
             # results must come from the binary itself, never from the invocation.
             verify_allocator_marker(rift_bin, a.allocator)
+        if a.runtime:
+            verify_runtime_marker(rift_bin, a.runtime, runtime_launch_args(a.runtime))
         run_all(a.duration, a.warmup, conn_list, rift_bin, a.mb_bin, engines,
-                rate=rate, recording=recording, allocator=a.allocator)
+                rate=rate, recording=recording, allocator=a.allocator, runtime=a.runtime)
     elif a.report:
         report(a.rift_version, a.mb_version, a.duration, a.connections)
     else:

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -329,5 +329,60 @@ class AllocatorMarker(unittest.TestCase):
         self.assertIsNone(bd.extract_allocator_marker(""))
 
 
+
+
+class RuntimeLaunchArgs(unittest.TestCase):
+    """Issue #746: --runtime pass-through builds the engine flag; unknown modes are hard errors."""
+
+    def test_none_adds_nothing(self):
+        self.assertEqual(bd.runtime_launch_args(None), [])
+
+    def test_work_stealing_is_explicit(self):
+        self.assertEqual(bd.runtime_launch_args("work-stealing"), ["--runtime", "work-stealing"])
+
+    def test_per_core_passes_through(self):
+        self.assertEqual(bd.runtime_launch_args("per-core"), ["--runtime", "per-core"])
+
+    def test_rejects_unknown_mode(self):
+        with self.assertRaises(ValueError):
+            bd.runtime_launch_args("thread-per-request")
+
+
+class TopologyMarker(unittest.TestCase):
+    """Issue #746: results are labeled by the binary's own `Runtime topology:` self-report —
+    on macOS a requested per-core falls back to work-stealing, and the probe must refuse to
+    run a sweep that would be mislabeled."""
+
+    def test_extracts_marker(self):
+        log = "INFO rift: Runtime topology: per-core x8\n"
+        self.assertEqual(bd.extract_topology_marker(log), "per-core x8")
+
+    def test_absent_is_none(self):
+        self.assertIsNone(bd.extract_topology_marker("INFO rift: Starting Rift\n"))
+
+    def test_match_exact_and_prefixed(self):
+        self.assertTrue(bd.topology_matches("work-stealing", "work-stealing"))
+        self.assertTrue(bd.topology_matches("per-core x8", "per-core"))
+        self.assertFalse(bd.topology_matches("work-stealing", "per-core"))
+        self.assertFalse(bd.topology_matches("per-core x8", "work-stealing"))
+
+
+class ResultSuffix(unittest.TestCase):
+    """Issue #746: allocator and runtime dimensions compose into one artefact suffix so no
+    combination overwrites another's results."""
+
+    def test_neither(self):
+        self.assertEqual(bd.result_suffix(None, None), "")
+
+    def test_allocator_only(self):
+        self.assertEqual(bd.result_suffix("jemalloc", None), "_jemalloc")
+
+    def test_runtime_only(self):
+        self.assertEqual(bd.result_suffix(None, "per-core"), "_per-core")
+
+    def test_both_compose(self):
+        self.assertEqual(bd.result_suffix("jemalloc", "per-core"), "_jemalloc_per-core")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Enabling half of #746 (the RFC-712 decision gate). Adds `rift_accepted_connections_total{worker=…}` — Counter resolved from its label once per accept loop, one atomic inc per accept, worker-only label (cardinality = core count) — and `bench_direct.py --runtime {work-stealing,per-core}` with the same self-report-probe discipline as `--allocator`: a per-core request on macOS aborts instead of benching the work-stealing fallback under a wrong label. Suffixes compose across both dimensions.

**First functional Linux validation of the whole RFC-712 stack** (container, evidence on the issue): `per-core x2` spread 300 fresh connections **156/144** across workers, zero failures, read through the new counters.

Gate: 11 new unittest cases (56 total green), full workspace green, clippy `--all-features -D warnings` clean, docs (metrics table + bench README + CHANGELOG). Review: clean, no findings.

Part of #746 — the issue stays open for the Linux x86_64 hardware decision sweep (pre-registered §7 rule; batch with #717's allocator matrix).

Milestone: none (turbo round)