### PR TITLE
fix(bench): RssSampler must not shadow threading.Thread._stop

### DIFF
--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -394,10 +394,14 @@ class RssSampler(threading.Thread):
         super().__init__(daemon=True)
         self.pid = pid
         self.samples = []
-        self._stop = threading.Event()
+        # NOT named `_stop`: threading.Thread has an internal `_stop()` method that
+        # `join()` calls on Python <=3.12 — shadowing it with an Event makes every
+        # join() raise `TypeError: 'Event' object is not callable` (found the hard
+        # way on ubuntu runners; macOS's Python 3.13 join() never calls it).
+        self._stop_event = threading.Event()
 
     def run(self):
-        while not self._stop.wait(1.0):
+        while not self._stop_event.wait(1.0):
             try:
                 out = subprocess.run(["ps", "-o", "rss=", "-p", str(self.pid)],
                                       capture_output=True, text=True)
@@ -408,7 +412,7 @@ class RssSampler(threading.Thread):
                 self.samples.append((time.time(), kb))
 
     def stop(self):
-        self._stop.set()
+        self._stop_event.set()
         self.join(timeout=2)
 
     def window(self, since_ts):

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -11,6 +11,7 @@ Run: python3 -m unittest test_bench_direct   (from tests/benchmark/scripts)
 import io
 import os
 import sys
+import threading
 import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -382,6 +383,29 @@ class ResultSuffix(unittest.TestCase):
 
     def test_both_compose(self):
         self.assertEqual(bd.result_suffix("jemalloc", "per-core"), "_jemalloc_per-core")
+
+
+
+
+class RssSamplerLifecycle(unittest.TestCase):
+    """Issue #746 follow-up: RssSampler must not shadow threading.Thread internals.
+    Naming its stop flag `_stop` broke every `join()` on Python <=3.12
+    (`Thread._stop()` is called internally) — invisible on Python 3.13 dev boxes."""
+
+    def test_start_sample_stop_joins_cleanly(self):
+        sampler = bd.RssSampler(os.getpid())
+        sampler.start()
+        import time as _time
+        _time.sleep(1.3)  # at least one sample tick
+        sampler.stop()    # join() raised TypeError on 3.12 before the rename
+        self.assertFalse(sampler.is_alive())
+
+    def test_no_thread_internal_shadowing(self):
+        sampler = bd.RssSampler(os.getpid())
+        shadowed = [a for a in ("_stop", "_started", "_tstate_lock", "_handle")
+                    if type(sampler).__mro__[0] is bd.RssSampler
+                    and a in sampler.__dict__ and hasattr(threading.Thread, a)]
+        self.assertEqual(shadowed, [], f"Thread internals shadowed: {shadowed}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The sampler's stop flag was named `_stop`, shadowing `threading.Thread`'s internal `_stop()` that `join()` calls on Python ≤3.12 — every `sampler.stop()` raised `TypeError: 'Event' object is not callable`, killing both decision-sweep jobs after their first variant on ubuntu runners. Invisible on dev macOS (Python 3.13's `join()` never calls `_stop`). Renamed to `_stop_event` + two regression tests (lifecycle join on ≤3.12, and a no-Thread-internal-shadowing assertion).

Part of #746 / #717 (unblocks the decision sweeps; re-dispatched from this branch).

Milestone: none (turbo round)