### PR TITLE
build(ci): parameterize decision-sweep runner label + topology connections

### DIFF
--- a/.github/workflows/decision-sweeps.yml
+++ b/.github/workflows/decision-sweeps.yml
@@ -23,6 +23,12 @@ on:
       duration:
         description: "oha duration per point"
         default: "12s"
+      runner:
+        description: "Runner label (e.g. ubuntu-latest, ubuntu-latest-16-cores if the plan has larger runners)"
+        default: "ubuntu-latest"
+      connections:
+        description: "Topology sweep connection counts"
+        default: "4,256"
 
 permissions:
   contents: read
@@ -30,7 +36,7 @@ permissions:
 jobs:
   allocator:
     if: ${{ inputs.sweep == 'both' || inputs.sweep == 'allocator' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +77,7 @@ jobs:
 
   topology:
     if: ${{ inputs.sweep == 'both' || inputs.sweep == 'topology' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +105,7 @@ jobs:
               echo "===== runtime=$rt rep=$rep ====="
               python3 scripts/bench_direct.py --run-all --runtime "$rt" \
                 --rift-bin ../../target/release/rift-http-proxy \
-                --sweep-connections 4,256 --duration "${{ inputs.duration }}" --warmup 2s
+                --sweep-connections "${{ inputs.connections }}" --duration "${{ inputs.duration }}" --warmup 2s
               cp "results/direct_rift_${rt}.csv" "results/direct_rift_${rt}_rep${rep}.csv"
             done
           done


### PR DESCRIPTION
Makes the runner label and topology connection counts `workflow_dispatch` inputs (defaults unchanged: `ubuntu-latest`, `4,256`). Probed `ubuntu-latest-16-cores`: not available on this account (job queued indefinitely — larger runners are an org Team/Enterprise feature), so the RFC-712 ≥8-core run's practical path is a **self-hosted runner** on a rented ≥16-core box: register it, then dispatch with `runner=self-hosted` and `connections=16,256,512` — no further code changes.

Part of #746.

Milestone: none (turbo round)