### PR TITLE
fix(build): forward quamina-matching so the dimension reaches what ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,16 @@ jobs:
           ./scripts/verify-docs-coverage.sh --self-test
           ./scripts/verify-docs-coverage.sh
 
+      # Issue #777: rift-http-proxy and rift-ffi take rift-mock-core with default-features = false,
+      # so a feature that is default-ON for the library reaches nothing users run unless it is
+      # forwarded. That is how the quamina dimension shipped into the library and out of the binary
+      # with CI green — its tests live in the one crate where it was enabled. --self-test first
+      # proves the checker isn't a no-op.
+      - name: Verify engine features reach the shipped artifacts
+        run: |
+          ./scripts/verify-feature-propagation.sh --self-test
+          ./scripts/verify-feature-propagation.sh
+
   image-hardening:
     name: Image Hardening
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,8 @@ record.
   matching results are unchanged — this is purely a prefilter (any predicate it cannot express
   — arrays, `null`, floats, `caseSensitive`/`keyCaseSensitive`, `except`/selector — safely
   falls through to full evaluation). It complements the `deepEquals`-on-body hash index. The
-  capability is behind a `quamina-matching` Cargo feature, default-on for `rift-mock-core`.
-  **Note:** `rift-http-proxy` and `rift-ffi` take `rift-mock-core` with `default-features = false`
-  and do not forward this feature, so the dimension is not currently active in the `rift` binary or
-  the C-ABI — see #777. Because it is a pure prefilter, this affects throughput only, never which
-  stub matches. (#767)
+  capability is behind a default-on `quamina-matching` Cargo feature, droppable for minimal or
+  FFI builds via `--no-default-features`. (#767, #777)
 
 - **Per-worker accept counters + runtime-topology bench support** (part of the RFC-712 gate,
   #746). `rift_accepted_connections_total{worker=…}` counts accepted connections per
@@ -120,6 +117,18 @@ record.
   JSON all fall back to the existing full comparison (correctness is never affected, only pruning).
 
 ### Fixed
+
+- **The quamina body-field dimension never reached the `rift` binary or the C-ABI.** It was
+  default-on for `rift-mock-core`, but `rift-http-proxy` and `rift-ffi` take that crate with
+  `default-features = false` and did not forward the feature — so the `#[cfg(not(...))]` no-op
+  branch is what shipped, and every body predicate fell through to a full Stage-2 scan in the
+  binary and in the C-ABI used by all four SDKs. CI stayed green throughout because the dimension's
+  tests run inside `rift-mock-core`, the one crate where it *was* enabled. Both crates now forward
+  it, and `scripts/verify-feature-propagation.sh` gates the invariant in CI: every default feature
+  of `rift-mock-core` must be forwarded by, and default-on in, every crate that takes it with
+  `default-features = false`. Matching **results** were never affected — the dimension is a pure
+  prefilter — so this is a throughput fix, not a correctness one. The end-to-end win has not yet
+  been measured in the binary (#779). (#777)
 
 - **An imposter with a numeric or boolean header value was rejected with a `400`.** Mountebank
   tolerates non-string scalar header values — its own recorders routinely emit

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -50,8 +50,12 @@ tempfile = "3.8"
 tracing-test = "0.2"
 
 [features]
-default = ["redis-backend", "javascript"]
+default = ["redis-backend", "javascript", "quamina-matching"]
 # Engine features are forwarded to BOTH rift-mock-core and rift-http-proxy so the two share one
 # feature set (mimalloc is deliberately never forwarded — see the dependency note above).
 redis-backend = ["rift-mock-core/redis-backend", "rift-http-proxy/redis-backend"]
 javascript = ["rift-mock-core/javascript", "rift-http-proxy/javascript"]
+# The quamina body-field candidate dimension (#767) — forwarded for the same reason as the two
+# above: without it the cdylib silently ships without the dimension (#777). Unlike mimalloc this
+# imposes nothing on the host process; it is an ordinary Rust dependency.
+quamina-matching = ["rift-mock-core/quamina-matching", "rift-http-proxy/quamina-matching"]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -118,9 +118,14 @@ tracing-test = "0.2"
 port_check = "0.2"
 
 [features]
-default = ["redis-backend", "javascript", "mimalloc"]
+default = ["redis-backend", "javascript", "mimalloc", "quamina-matching"]
 redis-backend = ["rift-mock-core/redis-backend"]
 javascript = ["rift-mock-core/javascript"]
+# The quamina body-field candidate dimension (#767). rift-mock-core is taken with
+# `default-features = false`, so a feature that is default-on THERE reaches nothing users run
+# unless it is forwarded here — which is exactly how #777 shipped the dimension into the library
+# and out of the binary. `scripts/verify-feature-propagation.sh` now gates that invariant.
+quamina-matching = ["rift-mock-core/quamina-matching"]
 # High-throughput global allocator for the server binary; drop it (e.g.
 # `--no-default-features`) for FFI/cross-compile builds that must not link it.
 mimalloc = ["dep:mimalloc"]

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -60,13 +60,13 @@ The engines and allocator are feature-gated. Relevant features:
 | `javascript` | on | on | JavaScript scripting engine (Boa) |
 | `mimalloc` | on | **never forwarded** | mimalloc global allocator (a `cdylib` must not impose an allocator on its host, so `rift-ffi` deliberately never enables it) |
 | `jemalloc` | off | n/a | Opt-in alternative allocator, kept for the #717 bake-off. If both `mimalloc` and `jemalloc` are enabled (as in CI's `--all-features` lanes), **mimalloc wins** — this is resolved by `cfg` precedence, not an error. mimalloc remains the shipped default. |
-| `quamina-matching` | **not forwarded** (see note) | **not forwarded** (see note) | Quamina-backed body-field candidate dimension. Defined on `rift-mock-core`, where it is on by default. Off ⇒ the dimension compiles to a no-op that never prunes and every body predicate is decided by the full Stage-2 evaluation — **matching results are identical either way**, only the prefilter speed differs. |
+| `quamina-matching` | on | on | Quamina-backed body-field candidate dimension. Off ⇒ the dimension compiles to a no-op that never prunes and every body predicate is decided by the full Stage-2 evaluation — **matching results are identical either way**, only the prefilter speed differs. |
 
-> **`quamina-matching` does not currently reach the server binary or the C-ABI.** Both
-> `rift-http-proxy` and `rift-ffi` depend on `rift-mock-core` with `default-features = false` and do
-> not forward this feature, so it is active only when you depend on `rift-mock-core` directly with
-> its defaults. Tracked in [#777](https://github.com/achird-labs/rift/issues/777). Because the
-> dimension is a pure prefilter, this affects throughput only — never which stub matches.
+> Because `rift-http-proxy` and `rift-ffi` take `rift-mock-core` with `default-features = false`,
+> each engine feature above must be explicitly forwarded to reach what actually ships.
+> `scripts/verify-feature-propagation.sh` enforces that in CI, so a feature cannot be default-on for
+> the library and silently absent from the binary — which is what
+> [#777](https://github.com/achird-labs/rift/issues/777) fixed.
 
 ---
 

--- a/scripts/verify-feature-propagation.sh
+++ b/scripts/verify-feature-propagation.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Feature-propagation gate (issue #777).
+#
+# `rift-mock-core` is the engine library, but nobody runs it directly: users run the `rift` binary
+# (`rift-http-proxy`) or embed the C-ABI (`rift-ffi`). Both of those depend on it with
+# `default-features = false` — deliberately, so a `cdylib` never inherits an allocator — which means
+# a feature that is default-ON for `rift-mock-core` reaches **nothing users run** unless the
+# dependent explicitly forwards it.
+#
+# That is exactly how #777 shipped: `quamina-matching` was default-on for `rift-mock-core`, its
+# tests ran there and passed, and the dimension was compiled out of the binary and the C-ABI. CI was
+# green the whole time, because the tests live in the one crate where the feature *was* enabled.
+#
+# This gate asserts the invariant that would have caught it: every default feature of
+# `rift-mock-core` is forwarded by every crate that takes it with `default-features = false`, and is
+# itself default-on there — so "on by default in the library" means "on by default in what ships".
+#
+# Deliberate non-forwards go in DELIBERATELY_NOT_FORWARDED below, with a reason. Adding one is a
+# decision, not a workaround: it means the shipped artifacts intentionally differ from the library.
+#
+# Usage:
+#   scripts/verify-feature-propagation.sh              # check the workspace (exit 1 on any gap)
+#   scripts/verify-feature-propagation.sh --self-test  # prove the checker flags a planted gap
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${MANIFEST:-$repo_root/Cargo.toml}"
+
+# Features intentionally NOT forwarded, as "crate:feature=reason". Empty today.
+# (`mimalloc` is NOT here: it is a `rift-http-proxy` feature, not a `rift-mock-core` one, so it is
+# outside this invariant entirely.)
+DELIBERATELY_NOT_FORWARDED=()
+
+check() {
+  local manifest="$1"
+  python3 - "$manifest" "${DELIBERATELY_NOT_FORWARDED[@]:-}" <<'PY'
+import json, subprocess, sys
+
+manifest = sys.argv[1]
+exempt = set(a for a in sys.argv[2:] if a)
+
+md = json.loads(subprocess.run(
+    ["cargo", "metadata", "--no-deps", "--format-version", "1", "--manifest-path", manifest],
+    capture_output=True, text=True, check=True).stdout)
+
+pkgs = {p["name"]: p for p in md["packages"]}
+LIB = "rift-mock-core"
+if LIB not in pkgs:
+    sys.exit(f"{LIB} not found in workspace metadata — has the crate been renamed?")
+
+lib_defaults = [f for f in pkgs[LIB]["features"].get("default", [])]
+
+# Every workspace crate that depends on the library with default-features = false must forward.
+dependents = []
+for name, p in pkgs.items():
+    for d in p["dependencies"]:
+        if d["name"] == LIB and d["kind"] is None and not d.get("uses_default_features", True):
+            dependents.append(name)
+            break
+
+failures = []
+for feat in lib_defaults:
+    for dep in sorted(set(dependents)):
+        if f"{dep}:{feat}" in {e.split('=')[0] for e in exempt}:
+            continue
+        feats = pkgs[dep]["features"]
+        target = f"{LIB}/{feat}"
+        forwarding = [k for k, v in feats.items() if target in v]
+        if not forwarding:
+            failures.append(
+                f"{dep}: does not forward {LIB}'s default feature '{feat}'.\n"
+                f"    Add:  {feat} = [\"{target}\"]   (and put '{feat}' in {dep}'s default = [...])\n"
+                f"    Effect today: '{feat}' is compiled OUT of {dep} — it reaches nothing users run.")
+            continue
+        # Forwarded, but is it on by default here too?
+        if not any(f in feats.get("default", []) for f in forwarding):
+            failures.append(
+                f"{dep}: forwards '{feat}' via {forwarding} but none of those are in its "
+                f"default = [...], so it is off unless a caller opts in.")
+
+if failures:
+    print("Feature-propagation gate FAILED:\n", file=sys.stderr)
+    for f in failures:
+        print(f"  - {f}\n", file=sys.stderr)
+    print(f"{LIB} defaults: {lib_defaults}", file=sys.stderr)
+    print(f"dependents taking it with default-features=false: {sorted(set(dependents))}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"Feature propagation OK: {LIB} defaults {lib_defaults} "
+      f"forwarded and default-on in {sorted(set(dependents))}.")
+PY
+}
+
+self_test() {
+  # Prove the checker is not a no-op: copy the workspace manifests, strip one passthrough, and
+  # require a failure. Copying only the manifests keeps this fast (no source tree copy needed —
+  # `cargo metadata --no-deps` reads manifests only).
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  ( cd "$repo_root" && git ls-files '*Cargo.toml' | while read -r f; do
+      mkdir -p "$tmp/$(dirname "$f")" && cp "$f" "$tmp/$f"
+    done )
+  # Planted gap: remove rift-http-proxy's javascript passthrough.
+  python3 - "$tmp/crates/rift-http-proxy/Cargo.toml" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+t = re.sub(r'^javascript = \[.*?\]\n', '', t, count=1, flags=re.M)
+open(p, 'w').write(t)
+PY
+  if MANIFEST="$tmp/Cargo.toml" check "$tmp/Cargo.toml" >/dev/null 2>&1; then
+    echo "SELF-TEST FAILED: the checker passed a manifest with a removed passthrough" >&2
+    exit 1
+  fi
+  echo "Self-test OK: the checker rejects a removed feature passthrough."
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+else
+  check "$MANIFEST"
+fi


### PR DESCRIPTION
The quamina body-field dimension (#719 spike → GO → #767 → PR #769 → oracle coverage #771) was
**compiled out of every artifact users run**.

`rift-mock-core` declares it default-on, but `rift-http-proxy` and `rift-ffi` both take that crate
with `default-features = false` — deliberately, so a `cdylib` never inherits an allocator — and
neither forwarded the feature. The `#[cfg(not(feature = "quamina-matching"))]` no-op branch is what
shipped, so every body predicate fell through to a full Stage-2 scan in the `rift` binary and in the
C-ABI behind all four SDKs.

**Before:**
```
cargo tree -p rift-mock-core  | grep quamina   ->  quamina v0.6.0
cargo tree -p rift-http-proxy | grep quamina   ->  (nothing)
cargo tree -p rift-ffi        | grep quamina   ->  (nothing)
```
**After:** all three link it.

## Why CI never caught it

The dimension's tests run *inside* `rift-mock-core` — the one crate where the feature was enabled.
They proved the matcher correct while the shipped artifacts didn't contain it. Any future
`rift-mock-core` default feature had the same blind spot.

## The guard

`scripts/verify-feature-propagation.sh`, following the repo's existing `verify-*.sh` + `--self-test`
convention, asserts: **every default feature of `rift-mock-core` is forwarded by, and default-on in,
every crate that takes it with `default-features = false`.**

- Reads `cargo metadata` rather than parsing TOML, so it can't drift from the real resolution.
- `DELIBERATELY_NOT_FORWARDED` allowlist (empty today) makes an intentional divergence a recorded
  decision instead of a silent regression. `mimalloc` isn't in it — that's a `rift-http-proxy`
  feature, not a `rift-mock-core` one, so it's outside the invariant entirely.
- Run against the **pre-fix** tree it independently reproduced the bug, naming both crates and the
  exact remedy, while correctly staying silent about `redis-backend`/`javascript`, which *were*
  forwarded.

## Scope

Matching **results** are unchanged — the dimension is a pure over-approximating prefilter and
Stage-2 always decides. This is a throughput fix, not a correctness one.

It is, however, a real change to what ships: quamina now genuinely enters the binary and the cdylib
for the first time. The end-to-end delta has never been measured there (the #767 numbers were taken
against the library), so that is filed separately as **#779** rather than asserted here.

The docs and CHANGELOG text describing the broken state — added in #778 while this was still
open — are corrected in the same commit that makes them false.

## Verification

`fmt` · `clippy --workspace --all-targets -D warnings` · `cargo test --workspace` (0 failures) ·
`verify-feature-propagation.sh` and its `--self-test` · `verify-ffi-cdylib.sh` (27 C-ABI symbols,
cdylib still self-contained — quamina adds no new dynamic imports) · `cargo check -p rift-http-proxy
--no-default-features --features redis-backend,javascript` still builds, since
`docs/embedding/ffi.md` recommends exactly that build and the feature had to stay droppable.

Closes #777. Refs #767, #769, #779.
