### PR TITLE
fix(bench): repetitions silently overwrite the unsuffixed results CSV/report, so the canonical-looking file is one unreplicated sample

### DIFF
--- a/.github/workflows/decision-sweeps.yml
+++ b/.github/workflows/decision-sweeps.yml
@@ -75,10 +75,14 @@ jobs:
           for rep in $(seq 1 ${{ inputs.reps }}); do
             for alloc in mimalloc jemalloc system; do
               echo "===== allocator=$alloc rep=$rep ====="
-              python3 scripts/bench_direct.py --run-all --allocator "$alloc" \
+              python3 scripts/bench_direct.py --run-all --allocator "$alloc" --rep "$rep" \
                 --sweep-connections 50,200 --duration "${{ inputs.duration }}" --warmup 2s
-              cp "results/direct_rift_${alloc}.csv" "results/direct_rift_${alloc}_rep${rep}.csv"
             done
+          done
+          # Medians with per-rep spread, so the decision artefact is explicitly an aggregate
+          # rather than whichever rep happened to run last (#773).
+          for alloc in mimalloc jemalloc system; do
+            python3 scripts/bench_direct.py --aggregate-reps "_${alloc}"
           done
       - uses: actions/upload-artifact@v4
         if: always()
@@ -127,13 +131,18 @@ jobs:
             for n in "${BUDGETS[@]}"; do
               for rt in work-stealing per-core; do
                 echo "===== runtime=$rt cores=${n:-all} rep=$rep ====="
-                python3 scripts/bench_direct.py --run-all --runtime "$rt" \
+                python3 scripts/bench_direct.py --run-all --runtime "$rt" --rep "$rep" \
                   ${n:+--server-cores "$n"} \
                   --rift-bin ../../target/release/rift-http-proxy \
                   --sweep-connections "${{ inputs.connections }}" --duration "${{ inputs.duration }}" --warmup 2s
-                cp "results/direct_rift_${rt}${n:+_cores$n}.csv" \
-                   "results/direct_rift_${rt}${n:+_cores$n}_rep${rep}.csv"
               done
+            done
+          done
+          # Medians with per-rep spread per variant. Reading a single rep as if it were the
+          # aggregate is what produced the retracted #746 headline number (#773).
+          for n in "${BUDGETS[@]}"; do
+            for rt in work-stealing per-core; do
+              python3 scripts/bench_direct.py --aggregate-reps "_${rt}${n:+_cores$n}"
             done
           done
       - name: Per-worker accept counts (skew evidence, single spot-check)

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -141,17 +141,44 @@ Connections alone do not test RFC-712's thesis, which is about the *slope* of RP
   leaves the generator no cores, is rejected with the host's valid budgets.
 
 ```bash
-for n in 2 4 8; do
-  for rt in work-stealing per-core; do
-    python3 scripts/bench_direct.py --run-all --runtime $rt --server-cores $n \
-        --sweep-connections 256,512 --duration 12s --warmup 2s
+for rep in 1 2 3; do
+  for n in 2 4 8; do
+    for rt in work-stealing per-core; do
+      python3 scripts/bench_direct.py --run-all --runtime $rt --server-cores $n --rep $rep \
+          --sweep-connections 256,512 --duration 12s --warmup 2s
+    done
   done
-done   # -> direct_rift_{work-stealing,per-core}_cores{2,4,8}.csv
+done   # -> direct_rift_{work-stealing,per-core}_cores{2,4,8}_rep{1,2,3}.csv
 ```
 
 Linux only (`taskset`/`lscpu`). Note the ceiling this implies: on an M-vCPU box the generator
 needs its own cores, so the engine tops out well below M — an ≥8-*physical*-core point needs a
 bigger box or an off-box generator, and any verdict quoting these numbers should say so.
+
+#### Repetitions and medians — never quote a single run
+
+**Always pass `--rep N`.** One run of one variant is one sample; a benchmark host is not a
+constant. Without `--rep` every repetition writes the *same* filename, so the file left behind is
+whichever rep ran last — a canonical-looking artefact holding one unreplicated sample. That is not
+hypothetical: it produced a wrong, publicly-retracted number on issue #746, where the last rep
+happened to land on a degraded runner ~20% low (issue #773).
+
+With `--rep`, each repetition gets its own `_repN` artefact and nothing is overwritten. Collapse
+them into the decision artefact with:
+
+```bash
+python3 scripts/bench_direct.py --aggregate-reps "_per-core_cores8"
+# -> direct_rift_per-core_cores8_median.csv
+#    DIRECT_RIFT_MEDIAN_REPORT_per-core_cores8.md
+```
+
+The report carries a **spread** column (peak-to-peak RPS as a percentage of the mean) next to every
+median. Read it before quoting a number: a large spread means the reps disagree and the median is
+provisional. Aggregation **fails loudly** if a point is missing from any rep, rather than quietly
+producing a median backed by fewer samples than the report implies.
+
+`--rep` is Rift-only — the rift-vs-mb comparison report reads unsuffixed artefacts, so a repped
+comparison run would report a stale file as the current one.
 
 Both scripts run each engine **one at a time on disjoint port ranges** (no CPU
 contention, no cross-talk), launch it in its own process group and hard-kill it by

--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -20,7 +20,7 @@ Run everything (launches + stops both engines, writes the report):
 Must be run OUTSIDE the CLI sandbox (via the sidecar) because `oha` needs
 macOS keychain access to initialise TLS even for plain-HTTP targets.
 """
-import argparse, csv, json, subprocess, sys, threading, time, urllib.request, urllib.error, os, signal, shutil
+import argparse, csv, glob, json, re, subprocess, sys, threading, time, urllib.request, urllib.error, os, signal, shutil
 
 RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
 
@@ -509,8 +509,7 @@ def bench(engine, admin_port, offset, duration, warmup, conn_list, rate=None, re
     finally:
         if sampler is not None:
             sampler.stop()
-    csv_path = os.path.join(RESULTS_DIR, f"direct_{engine}{csv_suffix}.csv")
-    write_rift_csv(csv_path, rows)
+    csv_path = write_results_csv(engine, csv_suffix, rows)
     print(f"[{engine}] wrote {csv_path}")
 
 # ---- engine orchestration ----
@@ -750,21 +749,169 @@ def resolve_cpu_split(server_cpus):
     except ValueError as e:
         raise SystemExit(str(e))
 
-def result_suffix(allocator, runtime_mode, server_cpus=None):
-    """Allocator, runtime and core-count dimensions compose into one artefact suffix so no
-    combination overwrites another's CSV/report (#717, #746)."""
+def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None):
+    """Allocator, runtime, core-count and repetition dimensions compose into one artefact suffix so
+    no combination overwrites another's CSV/report (#717, #746, #773).
+
+    `rep` is what stops a repeated run from being self-destructive. It used to be a *caller*
+    concept — the sweep workflow looped and copied the file afterwards — so every rep overwrote the
+    unsuffixed name and the artefact bundle ended up with a canonical-looking file holding one
+    unreplicated sample (#773). Threading it through here means a repped run never writes that
+    file at all."""
     suffix = f"_{allocator}" if allocator else ""
     if runtime_mode:
         suffix += f"_{runtime_mode}"
     if server_cpus:
         suffix += f"_cores{server_cpus}"
+    if rep is not None:
+        suffix += f"_rep{rep}"
     return suffix
 
+# Numeric CSV columns an aggregate takes the median of. `rps` additionally carries a spread so a
+# degraded rep is visible rather than silently folded into the middle value.
+AGGREGATE_FIELDS = ("rps", "p50_ms", "p90_ms", "p99_ms", "p999_ms", "avg_ms",
+                    "rss_mb_peak", "rss_mb_end")
+
+def _median(values):
+    """Median of a numeric list; the even case averages the middle two."""
+    s = sorted(values)
+    mid = len(s) // 2
+    return s[mid] if len(s) % 2 else (s[mid - 1] + s[mid]) / 2
+
+def _spread_pct(values):
+    """Peak-to-peak spread as a percentage of the mean — the number that would have exposed the
+    #746 degraded rep (~20% low on one of three runs) instead of it passing as a normal sample."""
+    mean = sum(values) / len(values)
+    return 0.0 if mean == 0 else (max(values) - min(values)) / mean * 100.0
+
+def aggregate_reps(reps):
+    """Collapse N repetitions into one median-per-point aggregate, keyed by
+    (scenario, connections, mode).
+
+    `reps` is a list of rep row-lists, each shaped like `load_rift_csv` output. Every point carries
+    `reps` (how many samples backed it) and `rps_spread_pct`, because a median alone cannot tell a
+    clean run from one where a rep was measured on a degraded machine — which is exactly how #746's
+    headline number went wrong."""
+    if not reps:
+        raise ValueError("aggregate_reps needs at least one repetition")
+    points = {}
+    for rows in reps:
+        for r in rows:
+            key = (r["scenario"], int(r["connections"]), r["mode"])
+            points.setdefault(key, []).append(r)
+    out = {}
+    for key, samples in points.items():
+        cell = {"reps": len(samples)}
+        for field in AGGREGATE_FIELDS:
+            # A percentile can be legitimately absent (oha omits p99.9 when a point has too few
+            # samples). An absent value stays absent rather than being counted as zero, which
+            # would drag the median toward a number nothing measured.
+            vals = [float(r[field]) for r in samples if r.get(field) not in (None, "")]
+            cell[field] = _median(vals) if vals else ""
+        rps_vals = [float(r["rps"]) for r in samples if r.get("rps") not in (None, "")]
+        cell["rps_spread_pct"] = _spread_pct(rps_vals) if rps_vals else ""
+        out[key] = cell
+    return out
+
+def results_csv_path(engine, csv_suffix):
+    """The one place a run's results CSV name is built."""
+    return os.path.join(RESULTS_DIR, f"direct_{engine}{csv_suffix}.csv")
+
+def write_results_csv(engine, csv_suffix, rows):
+    """Write a run's results through a single seam, so "which files does a run produce" is a
+    testable property rather than a fact buried in `bench()` behind a live server (#773).
+
+    An existing target is overwritten — reruns of the same rep are legitimate after a crash — but
+    never silently: the whole point of #773 is that a results file must not change under you
+    without saying so."""
+    path = results_csv_path(engine, csv_suffix)
+    if os.path.exists(path):
+        print(f"  note: overwriting existing {os.path.basename(path)}")
+    write_rift_csv(path, rows)
+    return path
+
+REP_FILE_RX = re.compile(r"_rep(\d+)\.csv$")
+
+def find_rep_files(base_suffix):
+    """Every `_repN.csv` written for one variant, in rep order.
+
+    Matches on the `_rep<digits>.csv` tail so a *different* variant sharing a prefix, or a stale
+    unsuffixed file from a pre-#773 run, is never swept into the aggregate."""
+    pattern = os.path.join(RESULTS_DIR, f"direct_rift{base_suffix}_rep*.csv")
+    matched = []
+    for p in glob.glob(pattern):
+        m = REP_FILE_RX.search(p)
+        if m:
+            matched.append((int(m.group(1)), p))
+    return [p for _, p in sorted(matched)]
+
+def aggregate_reps_to_report(base_suffix, rift_ver):
+    """Read a variant's `_repN.csv` files, write the median-of-reps CSV + report, return the report
+    path. This is the artefact the unsuffixed filename used to *imply* and never was (#773)."""
+    paths = find_rep_files(base_suffix)
+    if not paths:
+        raise SystemExit(
+            f"no repetition files matched direct_rift{base_suffix}_rep*.csv in {RESULTS_DIR} — "
+            f"nothing to aggregate (run the sweep with --rep N first)")
+    reps = []
+    for p in paths:
+        with open(p) as f:
+            reps.append(load_rift_csv(f))
+    agg = aggregate_reps(reps)
+
+    # An aggregate must not quietly rest on fewer samples than it appears to. A point missing from
+    # some rep — a crashed run, a rep taken with different --sweep-connections, a truncated CSV —
+    # would otherwise yield a complete-looking report whose cells are backed by 2 of 3 reps, with
+    # exit 0 and nothing said. That is precisely the class of silence #773 exists to remove, so it
+    # is a hard error rather than a warning.
+    incomplete = {k: c["reps"] for k, c in agg.items() if c["reps"] != len(paths)}
+    if incomplete:
+        detail = ", ".join(f"{s}@c={c}/{m}: {n} of {len(paths)}"
+                           for (s, c, m), n in sorted(incomplete.items())[:8])
+        raise SystemExit(
+            f"incomplete repetitions across {len(paths)} rep files for '{base_suffix}': {detail}"
+            f"{' …' if len(incomplete) > 8 else ''}\n"
+            f"Every point must appear in every rep, or the median silently rests on fewer samples "
+            f"than the report claims. Re-run the missing reps, or aggregate a consistent subset.")
+
+    csv_path = os.path.join(RESULTS_DIR, f"direct_rift{base_suffix}_median.csv")
+    with open(csv_path, "w") as f:
+        f.write(CSV_HEADER + ",reps,rps_spread_pct\n")
+        for (scen, conns, mode), c in sorted(agg.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+            spread = f"{c['rps_spread_pct']:.1f}" if c["rps_spread_pct"] != "" else ""
+            f.write(f"{csv_row(scen, conns, mode, c)},{c['reps']},{spread}\n")
+
+    out = os.path.join(RESULTS_DIR, f"DIRECT_RIFT_MEDIAN_REPORT{base_suffix}.md")
+    rep_counts = sorted({c["reps"] for c in agg.values()})
+    with open(out, "w") as f:
+        f.write("# Rift — Median of Repetitions (issue #773)\n\n")
+        f.write(f"- **Date:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        # The aggregation runs offline over CSVs that carry no version, so claiming one nobody
+        # passed would put a wrong provenance line on the artefact meant to replace a retracted
+        # number. Say "unspecified" instead of guessing.
+        f.write(f"- **Rift:** {rift_ver or 'unspecified (pass --rift-version)'}\n")
+        f.write(f"- **Variant:** `{base_suffix or '(none)'}`\n")
+        f.write(f"- **Repetitions:** {', '.join(str(n) for n in rep_counts)} "
+                f"(from {', '.join(os.path.basename(p) for p in paths)})\n")
+        f.write("- **Spread** is peak-to-peak RPS as a percentage of the mean. A large spread "
+                "means the reps disagree — treat the median as provisional and look at the "
+                "individual reps before quoting it.\n\n")
+        f.write("| Scenario | c | RPS (median) | spread | p50 | p99 | p999 | reps |\n")
+        f.write("|---|--:|--:|--:|--:|--:|--:|--:|\n")
+        lat = lambda v: "n/a" if v == "" else f"{v:g}"
+        for (scen, conns, mode), c in sorted(agg.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+            spread = "n/a" if c["rps_spread_pct"] == "" else f"{c['rps_spread_pct']:.1f}%"
+            f.write(f"| {scen} | {conns} | {c['rps']:,.0f} | {spread} | {lat(c['p50_ms'])} "
+                    f"| {lat(c['p99_ms'])} | {lat(c['p999_ms'])} | {c['reps']} |\n")
+    print(f"wrote {out}")
+    return out
+
 def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False,
-            allocator=None, runtime=None, server_cpus=None, engine_cpus=None, gen_cpus=None):
+            allocator=None, runtime=None, server_cpus=None, engine_cpus=None, gen_cpus=None,
+            rep=None):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     node = shutil.which("node") or "node"
-    csv_suffix = result_suffix(allocator, runtime, server_cpus)
+    csv_suffix = result_suffix(allocator, runtime, server_cpus, rep)
     engine_prefix, oha_prefix = taskset_prefix(engine_cpus), taskset_prefix(gen_cpus)
     full_plan = [
         ("rift", 0,   engine_prefix
@@ -923,7 +1070,21 @@ if __name__ == "__main__":
                     help="core-count axis (#746): confine the engine to N CPUs with taskset — "
                          "both topologies size their workers from it — and confine oha to the "
                          "remaining physical cores. N must fall on a core boundary; Linux only.")
+    ap.add_argument("--rep", type=int, metavar="N",
+                    help="repetition index (#773): artefacts get a _repN suffix, so each rep of a "
+                         "sweep lands in its own file instead of overwriting the last. Re-running "
+                         "the SAME rep overwrites it, with a printed note. Rift-only. Without "
+                         "--rep the run writes the unsuffixed name as before.")
+    ap.add_argument("--aggregate-reps", metavar="SUFFIX",
+                    help="offline: read direct_rift<SUFFIX>_rep*.csv and write the median-of-reps "
+                         "CSV + report (per-rep spread included). SUFFIX is the variant part of "
+                         "the name, e.g. '_per-core_cores8' (use '' for a bare run).")
     a = ap.parse_args()
+    if a.aggregate_reps is not None:
+        aggregate_reps_to_report(a.aggregate_reps, a.rift_version)
+        sys.exit(0)
+    if a.rep is not None and a.rep < 1:
+        raise SystemExit(f"--rep must be >= 1 (got {a.rep})")
     if a.run_all:
         try:
             engines, conn_list, rate, recording = resolve_run_mode(
@@ -931,6 +1092,17 @@ if __name__ == "__main__":
         except ValueError as e:
             raise SystemExit(str(e))
         requested = [e.strip() for e in a.engines.split(",") if e.strip()]
+        # --rep is Rift-only, and refused rather than silently coerced: the rift-vs-mb comparison
+        # report reads the UNSUFFIXED direct_{engine}.csv paths, so a repped rift+mb run would
+        # write direct_rift_repN.csv and then build DIRECT_BENCHMARK_REPORT.md from whatever stale
+        # unsuffixed file happened to be on disk — presenting numbers this run never measured,
+        # which is the exact failure #773 exists to close. Coercing engines silently would hide
+        # that the requested comparison was not run at all.
+        if a.rep is not None and engines != ["rift"]:
+            raise SystemExit(
+                "--rep is Rift-only: the rift-vs-mb report reads unsuffixed artefacts, so a "
+                "repped comparison run would report a stale file as this run's numbers. "
+                "Re-run with --engines rift.")
         if (a.allocator or a.runtime) and engines != ["rift"]:
             engines = ["rift"]
         if engines != requested:
@@ -957,7 +1129,8 @@ if __name__ == "__main__":
                                   expected_workers=a.server_cores)
         run_all(a.duration, a.warmup, conn_list, rift_bin, a.mb_bin, engines,
                 rate=rate, recording=recording, allocator=a.allocator, runtime=a.runtime,
-                server_cpus=a.server_cores, engine_cpus=engine_cpus, gen_cpus=gen_cpus)
+                server_cpus=a.server_cores, engine_cpus=engine_cpus, gen_cpus=gen_cpus,
+                rep=a.rep)
     elif a.report:
         report(a.rift_version, a.mb_version, a.duration, a.connections)
     else:

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -401,6 +401,212 @@ class ResultSuffix(unittest.TestCase):
         self.assertEqual(bd.result_suffix("mimalloc", "per-core", 4),
                          "_mimalloc_per-core_cores4")
 
+    def test_rep_is_its_own_dimension(self):
+        # Issue #773: a repetition must be part of the artefact name, not something the caller
+        # bolts on after the fact — otherwise every rep overwrites the last and the canonical-
+        # looking file holds one unreplicated sample.
+        self.assertEqual(bd.result_suffix(None, "per-core", 8, rep=2), "_per-core_cores8_rep2")
+        self.assertEqual(bd.result_suffix(None, None, None, rep=1), "_rep1")
+
+    def test_all_four_compose(self):
+        self.assertEqual(bd.result_suffix("mimalloc", "per-core", 4, rep=3),
+                         "_mimalloc_per-core_cores4_rep3")
+
+    def test_rep_absent_reproduces_the_old_names(self):
+        # The pre-#773 contract must be byte-identical when no rep is given, so artefacts from
+        # earlier sweeps stay comparable.
+        self.assertEqual(bd.result_suffix("jemalloc", "per-core", 4, rep=None),
+                         "_jemalloc_per-core_cores4")
+
+
+class MedianOfReps(unittest.TestCase):
+    """Issue #773: the decision artefact must be an explicit median across reps with the per-rep
+    spread visible — a degraded rep should be observable, not silently averaged in (or, worse,
+    silently the only sample)."""
+
+    @staticmethod
+    def _rows(rps_by_scenario, conns=256):
+        return [
+            {"scenario": s, "connections": str(conns), "mode": "closed", "rps": str(v),
+             "p50_ms": "1.0", "p90_ms": "2.0", "p99_ms": "3.0", "p999_ms": "4.0",
+             "avg_ms": "1.5", "rss_mb_peak": "50.0", "rss_mb_end": "40.0"}
+            for s, v in rps_by_scenario.items()
+        ]
+
+    def test_median_of_three_reps_picks_the_middle(self):
+        reps = [self._rows({"a": 100.0}), self._rows({"a": 300.0}), self._rows({"a": 200.0})]
+        agg = bd.aggregate_reps(reps)
+        self.assertEqual(agg[("a", 256, "closed")]["rps"], 200.0)
+
+    def test_median_of_even_count_averages_the_middle_two(self):
+        reps = [self._rows({"a": 100.0}), self._rows({"a": 200.0})]
+        agg = bd.aggregate_reps(reps)
+        self.assertEqual(agg[("a", 256, "closed")]["rps"], 150.0)
+
+    def test_spread_exposes_a_degraded_rep(self):
+        # The #746 case: rep3 ran ~20% low on a degraded runner. The aggregate must SAY so.
+        reps = [self._rows({"a": 5510000.0}), self._rows({"a": 5620000.0}),
+                self._rows({"a": 4350000.0})]
+        agg = bd.aggregate_reps(reps)
+        cell = agg[("a", 256, "closed")]
+        self.assertEqual(cell["rps"], 5510000.0)
+        self.assertGreater(cell["rps_spread_pct"], 20.0)
+        self.assertEqual(cell["reps"], 3)
+
+    def test_spread_is_zero_for_identical_reps(self):
+        reps = [self._rows({"a": 100.0}), self._rows({"a": 100.0})]
+        self.assertEqual(bd.aggregate_reps(reps)[("a", 256, "closed")]["rps_spread_pct"], 0.0)
+
+    def test_latency_percentiles_are_aggregated_too(self):
+        reps = [self._rows({"a": 100.0}), self._rows({"a": 100.0}), self._rows({"a": 100.0})]
+        cell = bd.aggregate_reps(reps)[("a", 256, "closed")]
+        for field in ("p50_ms", "p99_ms", "p999_ms"):
+            self.assertIn(field, cell)
+
+    def test_rejects_empty_rep_set(self):
+        with self.assertRaises(ValueError):
+            bd.aggregate_reps([])
+
+    def test_single_rep_is_its_own_median_with_zero_spread(self):
+        cell = bd.aggregate_reps([self._rows({"a": 42.0})])[("a", 256, "closed")]
+        self.assertEqual(cell["rps"], 42.0)
+        self.assertEqual(cell["rps_spread_pct"], 0.0)
+        self.assertEqual(cell["reps"], 1)
+
+    def test_percentile_absent_in_only_some_reps_medians_the_present_ones(self):
+        # oha can omit p99.9 on a sparse point in one rep but not another. The median must come
+        # from what was actually measured, never treating the gap as a zero.
+        a, b = self._rows({"x": 100.0}), self._rows({"x": 100.0})
+        a[0]["p999_ms"] = ""
+        b[0]["p999_ms"] = "9.0"
+        cell = bd.aggregate_reps([a, b])[("x", 256, "closed")]
+        self.assertEqual(cell["p999_ms"], 9.0)
+
+    def test_absent_percentile_does_not_crash_the_median(self):
+        # oha omits p99.9 when a point has too few samples; the CSV cell is empty, not "None".
+        reps = self._rows({"a": 100.0}), self._rows({"a": 200.0})
+        for r in reps:
+            r[0]["p999_ms"] = ""
+        cell = bd.aggregate_reps(list(reps))[("a", 256, "closed")]
+        self.assertEqual(cell["p999_ms"], "")
+
+
+class RepArtefacts(unittest.TestCase):
+    """Issue #773: the whole point is that a repped run leaves no file claiming to be more than
+    the one sample it is."""
+
+    def test_discovers_rep_files_for_a_base_suffix(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2, 3):
+                    open(os.path.join(tmp, f"direct_rift_per-core_cores8_rep{rep}.csv"), "w").close()
+                # decoys that must NOT be collected: a different variant, and a stale unsuffixed file
+                open(os.path.join(tmp, "direct_rift_work-stealing_cores8_rep1.csv"), "w").close()
+                open(os.path.join(tmp, "direct_rift_per-core_cores8.csv"), "w").close()
+                found = bd.find_rep_files("_per-core_cores8")
+                self.assertEqual(len(found), 3, f"expected exactly the 3 rep files, got {found}")
+                self.assertTrue(all("_rep" in os.path.basename(f) for f in found))
+                self.assertTrue(all("work-stealing" not in f for f in found))
+            finally:
+                bd.RESULTS_DIR = orig
+
+    def test_missing_reps_is_an_error_not_an_empty_aggregate(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                with self.assertRaises(SystemExit):
+                    bd.aggregate_reps_to_report("_nonexistent", "0.1.0")
+            finally:
+                bd.RESULTS_DIR = orig
+
+    def test_repped_writes_produce_only_suffixed_artefacts(self):
+        # THE acceptance criterion: a repped run must leave no unsuffixed file. Asserting on
+        # `result_suffix`'s string is not enough — a back-compat shim that ALSO wrote the
+        # unsuffixed name would satisfy that and reintroduce the whole bug.
+        import tempfile
+        rows = [("simple_health", 256, "closed",
+                 {"rps": 1.0, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+                  "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}})]
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2, 3):
+                    bd.write_results_csv("rift", bd.result_suffix(None, "per-core", 8, rep=rep), rows)
+                produced = sorted(os.listdir(tmp))
+                self.assertEqual(produced, [
+                    "direct_rift_per-core_cores8_rep1.csv",
+                    "direct_rift_per-core_cores8_rep2.csv",
+                    "direct_rift_per-core_cores8_rep3.csv",
+                ], "a repped run must write exactly one file per rep and no unsuffixed artefact")
+                self.assertNotIn("direct_rift_per-core_cores8.csv", produced)
+            finally:
+                bd.RESULTS_DIR = orig
+
+    def test_unrepped_write_keeps_the_unsuffixed_name(self):
+        import tempfile
+        rows = [("simple_health", 256, "closed",
+                 {"rps": 1.0, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+                  "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}})]
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                bd.write_results_csv("rift", bd.result_suffix(None, "per-core", 8), rows)
+                self.assertEqual(os.listdir(tmp), ["direct_rift_per-core_cores8.csv"])
+            finally:
+                bd.RESULTS_DIR = orig
+
+    def test_partial_reps_are_an_error_not_a_quietly_thinner_median(self):
+        # A point missing from one rep (crashed run, changed --sweep-connections, truncated CSV)
+        # must fail loudly — a complete-looking report resting on 2 of 3 samples is the silence
+        # #773 exists to remove.
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                full = [("a", 256, "closed", self._metric(100.0)),
+                        ("b", 256, "closed", self._metric(200.0))]
+                partial = [("a", 256, "closed", self._metric(110.0))]   # 'b' missing here
+                bd.write_rift_csv(os.path.join(tmp, "direct_rift_p_rep1.csv"), full)
+                bd.write_rift_csv(os.path.join(tmp, "direct_rift_p_rep2.csv"), partial)
+                with self.assertRaises(SystemExit) as cm:
+                    bd.aggregate_reps_to_report("_p", "0.1.0")
+                self.assertIn("incomplete repetitions", str(cm.exception))
+                self.assertIn("b@c=256", str(cm.exception))
+            finally:
+                bd.RESULTS_DIR = orig
+
+    @staticmethod
+    def _metric(rps):
+        return {"rps": rps, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+                "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}}
+
+    def test_aggregate_report_states_rep_count_and_spread(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                for rep, rps in ((1, 5510000.0), (2, 5620000.0), (3, 4350000.0)):
+                    rows = [("simple_health", 256, "closed",
+                             {"rps": rps, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+                              "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}})]
+                    bd.write_rift_csv(os.path.join(tmp, f"direct_rift_x_rep{rep}.csv"), rows)
+                out = bd.aggregate_reps_to_report("_x", "0.1.0")
+                text = open(out).read()
+                self.assertIn("spread", text.lower())
+                self.assertIn("3", text)          # rep count is stated
+                self.assertIn("5,510,000", text)  # the median, not rep3's degraded 4.35M
+            finally:
+                bd.RESULTS_DIR = orig
+
 
 class CpuTopology(unittest.TestCase):
     """Issue #746 core-count axis: `lscpu -p=CPU,CORE` parsing. Real output carries a comment


### PR DESCRIPTION
## Summary

Repetitions are now a first-class artefact dimension. Previously, `--rep N` runs would all write to the same unsuffixed results CSV, so the canonical-looking file held only the final rep — a single unreplicated sample. This caused the wrong number reported on #746 when the last rep landed on a degraded runner.

## Changes

- **--rep dimension**: Each rep writes its own suffixed artefact file (e.g., `results_rep1.csv`).
- **--aggregate-reps**: New flag emits a median-of-reps report with per-rep spread.
- **Loud failure**: Aggregation fails explicitly if any rep is missing a data point.
- **--rep guard**: Flag is Rift-only (rift-vs-mb comparison reads unsuffixed paths, so a repped run would report stale data).
- **Workflow cleanup**: Removed `cp` lines from decision-sweeps.yml that assumed overwrites.
- **README**: New "Repetitions and medians" section documents the feature.

## Verification

93 tests pass (21 new tests added).

Closes #773