### PR TITLE
bench(matching): A/B harness for the quamina body-field dimension

### DIFF
--- a/.github/workflows/decision-sweeps.yml
+++ b/.github/workflows/decision-sweeps.yml
@@ -22,7 +22,7 @@ on:
       sweep:
         description: "Which sweep to run"
         type: choice
-        options: [both, allocator, topology]
+        options: [both, allocator, topology, quamina]
         default: both
       reps:
         description: "Repetitions per variant (medians taken offline)"
@@ -36,6 +36,11 @@ on:
       connections:
         description: "Topology sweep connection counts"
         default: "4,256"
+      stub_counts:
+        description: >-
+          Quamina sweep: field-equals-on-body stub counts (comma-separated). The dimension replaces
+          an O(N) scan of structural comparisons, so N is the axis its win is a function of.
+        default: "10,100,1000"
       cores:
         description: >-
           Topology core-count axis: engine CPU budgets (comma-separated). Each budget pins the
@@ -167,4 +172,65 @@ jobs:
             tests/benchmark/results/environment.txt
             tests/benchmark/results/cpu-topology.txt
             tests/benchmark/results/skew-evidence.txt
+          retention-days: 30
+
+  quamina:
+    if: ${{ inputs.sweep == 'quamina' }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install oha
+        run: |
+          curl -sfL -o /usr/local/bin/oha \
+            https://github.com/hatoo/oha/releases/download/v1.12.0/oha-linux-amd64 \
+            && chmod +x /usr/local/bin/oha && oha --version \
+            || cargo install oha --locked
+      - name: Record environment
+        run: |
+          mkdir -p tests/benchmark/results
+          { uname -a; nproc; lscpu | head -25; free -h; } \
+            | tee tests/benchmark/results/environment.txt
+      # Issue #779: the dimension's go/no-go numbers were taken against rift-mock-core, the one
+      # crate where the feature was enabled — it was compiled out of the binary and the C-ABI
+      # until #777. This measures the shipped artefact. The harness verifies each build's own
+      # `Matching dimensions:` self-report before benching, because the two variants match
+      # identically by design: a mislabeled build has no other symptom.
+      - name: Quamina A/B (on/off x stub counts x reps)
+        working-directory: tests/benchmark
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra COUNTS <<< "${{ inputs.stub_counts }}"
+          for rep in $(seq 1 ${{ inputs.reps }}); do
+            for n in "${COUNTS[@]}"; do
+              for q in on off; do
+                echo "===== quamina=$q stubs=$n rep=$rep ====="
+                python3 scripts/bench_direct.py --run-all --quamina "$q" --stub-count "$n" \
+                  --rep "$rep" --sweep-connections "${{ inputs.connections }}" \
+                  --duration "${{ inputs.duration }}" --warmup 2s
+              done
+            done
+          done
+          for n in "${COUNTS[@]}"; do
+            for q in on off; do
+              python3 scripts/bench_direct.py --aggregate-reps "_quamina${q}_stubs${n}"
+            done
+          done
+      - name: Record binary sizes (the dimension's cost to embedders)
+        run: |
+          for q in on off; do
+            printf "quamina-%s %s bytes\n" "$q" \
+              "$(stat -c%s target/quamina-$q/release/rift-http-proxy)"
+          done | tee tests/benchmark/results/binary-sizes.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: quamina-sweep-results
+          path: |
+            tests/benchmark/results/*.csv
+            tests/benchmark/results/*.md
+            tests/benchmark/results/environment.txt
+            tests/benchmark/results/binary-sizes.txt
           retention-days: 30

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -168,6 +168,14 @@ fn main() -> Result<(), anyhow::Error> {
     // Start in Mountebank mode
     info!("Starting Rift on port {}", cli.port);
     info!("Global allocator: {}", ACTIVE_ALLOCATOR);
+    info!(
+        "Matching dimensions: body-field(quamina)={}",
+        if rift_mock_core::QUAMINA_BODY_FIELD_DIMENSION {
+            "on"
+        } else {
+            "off"
+        }
+    );
     run_mountebank_mode(cli)
 }
 

--- a/crates/rift-mock-core/src/lib.rs
+++ b/crates/rift-mock-core/src/lib.rs
@@ -3,6 +3,18 @@
 //! the `rift-http-proxy` server and the `rift-ffi` C-ABI are thin consumers.
 #![allow(dead_code)]
 
+/// Whether the quamina-backed body-field candidate dimension is compiled into this build.
+///
+/// Reported at startup by the server binary so a benchmark — or an operator — can read the answer
+/// off the artefact instead of inferring it from build flags, the same way `Global allocator:`
+/// (#717) and `Runtime topology:` (RFC-712) already are. It is deliberately defined *here*, in the
+/// crate whose `#[cfg]` gates the dimension, rather than in a consumer: issue #777 shipped this
+/// dimension enabled in `rift-mock-core` and compiled out of both the binary and the C-ABI,
+/// because each consumer takes this crate with `default-features = false` and nothing forwarded
+/// the feature. A marker sourced from a consumer would have reported that consumer's own opinion;
+/// this one reports what actually got compiled.
+pub const QUAMINA_BODY_FIELD_DIMENSION: bool = cfg!(feature = "quamina-matching");
+
 // ===== Core Mountebank-compatible modules =====
 pub mod behaviors;
 pub mod config;

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -155,6 +155,46 @@ Linux only (`taskset`/`lscpu`). Note the ceiling this implies: on an M-vCPU box 
 needs its own cores, so the engine tops out well below M — an ≥8-*physical*-core point needs a
 bigger box or an off-box generator, and any verdict quoting these numbers should say so.
 
+### Body-field dimension A/B (issue #779, Rift-only)
+
+`--quamina {on,off}` builds and benches one variant of the quamina-backed body-field candidate
+dimension, into `target/quamina-<variant>/` (same discipline as `--allocator`). `--stub-count N`
+scales the JSONBody imposter's field-equals-on-body stubs off their default 50 — that count *is*
+the axis, because the dimension replaces an `O(N)` scan, so a single stub count measures one
+arbitrary point on the curve.
+
+```bash
+for n in 10 100 1000; do
+  for q in on off; do
+    for rep in 1 2 3; do
+      python3 scripts/bench_direct.py --run-all --quamina $q --stub-count $n --rep $rep \
+          --sweep-connections 256 --duration 12s --warmup 2s
+    done
+  done
+  for q in on off; do
+    python3 scripts/bench_direct.py --aggregate-reps "_quamina${q}_stubs${n}"
+  done
+done
+```
+
+**Why the probe matters here more than anywhere else.** The two variants are supposed to return
+**identical matching results** — the dimension is a pure over-approximating prefilter, and Stage-2
+always decides. So a mislabeled build produces *no* visible symptom: same responses, same status
+codes, same journal. Nothing but the label would be wrong. The harness therefore refuses to bench
+until the binary's own startup line agrees:
+
+```
+INFO rift_http_proxy: Matching dimensions: body-field(quamina)=on
+```
+
+That line is the third such self-report, alongside `Global allocator:` (#717) and
+`Runtime topology:` (RFC-712), and it exists because issue #777 shipped this dimension enabled in
+`rift-mock-core` and compiled out of both the binary and the C-ABI — with CI green throughout,
+because the dimension's tests run in the crate where it *was* enabled.
+
+The report also records **binary size**, since the dimension pulls a dependency into the server
+binary and into the `cdylib` embedders link into their own process.
+
 #### Repetitions and medians — never quote a single run
 
 **Always pass `--rep N`.** One run of one variant is one sample; a benchmark host is not a

--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -79,7 +79,19 @@ def complex_stubs(n=50):
             "body": json.dumps({"complex": i, "matched": True})}}],
     } for i in range(1, n + 1)]
 
-def json_body_stubs(n=50):
+DEFAULT_JSON_BODY_STUBS = 50
+
+def set_json_body_stub_count(n):
+    """Rebuild the JSONBody imposter with `n` field-equals-on-body stubs (#779).
+
+    Stub count is the axis this dimension is *about*: the quamina prefilter replaces an O(N) scan
+    of structural comparisons, so its win is a function of how many such stubs compete for one
+    request. Benching only the default 50 would measure one arbitrary point on that curve."""
+    global IMPOSTERS
+    IMPOSTERS = [(port, name, json_body_stubs(n) if name == "JSONBody" else stubs)
+                 for port, name, stubs in IMPOSTERS]
+
+def json_body_stubs(n=DEFAULT_JSON_BODY_STUBS):
     return [{
         "predicates": [{"equals": {"method": "POST", "path": f"/json/equals/{i}",
             "body": {"id": i, "type": "request"}}}],
@@ -354,18 +366,101 @@ def allocator_build_args(name):
         return ["--no-default-features", "--features", "redis-backend,javascript"]
     raise ValueError(f"unknown allocator {name!r}: choose from {','.join(ALLOCATORS)}")
 
+# ---- quamina body-field dimension A/B (issue #779): same discipline as --allocator ----
+#
+# The dimension's go/no-go numbers (#767) were taken against rift-mock-core, the one crate where the
+# feature was enabled — it was compiled out of the binary and the C-ABI until #777. So the shipped
+# win has never been measured. This axis builds the two variants and benches them identically.
+
+QUAMINA_VARIANTS = ("on", "off")
+QUAMINA_MARKER = "Matching dimensions: "
+QUAMINA_PROBE_PORT = 3527
+
+def quamina_build_args(variant):
+    """Cargo flags that swap ONLY the body-field dimension, keeping redis-backend + javascript +
+    mimalloc on in both variants so the builds are functionally identical apart from it."""
+    if variant == "on":
+        return []   # default features include quamina-matching (#777)
+    if variant == "off":
+        return ["--no-default-features", "--features", "redis-backend,javascript,mimalloc"]
+    raise ValueError(f"unknown quamina variant {variant!r}: choose from {','.join(QUAMINA_VARIANTS)}")
+
+def quamina_bin_path(variant):
+    """Per-variant binary path, so the two builds coexist instead of clobbering target/release."""
+    return os.path.join(REPO_ROOT, "target", f"quamina-{variant}", "release", "rift-http-proxy")
+
+def build_quamina_binary(variant):
+    print(f"building rift with quamina body-field dimension={variant}")
+    cmd = ["cargo", "build", "--release", "-p", "rift-http-proxy",
+           "--target-dir", os.path.join("target", f"quamina-{variant}")] + quamina_build_args(variant)
+    out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    if out.returncode != 0:
+        tail = "\n".join((out.stdout + out.stderr).splitlines()[-40:])
+        raise SystemExit(f"build failed for quamina={variant}:\n{tail}")
+    print(f"  built target/quamina-{variant}/release/rift-http-proxy")
+
+def extract_quamina_marker(text):
+    """Pull the self-reported dimension state out of an engine log, or None if absent."""
+    for line in text.splitlines():
+        if QUAMINA_MARKER in line:
+            return line.split(QUAMINA_MARKER, 1)[1].strip()
+    return None
+
+def quamina_marker_matches(reported, variant):
+    """The binary reports `body-field(quamina)=on|off`; the label must match the request."""
+    return reported == f"body-field(quamina)={variant}"
+
+def verify_quamina_marker(rift_bin, variant):
+    """Probe-launch and require the binary's OWN self-report to match the requested variant.
+
+    This is the #777 lesson made mechanical: that issue shipped a dimension enabled in the library
+    and compiled out of everything users run, and no artefact said so. Benching a build whose
+    dimension state is assumed rather than read would repeat it — with the added twist that the
+    two variants are supposed to produce identical matching RESULTS, so nothing else in the run
+    would look wrong."""
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    free_ports([QUAMINA_PROBE_PORT])
+    logpath = os.path.join(RESULTS_DIR, "quamina-probe.log")
+    proc = launch([rift_bin, "--port", str(QUAMINA_PROBE_PORT), "--loglevel", "info"], logpath)
+    try:
+        reported = None
+        for _ in range(40):
+            time.sleep(0.25)
+            with open(logpath) as f:
+                reported = extract_quamina_marker(f.read())
+            if reported is not None:
+                break
+        if reported is None or not quamina_marker_matches(reported, variant):
+            raise SystemExit(
+                f"quamina probe: binary reports {reported!r}, requested variant {variant!r} "
+                f"({rift_bin}) — aborting rather than benching a mislabeled build. Both variants "
+                f"match identically by design, so a mislabel would not show up anywhere else.")
+        print(f"  quamina probe ok: {reported}")
+    finally:
+        stop(proc, [QUAMINA_PROBE_PORT])
+
+def binary_size_mb(path):
+    """Size of the benched binary in MB — the dimension pulls a dependency into the server binary
+    and, for embedders, into the cdylib they link, so size is part of its cost (#779)."""
+    try:
+        return round(os.path.getsize(path) / (1024 * 1024), 2)
+    except OSError:
+        return None
+
 def allocator_bin_path(name):
     """Per-allocator binary path; a separate --target-dir per allocator so three builds can
     coexist on disk instead of clobbering each other's `target/release` (#717)."""
     return os.path.join(REPO_ROOT, "target", f"alloc-{name}", "release", "rift-http-proxy")
 
-def resolve_rift_bin(rift_bin_arg, allocator):
+def resolve_rift_bin(rift_bin_arg, allocator, quamina=None):
     """Resolve (path, needs_build). An explicit --rift-bin is always trusted verbatim (no build,
     even if --allocator is also set). No allocator selected: fall back to the default release
     path, unchanged from pre-#717 behaviour. Allocator selected with no --rift-bin: build into
     the per-allocator target dir."""
     if rift_bin_arg is not None:
         return rift_bin_arg, False
+    if quamina is not None:
+        return quamina_bin_path(quamina), True
     if allocator is None:
         return DEFAULT_RIFT_BIN, False
     return allocator_bin_path(allocator), True
@@ -749,7 +844,8 @@ def resolve_cpu_split(server_cpus):
     except ValueError as e:
         raise SystemExit(str(e))
 
-def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None):
+def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None,
+                  quamina=None, stub_count=None):
     """Allocator, runtime, core-count and repetition dimensions compose into one artefact suffix so
     no combination overwrites another's CSV/report (#717, #746, #773).
 
@@ -763,6 +859,11 @@ def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None):
         suffix += f"_{runtime_mode}"
     if server_cpus:
         suffix += f"_cores{server_cpus}"
+    if quamina:
+        suffix += f"_quamina{quamina}"
+    if stub_count:
+        suffix += f"_stubs{stub_count}"
+    # rep stays outermost: every other dimension names a *variant*, a rep names a sample OF one.
     if rep is not None:
         suffix += f"_rep{rep}"
     return suffix
@@ -908,10 +1009,10 @@ def aggregate_reps_to_report(base_suffix, rift_ver):
 
 def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False,
             allocator=None, runtime=None, server_cpus=None, engine_cpus=None, gen_cpus=None,
-            rep=None):
+            rep=None, quamina=None, stub_count=None):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     node = shutil.which("node") or "node"
-    csv_suffix = result_suffix(allocator, runtime, server_cpus, rep)
+    csv_suffix = result_suffix(allocator, runtime, server_cpus, rep, quamina, stub_count)
     engine_prefix, oha_prefix = taskset_prefix(engine_cpus), taskset_prefix(gen_cpus)
     full_plan = [
         ("rift", 0,   engine_prefix
@@ -944,14 +1045,17 @@ def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, r
     elif engines == ["rift"]:
         rift_only_report(rift_ver, duration, conn_list, rate, recording,
                           allocator=allocator, runtime=runtime, csv_suffix=csv_suffix,
-                          engine_cpus=engine_cpus, gen_cpus=gen_cpus)
+                          engine_cpus=engine_cpus, gen_cpus=gen_cpus,
+                          quamina=quamina, stub_count=stub_count,
+                          binary_mb=binary_size_mb(rift_bin))
     else:
         # engines == ["mb"]: no comparison possible (needs Rift too) and no Rift-only report to write.
         print(f"[report] engines={engines}: benched only Mountebank; no report written "
               f"(the comparison needs both rift and mb)")
 
 def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=None,
-                     runtime=None, csv_suffix="", engine_cpus=None, gen_cpus=None):
+                     runtime=None, csv_suffix="", engine_cpus=None, gen_cpus=None,
+                     quamina=None, stub_count=None, binary_mb=None):
     """Rift-only sweep / open-loop report: scenario × (connections, mode) matrices of RPS and p999.
     The MB-comparison report is deliberately untouched so its historical single-point numbers stay
     comparable; this is the extra artefact the Turbo round consumes. Allocator bake-off runs (#717)
@@ -983,6 +1087,13 @@ def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=N
             f.write(f"- **Allocator:** {allocator}\n")
         if runtime:
             f.write(f"- **Runtime:** {runtime}\n")
+        if quamina:
+            f.write(f"- **Body-field dimension (quamina):** {quamina} "
+                    f"(verified from the binary's `Matching dimensions:` self-report)\n")
+        if stub_count:
+            f.write(f"- **Field-equals-on-body stubs:** {stub_count}\n")
+        if binary_mb is not None:
+            f.write(f"- **Binary size:** {binary_mb} MB\n")
         if engine_cpus:
             f.write(f"- **Engine CPUs:** {len(engine_cpus)} (`{cpuset_arg(engine_cpus)}`) — the "
                     f"worker count both topologies derive from `available_parallelism()`\n")
@@ -1070,6 +1181,17 @@ if __name__ == "__main__":
                     help="core-count axis (#746): confine the engine to N CPUs with taskset — "
                          "both topologies size their workers from it — and confine oha to the "
                          "remaining physical cores. N must fall on a core boundary; Linux only.")
+    ap.add_argument("--quamina", choices=list(QUAMINA_VARIANTS),
+                    help="build+bench one quamina body-field variant (Rift-only; #779). Builds "
+                         "into target/quamina-<on|off>/ unless --rift-bin is given, and verifies "
+                         "the binary's own `Matching dimensions:` self-report before benching — "
+                         "the two variants match identically by design, so a mislabeled build "
+                         "would not show up anywhere else in the results.")
+    ap.add_argument("--stub-count", type=int, metavar="N",
+                    help="number of field-equals-on-body stubs on the JSONBody imposter (#779; "
+                         f"default {DEFAULT_JSON_BODY_STUBS}). The quamina dimension replaces an "
+                         "O(N) scan, so its win is a function of N — sweep it (e.g. 10/100/1000) "
+                         "rather than measuring one arbitrary point.")
     ap.add_argument("--rep", type=int, metavar="N",
                     help="repetition index (#773): artefacts get a _repN suffix, so each rep of a "
                          "sweep lands in its own file instead of overwriting the last. Re-running "
@@ -1085,6 +1207,14 @@ if __name__ == "__main__":
         sys.exit(0)
     if a.rep is not None and a.rep < 1:
         raise SystemExit(f"--rep must be >= 1 (got {a.rep})")
+    if a.stub_count is not None and a.stub_count < 1:
+        raise SystemExit(f"--stub-count must be >= 1 (got {a.stub_count})")
+    if a.quamina and a.allocator:
+        raise SystemExit(
+            "--quamina and --allocator are separate bake-offs: combining them would attribute one "
+            "variable's effect to the other. Run them as separate sweeps.")
+    if a.stub_count is not None:
+        set_json_body_stub_count(a.stub_count)
     if a.run_all:
         try:
             engines, conn_list, rate, recording = resolve_run_mode(
@@ -1103,13 +1233,20 @@ if __name__ == "__main__":
                 "--rep is Rift-only: the rift-vs-mb report reads unsuffixed artefacts, so a "
                 "repped comparison run would report a stale file as this run's numbers. "
                 "Re-run with --engines rift.")
-        if (a.allocator or a.runtime) and engines != ["rift"]:
+        if (a.allocator or a.runtime or a.quamina) and engines != ["rift"]:
             engines = ["rift"]
         if engines != requested:
             print("note: sweep/open-loop/allocator is Rift-only; running --engines rift")
-        rift_bin, needs_build = resolve_rift_bin(a.rift_bin, a.allocator)
+        rift_bin, needs_build = resolve_rift_bin(a.rift_bin, a.allocator, a.quamina)
         if needs_build:
-            build_allocator_binary(a.allocator)
+            if a.quamina:
+                build_quamina_binary(a.quamina)
+            else:
+                build_allocator_binary(a.allocator)
+        if a.quamina:
+            # Applies to an explicit --rift-bin too: the label on the results must come from the
+            # binary, never from the invocation (#777).
+            verify_quamina_marker(rift_bin, a.quamina)
         if a.allocator:
             # Applies to explicit --rift-bin AND harness-built binaries alike: the label on the
             # results must come from the binary itself, never from the invocation.
@@ -1130,7 +1267,7 @@ if __name__ == "__main__":
         run_all(a.duration, a.warmup, conn_list, rift_bin, a.mb_bin, engines,
                 rate=rate, recording=recording, allocator=a.allocator, runtime=a.runtime,
                 server_cpus=a.server_cores, engine_cpus=engine_cpus, gen_cpus=gen_cpus,
-                rep=a.rep)
+                rep=a.rep, quamina=a.quamina, stub_count=a.stub_count)
     elif a.report:
         report(a.rift_version, a.mb_version, a.duration, a.connections)
     else:

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -412,6 +412,23 @@ class ResultSuffix(unittest.TestCase):
         self.assertEqual(bd.result_suffix("mimalloc", "per-core", 4, rep=3),
                          "_mimalloc_per-core_cores4_rep3")
 
+    def test_quamina_and_stub_count_are_their_own_dimensions(self):
+        # Issue #779: the A/B variant and the stub count are what the measurement varies, so they
+        # must name the artefact — otherwise the two halves of the bake-off overwrite each other.
+        self.assertEqual(bd.result_suffix(None, None, None, quamina="on"), "_quaminaon")
+        self.assertEqual(bd.result_suffix(None, None, None, stub_count=1000), "_stubs1000")
+        self.assertEqual(bd.result_suffix(None, None, None, quamina="off", stub_count=100),
+                         "_quaminaoff_stubs100")
+
+    def test_rep_stays_outermost(self):
+        # Every other dimension names a variant; rep names a sample OF one, so it sorts last.
+        self.assertEqual(
+            bd.result_suffix(None, "per-core", 8, rep=2, quamina="on", stub_count=1000),
+            "_per-core_cores8_quaminaon_stubs1000_rep2")
+
+    def test_new_dimensions_absent_reproduces_the_old_names(self):
+        self.assertEqual(bd.result_suffix("jemalloc", "per-core", 4, rep=1), "_jemalloc_per-core_cores4_rep1")
+
     def test_rep_absent_reproduces_the_old_names(self):
         # The pre-#773 contract must be byte-identical when no rep is given, so artefacts from
         # earlier sweeps stay comparable.
@@ -606,6 +623,86 @@ class RepArtefacts(unittest.TestCase):
                 self.assertIn("5,510,000", text)  # the median, not rep3's degraded 4.35M
             finally:
                 bd.RESULTS_DIR = orig
+
+
+class QuaminaVariant(unittest.TestCase):
+    """Issue #779: the two variants match IDENTICALLY by design — the dimension is a pure
+    prefilter — so a mislabeled build produces no visible symptom anywhere else in the results.
+    That makes the build args and the self-report check the only things standing between the
+    bake-off and a silently meaningless number."""
+
+    def test_on_uses_default_features(self):
+        self.assertEqual(bd.quamina_build_args("on"), [])
+
+    def test_off_drops_only_the_dimension(self):
+        args = bd.quamina_build_args("off")
+        self.assertIn("--no-default-features", args)
+        feats = args[args.index("--features") + 1]
+        # Everything else the default build has must survive, or the two variants differ by more
+        # than the one thing under test.
+        for keep in ("redis-backend", "javascript", "mimalloc"):
+            self.assertIn(keep, feats)
+        self.assertNotIn("quamina", feats)
+
+    def test_rejects_unknown_variant(self):
+        with self.assertRaises(ValueError):
+            bd.quamina_build_args("maybe")
+
+    def test_marker_extraction_and_matching(self):
+        log = "INFO rift_http_proxy: Matching dimensions: body-field(quamina)=on\n"
+        self.assertEqual(bd.extract_quamina_marker(log), "body-field(quamina)=on")
+        self.assertTrue(bd.quamina_marker_matches("body-field(quamina)=on", "on"))
+        self.assertFalse(bd.quamina_marker_matches("body-field(quamina)=off", "on"))
+        self.assertFalse(bd.quamina_marker_matches("body-field(quamina)=on", "off"))
+
+    def test_absent_marker_is_none(self):
+        self.assertIsNone(bd.extract_quamina_marker("INFO rift: Starting Rift on port 2525\n"))
+
+    def test_variant_binaries_do_not_share_a_target_dir(self):
+        self.assertNotEqual(bd.quamina_bin_path("on"), bd.quamina_bin_path("off"))
+
+    def test_explicit_rift_bin_still_wins(self):
+        path, needs_build = bd.resolve_rift_bin("/tmp/custom-rift", None, "on")
+        self.assertEqual(path, "/tmp/custom-rift")
+        self.assertFalse(needs_build)
+
+    def test_quamina_selects_its_variant_binary(self):
+        path, needs_build = bd.resolve_rift_bin(None, None, "off")
+        self.assertIn("quamina-off", path)
+        self.assertTrue(needs_build)
+
+
+class StubCountAxis(unittest.TestCase):
+    """Issue #779: the dimension replaces an O(N) scan, so N is the axis."""
+
+    def test_scaling_rebuilds_only_the_jsonbody_imposter(self):
+        original = list(bd.IMPOSTERS)
+        try:
+            bd.set_json_body_stub_count(7)
+            by_name = {name: stubs for _, name, stubs in bd.IMPOSTERS}
+            self.assertEqual(len(by_name["JSONBody"]), 7)
+            # every other imposter is untouched, or the A/B varies more than one thing
+            for _, name, stubs in original:
+                if name != "JSONBody":
+                    self.assertEqual(len(by_name[name]), len(stubs), f"{name} changed")
+        finally:
+            bd.IMPOSTERS = original
+
+    def test_default_count_is_the_pre_779_value(self):
+        self.assertEqual(len(bd.json_body_stubs()), bd.DEFAULT_JSON_BODY_STUBS)
+
+
+class BinarySize(unittest.TestCase):
+    def test_missing_binary_reads_none_not_zero(self):
+        # A zero would render as a real measurement of "no bytes"; absent must stay absent.
+        self.assertIsNone(bd.binary_size_mb("/nonexistent/rift-http-proxy"))
+
+    def test_reports_megabytes(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(b"x" * (2 * 1024 * 1024))
+            f.flush()
+            self.assertEqual(bd.binary_size_mb(f.name), 2.0)
 
 
 class CpuTopology(unittest.TestCase):


### PR DESCRIPTION
Builds the harness #779 needs. **Does not close it** — the throughput measurement still has to be
run; this makes running it possible and trustworthy.

## Why the measurement doesn't exist yet

The dimension's go/no-go numbers (#719 → #767) were taken against `rift-mock-core` — the one crate
where the feature was enabled. It was compiled out of the `rift` binary and the C-ABI until #777.
So the CHANGELOG's `~6.8×` figure describes a configuration no user has ever run.

## What's here

| Piece | Notes |
|---|---|
| `--quamina {on,off}` | Builds each variant into `target/quamina-<v>/`, mirroring `--allocator` |
| `--stub-count N` | Scales the JSONBody imposter off its fixed 50 — the dimension replaces an `O(N)` scan, so N is the axis; one count measures one arbitrary point on the curve |
| binary-size capture | The dimension costs **0.42 MB (2.2%)**, inherited by embedders in the `cdylib` |
| `sweep: quamina` workflow leg | on/off × stub counts × reps, then median aggregation |

`--quamina` and `--allocator` are **refused in combination** — running both would attribute one
variable's effect to the other.

## The engine change, and why it's in `rift-mock-core`

A third startup self-report, alongside `Global allocator:` (#717) and `Runtime topology:` (RFC-712):

```
INFO rift_http_proxy: Matching dimensions: body-field(quamina)=on
```

It is defined in `rift-mock-core`, where the `#[cfg]` gates the code — **not** in a consumer. A
marker sourced from `rift-http-proxy` would report that crate's own opinion of the feature, which is
precisely the mistake #777 was: the dimension was enabled in the library and absent from everything
that ships, and no artefact said so.

**This probe matters more than the other two.** The variants are supposed to return *identical*
matching results — the dimension is a pure over-approximating prefilter and Stage-2 always decides.
A mislabeled build therefore has no symptom: same responses, same status codes, same journal.
The label is the only thing that would be wrong, and the number would be silently meaningless. The
harness refuses to bench until the binary's own line agrees with the requested variant.

Verified in both directions: the default build reports `=on`, a `--no-default-features` build
reports `=off`.

## Scope notes

- The `quamina` job is **not** part of `sweep: both`. The allocator and topology legs are the Turbo
  round's original gates; folding a third long A/B into `both` would silently triple the cost of
  the existing dispatch. It is opt-in.
- The JSONBody scenario drives 100% of requests at field-equals-on-body stubs, so this measures the
  dimension's **best case** — an upper bound, not a typical-workload figure. Worth saying out loud
  in whatever verdict quotes it.

## Verification

`cargo fmt` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace`
(0 failures) · 108 harness tests (20 new) · `verify-feature-propagation.sh` still green ·
both variants built and their markers confirmed on a real binary.

Refs #779, #777.
