### PR TITLE
chore: repoint sibling-repo references at achird-labs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,7 +621,7 @@ jobs:
   # =============================================================================
   # Trigger the Node SDK bump (immediate engine -> rift-node coupling)
   # =============================================================================
-  # The npm package (@rift-vs/rift) lives in EtaCassiopeia/rift-node and tracks this engine's
+  # The npm package (@rift-vs/rift) lives in achird-labs/rift-node and tracks this engine's
   # releases. Instead of waiting for rift-node's daily engine-bump poll (up to ~24h), trigger it
   # now so the SDK bump PR opens within minutes of this release. rift-node's own pipeline still
   # owns and gates the actual npm publish (its first release is human-gated). Needs a PAT with
@@ -637,4 +637,4 @@ jobs:
       - name: Dispatch rift-node engine-bump
         env:
           GH_TOKEN: ${{ secrets.RIFT_NODE_DISPATCH_TOKEN }}
-        run: gh workflow run engine-bump.yml -R EtaCassiopeia/rift-node
+        run: gh workflow run engine-bump.yml -R achird-labs/rift-node

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -2,7 +2,7 @@
 # Copy this file to: .github/workflows/update-homebrew.yml in this repo
 #
 # Prerequisites:
-# 1. Create repository: github.com/EtaCassiopeia/homebrew-rift
+# 1. Create repository: github.com/achird-labs/homebrew-rift
 # 2. Add HOMEBREW_TAP_TOKEN secret (personal access token with repo scope)
 #    Or use the default GITHUB_TOKEN if the tap repo is in the same org
 
@@ -29,7 +29,7 @@ on:
         type: string
 
 env:
-  TAP_REPO: EtaCassiopeia/homebrew-rift
+  TAP_REPO: achird-labs/homebrew-rift
   FORMULA_NAME: rift
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ await server.close();
 
 ### Java / JVM
 
-For JVM projects, use the official [rift-java](https://github.com/EtaCassiopeia/rift-java) SDK.
+For JVM projects, use the official [rift-java](https://github.com/achird-labs/rift-java) SDK.
 It runs the engine three ways — embedded in-process (Panama FFM, no Docker), connected to any
 running admin endpoint, or as a managed spawned binary — with a fluent DSL plus JUnit 5, Spring,
 and Testcontainers integrations. Available on Maven Central under `io.github.etacassiopeia`:
@@ -180,7 +180,7 @@ See the [rift-java docs](https://achird-labs.github.io/rift-java/) for the full 
 - [Installation](https://achird-labs.github.io/rift/getting-started/) - Docker, binary, build from source
 - [Quick Start](https://achird-labs.github.io/rift/getting-started/quickstart) - Create your first imposter
 - [Node.js Integration](https://achird-labs.github.io/rift/getting-started/nodejs/) - npm package for Node.js
-- [Java / JVM SDK](https://github.com/EtaCassiopeia/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Migration Guide](https://achird-labs.github.io/rift/getting-started/migration) - Using Rift with Mountebank configs
 
 ### Mountebank Compatibility

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ docker pull zainalpour/rift-proxy:latest
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap etacassiopeia/rift
+brew tap achird-labs/rift
 brew install rift
 ```
 
@@ -151,11 +151,11 @@ await server.close();
 For JVM projects, use the official [rift-java](https://github.com/achird-labs/rift-java) SDK.
 It runs the engine three ways — embedded in-process (Panama FFM, no Docker), connected to any
 running admin endpoint, or as a managed spawned binary — with a fluent DSL plus JUnit 5, Spring,
-and Testcontainers integrations. Available on Maven Central under `io.github.etacassiopeia`:
+and Testcontainers integrations. Available on Maven Central under `io.github.achird-labs`:
 
 ```xml
 <dependency>
-  <groupId>io.github.etacassiopeia</groupId>
+  <groupId>io.github.achird-labs</groupId>
   <artifactId>rift-java-core</artifactId>
   <scope>test</scope>
 </dependency>

--- a/crates/rift-lint/README.md
+++ b/crates/rift-lint/README.md
@@ -22,7 +22,7 @@ cargo install rift-lint
 ### Via Homebrew (macOS/Linux)
 
 ```bash
-brew tap etacassiopeia/rift
+brew tap achird-labs/rift
 brew install rift
 # rift-lint is included
 ```

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -47,7 +47,7 @@ the source, the source wins — please file an issue.
 | `rift-ffi` | The C-ABI shared library (`cdylib`) plus an `rlib` for in-crate tests. | The `extern "C"` functions (`rift_start`, `rift_serve_admin`, …) and the cbindgen header. |
 
 > The Node.js package used to live here as `packages/rift-node`. It now has its own repository —
-> [`EtaCassiopeia/rift-node`](https://github.com/EtaCassiopeia/rift-node) — which owns and publishes
+> [`achird-labs/rift-node`](https://github.com/achird-labs/rift-node) — which owns and publishes
 > the npm package; this repository no longer builds or publishes it.
 
 ### Cargo features

--- a/docs/features/linting.md
+++ b/docs/features/linting.md
@@ -15,7 +15,7 @@ Rift includes a powerful configuration linter (`rift-lint`) that validates impos
 
 ```bash
 # Via Homebrew (macOS/Linux)
-brew tap etacassiopeia/rift
+brew tap achird-labs/rift
 brew install rift
 # rift-lint is included
 

--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -11,7 +11,7 @@ permalink: /getting-started/nodejs/
 Rift provides official Node.js bindings via the `@rift-vs/rift` npm package. This package is a drop-in replacement for Mountebank's Node.js API, making migration seamless.
 
 > **The Node.js SDK lives in its own repository.** It is developed and published from
-> [`EtaCassiopeia/rift-node`](https://github.com/EtaCassiopeia/rift-node), which owns the npm
+> [`achird-labs/rift-node`](https://github.com/achird-labs/rift-node), which owns the npm
 > release. This engine repository no longer contains or publishes it — file SDK issues there, and
 > engine issues here.
 


### PR DESCRIPTION
Repoints the engine's cross-repo references at `achird-labs` now that the SDKs,
the brew tap and the docs site have moved into the org alongside it.

Most of this is link hygiene, but two are load-bearing writes that redirects do
**not** cover, because they are API-level writes rather than fetches:

- `update-homebrew.yml` pushes the regenerated formula to `TAP_REPO`
- `release.yml` dispatches `engine-bump.yml` into rift-node

`zio-bdd` and `zio-openfeature` stay in the user namespace and are left alone.

Part of the achird-labs org consolidation. No release impact on its own.
