### PR TITLE
bench(perf): cover the matching dimensions the suite never measured

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -155,6 +155,45 @@ Linux only (`taskset`/`lscpu`). Note the ceiling this implies: on an M-vCPU box 
 needs its own cores, so the engine tops out well below M — an ≥8-*physical*-core point needs a
 bigger box or an off-box generator, and any verdict quoting these numbers should say so.
 
+### Matching-dimension scenarios (Rift-only, additive)
+
+Several Turbo optimizations had **no benchmark coverage at all** — the suite could not have
+detected a regression in them. These scenarios close that, and are kept **separate** from the
+13-scenario Mountebank comparison set, which is a stability contract: it must stay comparable with
+previously published numbers (enforced by `DefaultRunUnchanged` in the tests). They ride with
+Rift-only sweeps, exactly like `recording_on`.
+
+| Scenario | Covers | Was measured before? |
+|---|---|---|
+| `deepequals_body` | #740 `deepEquals` structural-hash index | no — `deepEquals` appeared nowhere |
+| `literal_prefix` / `literal_contains` | #732 anchored/unanchored Aho-Corasick | barely — 1 `startsWith`, 2 `contains` in ~860 stubs |
+| `method_mix` | #729 method dimension | no — every scenario was GET or POST |
+| `body_field_scale` | #767 quamina body-field automaton | no — see the trap below |
+
+#### The trap `body_field_scale` exists to avoid
+
+`json_body_equals` gives every stub a **unique path**, so the path dimension prunes the candidate
+set to one stub *before* the body is consulted. The body-field automaton then re-derives what the
+path index already knew. Benchmarking the quamina dimension against it measures **pure overhead**:
+run 29738479074 showed −8% at 10, 100 *and* 1000 stubs — flat with N, which is the signature of
+measuring a cost with no corresponding benefit.
+
+`body_field_scale` puts N stubs on **one shared path and method**, discriminated only by a body
+field, so the `O(N)` structural scan the dimension replaces is actually on the critical path.
+Scale it with `--body-field-stubs N`:
+
+```bash
+for n in 10 100 1000; do
+  for q in on off; do
+    python3 scripts/bench_direct.py --run-all --quamina $q --body-field-stubs $n --rep 1 \
+        --sweep-connections 256 --duration 12s --warmup 2s
+  done
+done
+```
+
+A test asserts these stubs share exactly one path and one method — if that ever changes, the
+scenario silently stops testing the dimension while still appearing to.
+
 ### Body-field dimension A/B (issue #779, Rift-only)
 
 `--quamina {on,off}` builds and benches one variant of the quamina-backed body-field candidate

--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -111,6 +111,83 @@ def json_body_stubs(n=DEFAULT_JSON_BODY_STUBS):
         "responses": [{"is": {"statusCode": 200, "body": json.dumps({"matched": "equals", "id": i})}}],
     } for i in range(1, n + 1)]
 
+DEFAULT_BODY_FIELD_STUBS = 200
+
+def body_field_stubs(n=DEFAULT_BODY_FIELD_STUBS):
+    """N stubs on ONE shared path+method, discriminated ONLY by a body field value.
+
+    This is the workload the quamina body-field dimension (#767) exists for, and the suite had
+    nothing like it. `json_body_stubs` gives every stub a unique path, so the path dimension prunes
+    the candidate set to one before the body is consulted — the automaton then re-derives what the
+    path index already knew, and the run measures pure overhead rather than the dimension's benefit
+    (observed: -8% at every N in run 29738479074, flat with N, which is the signature of measuring
+    overhead alone).
+
+    Sharing the path across all N is what forces the body field to be the discriminator, so the
+    `O(N)` structural scan the dimension replaces is actually on the critical path."""
+    return [{
+        "predicates": [{"equals": {"method": "POST", "path": "/orders/submit",
+            "body": {"orderId": f"ord-{i}", "channel": "web"}}}],
+        "responses": [{"is": {"statusCode": 200,
+            "body": json.dumps({"body_field_matched": True, "order": i})}}],
+    } for i in range(1, n + 1)]
+
+def set_body_field_stub_count(n):
+    """Scale the BodyField imposter and retarget its scenario together (#784's lesson)."""
+    global IMPOSTERS, DIMENSION_SCENARIOS
+    IMPOSTERS = [(port, name, body_field_stubs(n) if name == "BodyField" else stubs)
+                 for port, name, stubs in IMPOSTERS]
+    target = max(1, n // 2)
+    DIMENSION_SCENARIOS = [
+        (name, port, method, path,
+         json.dumps({"orderId": f"ord-{target}", "channel": "web"}, separators=(",", ":")), headers)
+        if name == "body_field_scale" else (name, port, method, path, body, headers)
+        for name, port, method, path, body, headers in DIMENSION_SCENARIOS
+    ]
+
+def deepequals_body_stubs(n=50):
+    """`deepEquals`-on-body stubs — the dimension #740 indexes by structural body hash.
+
+    Distinct from `json_body_stubs`, which uses `equals`: the two take different index paths
+    (structural hash vs the quamina field automaton), and until now the suite exercised only the
+    latter, so #740's `O(stubs x body)` -> `O(body)` change was measured by nothing."""
+    return [{
+        "predicates": [{"deepEquals": {"method": "POST", "path": f"/deep/equals/{i}",
+            "body": {"order": {"id": i, "items": [{"sku": f"sku-{i}", "qty": i}]},
+                     "meta": {"source": "bench"}}}}],
+        "responses": [{"is": {"statusCode": 200,
+            "body": json.dumps({"matched": "deepEquals", "order": i})}}],
+    } for i in range(1, n + 1)]
+
+def literal_prefix_stubs(n=100):
+    """`startsWith` / `contains` path stubs — the anchored/unanchored Aho-Corasick literal
+    dimension (#732). The suite had exactly one `startsWith` and two `contains` across ~860 stubs,
+    so a single-pass literal scan over many anchors was effectively untested."""
+    out = []
+    for i in range(1, n + 1):
+        out.append({
+            "predicates": [{"startsWith": {"path": f"/literal/prefix{i}/"}}],
+            "responses": [{"is": {"statusCode": 200, "body": json.dumps({"literal": i, "kind": "prefix"})}}],
+        })
+        out.append({
+            "predicates": [{"contains": {"path": f"/needle{i}/"}}],
+            "responses": [{"is": {"statusCode": 200, "body": json.dumps({"literal": i, "kind": "contains"})}}],
+        })
+    return out
+
+def method_mix_stubs(n=50):
+    """Same path, different verbs — the method candidate dimension (#729).
+
+    Every pre-existing scenario is GET or POST, so a request whose method is the *only* thing
+    separating it from n-1 other stubs never happened. Sharing one path across the verbs is what
+    forces the method dimension to do the pruning."""
+    verbs = ("PUT", "DELETE", "PATCH", "OPTIONS")
+    return [{
+        "predicates": [{"equals": {"method": verb, "path": f"/method/{i}"}}],
+        "responses": [{"is": {"statusCode": 200,
+            "body": json.dumps({"method_matched": verb, "id": i})}}],
+    } for i in range(1, n + 1) for verb in verbs]
+
 def jsonpath_stubs(n=50):
     # Mountebank applies a jsonpath selector as a modifier on a SINGLE-operator predicate, so the
     # method/path match and the selected-value match must be separate predicates. Rift accepts the
@@ -175,6 +252,10 @@ IMPOSTERS = [
     (4553, "Template", template_stubs()),
     (4554, "Header", header_stubs()),
     (4555, "Query", query_stubs()),
+    (4556, "DeepEquals", deepequals_body_stubs()),
+    (4557, "Literal", literal_prefix_stubs()),
+    (4558, "MethodMix", method_mix_stubs()),
+    (4559, "BodyField", body_field_stubs()),
 ]
 
 # scenarios: (name, base_port, method, path, body, headers)
@@ -199,6 +280,26 @@ SCENARIOS = [
 # and would inflate throughput. Each scenario therefore declares a substring its MATCHED body must
 # contain (engine-agnostic: chosen to prove the match without asserting engine-specific rendering
 # like template substitution). `no_match` is the control: its body MUST be empty.
+# Scenarios covering optimizations the MB-comparison set does not reach. Kept SEPARATE because
+# that set is a stability contract — it must stay byte-comparable with previously published
+# Mountebank numbers (see `DefaultRunUnchanged` in the tests) — so these are additive, exactly like
+# `recording_on`. They run in Rift-only sweeps.
+DIMENSION_SCENARIOS = [
+    # Issue #740: deepEquals-on-body, indexed by structural body hash. Zero coverage before this.
+    ("deepequals_body",   4556, "POST", "/deep/equals/25",
+     '{"order":{"id":25,"items":[{"sku":"sku-25","qty":25}]},"meta":{"source":"bench"}}',
+     {"Content-Type": "application/json"}),
+    # Issue #732: single-pass literal dimension, anchored (startsWith) and unanchored (contains).
+    ("literal_prefix",    4557, "GET",  "/literal/prefix100/deep/path", None, {}),
+    ("literal_contains",  4557, "GET",  "/x/needle100/y", None, {}),
+    # Issue #729: method is the ONLY discriminator across these stubs.
+    ("method_mix",        4558, "DELETE", "/method/25", None, {}),
+    # Issue #767: one shared path, body field is the ONLY discriminator — the workload the
+    # quamina dimension indexes. Scale it with --body-field-stubs.
+    ("body_field_scale",  4559, "POST", "/orders/submit",
+     '{"orderId":"ord-100","channel":"web"}', {"Content-Type": "application/json"}),
+]
+
 EXPECT_BODY = {
     "simple_health": "OK",
     "api_first": '"total": 2',
@@ -213,6 +314,11 @@ EXPECT_BODY = {
     "template": '"template": 25',
     "header_last": '"routed_to": 100',
     "query_last": '"page": 100',
+    "deepequals_body": '"matched": "deepEquals"',
+    "literal_prefix": '"kind": "prefix"',
+    "literal_contains": '"kind": "contains"',
+    "method_mix": '"method_matched": "DELETE"',
+    "body_field_scale": '"body_field_matched": true',
     # recording_on hits the same api_middle path on a recordRequests imposter, so it matches
     # the same stub and returns the same body marker.
     "recording_on": '"name": "resource5_5"',
@@ -587,7 +693,8 @@ def bench(engine, admin_port, offset, duration, warmup, conn_list, rate=None, re
     load_imposters(admin, offset, recording=recording)
     time.sleep(1)
     mode = mode_label(rate)
-    scenarios = SCENARIOS + ([RECORDING_SCENARIO] if recording else [])
+    # Dimension scenarios ride with the Rift-only sweeps (same rule as recording_on).
+    scenarios = SCENARIOS + (DIMENSION_SCENARIOS + [RECORDING_SCENARIO] if recording else [])
     rows = []
     sampler = RssSampler(pid) if pid is not None else None
     if sampler is not None:
@@ -858,7 +965,7 @@ def resolve_cpu_split(server_cpus):
         raise SystemExit(str(e))
 
 def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None,
-                  quamina=None, stub_count=None):
+                  quamina=None, stub_count=None, body_field_stubs=None):
     """Allocator, runtime, core-count and repetition dimensions compose into one artefact suffix so
     no combination overwrites another's CSV/report (#717, #746, #773).
 
@@ -876,6 +983,8 @@ def result_suffix(allocator, runtime_mode, server_cpus=None, rep=None,
         suffix += f"_quamina{quamina}"
     if stub_count:
         suffix += f"_stubs{stub_count}"
+    if body_field_stubs:
+        suffix += f"_bfstubs{body_field_stubs}"
     # rep stays outermost: every other dimension names a *variant*, a rep names a sample OF one.
     if rep is not None:
         suffix += f"_rep{rep}"
@@ -1022,10 +1131,11 @@ def aggregate_reps_to_report(base_suffix, rift_ver):
 
 def run_all(duration, warmup, conn_list, rift_bin, mb_bin, engines, rate=None, recording=False,
             allocator=None, runtime=None, server_cpus=None, engine_cpus=None, gen_cpus=None,
-            rep=None, quamina=None, stub_count=None):
+            rep=None, quamina=None, stub_count=None, body_field_stubs=None):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     node = shutil.which("node") or "node"
-    csv_suffix = result_suffix(allocator, runtime, server_cpus, rep, quamina, stub_count)
+    csv_suffix = result_suffix(allocator, runtime, server_cpus, rep, quamina, stub_count,
+                               body_field_stubs)
     engine_prefix, oha_prefix = taskset_prefix(engine_cpus), taskset_prefix(gen_cpus)
     full_plan = [
         ("rift", 0,   engine_prefix
@@ -1078,7 +1188,10 @@ def rift_only_report(rift_ver, duration, conn_list, rate, recording, allocator=N
         rows = load_rift_csv(f)
     cols = list(dict.fromkeys((int(r["connections"]), r["mode"]) for r in rows))
     cell = {(r["scenario"], (int(r["connections"]), r["mode"])): r for r in rows}
-    scen_order = [s[0] for s in SCENARIOS] + ([RECORDING_SCENARIO[0]] if recording else [])
+    # Must mirror the order `bench()` runs them in, or a measured scenario is silently missing
+    # from the report — the row would simply not be emitted, with nothing saying so.
+    scen_order = [s[0] for s in SCENARIOS] + (
+        [s[0] for s in DIMENSION_SCENARIOS] + [RECORDING_SCENARIO[0]] if recording else [])
     def colhdr(k):
         c, mode = k
         return f"c={c}" if mode == "closed" else f"c={c} {mode}"
@@ -1205,6 +1318,12 @@ if __name__ == "__main__":
                          f"default {DEFAULT_JSON_BODY_STUBS}). The quamina dimension replaces an "
                          "O(N) scan, so its win is a function of N — sweep it (e.g. 10/100/1000) "
                          "rather than measuring one arbitrary point.")
+    ap.add_argument("--body-field-stubs", type=int, metavar="N",
+                    help=f"number of stubs sharing one path and discriminated only by a body field "
+                         f"(#767/#779; default {DEFAULT_BODY_FIELD_STUBS}). This is the axis the "
+                         f"quamina body-field dimension is measured on — unlike --stub-count, whose "
+                         f"stubs have unique paths and are therefore pruned by the path dimension "
+                         f"before the body matters.")
     ap.add_argument("--rep", type=int, metavar="N",
                     help="repetition index (#773): artefacts get a _repN suffix, so each rep of a "
                          "sweep lands in its own file instead of overwriting the last. Re-running "
@@ -1228,6 +1347,10 @@ if __name__ == "__main__":
             "variable's effect to the other. Run them as separate sweeps.")
     if a.stub_count is not None:
         set_json_body_stub_count(a.stub_count)
+    if a.body_field_stubs is not None:
+        if a.body_field_stubs < 1:
+            raise SystemExit(f"--body-field-stubs must be >= 1 (got {a.body_field_stubs})")
+        set_body_field_stub_count(a.body_field_stubs)
     if a.run_all:
         try:
             engines, conn_list, rate, recording = resolve_run_mode(
@@ -1280,7 +1403,8 @@ if __name__ == "__main__":
         run_all(a.duration, a.warmup, conn_list, rift_bin, a.mb_bin, engines,
                 rate=rate, recording=recording, allocator=a.allocator, runtime=a.runtime,
                 server_cpus=a.server_cores, engine_cpus=engine_cpus, gen_cpus=gen_cpus,
-                rep=a.rep, quamina=a.quamina, stub_count=a.stub_count)
+                rep=a.rep, quamina=a.quamina, stub_count=a.stub_count,
+                body_field_stubs=a.body_field_stubs)
     elif a.report:
         report(a.rift_version, a.mb_version, a.duration, a.connections)
     else:

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -232,6 +232,42 @@ class DefaultRunUnchanged(unittest.TestCase):
         self.assertEqual(names[-1], "query_last")
 
 
+class DimensionSetIsAdditive(unittest.TestCase):
+    """The MB-comparison set is a stability contract; dimension scenarios must never leak into it,
+    or previously published Mountebank numbers stop being comparable."""
+
+    def test_dimension_scenarios_are_not_in_the_mb_set(self):
+        mb = {s[0] for s in bd.SCENARIOS}
+        for name, *_ in bd.DIMENSION_SCENARIOS:
+            self.assertNotIn(name, mb, f"{name} leaked into the MB-comparison set")
+
+    def test_dimension_scenarios_use_their_own_ports(self):
+        mb_ports = {s[1] for s in bd.SCENARIOS}
+        for name, port, *_ in bd.DIMENSION_SCENARIOS:
+            self.assertNotIn(port, mb_ports, f"{name} shares a port with the MB set")
+
+    def test_report_lists_every_scenario_the_sweep_measures(self):
+        # A scenario that is benched but missing from `scen_order` is measured and then silently
+        # dropped from the report — cost paid, number invisible.
+        import tempfile
+        rows = [(name, 256, "closed",
+                 {"rps": 1.0, "p50_ms": 0.5, "p90_ms": 0.8, "p99_ms": 1.2,
+                  "p999_ms": 3.1, "avg_ms": 0.6, "codes": {"200": 1}})
+                for name, *_ in bd.SCENARIOS + bd.DIMENSION_SCENARIOS + [bd.RECORDING_SCENARIO]]
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bd.RESULTS_DIR
+            bd.RESULTS_DIR = tmp
+            try:
+                bd.write_rift_csv(os.path.join(tmp, "direct_rift.csv"), rows)
+                bd.rift_only_report("0.1.0", "12s", [256], None, True)
+                with open(os.path.join(tmp, "DIRECT_RIFT_SWEEP_REPORT.md")) as f:
+                    text = f.read()
+            finally:
+                bd.RESULTS_DIR = orig
+        for name, *_ in bd.DIMENSION_SCENARIOS:
+            self.assertIn(name, text, f"{name} was benched but is absent from the report")
+
+
 class AllocatorBuildArgs(unittest.TestCase):
     """Issue #717: each allocator maps to cargo flags that swap ONLY the allocator, keeping the
     functional feature set (redis-backend, javascript) identical so the comparison is fair."""
@@ -671,6 +707,141 @@ class QuaminaVariant(unittest.TestCase):
         path, needs_build = bd.resolve_rift_bin(None, None, "off")
         self.assertIn("quamina-off", path)
         self.assertTrue(needs_build)
+
+
+class ScenarioReachability(unittest.TestCase):
+    """Every scenario must address a stub that actually exists.
+
+    #784 shipped a scenario pointing at `/json/equals/25` against a 10-stub imposter: the request
+    fell through to the no-match default and the run aborted after a full release build. The
+    runtime body assertion caught it, but only in CI. This is the same check, statically, for
+    every scenario — so adding a scenario whose target nothing serves fails in milliseconds."""
+
+    @staticmethod
+    def _predicate_serves(pred, method, path):
+        """Does this predicate plausibly match? Covers the operator forms the suite uses."""
+        import re as _re
+        for op, spec in pred.items():
+            if op in ("startsWith", "contains", "matches", "equals", "deepEquals", "exists"):
+                want_path = spec.get("path") if isinstance(spec, dict) else None
+                want_method = spec.get("method") if isinstance(spec, dict) else None
+                if want_method and want_method != method:
+                    return False
+                if want_path is None:
+                    continue
+                bare = path.split("?", 1)[0]
+                if op in ("equals", "deepEquals") and bare != want_path:
+                    return False
+                if op == "startsWith" and not bare.startswith(want_path):
+                    return False
+                if op == "contains" and want_path not in bare:
+                    return False
+                if op == "matches" and not _re.search(want_path, bare):
+                    return False
+            elif op in ("and", "or"):
+                results = [ScenarioReachability._predicate_serves(p, method, path) for p in spec]
+                if (op == "and" and not all(results)) or (op == "or" and not any(results)):
+                    return False
+        return True
+
+    def test_every_scenario_targets_a_stub_that_exists(self):
+        by_port = {port: stubs for port, _, stubs in bd.IMPOSTERS}
+        unreachable = []
+        for name, port, method, path, _body, _headers in bd.SCENARIOS + bd.DIMENSION_SCENARIOS:
+            if name == "no_match":
+                continue          # deliberately matches nothing — that IS the scenario
+            stubs = by_port.get(port)
+            self.assertIsNotNone(stubs, f"{name}: no imposter on port {port}")
+            if not any(all(self._predicate_serves(p, method, path) for p in st.get("predicates", []))
+                       for st in stubs):
+                unreachable.append(f"{name} -> {method} {path} (port {port})")
+        self.assertEqual(unreachable, [], "scenarios whose target no stub serves: " + str(unreachable))
+
+    def test_the_no_match_scenario_really_matches_nothing(self):
+        # Its whole point is the fall-through path; if a stub started serving it, the scenario
+        # would silently stop measuring what it claims to.
+        scen = {s[0]: s for s in bd.SCENARIOS}["no_match"]
+        stubs = {p: s for p, _, s in bd.IMPOSTERS}[scen[1]]
+        served = any(all(self._predicate_serves(p, scen[2], scen[3]) for p in st.get("predicates", []))
+                     for st in stubs)
+        self.assertFalse(served, "no_match now matches a stub — it no longer measures fall-through")
+
+    def test_every_scenario_has_a_body_marker(self):
+        for name, *_ in bd.SCENARIOS + bd.DIMENSION_SCENARIOS:
+            self.assertIn(name, bd.EXPECT_BODY,
+                          f"{name} has no EXPECT_BODY marker, so a fall-through would go unnoticed")
+
+    def test_imposter_ports_are_unique(self):
+        ports = [p for p, _, _ in bd.IMPOSTERS]
+        self.assertEqual(len(ports), len(set(ports)), f"duplicate imposter ports: {ports}")
+
+
+class NewDimensionCoverage(unittest.TestCase):
+    """The scenarios added for optimizations that previously had none."""
+
+    def test_deepequals_dimension_is_exercised(self):
+        # Issue #740's structural-hash index. Before this, `deepEquals` appeared nowhere.
+        stubs = {n: s for _, n, s in bd.IMPOSTERS}["DeepEquals"]
+        self.assertTrue(all("deepEquals" in st["predicates"][0] for st in stubs))
+        self.assertIn("deepequals_body", {s[0] for s in bd.DIMENSION_SCENARIOS})
+
+    def test_deepequals_bodies_are_objects_not_scalars(self):
+        # The index only applies to a JSON object/array body; a scalar falls back to full
+        # comparison, so a scalar-bodied scenario would measure the unindexed path by accident.
+        for st in {n: s for _, n, s in bd.IMPOSTERS}["DeepEquals"]:
+            self.assertIsInstance(st["predicates"][0]["deepEquals"]["body"], dict)
+
+    def test_literal_dimension_has_both_anchored_and_unanchored(self):
+        # #732 indexes startsWith (anchored) and contains (unanchored) differently.
+        ops = {op for st in {n: s for _, n, s in bd.IMPOSTERS}["Literal"]
+               for op in st["predicates"][0]}
+        self.assertEqual(ops, {"startsWith", "contains"})
+
+    def test_body_field_stubs_share_one_path_so_the_body_is_the_discriminator(self):
+        # THE lesson from run 29738479074: json_body_stubs gives every stub a unique path, so the
+        # path dimension prunes to one candidate before the body is consulted and the quamina
+        # automaton measures pure overhead (-8%, flat with N — the signature of measuring nothing).
+        # If these stubs ever gain distinct paths, this benchmark silently stops testing the
+        # dimension while still looking like it does.
+        stubs = {n: s for _, n, s in bd.IMPOSTERS}["BodyField"]
+        eqs = [st["predicates"][0]["equals"] for st in stubs]
+        self.assertEqual(len({e["path"] for e in eqs}), 1,
+                         "BodyField stubs must share ONE path, or the path dimension prunes first "
+                         "and this scenario measures overhead instead of the body-field index")
+        self.assertEqual(len({e["method"] for e in eqs}), 1, "and one method, for the same reason")
+        self.assertEqual(len({e["body"]["orderId"] for e in eqs}), len(stubs),
+                         "each stub must differ in the discriminating body field")
+
+    def test_body_field_scaling_retargets_its_scenario(self):
+        orig_i, orig_d = list(bd.IMPOSTERS), list(bd.DIMENSION_SCENARIOS)
+        try:
+            for n in (2, 10, 200, 1000):
+                bd.IMPOSTERS, bd.DIMENSION_SCENARIOS = list(orig_i), list(orig_d)
+                bd.set_body_field_stub_count(n)
+                stubs = {nm: s for _, nm, s in bd.IMPOSTERS}["BodyField"]
+                ids = {st["predicates"][0]["equals"]["body"]["orderId"] for st in stubs}
+                scen = {s[0]: s for s in bd.DIMENSION_SCENARIOS}["body_field_scale"]
+                self.assertIn(json.loads(scen[4])["orderId"], ids,
+                              f"n={n}: scenario body targets an orderId no stub serves")
+        finally:
+            bd.IMPOSTERS, bd.DIMENSION_SCENARIOS = orig_i, orig_d
+
+    def test_method_mix_shares_paths_across_verbs(self):
+        # If each verb had its own path, the path dimension would prune first and the method
+        # dimension would never be the discriminator.
+        stubs = {n: s for _, n, s in bd.IMPOSTERS}["MethodMix"]
+        by_path = {}
+        for st in stubs:
+            eq = st["predicates"][0]["equals"]
+            by_path.setdefault(eq["path"], set()).add(eq["method"])
+        self.assertTrue(all(len(v) > 1 for v in by_path.values()),
+                        "each path must be served by multiple verbs")
+
+    def test_non_get_post_methods_are_now_exercised(self):
+        methods = {s[2] for s in bd.SCENARIOS + bd.DIMENSION_SCENARIOS}
+        self.assertTrue(methods - {"GET", "POST"},
+                        "no scenario uses a verb beyond GET/POST, so #729's method dimension "
+                        "is still unmeasured")
 
 
 class StubCountAxis(unittest.TestCase):


### PR DESCRIPTION
Five Turbo optimizations had **no benchmark coverage at all** — a regression in any of them would have gone unnoticed. Audited against master:

| Optimization | Coverage before this PR |
|---|---|
| #740 `deepEquals` structural-hash index | **none** — `deepEquals` appeared nowhere in the suite |
| #729 method dimension | **none** — every scenario was GET or POST |
| #732 literal dimension | ~860 stubs contained **one** `startsWith` and **two** `contains` |
| #767 quamina body-field automaton | none that actually exercises it — see below |

## The trap `body_field_scale` exists to avoid

The obvious benchmark for the quamina dimension is `json_body_equals`. It is **wrong**, and it took a full sweep to see why.

`json_body_stubs` gives every stub a **unique path**, so the path dimension prunes the candidate set to a single stub *before* the body is consulted. The body-field automaton then re-derives what the path index already knew.

[Run 29738479074](https://github.com/achird-labs/rift/actions/runs/29738479074) measured it at 3 reps, medians, rep spread 1.1–1.6%:

| stubs | off | on | Δ |
|--:|--:|--:|--:|
| 10 | 313,965 | 289,356 | −7.8% |
| 100 | 317,364 | 287,243 | −9.5% |
| 1000 | 302,262 | 278,451 | −7.9% |

**Flat with N** — the signature of paying a cost with no benefit attached, not of an index that scales. Reporting that as "quamina is an 8% regression" would have been a wrong conclusion from a real number.

`body_field_scale` puts N stubs on **one shared path and method**, discriminated only by a body field, so the `O(N)` structural scan the dimension replaces is genuinely on the critical path. `--body-field-stubs N` is its axis.

## Kept out of the Mountebank set, deliberately

The 13-scenario comparison set is a stability contract (`DefaultRunUnchanged`: *"the default MB-comparison scenario set must not change"*) protecting comparability with previously published numbers. These are **additive**, riding with Rift-only sweeps exactly like `recording_on`. Tests assert they never leak into that set or share its ports.

Whether to eventually extend the MB table with these is a separate call — they would likely produce the largest multiples in it, but it invalidates historical comparability.

## Guards, each for a mistake already made once

- every scenario's target must resolve to a stub that exists — the #784 bug, caught statically instead of after a CI release build
- `no_match` must keep matching nothing, or it stops measuring fall-through
- every scenario needs an `EXPECT_BODY` marker, so a fall-through aborts instead of measuring the default path
- the report must list every scenario the sweep measures — otherwise a benched scenario is silently dropped from the table, cost paid and number invisible
- `BodyField` stubs must share exactly one path and method

## Verification

124 unit tests, plus a live check against a real engine: **all 18 scenarios return their expected body marker** (`body_field_scale` correctly resolves to order 100 of 200).

Refs #740, #732, #729, #767, #779.
