### PR TITLE
bench(ci): point the quamina sweep at the axis that measures the dimension

### DIFF
--- a/.github/workflows/decision-sweeps.yml
+++ b/.github/workflows/decision-sweeps.yml
@@ -38,8 +38,12 @@ on:
         default: "4,256"
       stub_counts:
         description: >-
-          Quamina sweep: field-equals-on-body stub counts (comma-separated). The dimension replaces
-          an O(N) scan of structural comparisons, so N is the axis its win is a function of.
+          Quamina sweep: stub counts for the body_field_scale scenario (comma-separated), driving
+          --body-field-stubs. These stubs share ONE path and method and differ only in a body
+          field, so the body-field automaton is the discriminator. Do not point this at
+          --stub-count: those stubs have unique paths, so the path dimension prunes to one
+          candidate before the body is consulted and the sweep measures pure overhead (run
+          29738479074: -8% flat at 10/100/1000, the signature of a cost with no benefit).
         default: "10,100,1000"
       cores:
         description: >-
@@ -207,7 +211,7 @@ jobs:
             for n in "${COUNTS[@]}"; do
               for q in on off; do
                 echo "===== quamina=$q stubs=$n rep=$rep ====="
-                python3 scripts/bench_direct.py --run-all --quamina "$q" --stub-count "$n" \
+                python3 scripts/bench_direct.py --run-all --quamina "$q" --body-field-stubs "$n" \
                   --rep "$rep" --sweep-connections "${{ inputs.connections }}" \
                   --duration "${{ inputs.duration }}" --warmup 2s
               done
@@ -215,7 +219,7 @@ jobs:
           done
           for n in "${COUNTS[@]}"; do
             for q in on off; do
-              python3 scripts/bench_direct.py --aggregate-reps "_quamina${q}_stubs${n}"
+              python3 scripts/bench_direct.py --aggregate-reps "_quamina${q}_bfstubs${n}"
             done
           done
       - name: Record binary sizes (the dimension's cost to embedders)


### PR DESCRIPTION
The quamina sweep drove `--stub-count`, whose stubs have **unique paths**. The path dimension therefore prunes the candidate set to a single stub before the body is consulted — the quamina automaton then re-derives what the path index already knew.

[Run 29738479074](https://github.com/achird-labs/rift/actions/runs/29738479074) measured that at 3 reps with 1.1–1.6% spread:

| stubs | off | on | delta |
|--:|--:|--:|--:|
| 10 | 313,965 | 289,356 | -7.8% |
| 100 | 317,364 | 287,243 | -9.5% |
| 1000 | 302,262 | 278,451 | -7.9% |

**Flat with N.** An index replacing an `O(N)` scan should improve as N grows; a cost with no benefit attached stays constant. The sweep was measuring overhead at three scales and learning nothing about the dimension.

It now drives `--body-field-stubs` (added in #785), whose stubs share one path and method and differ only in a body field, so the `O(N)` structural scan the dimension replaces is genuinely on the critical path.

Artefacts move from `_stubsN` to `_bfstubsN` so corrected runs cannot be confused with the earlier ones.

The -8% figure is still meaningful on its own terms — it is the cost the dimension imposes on workloads it cannot help, and unique-path stubs are common. That belongs in the #779 verdict alongside the benefit number, not instead of it.

Refs #779, #785.