### PR TITLE
bench(ci): build the quamina variants once with bounded parallelism

### DIFF
--- a/.github/workflows/decision-sweeps.yml
+++ b/.github/workflows/decision-sweeps.yml
@@ -202,6 +202,23 @@ jobs:
       # until #777. This measures the shipped artefact. The harness verifies each build's own
       # `Matching dimensions:` self-report before benching, because the two variants match
       # identically by design: a mislabeled build has no other symptom.
+      # Build both variants ONCE, mirroring the topology job's "Build engine once". Previously
+      # every one of the 18 matrix invocations re-entered cargo, and the two cold builds ran with
+      # unbounded parallelism: run 29747275803 was OOM-killed (exit 137) ~100s into the first one,
+      # while the identical build had succeeded an hour earlier — a memory spike, not a code fault.
+      # --jobs bounds the peak so the build cost is paid once, predictably.
+      - name: Build both quamina variants once
+        run: |
+          set -euo pipefail
+          for q in on off; do
+            if [ "$q" = "on" ]; then FEATURES=(); else
+              FEATURES=(--no-default-features --features redis-backend,javascript,mimalloc); fi
+            echo "===== building quamina=$q ====="
+            cargo build --release -p rift-http-proxy --jobs 4 \
+              --target-dir "target/quamina-$q" "${FEATURES[@]}"
+          done
+          ls -l target/quamina-on/release/rift-http-proxy target/quamina-off/release/rift-http-proxy
+
       - name: Quamina A/B (on/off x stub counts x reps)
         working-directory: tests/benchmark
         run: |
@@ -211,7 +228,11 @@ jobs:
             for n in "${COUNTS[@]}"; do
               for q in on off; do
                 echo "===== quamina=$q stubs=$n rep=$rep ====="
+                # --rift-bin points at the prebuilt variant so the harness does not re-enter
+                # cargo 18 times. The marker probe still runs, so the label is still verified
+                # against the binary rather than trusted from the invocation.
                 python3 scripts/bench_direct.py --run-all --quamina "$q" --body-field-stubs "$n" \
+                  --rift-bin "../../target/quamina-$q/release/rift-http-proxy" \
                   --rep "$rep" --sweep-connections "${{ inputs.connections }}" \
                   --duration "${{ inputs.duration }}" --warmup 2s
               done


### PR DESCRIPTION
[Run 29747275803](https://github.com/achird-labs/rift/actions/runs/29747275803) was **OOM-killed** — exit 137, ~100s into the first `cargo build`, before any benchmarking happened.

The identical build succeeded an hour earlier in [run 29738479074](https://github.com/achird-labs/rift/actions/runs/29738479074) on the same `ubuntu-16core` class, and #785 changed only Python. So this is a memory spike under unbounded build parallelism, not a code fault — a flake.

Rather than just re-running it, this removes the exposure:

## 1. Build once, not eighteen times

`resolve_rift_bin` returns `needs_build=True` whenever `--quamina` is set, so **every** matrix invocation re-entered cargo — 3 stub counts × 2 variants × 3 reps = **18 cargo invocations**, of which the first two were cold builds.

The variants are now built in a dedicated step, mirroring the topology job's existing `Build engine once`. The matrix passes `--rift-bin` to the prebuilt binary.

**The marker probe still runs** against that binary, so the variant label is still verified from the artefact rather than trusted from the invocation — that check is what makes the A/B meaningful, since the two variants match identically by design.

## 2. Bound the peak

The single build now runs with `--jobs 4`. Release builds of `boa_engine` and `quamina` can spike concurrently on a 16-core runner; capping parallelism trades a little wall-clock for a build that fits predictably in memory. Paid once now, not eighteen times.

Refs #779.
