### PR TITLE
bench: trace imposter creation individually

### DIFF
--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -373,10 +373,16 @@ def load_imposters(admin, offset, recording=False):
                for port, name, stubs in IMPOSTERS]
     if recording:
         configs.append(recording_imposter_config(offset))
-    for cfg in configs:
+    # Per-imposter progress. Without it, a crash during loading tells you only that it happened
+    # somewhere across 14 creations: run 29751530395 died here with SIGKILL, no OOM evidence and
+    # memory flat, and the summary print at the end meant there was nothing to localise it with.
+    for i, cfg in enumerate(configs, 1):
+        t0 = time.time()
         status, body = post_json(admin + "/imposters", cfg)
         if status != 201:
             raise SystemExit(f"  ! create imposter {cfg['port']} ({cfg['name']}) failed: HTTP {status}: {body[:200]}")
+        print(f"    [{i}/{len(configs)}] {cfg['name']} port={cfg['port']} "
+              f"stubs={len(cfg['stubs'])} in {time.time() - t0:.2f}s")
     print(f"  loaded {len(configs)} imposters "
           f"({sum(len(c['stubs']) for c in configs)} stubs) at offset +{offset}")
 


### PR DESCRIPTION
The #788 diagnostics did their job — they eliminated the theory I was about to act on.

[Run 29751530395](https://github.com/achird-labs/rift/actions/runs/29751530395) with streaming output:

```
Mem: 62656 MB available    /dev/root 797G free
===== quamina=on stubs=10 rep=1 =====
  quamina probe ok: body-field(quamina)=on
[rift] admin ready on 2525; loading imposters
<KILLED 137>

--- memory after failure ---
Mem: 62659 MB available    /dev/root 797G free
--- kernel OOM evidence (if any) ---
<empty>
```

**It is not an OOM.** Memory is flat across the failure, disk is untouched, and `dmesg` shows no kernel OOM kill. The process was killed deliberately. It dies inside `load_imposters`, on the `quamina=on` variant.

## Hypotheses tested and rejected

- **Quamina automaton construction explodes on shared-path stubs.** Plausible — `body_field_scale` creates a workload that has never existed in this repo. Tested locally against a real quamina-on binary: all 14 imposters including `BodyField` at 200 stubs create in **0.01s at 27 MB total RSS**. Rejected.
- **`free_ports` SIGKILLs the harness itself.** `lsof -ti tcp:PORT` matches client sockets, not only listeners, and it is the only `SIGKILL` in the harness. Tested: after `urllib` closes, `lsof` returns only the server PID. Not reproduced.
- **The #787 build fix was insufficient.** No — both builds complete and the binaries are listed. That failure and this one share an exit code and nothing else.

## What this adds

`load_imposters` printed a single summary *after* all 14 creations succeeded, so a crash partway through localises to nothing. It now prints each creation with its stub count and duration, so the next run names the imposter.

That is the remaining unknown. Everything else about this failure is now characterised.

Refs #779.
