### PR TITLE
fix(bench): move DeepEquals off RECORDING_PORT and stop free_ports killing the harness

### DIFF
--- a/tests/benchmark/scripts/bench_direct.py
+++ b/tests/benchmark/scripts/bench_direct.py
@@ -252,7 +252,7 @@ IMPOSTERS = [
     (4553, "Template", template_stubs()),
     (4554, "Header", header_stubs()),
     (4555, "Query", query_stubs()),
-    (4556, "DeepEquals", deepequals_body_stubs()),
+    (4560, "DeepEquals", deepequals_body_stubs()),
     (4557, "Literal", literal_prefix_stubs()),
     (4558, "MethodMix", method_mix_stubs()),
     (4559, "BodyField", body_field_stubs()),
@@ -286,7 +286,7 @@ SCENARIOS = [
 # `recording_on`. They run in Rift-only sweeps.
 DIMENSION_SCENARIOS = [
     # Issue #740: deepEquals-on-body, indexed by structural body hash. Zero coverage before this.
-    ("deepequals_body",   4556, "POST", "/deep/equals/25",
+    ("deepequals_body",   4560, "POST", "/deep/equals/25",
      '{"order":{"id":25,"items":[{"sku":"sku-25","qty":25}]},"meta":{"source":"bench"}}',
      {"Content-Type": "application/json"}),
     # Issue #732: single-pass literal dimension, anchored (startsWith) and unanchored (contains).
@@ -743,16 +743,34 @@ def admin_port_for(offset):
     return 2525 + offset
 
 def free_ports(ports):
-    """Force-free ports by killing whatever listens on them (lsof + SIGKILL)."""
+    """Force-free ports by killing whatever LISTENS on them (lsof + SIGKILL).
+
+    `-sTCP:LISTEN` is load-bearing, not tidiness. A bare `lsof -ti tcp:PORT` matches every socket
+    on that port including the *client* end, so the harness's own connections to the admin port
+    made it a candidate for its own SIGKILL. That is not hypothetical: it masked a real error for
+    four CI runs. `load_imposters` raised SystemExit("Port 4556 is already in use"), the `finally`
+    in `run_all` called this function during cleanup, and the interpreter was killed before it
+    could print the message — turning an actionable one-line error into a bare exit 137 with no
+    output at all. The self-PID guard below is belt-and-braces for the same reason: nothing here
+    should ever be able to kill the process doing the killing."""
+    own = {os.getpid(), os.getpgrp()}
     for p in ports:
         try:
-            pids = subprocess.run(["lsof", "-ti", f"tcp:{p}"], capture_output=True, text=True).stdout.split()
+            pids = subprocess.run(["lsof", "-ti", f"tcp:{p}", "-sTCP:LISTEN"],
+                                  capture_output=True, text=True).stdout.split()
         except Exception:
             pids = []
         for pid in pids:
             try:
-                os.kill(int(pid), signal.SIGKILL)
-                print(f"  freed port {p} (killed pid {pid})")
+                pid_i = int(pid)
+            except ValueError:
+                continue
+            if pid_i in own:
+                print(f"  refusing to kill self (pid {pid_i}) while freeing port {p}")
+                continue
+            try:
+                os.kill(pid_i, signal.SIGKILL)
+                print(f"  freed port {p} (killed pid {pid_i})")
             except Exception:
                 pass
 

--- a/tests/benchmark/scripts/test_bench_direct.py
+++ b/tests/benchmark/scripts/test_bench_direct.py
@@ -775,6 +775,45 @@ class ScenarioReachability(unittest.TestCase):
         ports = [p for p, _, _ in bd.IMPOSTERS]
         self.assertEqual(len(ports), len(set(ports)), f"duplicate imposter ports: {ports}")
 
+    def test_no_imposter_collides_with_a_reserved_port(self):
+        """The check that was missing.
+
+        The previous version compared imposter ports only against each other, so it happily
+        allowed DeepEquals onto 4556 — which is RECORDING_PORT. The recording imposter is created
+        last, hit `400 Port 4556 is already in use`, and the resulting error was then masked by
+        cleanup (see `free_ports`), costing four CI runs to find. Every port the harness reserves
+        belongs in this check, not just the imposter list."""
+        reserved = {
+            bd.RECORDING_PORT: "RECORDING_PORT",
+            bd.admin_port_for(0): "rift admin",
+            bd.admin_port_for(100): "mountebank admin",
+            9090: "metrics",
+            bd.ALLOC_PROBE_PORT: "allocator probe",
+            bd.TOPOLOGY_PROBE_PORT: "topology probe",
+            bd.QUAMINA_PROBE_PORT: "quamina probe",
+        }
+        for port, name, _ in bd.IMPOSTERS:
+            self.assertNotIn(port, reserved,
+                             f"imposter {name} is on port {port}, reserved for "
+                             f"{reserved.get(port)}")
+
+    def test_the_mb_offset_does_not_alias_a_rift_port(self):
+        """Mountebank runs at +100. If that offset ever mapped one engine's port onto another's,
+        the two engines would fight over a listener mid-run."""
+        rift_ports = {p for p, _, _ in bd.IMPOSTERS} | {bd.RECORDING_PORT, bd.admin_port_for(0)}
+        mb_ports = {p + 100 for p, _, _ in bd.IMPOSTERS} | {
+            bd.RECORDING_PORT + 100, bd.admin_port_for(100)}
+        self.assertEqual(rift_ports & mb_ports, set(),
+                         f"offset collision between engines: {rift_ports & mb_ports}")
+
+    def test_free_ports_only_targets_listeners(self):
+        """A bare `lsof -ti tcp:PORT` matches client sockets too, so the harness could SIGKILL
+        itself during cleanup and destroy the error it was reporting."""
+        import inspect
+        src = inspect.getsource(bd.free_ports)
+        self.assertIn("-sTCP:LISTEN", src)
+        self.assertIn("os.getpid()", src)
+
 
 class NewDimensionCoverage(unittest.TestCase):
     """The scenarios added for optimizations that previously had none."""


### PR DESCRIPTION
Found it. Two bugs, and the second hid the first for four CI runs.

## The cause

The per-imposter trace from #789 pinned it immediately:

```
[11/15] DeepEquals port=4556 stubs=50 in 0.00s
...
[14/15] BodyField  port=4559 stubs=10 in 0.00s
<KILLED 137>            <- [15/15] is the recording imposter, on port 4556
```

`RECORDING_PORT = 4556`, and #785 put the `DeepEquals` imposter on **4556**. The recording imposter is created last, so it hit a perfectly clean `400 Port 4556 is already in use`. DeepEquals moves to 4560.

## Why an actionable error looked like an OOM

`load_imposters` raised `SystemExit("Port 4556 is already in use")`. Then `run_all`'s `finally` called `stop()` → `free_ports()`, which ran `lsof -ti tcp:PORT` and SIGKILLed **every** match.

That matches **client** sockets, not just listeners — so the harness killed itself during cleanup, *before* the interpreter printed the `SystemExit` message. A one-line diagnosis became a bare `exit 137` with no output, which reads exactly like an OOM. I spent three runs chasing memory, and disproved a quamina-automaton theory I was close to filing as an engine bug.

`free_ports` now filters `-sTCP:LISTEN` — which is what its own docstring always claimed ("killing whatever **listens** on them") — and refuses to kill its own pid or process group.

## The guard that should have caught it

`test_imposter_ports_are_unique` from #785 compared imposter ports **only against each other**, so the collision with `RECORDING_PORT` sailed through. It now checks every port the harness reserves — `RECORDING_PORT`, both admin ports, metrics, and all three probe ports — plus that the `+100` Mountebank offset never aliases a Rift port.

## Verification

Against a real quamina-on binary, all **15** imposters create, including the recording imposter that broke the sweep:

```
[11/15] DeepEquals   port=4560 stubs=50  OK
[15/15] Recording    port=4556 stubs=310 OK
```

127 tests pass.

Refs #779, #785.
