### PR TITLE
docs(performance): refresh benchmark numbers on two hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,32 @@ Rift is a high-performance, [Mountebank](https://www.mbtest.dev/)-compatible moc
 
 ### Blazing Fast Performance
 
-| Workload | Mountebank | Rift | Speedup |
-|:---------|-----------:|-----:|:--------|
-| Simple static stub | 4,141 RPS | 214,028 RPS | **~52x** |
-| Deep path match (410 stubs) | 1,342 RPS | 208,580 RPS | **~155x** |
-| Complex AND/OR predicates | 4,619 RPS | 191,724 RPS | **~42x** |
-| JSON body equals | 7,780 RPS | 203,490 RPS | **~26x** |
-| JSONPath predicate | 3,586 RPS | 201,029 RPS | **~56x** |
-| XPath predicate | 5,640 RPS | 185,417 RPS | **~33x** |
-| Regex path (100 patterns) | 107 RPS | 48,029 RPS | **~449x** |
+Both engines, same machine, same load — measured on two very different hosts so you can see how
+much of the gap is the engine and how much is the hardware:
 
-<sub>Measured 2026-07-07 — Rift `0.11.0` (built from `master`) vs Mountebank `2.9.1`, native
-processes (no Docker) on Apple Silicon (macOS), `oha` at 50 keep-alive connections, 20s/scenario
-after warmup, each engine run alone on the same machine. Throughput scales with matching
-complexity: Rift stays flat while Mountebank's per-request cost grows with stub count and predicate
-type. Full methodology and all 13 scenarios: [`tests/benchmark`](tests/benchmark/). Your numbers
-will vary with hardware and config.</sub>
+| Workload | Apple M4 laptop<br><sub>Mountebank → Rift</sub> | AMD EPYC 9V74, 16 vCPU<br><sub>Mountebank → Rift</sub> |
+|:---------|:--------------------------|:----------------------------|
+| Simple static stub | 8,898 → 214,818 RPS (**24x**) | 5,982 → 324,952 RPS (**54x**) |
+| Deep path match (410 stubs) | 1,344 → 209,523 RPS (**156x**) | 542 → 322,530 RPS (**595x**) |
+| Complex AND/OR predicates | 4,703 → 191,987 RPS (**41x**) | 1,814 → 259,548 RPS (**143x**) |
+| JSON body equals | 7,611 → 199,670 RPS (**26x**) | 2,730 → 294,294 RPS (**108x**) |
+| JSONPath predicate | 4,312 → 199,404 RPS (**46x**) | 1,921 → 304,796 RPS (**159x**) |
+| XPath predicate | 5,542 → 187,869 RPS (**34x**) | 1,966 → 247,897 RPS (**126x**) |
+| Regex path (100 patterns) | 112 → 207,024 RPS (**1,857x**) | 52 → 317,851 RPS (**6,160x**) |
+
+Read the two columns together, not separately. Rift gets **faster** with more cores (215k → 325k);
+Mountebank gets **slower** (8,898 → 5,982), because it is single-threaded and the server's
+individual cores are slower than the laptop's. So the EPYC multipliers are inflated at both ends —
+the M4 column is the more conservative read, and it is still 24x–1,857x.
+
+<sub>Measured 2026-07-20 — Rift built from `master` (`924cf73`) vs Mountebank `2.9.1`, native
+processes (no Docker), `oha` at 50 keep-alive connections, 20s/scenario after warmup, each engine
+run alone on the same machine. Each figure is the median of 3 repetitions; per-scenario spread was
+≤12% on the M4 (a laptop thermally throttles over a 30-minute run — both engines lost ~7% between
+the first and last repetition) and ≤5% on EPYC. Throughput scales with matching complexity: Rift
+stays flat while Mountebank's per-request cost grows with stub count and predicate type. Full
+methodology and all 13 scenarios: [`tests/benchmark`](tests/benchmark/). Your numbers will vary
+with hardware and config.</sub>
 
 ### Full Feature Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,13 +33,17 @@ Built in Rust with async I/O, Rift delivers exceptional performance:
 
 | Feature | Mountebank | Rift | Speedup |
 |:--------|:-----------|:-----|:--------|
-| Simple stubs | 4,093 RPS | 199,228 RPS | **49x faster** |
-| Regex (100th pattern) | 106 RPS | 54,434 RPS | **515x faster** |
-| JSONPath predicates | 4,480 RPS | 173,671 RPS | **39x faster** |
-| API stub — no match (404) | 1,309 RPS | 206,865 RPS | **158x faster** |
-| Complex predicates | 4,646 RPS | 181,320 RPS | **39x faster** |
+| Simple stubs | 8,898 RPS | 214,818 RPS | **24x faster** |
+| Regex (100th pattern) | 112 RPS | 207,024 RPS | **1,857x faster** |
+| JSONPath predicates | 4,312 RPS | 199,404 RPS | **46x faster** |
+| API stub — no match (404) | 1,351 RPS | 209,763 RPS | **155x faster** |
+| Complex predicates | 4,703 RPS | 191,987 RPS | **41x faster** |
 
-See the [performance page](performance/) for the full suite and method.
+<sub>Apple M4 laptop, 50 connections, median of 3 repetitions. On a 16-vCPU AMD EPYC server the
+same suite reaches 325k RPS and 6,160x on regex — but Mountebank is *slower* there, so the M4
+figures above are the conservative read.</sub>
+
+See the [performance page](performance/) for both hosts, the full suite, and the method.
 
 ### Full Feature Compatibility
 

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -7,50 +7,80 @@ permalink: /performance/
 
 # Performance
 
-Rift delivers **10–500x** the throughput of Mountebank on identical imposter
+Rift delivers **20–6,000x** the throughput of Mountebank on identical imposter
 configs, with sub-millisecond tail latency that stays flat as stub count grows.
 
 ---
 
 ## Benchmark Summary
 
-Native processes on Apple M4 (10 cores) / macOS · Rift 0.1.0 · Mountebank 2.9.1 ·
-`oha`, 50 connections, 20s/scenario. Full method and reproduction:
+The suite was run on two deliberately different hosts. Publishing both is the point:
+the multiplier depends heavily on the machine, and a single number would overstate
+the result.
+
+- **Apple M4 laptop** (10 cores, macOS) — the conservative read
+- **AMD EPYC 9V74** (16 vCPU, 62 GiB, Linux) — the server read
+
+Rift built from `master` (`924cf73`) · Mountebank 2.9.1 · `oha`, 50 keep-alive
+connections, 20s/scenario after warmup, native processes (no Docker), each engine run
+alone. Every figure is the **median of 3 repetitions**. Measured 2026-07-20. Full
+method and reproduction:
 [`tests/benchmark`](https://github.com/achird-labs/rift/tree/master/tests/benchmark).
 
-| Feature | Mountebank | Rift | Speedup |
-|:--------|:-----------|:-----|:--------|
-| Regex (100th pattern) | 106 RPS | 54,434 RPS | **515x** |
-| API stub — no match (404) | 1,309 RPS | 206,865 RPS | **158x** |
-| API stub — last match | 1,351 RPS | 201,403 RPS | **149x** |
-| Query-param routing | 2,366 RPS | 118,228 RPS | **50x** |
-| Header routing | 3,050 RPS | 148,739 RPS | **49x** |
-| Complex AND/OR predicates | 4,646 RPS | 181,320 RPS | **39x** |
-| JSONPath predicates | 4,480 RPS | 173,671 RPS | **39x** |
-| XPath predicates | 5,552 RPS | 174,567 RPS | **31x** |
-| JSON body matching | 7,802 RPS | 188,247 RPS | **24x** |
-| Template responses | 9,446 RPS | 189,649 RPS | **20x** |
+| Scenario | MB (M4) | Rift (M4) | M4 speedup | MB (EPYC) | Rift (EPYC) | EPYC speedup |
+|:---------|--------:|----------:|:-----------|----------:|------------:|:-------------|
+| Regex (100th pattern) | 112 | 207,024 | **1,857x** | 52 | 317,851 | **6,160x** |
+| API stub — no match (404) | 1,351 | 209,763 | **155x** | 549 | 332,574 | **606x** |
+| API stub — last match | 1,344 | 209,523 | **156x** | 542 | 322,530 | **595x** |
+| API stub — middle match | 3,437 | 210,151 | **61x** | 1,081 | 324,067 | **300x** |
+| API stub — first match | 8,546 | 211,378 | **25x** | 5,728 | 323,408 | **57x** |
+| Query-param routing | 2,751 | 164,133 | **60x** | 1,112 | 211,748 | **190x** |
+| Header routing | 3,016 | 158,596 | **53x** | 1,202 | 201,940 | **168x** |
+| Complex AND/OR predicates | 4,703 | 191,987 | **41x** | 1,814 | 259,548 | **143x** |
+| JSONPath predicates | 4,312 | 199,404 | **46x** | 1,921 | 304,796 | **159x** |
+| XPath predicates | 5,542 | 187,869 | **34x** | 1,966 | 247,897 | **126x** |
+| JSON body matching | 7,611 | 199,670 | **26x** | 2,730 | 294,294 | **108x** |
+| Template responses | 9,022 | 194,236 | **22x** | 3,152 | 283,815 | **90x** |
+| Simple static stub | 8,898 | 214,818 | **24x** | 5,982 | 324,952 | **54x** |
 
-> Absolute numbers are unconstrained (whole machine) and scale with hardware. What's
-> stable across machines is the *shape*: Rift stays flat where Mountebank degrades.
+### How to read the two columns
+
+Going from the laptop to the 16-vCPU server, **Rift gets faster (215k → 325k) and
+Mountebank gets slower (8,898 → 5,982)**. Mountebank is single-threaded, so it can
+only use one core, and this server's individual cores are slower than the M4's — it
+gains nothing from the other 15. Rift uses them all.
+
+That means the EPYC multipliers are inflated at *both* ends, and the honest headline
+is the M4 column. It is still 22x–1,857x.
+
+Tail latency is the more stable comparison: Rift's p99 is **0.43–0.97 ms on both
+hosts**, while Mountebank's ranges from 2.9 ms to 1.7 *seconds* depending on scenario.
+
+> Measurement caveat: a laptop thermally throttles under a 30-minute run — both
+> engines lost ~7% between the first and last repetition, and per-scenario spread
+> reached 12% on the M4 versus 5% on EPYC. Treat M4 figures as ±10%.
 
 ---
 
 ## Why throughput stays flat
 
-Rift holds ~120k–210k RPS whether the matching stub is first, middle, or last — and
-on a no-match 404 — while Mountebank degrades linearly with stub count:
+Rift holds ~210k RPS (M4) / ~325k RPS (EPYC) whether the matching stub is first,
+middle, or last — and on a no-match 404 — while Mountebank degrades linearly with
+stub count:
 
 | API stub position | Mountebank (RPS) | Rift (RPS) | Speedup |
 |:------------------|:-----------------|:-----------|:--------|
-| First | 8,124 | 209,555 | **26x** |
-| Middle | 3,071 | 198,504 | **65x** |
-| Last | 1,351 | 201,403 | **149x** |
-| No match (404) | 1,309 | 206,865 | **158x** |
+| First | 8,546 | 211,378 | **25x** |
+| Middle | 3,437 | 210,151 | **61x** |
+| Last | 1,344 | 209,523 | **156x** |
+| No match (404) | 1,351 | 209,763 | **155x** |
 
-Regex is the exception on *both* sides: it can't be hash-dispatched, so it's Rift's
-own slowest matcher (~54k RPS) — but Mountebank's per-stub JS `RegExp` scan collapses
-to 106 RPS at the 100th pattern, a 515x gap.
+Regex used to be the exception on Rift's side too — it can't be hash-dispatched, and
+at the 100th pattern Rift managed ~54k RPS against Mountebank's 106. The
+candidate-bitset matching framework removed that cliff: regex now runs at **207k RPS**,
+in line with every other predicate type. Mountebank's per-stub JS `RegExp` scan still
+collapses to 112 RPS at the 100th pattern, so the gap widened from 515x to **1,857x**
+— not because Mountebank got slower, but because Rift stopped having a slow path.
 
 On the admin control plane, creating 1,000 fully-overlapping stubs (the O(n²) case
 issue #423 fixed) takes Rift 6.6ms vs Mountebank's 114.7ms, and grows memory +9MB vs
@@ -242,12 +272,12 @@ resources:
 
 | Tool | Language | Typical RPS | Best For |
 |:-----|:---------|:------------|:---------|
-| **Rift** | Rust | 100,000+ | High-performance mocking |
+| **Rift** | Rust | 200,000+ | High-performance mocking |
 | Mountebank | Node.js | 500-2,000 | Feature-rich service virtualization |
 | WireMock | Java | 1,000-5,000 | Java ecosystem integration |
 | MockServer | Java | 1,000-3,000 | Contract testing |
 
-Rift provides 10-500x better performance while maintaining Mountebank compatibility.
+Rift provides 20-6,000x better performance while maintaining Mountebank compatibility.
 (Rift's figure is native/unconstrained; it scales with hardware.)
 
 ---

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -270,29 +270,67 @@ Outputs land in `results/` and are gitignored (machine-specific — regenerate p
 
 ## Latest results
 
-Native processes, unconstrained, on **Apple M4 (10 cores) / macOS**. Rift `0.1.0`
-@ `f029cf8`, Mountebank `2.9.1`, `oha` at 50 keep-alive connections, 20s/scenario
-after a 3s warmup. Fixture: 10 imposters, 862 stubs.
+Measured 2026-07-20. Rift built from `master` @ `924cf73`, Mountebank `2.9.1`, `oha`
+at 50 keep-alive connections, 20s/scenario after a 3s warmup, native processes
+(no Docker), each engine run alone. Fixture: 14 imposters, 1,512 stubs. Every figure
+is the **median of 3 repetitions** — reproduce with `--rep 1|2|3` then
+`--aggregate-comparison`.
+
+Two hosts, because the multiplier is hardware-dependent:
+
+- **M4** — Apple M4, 10 cores, macOS (laptop)
+- **EPYC** — AMD EPYC 9V74, 16 vCPU, 62 GiB, Linux (`benchmark-publish.yml`)
 
 ### Request serving
 
-| Scenario | Mountebank (RPS) | Rift (RPS) | Speedup | p99 MB → Rift (ms) |
-|---|--:|--:|--:|---|
-| simple_health | 4,093 | 199,228 | **49x** | 1502* → 0.7 |
-| api_first | 8,124 | 209,555 | **26x** | 2.9 → 0.5 |
-| api_middle | 3,071 | 198,504 | **65x** | 44.1 → 0.6 |
-| api_last | 1,351 | 201,403 | **149x** | 40.3 → 0.6 |
-| no_match (404) | 1,309 | 206,865 | **158x** | 53.1 → 0.5 |
-| regex_last | 106 | 54,434 | **515x** | 640.9 → 1.8 |
-| complex_and_or | 4,646 | 181,320 | **39x** | 17.0 → 0.8 |
-| json_body_equals | 7,802 | 188,247 | **24x** | 9.1 → 0.8 |
-| jsonpath | 4,480 | 173,671 | **39x** | 17.0 → 1.0 |
-| xpath | 5,552 | 174,567 | **31x** | 15.1 → 0.8 |
-| template | 9,446 | 189,649 | **20x** | 7.2 → 0.6 |
-| header_route | 3,050 | 148,739 | **49x** | 34.5 → 0.8 |
-| query_param | 2,366 | 118,228 | **50x** | 49.9 → 1.1 |
+| Scenario | MB (M4) | Rift (M4) | M4 | MB (EPYC) | Rift (EPYC) | EPYC |
+|---|--:|--:|--:|--:|--:|--:|
+| simple_health | 8,898 | 214,818 | **24x** | 5,982 | 324,952 | **54x** |
+| api_first | 8,546 | 211,378 | **25x** | 5,728 | 323,408 | **57x** |
+| api_middle | 3,437 | 210,151 | **61x** | 1,081 | 324,067 | **300x** |
+| api_last | 1,344 | 209,523 | **156x** | 542 | 322,530 | **595x** |
+| no_match (404) | 1,351 | 209,763 | **155x** | 549 | 332,574 | **606x** |
+| regex_last | 112 | 207,024 | **1,857x** | 52 | 317,851 | **6,160x** |
+| complex_and_or | 4,703 | 191,987 | **41x** | 1,814 | 259,548 | **143x** |
+| json_body_equals | 7,611 | 199,670 | **26x** | 2,730 | 294,294 | **108x** |
+| jsonpath | 4,312 | 199,404 | **46x** | 1,921 | 304,796 | **159x** |
+| xpath | 5,542 | 187,869 | **34x** | 1,966 | 247,897 | **126x** |
+| template | 9,022 | 194,236 | **22x** | 3,152 | 283,815 | **90x** |
+| header_route | 3,016 | 158,596 | **53x** | 1,202 | 201,940 | **168x** |
+| query_param | 2,751 | 164,133 | **60x** | 1,112 | 211,748 | **190x** |
 
-<sub>*Mountebank's `simple_health` p99 spike is a Node GC pause during the run; its median was 1.8ms.</sub>
+p99 latency, same runs:
+
+| Scenario | p99 MB → Rift, M4 (ms) | p99 MB → Rift, EPYC (ms) |
+|---|---|---|
+| simple_health | 2.9 → 0.46 | 9.6 → 0.49 |
+| api_first | 2.9 → 0.47 | 10.4 → 0.49 |
+| api_middle | 46.0 → 0.46 | 51.2 → 0.49 |
+| api_last | 40.3 → 0.45 | 114.4 → 0.49 |
+| no_match (404) | 40.0 → 0.43 | 96.1 → 0.48 |
+| regex_last | 613.9 → 0.46 | 1741.6 → 0.51 |
+| complex_and_or | 13.5 → 0.77 | 28.1 → 0.73 |
+| json_body_equals | 8.5 → 0.58 | 22.1 → 0.59 |
+| jsonpath | 16.2 → 0.54 | 30.3 → 0.56 |
+| xpath | 13.0 → 0.70 | 30.0 → 0.75 |
+| template | 7.2 → 0.51 | 19.5 → 0.61 |
+| header_route | 34.9 → 0.72 | 46.3 → 0.97 |
+| query_param | 31.8 → 0.66 | 50.0 → 0.91 |
+
+Reading notes:
+
+- **Rift is faster on EPYC (215k → 325k); Mountebank is *slower* (8,898 → 5,982).**
+  Mountebank is single-threaded, and this server's individual cores are slower than
+  the M4's, so it gains nothing from the extra 15. The EPYC multipliers are therefore
+  inflated at both ends — quote the M4 column when a conservative figure is wanted.
+- **`regex_last` is the headline change since the previous run** (54,434 → 207,024 RPS
+  on comparable hardware). The candidate-bitset matching framework removed regex as
+  Rift's slow path; it is now in line with every other predicate type. Mountebank did
+  not change.
+- **M4 figures carry ~±10%.** A laptop thermally throttles over a 30-minute run: both
+  engines lost ~7% aggregate between the first and last repetition, and per-scenario
+  spread reached 12% (versus 5% on EPYC). This is why the table is a median of 3 and
+  not a single sample.
 
 ### Admin create/read
 
@@ -310,16 +348,22 @@ stub-overlap analysis, a Rift extension Mountebank does not perform.
 
 ### Key findings
 
-1. **Position-independent matching.** Rift holds ~200k RPS whether the matching stub
-   is first, middle, or last — and on a no-match 404. Mountebank degrades linearly
-   with stub count (8,124 → 1,309 RPS, first → no-match): up to **158x** at the tail.
-2. **Regex is the extreme.** 515x (Rift 54k vs MB 106) — Mountebank's per-stub JS
-   `RegExp` scan collapses at the 100th pattern. Regex is also Rift's *own* slowest
-   matcher (~54k vs ~180k elsewhere), since a regex can't be hash-dispatched.
-3. **Structured predicates** (JSONPath, XPath, JSON body, complex AND/OR): **24–39x**.
-   Native Rust evaluation stays 174k–188k RPS vs Mountebank's JS 4.5k–7.8k.
-4. **Sub-millisecond tail.** Rift p99 stays 0.5–1.8ms across every scenario;
-   Mountebank ranges 3–641ms depending on stub count, position, and predicate type.
+1. **Position-independent matching.** Rift holds ~210k RPS (M4) / ~325k RPS (EPYC)
+   whether the matching stub is first, middle, or last — and on a no-match 404.
+   Mountebank degrades linearly with stub count (8,546 → 1,351 RPS, first → no-match):
+   up to **155x** at the tail on the M4, **606x** on EPYC.
+2. **Regex is no longer Rift's slow path.** It used to be the one predicate type that
+   couldn't be hash-dispatched (~54k RPS vs ~180k elsewhere); the candidate-bitset
+   matching framework brought it to **207k RPS**, in line with everything else.
+   Mountebank's per-stub JS `RegExp` scan still collapses at the 100th pattern, so the
+   gap is now **1,857x** (M4) / **6,160x** (EPYC) — widened by Rift improving, not by
+   Mountebank regressing.
+3. **Structured predicates** (JSONPath, XPath, JSON body, complex AND/OR): **26–46x**
+   on the M4, **108–159x** on EPYC. Native Rust evaluation stays 188k–200k RPS (M4)
+   vs Mountebank's JS 4.3k–7.6k.
+4. **Sub-millisecond tail.** Rift p99 stays **0.43–0.97ms on both hosts**, across every
+   scenario; Mountebank ranges from 2.9ms to 1.7 *seconds* depending on stub count,
+   position, and predicate type.
 5. **Admin plane / overlap analysis.** Creating 1,000 fully-overlapping stubs, Rift
    creates in **6.6ms vs Mountebank's 114.7ms** and grows RSS **+9MB vs +51MB**, while
    still computing 101 stub-overlap warnings Mountebank never produces.


### PR DESCRIPTION
The published benchmark figures predated the Turbo optimization round, so the one
result that round actually moved was invisible.

## What moved

`regex_last` went from **54,434 → 207,024 RPS** on comparable hardware. It used to be
Rift's only slow path — the one predicate type that can't be hash-dispatched — and the
candidate-bitset matching framework brought it in line with everything else. Mountebank
went 106 → 112 over the same period, so the gap widened from 515x to **1,857x** because
Rift improved, not because Mountebank regressed. Every page now says that explicitly;
"1,857x" on its own invites the wrong inference.

## Two hosts, not one headline

| | Apple M4 laptop | AMD EPYC 9V74, 16 vCPU |
|---|--:|--:|
| Rift, simple stub | 214,818 | 324,952 |
| Mountebank, simple stub | 8,898 | **5,982** |
| Regex, 100th pattern | 1,857x | 6,160x |

Going to the server **Rift speeds up and Mountebank slows down** — it is single-threaded
and this server's individual cores are slower than the M4's, so it gains nothing from the
other 15. The EPYC multipliers are therefore inflated at *both* ends. Publishing only the
6,160x figure would not survive scrutiny, so both columns ship together and each page
states which is the conservative read (the M4 — still 22x–1,857x).

## Honesty caveats now published, not buried

- Every figure is a **median of 3 repetitions**, reproducible via `--rep N` +
  `--aggregate-comparison`.
- **M4 figures carry ~±10%.** Both engines lost ~7% aggregate between the first and last
  repetition — a laptop thermally throttling over a 30-minute run. Per-scenario spread
  reached 12% on M4 vs 5% on EPYC. Stated inline with the reason.
- Tail latency is the more stable comparison and is included: Rift p99 **0.43–0.97 ms on
  both hosts**; Mountebank 2.9 ms to 1.7 *seconds*.

## Provenance

- EPYC: `benchmark-publish.yml` run [29767296487](https://github.com/achird-labs/rift/actions/runs/29767296487), c=50, 20s, 3 reps.
- M4: local run on a quiesced machine, same harness/flags/versions, 3 reps.
- Both: Rift `master` @ `924cf73`, Mountebank `2.9.1`, `oha`, native processes, each engine alone.

Docs-only — no code touched. `verify-docs-coverage.sh` green.
