### PR TITLE
chore(release): correct release-blocking docs and guard the manual publish path

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -42,6 +42,29 @@ jobs:
             exit 1
           fi
 
+      # The workspace version in git is a placeholder — `release.yml` rewrites it from the tag at
+      # build time, so nothing on a branch ever carries the real version. Publishing from here
+      # would therefore upload the placeholder: crates.io accepts it (it is a version that has
+      # never been published), leaving a `0.1.0` that is newer by upload date but *lower* than
+      # every real release by semver, so `cargo add rift-http-proxy` keeps resolving 0.14.x while
+      # the newest-looking artifact on the page is a fake. Refuse instead, and point at the
+      # workflow that does set the version.
+      - name: Refuse to publish the placeholder version
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c "import sys,json;p=[x for x in json.load(sys.stdin)['packages'] if x['name']=='${{ inputs.crate }}'];print(p[0]['version'] if p else '')")
+          echo "Resolved version for ${{ inputs.crate }}: ${VERSION:-<none>}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not resolve a version for ${{ inputs.crate }}"
+            exit 1
+          fi
+          if [ "$VERSION" = "0.1.0" ]; then
+            echo "::error::refusing to publish the placeholder version 0.1.0. Releases are cut by \
+          tagging (release.yml), which rewrites the workspace version from the tag and publishes \
+          every crate in dependency order. Use that instead of this workflow."
+            exit 1
+          fi
+
       - name: Run tests
         run: cargo test -p ${{ inputs.crate }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,22 @@ record.
 
 - **Field-level `equals`-on-body predicates are now indexed by an automaton** (quamina), so
   "which of N field-equals-on-body stubs matches this request body" is one automaton pass
-  instead of an `O(N)` scan of structural comparisons in the second matching stage. At 1000
-  such stubs this recovers throughput from ~6.8× collapsed toward the indexed-path ceiling;
-  matching results are unchanged — this is purely a prefilter (any predicate it cannot express
-  — arrays, `null`, floats, `caseSensitive`/`keyCaseSensitive`, `except`/selector — safely
-  falls through to full evaluation). It complements the `deepEquals`-on-body hash index. The
-  capability is behind a default-on `quamina-matching` Cargo feature, droppable for minimal or
-  FFI builds via `--no-default-features`. (#767, #777)
+  instead of an `O(N)` scan of structural comparisons in the second matching stage. Measured in
+  the shipped binary (#779) on stubs that share a path and differ only by a body field, where the
+  dimension is what does the discriminating:
+
+  | stubs sharing a path | without | with | Δ |
+  |--:|--:|--:|--:|
+  | 10 | 452,698 | 440,370 | −2.7% |
+  | 100 | 317,912 | 436,007 | **+37.1%** |
+  | 1000 | 84,210 | 404,809 | **+380.7%** |
+
+  Without it throughput collapses as such stubs accumulate (453k → 84k); with it, it stays flat
+  (440k → 405k). Matching results are unchanged — this is purely a prefilter (any predicate it
+  cannot express — arrays, `null`, floats, `caseSensitive`/`keyCaseSensitive`, `except`/selector
+  — safely falls through to full evaluation). It complements the `deepEquals`-on-body hash index.
+  The capability is behind a default-on `quamina-matching` Cargo feature, droppable for minimal
+  or FFI builds via `--no-default-features`; it costs ~0.49 MB of binary size. (#767, #777, #779)
 
 - **Per-worker accept counters + runtime-topology bench support** (part of the RFC-712 gate,
   #746). `rift_accepted_connections_total{worker=…}` counts accepted connections per
@@ -127,8 +136,8 @@ record.
   it, and `scripts/verify-feature-propagation.sh` gates the invariant in CI: every default feature
   of `rift-mock-core` must be forwarded by, and default-on in, every crate that takes it with
   `default-features = false`. Matching **results** were never affected — the dimension is a pure
-  prefilter — so this is a throughput fix, not a correctness one. The end-to-end win has not yet
-  been measured in the binary (#779). (#777)
+  prefilter — so this is a throughput fix, not a correctness one. The end-to-end win was
+  subsequently measured in the shipped binary and is quoted under *Added* above (#779). (#777)
 
 - **An imposter with a numeric or boolean header value was rejected with a `400`.** Mountebank
   tolerates non-string scalar header values — its own recorders routinely emit

--- a/crates/rift-tui/README.md
+++ b/crates/rift-tui/README.md
@@ -14,19 +14,15 @@ Interactive Terminal User Interface for [Rift HTTP Proxy](https://github.com/ach
 
 ## Installation
 
-### From Source
-
-```bash
-cargo install rift-tui
-```
-
-### Build from Repository
+`rift-tui` is not published to crates.io — build it from the repository:
 
 ```bash
 git clone https://github.com/achird-labs/rift.git
 cd rift
 cargo build --release --bin rift-tui
 ```
+
+The binary lands at `target/release/rift-tui`.
 
 ## Usage
 


### PR DESCRIPTION
Audit of the release pipeline ahead of the next tag under `achird-labs`. Most of it is already
correct — this fixes the three things that were not.

## What was wrong

**1. The changelog would have shipped a retracted number as release notes.**

The `[Unreleased]` entry for the quamina body-field dimension quoted **~6.8×**. That was measured
against `rift-mock-core` — the one crate where the feature was enabled. #777 then discovered the
dimension was compiled out of *both* the `rift` binary and the C-ABI, so the figure described a
configuration no user has ever run. `release.yml` builds release notes from a template, but the
CHANGELOG ships inside every release archive, so it would have gone out verbatim.

Replaced with what #779 measured **in the shipped binary**, on the workload the dimension actually
serves (stubs sharing a path, discriminated only by a body field):

| stubs sharing a path | without | with | Δ |
|--:|--:|--:|--:|
| 10 | 452,698 | 440,370 | −2.7% |
| 100 | 317,912 | 436,007 | **+37.1%** |
| 1000 | 84,210 | 404,809 | **+380.7%** |

The honest framing is the collapse it prevents: without the dimension throughput falls 453k → 84k as
such stubs accumulate; with it, it stays flat. The #777 entry also no longer says the win "has not
yet been measured" — it since has been.

**2. `publish-crate.yml` would have published `0.1.0`.**

The workspace version in git is a placeholder; `release.yml` rewrites it from the tag at build time.
`publish-crate.yml` has no such step, so a manual dispatch from a branch publishes the placeholder.
crates.io *accepts* that — `0.1.0` has never been published — leaving an artifact that is newest by
upload date and **lowest by semver**, so `cargo add rift-http-proxy` keeps resolving 0.14.x while the
newest-looking thing on the crate page is a fake. It now resolves the version via `cargo metadata`
and refuses the placeholder, naming the tag-driven workflow instead.

**3. `cargo install rift-tui` does not work.**

`crates/rift-tui/README.md` documented it. `rift-tui` has never been published to crates.io (only
`rift-lint`, `rift-types`, `rift-mock-core` and `rift-http-proxy` are). The README now documents the
build-from-source path that actually works.

## What I verified is already correct

| Area | State |
|---|---|
| Repo secrets | All 5 present: `CARGO_REGISTRY_TOKEN`, `DOCKERHUB_TOKEN`, `DOCKERHUB_USERNAME`, `HOMEBREW_TAP_TOKEN`, `RIFT_NODE_DISPATCH_TOKEN` |
| Homebrew tap | `achird-labs/homebrew-rift` exists, formula at 0.14.0, URLs + homepage on `achird-labs` |
| Docker Hub | `zainalpour/rift-proxy` + `rift-lint` live, v0.14.0 published with cosign signatures |
| crates.io | 4 crates at 0.14.0; `Cargo.toml` metadata already points at `achird-labs` |
| GitHub Pages | `https://achird-labs.github.io/rift/` → 200; `docs/_config.yml` correct |
| SDK dispatch | `achird-labs/rift-node` exists and has `engine-bump.yml` |
| Release notes template | `achird-labs` download URLs; both `cargo install` targets genuinely published |
| Old-org refs | Only 3 left, and all are correct — they point at `EtaCassiopeia/zio-bdd` and `zio-openfeature`, which really do live there |

## Decisions left to a human (not changed here)

- **Docker Hub is a personal namespace.** Images publish to `zainalpour/rift-proxy` while everything
  else moved to `achird-labs`. Docs and the release template agree with it, so nothing is broken —
  but it is the one asset not under the org. Moving it means a new Docker Hub org, re-pointing
  `DOCKERHUB_USERNAME`, and 35 doc references.
- **`NPM_TOKEN` is still configured** on this repo but unused since #772 moved npm publishing to
  rift-node. Worth deleting as least-privilege.
- **`rift-tui` / `rift-ffi` are unpublished but carry `publish = true`** (the default). Either
  publish them, or set `publish = false` to make the intent explicit and prevent an accidental
  upload.
- **`[Unreleased]` has duplicate `### Added` / `### Fixed` headings** (3 and 2 respectively) from
  successive merges. Cosmetic, but they will render as repeated sections. Left alone rather than
  restructuring 175 lines of release-critical text in the same PR that fixes its accuracy.
- **crates.io/npm metadata for 0.14.0 still shows `EtaCassiopeia/rift`** — baked into the published
  artifact. Self-corrects on the next publish; nothing to do.
