### PR TITLE
Error envelope: add a stable `type` slug on every door, freeze `code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ record.
 
 ### Added
 
+- **Every error response now carries a `type` field** — a stable symbolic slug identifying the
+  error, on every door that serves the Mountebank `errors` envelope (issue #797):
+
+  ```json
+  {"errors":[{"code":"503","type":"imposter disabled","message":"Imposter is disabled"}]}
+  ```
+
+  Six of the slugs are Mountebank's own error types, copied verbatim from its `errors.js`
+  (`bad data`, `invalid injection`, `resource conflict`, `insufficient access`, `no such resource`,
+  `unauthorized`), so a client that already maps Mountebank error types keeps working. The rest name
+  doors Mountebank has no equivalent for (`script error`, `script timeout`, `behavior error`,
+  `imposter disabled`, `request too large`, `upstream failure`, `timeout`, …).
+
+  **`code` is unchanged on every door** — this release adds a field and rewrites none. `code` stays
+  what it has always been: the HTTP status as a string on most doors and a Mountebank slug on five
+  (the four `inject` doors plus admin auth), which is precisely the inconsistency that made it
+  unusable for branching. It is now documented as legacy; new consumers should read `type`.
+  A per-door test asserts both halves — that `type` is the pinned slug *and* that `code` is
+  byte-identical to 0.14.0 — so the non-breakage is enforced rather than asserted in prose.
+
 - **Field-level `equals`-on-body predicates are now indexed by an automaton** (quamina), so
   "which of N field-equals-on-body stubs matches this request body" is one automaton pass
   instead of an `O(N)` scan of structural comparisons in the second matching stage. Measured in

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -12,6 +12,7 @@ use crate::imposter::{
     Imposter, ImposterConfig, ImposterError, ImposterManager, ScriptBaseDir, Stub, StubResponse,
     VerifyOptions, resolve_scripts,
 };
+use crate::response::ErrorKind;
 use crate::scripting::validate_stubs;
 use bytes::Bytes;
 use http_body_util::Full;
@@ -66,7 +67,8 @@ pub(crate) fn reject_stubs_if_injection_disallowed(
 pub(crate) fn injection_disallowed_response() -> Response<Full<Bytes>> {
     let body = serde_json::json!({
         "errors": [{
-            "code": "invalid injection",
+            "code": ErrorKind::InvalidInjection.slug(),
+            "type": ErrorKind::InvalidInjection.slug(),
             "message": "inject requires --allowInjection to be set. See \
                         http://www.mbtest.org/docs/api/injection for more information.",
         }]
@@ -311,7 +313,8 @@ async fn replace_all_from_bytes(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &serde_json::json!({
                     "errors": [{
-                        "code": "500",
+                        "code": StatusCode::INTERNAL_SERVER_ERROR.as_str(),
+                        "type": ErrorKind::InternalError.slug(),
                         "message": format!(
                             "Replace partially failed: {}",
                             failures.join("; ")

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -2,6 +2,7 @@
 
 use crate::admin_api::types::*;
 use crate::imposter::ImposterManager;
+use crate::response::ErrorKind;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Response, StatusCode};
@@ -233,7 +234,8 @@ pub async fn handle_reload(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &serde_json::json!({
                     "errors": [{
-                        "code": "500",
+                        "code": StatusCode::INTERNAL_SERVER_ERROR.as_str(),
+                        "type": ErrorKind::InternalError.slug(),
                         "message": format!("Reload partially failed: {}", failures.join("; ")),
                     }],
                     "failed": failures,

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -383,7 +383,7 @@ fn box_full(resp: Response<Full<Bytes>>) -> Response<AdminBody> {
 }
 
 fn unauthorized_response() -> Response<Full<Bytes>> {
-    let body = r#"{"errors":[{"code":"unauthorized","message":"Invalid authorization token"}]}"#;
+    let body = r#"{"errors":[{"code":"unauthorized","type":"unauthorized","message":"Invalid authorization token"}]}"#;
     Response::builder()
         .status(StatusCode::UNAUTHORIZED)
         .header("Content-Type", "application/json")
@@ -413,6 +413,14 @@ mod tests {
         let body_str = std::str::from_utf8(&body_bytes).unwrap();
         let json: serde_json::Value = serde_json::from_str(body_str).unwrap();
         assert_eq!(json["errors"][0]["code"], "unauthorized");
+        // Issue #797 invariant 3: on a door whose `code` is already a slug, `type` is that same
+        // slug. Asserted here because this envelope is a hand-written literal, not built by
+        // `error_body_typed` — nothing else would catch the two drifting apart.
+        assert_eq!(json["errors"][0]["type"], "unauthorized");
+        assert_eq!(
+            json["errors"][0]["type"], json["errors"][0]["code"],
+            "type and code must agree on a slug door"
+        );
         assert!(!json["errors"][0]["message"].as_str().unwrap().is_empty());
     }
 

--- a/crates/rift-http-proxy/tests/issue_797_error_envelope_type.rs
+++ b/crates/rift-http-proxy/tests/issue_797_error_envelope_type.rs
@@ -1,0 +1,217 @@
+//! Issue #797: every engine-originated error envelope carries a `type` slug, and `code` is frozen.
+//!
+//! This is a **door walk**: it drives each error door the issue inventoried and asserts two things
+//! per door — the new `type` is the slug the design pins, *and* `code` is byte-identical to what
+//! 0.14.0 served. The second half is the non-breakage proof. It is deliberately asserted here
+//! rather than argued in a PR description, because `rift-conformance` pins these same `code` values
+//! and a regression would otherwise only surface in that downstream repo.
+
+use rift_http_proxy::imposter::ImposterManager;
+use serde_json::Value;
+use std::time::Duration;
+
+/// Assert one door: `code` unchanged, `type` present and equal to the pinned slug.
+fn assert_door(body: &Value, expected_code: &str, expected_type: &str, door: &str) {
+    assert_eq!(
+        body["errors"][0]["code"], expected_code,
+        "{door}: `code` must stay byte-identical to 0.14.0 (frozen), got: {body}"
+    );
+    assert_eq!(
+        body["errors"][0]["type"], expected_type,
+        "{door}: `type` must be the pinned slug, got: {body}"
+    );
+}
+
+async fn get(url: &str) -> (u16, Value) {
+    let resp = reqwest::Client::new().get(url).send().await.expect("send");
+    let status = resp.status().as_u16();
+    let body = resp.json::<Value>().await.expect("json body");
+    (status, body)
+}
+
+// A disabled imposter answers 503. `code` stays "503"; `type` names the door.
+#[tokio::test]
+async fn disabled_imposter_door() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19921, "protocol": "http",
+        "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    manager
+        .get_imposter(19921)
+        .expect("imposter exists")
+        .set_enabled(false);
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19921/x").await;
+    assert_eq!(status, 503);
+    assert_door(&body, "503", "imposter disabled", "disabled imposter");
+}
+
+// A throwing response-`inject` answers 400 with Mountebank's slug already in `code` (#355). On the
+// five doors whose `code` is already a slug, `type` must equal it — invariant 3.
+#[tokio::test]
+async fn response_inject_error_door_has_type_equal_to_code() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19922, "protocol": "http", "stubs": [
+            { "responses": [{ "inject": "function (config) { throw new Error('boom'); }" }] }
+        ]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19922/x").await;
+    assert_eq!(status, 400);
+    assert_door(
+        &body,
+        "invalid injection",
+        "invalid injection",
+        "response inject error",
+    );
+}
+
+// A throwing predicate-`inject` answers 400 with the predicate-specific slug.
+#[tokio::test]
+async fn predicate_inject_error_door_has_type_equal_to_code() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19923, "protocol": "http", "stubs": [{
+            "predicates": [{ "inject": "function (config) { throw new Error('boom'); }" }],
+            "responses": [{ "is": { "statusCode": 200 } }]
+        }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19923/x").await;
+    assert_eq!(status, 400);
+    assert_door(
+        &body,
+        "invalid predicate injection",
+        "invalid predicate injection",
+        "predicate inject error",
+    );
+}
+
+// A `_rift.script` that throws answers 500. `code` stays "500" — the status string — while `type`
+// distinguishes it from every other 500, which is the whole point of the field.
+#[tokio::test]
+async fn script_error_door() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19924, "protocol": "http", "stubs": [{
+            "responses": [{
+                "_rift": { "script": { "engine": "rhai", "code": "throw \"script-boom\"" } }
+            }]
+        }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19924/x").await;
+    assert_eq!(status, 500);
+    assert_door(&body, "500", "script error", "script error");
+}
+
+// An over-size request body answers 413 purely from the default status→slug table — no door-side
+// change was needed for it, which is the property that keeps ~85 call sites untouched.
+#[tokio::test]
+async fn oversize_body_door_uses_the_default_table() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19925, "protocol": "http",
+        "stubs": [{ "responses": [{ "is": { "statusCode": 200 } }] }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Comfortably past MAX_REQUEST_BODY_SIZE.
+    let huge = "x".repeat(11 * 1024 * 1024);
+    let resp = reqwest::Client::new()
+        .post("http://127.0.0.1:19925/x")
+        .body(huge)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 413);
+    let body: Value = resp.json().await.expect("json body");
+    assert_door(&body, "413", "request too large", "oversize body");
+}
+
+// strictBehaviors decorate failure answers 500 with the shared behavior slug.
+#[tokio::test]
+async fn strict_behaviors_decorate_door() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19926, "protocol": "http", "strictBehaviors": true,
+        "stubs": [{
+            "responses": [{
+                "is": { "statusCode": 200, "body": "original" },
+                "_behaviors": { "decorate": "function (request, response) { throw new Error('dec-boom'); }" }
+            }]
+        }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19926/x").await;
+    assert_eq!(status, 500);
+    assert_door(&body, "500", "behavior error", "strictBehaviors decorate");
+}
+
+// The second behavior door. `decorate` and `shellTransform` are separate call sites that happen to
+// share `ErrorKind::BehaviorError` — walking only one would let the other drift to a different slug
+// unnoticed, since nothing in the type system ties them together.
+#[tokio::test]
+async fn strict_behaviors_shell_transform_door() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19927, "protocol": "http", "strictBehaviors": true,
+        "stubs": [{
+            "responses": [{
+                "is": { "statusCode": 200, "body": "original" },
+                "_behaviors": { "shellTransform": "exit 1" }
+            }]
+        }]
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19927/x").await;
+    assert_eq!(status, 500);
+    assert_door(
+        &body,
+        "500",
+        "behavior error",
+        "strictBehaviors shellTransform",
+    );
+}
+
+// `defaultForward` to a dead upstream answers 502 straight from the default status→slug table —
+// the second door (with over-size body) proving the table carries doors nobody had to touch.
+#[tokio::test]
+async fn default_forward_upstream_failure_door() {
+    let manager = ImposterManager::new();
+    let config = serde_json::from_value(serde_json::json!({
+        "port": 19928, "protocol": "http",
+        // Port 1 is reserved and never listening, so the forward fails to connect.
+        "defaultForward": "http://127.0.0.1:1",
+        "stubs": []
+    }))
+    .expect("config");
+    manager.create_imposter(config).await.expect("create");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = get("http://127.0.0.1:19928/anything").await;
+    assert_eq!(status, 502);
+    assert_door(&body, "502", "upstream failure", "defaultForward upstream");
+}

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -114,9 +114,14 @@ const SCRIPT_TIMEOUT_HEADER: &str = "x-rift-script-timeout";
 /// `{"errors":[{code,message}]}` envelope with a timeout-specific `code`, plus the shared
 /// `x-rift-inject-error` marker and the [`SCRIPT_TIMEOUT_HEADER`] that tells a timeout apart from a
 /// genuinely broken inject (which stays a 400).
-fn inject_timeout_response(code: &str, message: &str) -> Response<Full<Bytes>> {
+/// On this door `code` is already a slug, so `type` is the same string (issue #797 invariant 3) —
+/// taking the kind rather than a `&str` is what keeps the two from drifting apart.
+fn inject_timeout_response(
+    kind: crate::response::ErrorKind,
+    message: &str,
+) -> Response<Full<Bytes>> {
     let body = serde_json::json!({
-        "errors": [{ "code": code, "message": message }]
+        "errors": [{ "code": kind.slug(), "type": kind.slug(), "message": message }]
     })
     .to_string();
     build_response_with_headers(
@@ -260,14 +265,18 @@ fn upstream_error_response(
 
 fn matcher_error_response(e: &anyhow::Error) -> Response<Full<Bytes>> {
     if let Some(t) = e.downcast_ref::<crate::scripting::ScriptTimeoutError>() {
-        return inject_timeout_response("predicate injection timeout", &t.to_string());
+        return inject_timeout_response(
+            crate::response::ErrorKind::PredicateInjectionTimeout,
+            &t.to_string(),
+        );
     }
     #[cfg(feature = "javascript")]
     {
         if let Some(pred_err) = e.downcast_ref::<crate::scripting::PredicateInjectionError>() {
             let body = serde_json::json!({
                 "errors": [{
-                    "code": "invalid predicate injection",
+                    "code": crate::response::ErrorKind::InvalidPredicateInjection.slug(),
+                    "type": crate::response::ErrorKind::InvalidPredicateInjection.slug(),
                     "message": pred_err.to_string(),
                 }]
             })
@@ -384,7 +393,11 @@ async fn handle_request_inner(
                 ("x-rift-imposter-disabled", "true"),
                 ("content-type", "application/json"),
             ],
-            crate::response::error_body(StatusCode::SERVICE_UNAVAILABLE, "Imposter is disabled"),
+            crate::response::error_body_typed(
+                StatusCode::SERVICE_UNAVAILABLE,
+                crate::response::ErrorKind::ImposterDisabled,
+                "Imposter is disabled",
+            ),
         ));
     }
 
@@ -732,7 +745,10 @@ async fn handle_request_inner(
                     // A deadline miss (issue #499) is a transient 504 a client can retry, not the
                     // permanent-config 400 below — distinguish it before the parity mapping.
                     if let Some(t) = e.downcast_ref::<crate::scripting::ScriptTimeoutError>() {
-                        return Ok(inject_timeout_response("injection timeout", &t.to_string()));
+                        return Ok(inject_timeout_response(
+                            crate::response::ErrorKind::InjectionTimeout,
+                            &t.to_string(),
+                        ));
                     }
                     // Mountebank-shaped error parity (issue #355 Item 5): a failing inject is a
                     // 400 with `{"errors":[{"code":"invalid injection","message":"..."}]}`, not a
@@ -740,7 +756,8 @@ async fn handle_request_inner(
                     // (config) problem, not a server fault.
                     let body = serde_json::json!({
                         "errors": [{
-                            "code": "invalid injection",
+                            "code": crate::response::ErrorKind::InvalidInjection.slug(),
+                            "type": crate::response::ErrorKind::InvalidInjection.slug(),
                             "message": format!("{e}"),
                         }]
                     })
@@ -997,16 +1014,18 @@ async fn handle_request_inner(
                     let (status, body) = if timed_out {
                         (
                             StatusCode::GATEWAY_TIMEOUT,
-                            crate::response::error_body(
+                            crate::response::error_body_typed(
                                 StatusCode::GATEWAY_TIMEOUT,
+                                crate::response::ErrorKind::ScriptTimeout,
                                 &format!("Script timeout: {e}"),
                             ),
                         )
                     } else {
                         (
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            crate::response::error_body(
+                            crate::response::error_body_typed(
                                 StatusCode::INTERNAL_SERVER_ERROR,
+                                crate::response::ErrorKind::ScriptError,
                                 &format!("Script error: {e}"),
                             ),
                         )
@@ -1293,8 +1312,9 @@ async fn handle_request_inner(
                                 return Ok(build_response_with_headers(
                                     status,
                                     hdrs,
-                                    crate::response::error_body(
+                                    crate::response::error_body_typed(
                                         status,
+                                        crate::response::ErrorKind::BehaviorError,
                                         &format!("decorate failed (strictBehaviors): {e}"),
                                     ),
                                 ));
@@ -1348,8 +1368,9 @@ async fn handle_request_inner(
                                         ("x-rift-shelltransform-error", "true"),
                                         ("content-type", "application/json"),
                                     ],
-                                    crate::response::error_body(
+                                    crate::response::error_body_typed(
                                         StatusCode::INTERNAL_SERVER_ERROR,
+                                        crate::response::ErrorKind::BehaviorError,
                                         &format!("shellTransform failed (strictBehaviors): {e}"),
                                     ),
                                 ));
@@ -1392,8 +1413,9 @@ async fn handle_request_inner(
                                         ("x-rift-binary-error", "true"),
                                         ("content-type", "application/json"),
                                     ],
-                                    crate::response::error_body(
+                                    crate::response::error_body_typed(
                                         StatusCode::INTERNAL_SERVER_ERROR,
+                                        crate::response::ErrorKind::BehaviorError,
                                         &format!(
                                             "binary base64 decode failed (strictBehaviors): {e}"
                                         ),
@@ -1802,7 +1824,10 @@ mod matcher_error_response_tests {
     #[tokio::test]
     async fn inject_timeout_response_is_504_with_code_and_markers() {
         use http_body_util::BodyExt;
-        let resp = inject_timeout_response("injection timeout", "inject timed out after 1ms");
+        let resp = inject_timeout_response(
+            crate::response::ErrorKind::InjectionTimeout,
+            "inject timed out after 1ms",
+        );
         assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
         assert!(resp.headers().contains_key("x-rift-inject-error"));
         assert!(
@@ -1822,6 +1847,34 @@ mod matcher_error_response_tests {
         assert!(
             body.contains("\"code\":\"injection timeout\""),
             "body must carry the timeout-specific code, got: {body}"
+        );
+        // Issue #797 invariant 3: `type` mirrors the slug `code` on this door.
+        assert!(
+            body.contains("\"type\":\"injection timeout\""),
+            "body must carry the matching type slug, got: {body}"
+        );
+    }
+
+    // The predicate-side sibling of the door above. It has no end-to-end coverage (a real Boa
+    // busy-loop parks a shared-pool worker), so its envelope is pinned here — otherwise
+    // `ErrorKind::PredicateInjectionTimeout` would ship with no test at all.
+    #[tokio::test]
+    async fn predicate_inject_timeout_response_carries_matching_code_and_type() {
+        use http_body_util::BodyExt;
+        let resp = inject_timeout_response(
+            crate::response::ErrorKind::PredicateInjectionTimeout,
+            "predicate inject timed out after 1ms",
+        );
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let body = String::from_utf8(bytes.to_vec()).expect("utf8");
+        assert!(
+            body.contains("\"code\":\"predicate injection timeout\""),
+            "code must stay the 0.14.0 slug, got: {body}"
+        );
+        assert!(
+            body.contains("\"type\":\"predicate injection timeout\""),
+            "type must mirror it, got: {body}"
         );
     }
 

--- a/crates/rift-mock-core/src/response/mod.rs
+++ b/crates/rift-mock-core/src/response/mod.rs
@@ -17,7 +17,120 @@ pub struct ErrorResponse {
 #[derive(Debug, Serialize)]
 pub struct ErrorDetail {
     pub code: String,
+    /// The stable symbolic error type (issue #797). Unlike [`code`](Self::code) — which is a status
+    /// string on most doors and a Mountebank slug on a few, frozen that way for compatibility —
+    /// this is *always* a slug, on every door. New consumers should read this field.
+    #[serde(rename = "type")]
+    pub error_type: String,
     pub message: String,
+}
+
+/// The symbolic type of an error, independent of its HTTP status (issue #797).
+///
+/// An enum rather than free strings so a typo is a compile error and the whole slug set stays
+/// enumerable for the docs and the pinning tests. The first six variants are Mountebank's own
+/// error types, copied verbatim from its `src/util/errors.js` (2.9.1) — a client that already maps
+/// Mountebank error types keeps working. The rest name doors Mountebank does not have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorKind {
+    // --- Mountebank-canonical (src/util/errors.js) ---
+    BadData,
+    InvalidInjection,
+    ResourceConflict,
+    InsufficientAccess,
+    NoSuchResource,
+    Unauthorized,
+    // --- Rift doors Mountebank has no equivalent for ---
+    InvalidPredicateInjection,
+    InjectionTimeout,
+    PredicateInjectionTimeout,
+    ScriptError,
+    ScriptTimeout,
+    BehaviorError,
+    ImposterDisabled,
+    RequestTooLarge,
+    UpstreamFailure,
+    Unavailable,
+    Timeout,
+    InternalError,
+    ClientError,
+    ServerError,
+}
+
+impl ErrorKind {
+    /// Every variant as of writing — keep in sync by hand when adding one. The exhaustive,
+    /// wildcard-free match in [`slug`](Self::slug) is the half of the guard the compiler enforces;
+    /// this array is what lets the shape test iterate them.
+    pub const ALL: [ErrorKind; 20] = [
+        ErrorKind::BadData,
+        ErrorKind::InvalidInjection,
+        ErrorKind::ResourceConflict,
+        ErrorKind::InsufficientAccess,
+        ErrorKind::NoSuchResource,
+        ErrorKind::Unauthorized,
+        ErrorKind::InvalidPredicateInjection,
+        ErrorKind::InjectionTimeout,
+        ErrorKind::PredicateInjectionTimeout,
+        ErrorKind::ScriptError,
+        ErrorKind::ScriptTimeout,
+        ErrorKind::BehaviorError,
+        ErrorKind::ImposterDisabled,
+        ErrorKind::RequestTooLarge,
+        ErrorKind::UpstreamFailure,
+        ErrorKind::Unavailable,
+        ErrorKind::Timeout,
+        ErrorKind::InternalError,
+        ErrorKind::ClientError,
+        ErrorKind::ServerError,
+    ];
+
+    /// The wire slug. Lowercase, space-separated; pinned by tests.
+    #[must_use]
+    pub fn slug(self) -> &'static str {
+        match self {
+            ErrorKind::BadData => "bad data",
+            ErrorKind::InvalidInjection => "invalid injection",
+            ErrorKind::ResourceConflict => "resource conflict",
+            ErrorKind::InsufficientAccess => "insufficient access",
+            ErrorKind::NoSuchResource => "no such resource",
+            ErrorKind::Unauthorized => "unauthorized",
+            ErrorKind::InvalidPredicateInjection => "invalid predicate injection",
+            ErrorKind::InjectionTimeout => "injection timeout",
+            ErrorKind::PredicateInjectionTimeout => "predicate injection timeout",
+            ErrorKind::ScriptError => "script error",
+            ErrorKind::ScriptTimeout => "script timeout",
+            ErrorKind::BehaviorError => "behavior error",
+            ErrorKind::ImposterDisabled => "imposter disabled",
+            ErrorKind::RequestTooLarge => "request too large",
+            ErrorKind::UpstreamFailure => "upstream failure",
+            ErrorKind::Unavailable => "unavailable",
+            ErrorKind::Timeout => "timeout",
+            ErrorKind::InternalError => "internal error",
+            ErrorKind::ClientError => "client error",
+            ErrorKind::ServerError => "server error",
+        }
+    }
+
+    /// The kind a door gets when it does not name one — the ~85 call sites that reach
+    /// [`error_body`] with only a status. The unlisted-status fallback is the status *class*, never
+    /// the status string: `type` must never be something a client could mistake for `code`.
+    #[must_use]
+    pub fn for_status(status: StatusCode) -> Self {
+        match status {
+            StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => ErrorKind::BadData,
+            StatusCode::UNAUTHORIZED => ErrorKind::Unauthorized,
+            StatusCode::FORBIDDEN => ErrorKind::InsufficientAccess,
+            StatusCode::NOT_FOUND => ErrorKind::NoSuchResource,
+            StatusCode::CONFLICT => ErrorKind::ResourceConflict,
+            StatusCode::PAYLOAD_TOO_LARGE => ErrorKind::RequestTooLarge,
+            StatusCode::INTERNAL_SERVER_ERROR => ErrorKind::InternalError,
+            StatusCode::BAD_GATEWAY => ErrorKind::UpstreamFailure,
+            StatusCode::SERVICE_UNAVAILABLE => ErrorKind::Unavailable,
+            StatusCode::GATEWAY_TIMEOUT => ErrorKind::Timeout,
+            s if s.is_client_error() => ErrorKind::ClientError,
+            _ => ErrorKind::ServerError,
+        }
+    }
 }
 
 /// The serialized body of a Mountebank-format error, for callers that need to attach their own
@@ -26,9 +139,20 @@ pub struct ErrorDetail {
 /// The `unwrap_or_else` is a terminal last resort, not a swallow: `ErrorResponse` is plain `String`
 /// fields, so serde has no data-dependent way to fail here.
 pub(crate) fn error_body(status: StatusCode, message: &str) -> String {
+    error_body_typed(status, ErrorKind::for_status(status), message)
+}
+
+/// [`error_body`] for a door that names its own [`ErrorKind`], because the status alone is too
+/// coarse to identify it — a 500 from a failing script and a 500 from a broken response builder
+/// are the same status but different doors (issue #797).
+///
+/// `code` is *not* affected by the kind: it stays the status string, so naming a kind can never
+/// change what an existing client reads.
+pub(crate) fn error_body_typed(status: StatusCode, kind: ErrorKind, message: &str) -> String {
     let error = ErrorResponse {
         errors: vec![ErrorDetail {
             code: status.as_str().to_string(),
+            error_type: kind.slug().to_string(),
             message: message.to_string(),
         }],
     };
@@ -37,8 +161,17 @@ pub(crate) fn error_body(status: StatusCode, message: &str) -> String {
 
 /// Create a Mountebank-format error response.
 pub fn error_response(status: StatusCode, message: &str) -> Response<Full<Bytes>> {
+    error_response_typed(status, ErrorKind::for_status(status), message)
+}
+
+/// [`error_response`] for a door that names its own [`ErrorKind`] (issue #797).
+pub fn error_response_typed(
+    status: StatusCode,
+    kind: ErrorKind,
+    message: &str,
+) -> Response<Full<Bytes>> {
     ErrorResponseBuilder::new(status)
-        .body(error_body(status, message))
+        .body(error_body_typed(status, kind, message))
         .header("Content-Type", "application/json")
         .build_full()
 }
@@ -94,5 +227,130 @@ impl From<ImposterError> for Response<Full<Bytes>> {
             ),
             ImposterError::Backend(e) => crate::extensions::decorate::backend_error_response(&e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_of(status: StatusCode) -> serde_json::Value {
+        serde_json::from_str(&error_body(status, "msg")).expect("valid json")
+    }
+
+    // AC2: the status → default-slug table IS the specification for every door that does not name
+    // its own kind (~85 call sites reach `error_body` without one). Pinning it here is what stops a
+    // door's `type` changing as a side effect of an unrelated edit.
+    #[test]
+    fn status_to_default_slug_table_is_pinned() {
+        let expected = [
+            (StatusCode::BAD_REQUEST, "bad data"),
+            (StatusCode::UNPROCESSABLE_ENTITY, "bad data"),
+            (StatusCode::UNAUTHORIZED, "unauthorized"),
+            (StatusCode::FORBIDDEN, "insufficient access"),
+            (StatusCode::NOT_FOUND, "no such resource"),
+            (StatusCode::CONFLICT, "resource conflict"),
+            (StatusCode::PAYLOAD_TOO_LARGE, "request too large"),
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
+            (StatusCode::BAD_GATEWAY, "upstream failure"),
+            (StatusCode::SERVICE_UNAVAILABLE, "unavailable"),
+            (StatusCode::GATEWAY_TIMEOUT, "timeout"),
+            // Unlisted statuses fall back to the class, never to a status string.
+            (StatusCode::IM_A_TEAPOT, "client error"),
+            (StatusCode::NOT_IMPLEMENTED, "server error"),
+        ];
+        for (status, slug) in expected {
+            assert_eq!(
+                ErrorKind::for_status(status).slug(),
+                slug,
+                "default slug for {status}"
+            );
+        }
+    }
+
+    // The six slugs Rift shares with Mountebank are copied from its `src/util/errors.js` (2.9.1),
+    // not invented. Drift here is a silent compatibility break for any client that maps Mountebank
+    // error types, so the wording is pinned verbatim.
+    #[test]
+    fn mountebank_canonical_slugs_are_verbatim() {
+        assert_eq!(ErrorKind::BadData.slug(), "bad data");
+        assert_eq!(ErrorKind::InvalidInjection.slug(), "invalid injection");
+        assert_eq!(ErrorKind::ResourceConflict.slug(), "resource conflict");
+        assert_eq!(ErrorKind::InsufficientAccess.slug(), "insufficient access");
+        assert_eq!(ErrorKind::NoSuchResource.slug(), "no such resource");
+        assert_eq!(ErrorKind::Unauthorized.slug(), "unauthorized");
+    }
+
+    // Every slug is lowercase, space-separated, non-empty — the shape clients pattern-match on.
+    #[test]
+    fn every_slug_is_a_lowercase_space_separated_token() {
+        for kind in ErrorKind::ALL {
+            let s = kind.slug();
+            assert!(!s.is_empty(), "{kind:?} has an empty slug");
+            assert!(
+                s.chars().all(|c| c.is_ascii_lowercase() || c == ' '),
+                "{kind:?} slug {s:?} must be lowercase words separated by single spaces"
+            );
+            assert!(
+                !s.starts_with(' ') && !s.ends_with(' ') && !s.contains("  "),
+                "{kind:?} slug {s:?} has stray whitespace"
+            );
+        }
+    }
+
+    // AC1/invariant 2, the non-breakage proof: `code` stays the status string on every
+    // status-derived door, byte for byte, while `type` is added alongside it.
+    #[test]
+    fn error_body_adds_type_and_leaves_code_as_the_status_string() {
+        for status in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::PAYLOAD_TOO_LARGE,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            let body = body_of(status);
+            assert_eq!(
+                body["errors"][0]["code"],
+                status.as_str(),
+                "code must remain the status string for {status}"
+            );
+            assert_eq!(
+                body["errors"][0]["type"],
+                ErrorKind::for_status(status).slug(),
+                "type must be the default slug for {status}"
+            );
+            assert_eq!(body["errors"][0]["message"], "msg");
+        }
+    }
+
+    // A door that names its own kind overrides `type` only — `code` is still the status string, so
+    // naming a kind can never change what a 0.14.0 client reads.
+    #[test]
+    fn typed_body_overrides_type_but_never_code() {
+        let raw = error_body_typed(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::ScriptError,
+            "boom",
+        );
+        let body: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+        assert_eq!(body["errors"][0]["code"], "500");
+        assert_eq!(body["errors"][0]["type"], "script error");
+        assert_ne!(
+            body["errors"][0]["type"],
+            ErrorKind::for_status(StatusCode::INTERNAL_SERVER_ERROR).slug(),
+            "this test is only meaningful if the named kind differs from the status default"
+        );
+    }
+
+    // The field is serialized as `type`, not the Rust identifier.
+    #[test]
+    fn the_field_is_named_type_on_the_wire() {
+        let raw = error_body(StatusCode::NOT_FOUND, "nope");
+        assert!(raw.contains("\"type\""), "wire field must be `type`: {raw}");
+        assert!(
+            !raw.contains("error_type"),
+            "the Rust field name must not leak: {raw}"
+        );
     }
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -690,6 +690,61 @@ Get server logs (if logging enabled).
 
 ## Error Responses
 
+Every error Rift serves in the Mountebank `errors` envelope — on the admin plane and on the imposter
+port alike — carries three fields:
+
+```json
+{ "errors": [ { "code": "...", "type": "...", "message": "..." } ] }
+```
+
+**One shape is not in this family.** A backend outage (an unavailable flow-store or proxy store, and
+any matcher failure that is not an injection error) is reported as:
+
+```json
+{ "error": "backendUnavailable", "feature": "...", "detail": "..." }
+```
+
+— a different envelope with no `errors` array and no `type`. Check for the `errors` key before
+indexing into it. Unifying the two is tracked separately.
+
+| Field | Read it? | What it is |
+|:------|:---------|:-----------|
+| `type` | **yes** | The stable symbolic error type. Always a lowercase slug, on every door. This is the field to branch on. |
+| `code` | legacy | The HTTP status as a string on most doors, but a slug on a few (`invalid injection`, `unauthorized`, …). Frozen for backward compatibility — it is *not* reliably parseable as either. |
+| `message` | human | Free text. Never pattern-match it. |
+
+`type` was added in 0.15.0 (issue #797). `code` is unchanged from earlier releases, so existing
+clients keep working; new clients should read `type` instead.
+
+### Error types
+
+Six are Mountebank's own error types, so a client that already maps Mountebank errors keeps working:
+
+| `type` | Typical status |
+|:-------|:---------------|
+| `bad data` | 400, 422 |
+| `unauthorized` | 401 |
+| `insufficient access` | 403 |
+| `no such resource` | 404 |
+| `resource conflict` | 409 |
+| `invalid injection` | 400 |
+
+The rest name doors Mountebank does not have:
+
+| `type` | Typical status |
+|:-------|:---------------|
+| `invalid predicate injection` | 400 |
+| `injection timeout` / `predicate injection timeout` | 504 |
+| `script error` / `script timeout` | 500 / 504 |
+| `behavior error` | 500 |
+| `imposter disabled` | 503 |
+| `request too large` | 413 |
+| `upstream failure` | 502 |
+| `unavailable` | 503 |
+| `timeout` | 504 |
+| `internal error` | 500 |
+| `client error` / `server error` | any other 4xx / 5xx |
+
 ### 400 Bad Request
 
 Invalid request body or parameters.
@@ -698,7 +753,8 @@ Invalid request body or parameters.
 {
   "errors": [
     {
-      "code": "bad data",
+      "code": "400",
+      "type": "bad data",
       "message": "invalid JSON"
     }
   ]
@@ -713,7 +769,8 @@ Imposter doesn't exist.
 {
   "errors": [
     {
-      "code": "no such resource",
+      "code": "404",
+      "type": "no such resource",
       "message": "Imposter not found on port 4545"
     }
   ]
@@ -722,13 +779,29 @@ Imposter doesn't exist.
 
 ### 409 Conflict
 
-Port already in use.
+A stub with that `id` already exists on the imposter.
 
 ```json
 {
   "errors": [
     {
-      "code": "port conflict",
+      "code": "409",
+      "type": "resource conflict",
+      "message": "A stub with id 'login' already exists"
+    }
+  ]
+}
+```
+
+Note that a port already being in use is **not** a 409 — it is a `400` / `bad data`, because the
+request describes an imposter that cannot be created:
+
+```json
+{
+  "errors": [
+    {
+      "code": "400",
+      "type": "bad data",
       "message": "Port 4545 is already in use"
     }
   ]
@@ -746,6 +819,7 @@ binds `0.0.0.0` and `--apikey` is optional.
   "errors": [
     {
       "code": "413",
+      "type": "request too large",
       "message": "Request body exceeds the 67108864-byte admin API limit"
     }
   ]

--- a/docs/mountebank/imposters.md
+++ b/docs/mountebank/imposters.md
@@ -440,8 +440,12 @@ These are errors served on the **imposter port** — distinct from the admin API
 plane, with `Content-Type: application/json`:
 
 ```json
-{ "errors": [ { "code": "...", "message": "..." } ] }
+{ "errors": [ { "code": "...", "type": "...", "message": "..." } ] }
 ```
+
+Branch on **`type`** — it is always a stable symbolic slug. `code` is legacy: the HTTP status as a
+string on most doors, a slug on a few, frozen for backward compatibility. See
+[Error Responses](../api/index.md#error-responses) for the full type list.
 
 | Status | When |
 |:-------|:-----|


### PR DESCRIPTION
`errors[].code` was populated two different ways depending on which door answered — the HTTP status
as a string on ~85 doors, a Mountebank slug on five — so a client could neither parse it as a status
nor treat it as a symbolic identifier.

Every error in the Mountebank `errors` envelope now carries a **`type`** field that is always a
stable slug, and **`code` is frozen exactly as it is**:

```json
{"errors":[{"code":"503","type":"imposter disabled","message":"Imposter is disabled"}]}
```

## Why additive, and not Mountebank parity

The issue offered two resolutions; this is a third, and it dominates both.

`code`'s status form comes from **one helper** that knows only `(status, message)` — it has no idea
which door called it. So "slug in `code` everywhere" needs a door identity threaded through the call
sites *anyway*: the same per-door work, plus a break for every consumer. Additive `type` is
therefore not an alternative to parity — it is a **prerequisite**. A future major can set
`code = type` on top of this and be done.

The rejected third option ("status everywhere, slug into `type`") would have moved the four `inject`
doors *away* from the Mountebank-shaped values #355 built deliberately — discarding the one place
the envelope already matches Mountebank.

## Non-breakage is enforced, not claimed

`rift-conformance` pins these `code` values in a separate repo, so this is the load-bearing part.
A door-walk drives **eight doors** and asserts per door that `type` is the pinned slug **and** that
`code` is byte-identical to 0.14.0:

| Door | `code` (frozen) | `type` (new) |
|:-----|:----------------|:-------------|
| disabled imposter | `503` | `imposter disabled` |
| response `inject` error | `invalid injection` | `invalid injection` |
| predicate `inject` error | `invalid predicate injection` | *(same)* |
| script error | `500` | `script error` |
| over-size body | `413` | `request too large` |
| strictBehaviors decorate | `500` | `behavior error` |
| strictBehaviors shellTransform | `500` | `behavior error` |
| `defaultForward` upstream | `502` | `upstream failure` |

Plus unit coverage for the two inject-**timeout** doors and admin auth (all three are hand-written
literals, and their pre-existing tests asserted `code` only). **No pre-existing `code` assertion was
edited, weakened, or deleted.**

## Implementation

Two-tier, so ~85 call sites are untouched:

- a **pinned status→slug table** supplies the default (`400`→`bad data`, `404`→`no such resource`,
  `409`→`resource conflict`, …), itself pinned by a unit test — that table *is* the spec;
- a door whose slug must be more specific than its status names its own `ErrorKind`
  (`script error`, `script timeout`, `behavior error`, `imposter disabled`).

`code` is never affected by the kind, so naming one cannot change what an existing client reads —
asserted directly by `typed_body_overrides_type_but_never_code`.

Six slugs are Mountebank's own, read out of `src/util/errors.js` at the pinned 2.9.1 rather than
recalled: `bad data`, `invalid injection`, `resource conflict`, `insufficient access`,
`no such resource`, `unauthorized`. **This corrected the ratified design**, which merged 401 and 403
onto `insufficient access`; Mountebank has both, and rift's auth door already serves 401
`unauthorized`.

## Two pre-existing docs bugs fixed on the way

- `docs/api/index.md` documented `code` as slugs (`"bad data"`, `"no such resource"`,
  `"port conflict"`) that the code **has never emitted** — it emits `"400"`, `"404"`, `"409"`. The
  docs promised the slug convention all along; this change makes that promise true, under `type`.
  (`port conflict` was never a Mountebank slug either — `resource conflict` is.)
- The 409 example was paired with "port already in use", which is actually a **400**. 409 is the
  duplicate-stub-id door. Both are now documented correctly.

## Scope note

`extensions/decorate.rs::backend_error_response` serves a *different* envelope
(`{"error":"backendUnavailable","detail":…}`) with no `code` at all, and is reachable (backend
outage; matcher fall-through). It is deliberately **not** normalized here — that is a separate
breaking change. Review caught that my first draft of the docs over-claimed "every door"; the docs
now name this shape explicitly and tell clients to check for the `errors` key. Worth a follow-up
issue to unify.

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` → **0** · same with
`--no-default-features` → **0** · workspace tests green · `-p rift-mock-core
--no-default-features` **1144 pass / 0 fail**.

Review: 3 agents. The code reviewer verified the freeze invariant site-by-site and found no door
where `code` can change; its blocker (docs over-claim) and the test analyst's three coverage
blockers are all fixed in this branch.

Closes #797.
