### PR TITLE
fix(errors): serve the error envelope on the backend-unavailable door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The backend-error door now serves the standard error envelope.** An unavailable flow-store or
+  proxy store — and any matcher failure that is not an injection error — used to answer with only
+  its own pre-envelope shape (`{"error":"backendUnavailable","feature":…,"detail":…}`), with no
+  `errors` array and no `type`. A client that followed 0.15.0's guidance and switched to reading
+  `errors[0].type` got nothing here and silently fell through to its default error mapping. This is
+  not an embedder-only path: it is reached from eight scenario handlers and the recorded-requests
+  clear on the admin plane, several imposter-handler paths, and the matcher fall-through, so any
+  Redis-backed flow-store outage hit it.
+
+  It now serves the envelope with a dedicated `backend unavailable` slug (a generic `unavailable`
+  would not tell a backend outage apart from any other 503), carrying `feature` and `detail` inside
+  `errors[0]` so the *which backend failed* context stays machine-readable rather than flattened
+  into prose. (#800)
+
+  **Deprecation:** the **top-level** `error`/`feature`/`detail` keys are unchanged and still
+  served, so nothing breaks — but they are deprecated and will be **removed in 0.17.0** (#801).
+  Read `errors[0]` instead.
+
+
 ## [0.15.0] - 2026-07-21
 
 ### Added

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1455,6 +1455,9 @@ mod requests_filter_tests {
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
         assert_eq!(json["error"], "backendUnavailable");
+        // Issue #800: the admin plane serves the envelope on this door as well.
+        assert_eq!(json["errors"][0]["code"], "503");
+        assert_eq!(json["errors"][0]["type"], "backend unavailable");
         let _ = manager.delete_imposter(19742).await;
     }
 

--- a/crates/rift-mock-core/src/extensions/decorate.rs
+++ b/crates/rift-mock-core/src/extensions/decorate.rs
@@ -72,13 +72,31 @@ pub trait ResponseDecorator: Send + Sync {
 }
 
 /// Map a backend/handler error to its response: [`BackendUnavailable`] anywhere in the
-/// chain → `503 {"error":"backendUnavailable",...}`; anything else → `500
-/// {"error":"internalError",...}`. Never a silent fallback.
+/// chain → `503`; anything else → `500`. Never a silent fallback.
+///
+/// Serves **two shapes in one body** (issue #800). This door predates the #611/#797 envelope
+/// sweeps and was the last one still serving only its own `{"error":"backendUnavailable",…}`
+/// shape, so a client that followed #797's guidance and switched to reading `errors[0].type` got
+/// nothing here. It now carries the Mountebank envelope *as well*:
+///
+/// - `errors[0]` — the envelope, with the `type` slug new consumers branch on. `feature`/`detail`
+///   ride inside the error object rather than being flattened into `message`, because naming
+///   *which* backend failed is this door's whole purpose.
+/// - top-level `error`/`feature`/`detail` — the legacy 0.15.0 keys, **frozen**. Deprecated in
+///   0.16.0, removed in 0.17.0 by issue #801. They stay because `rift-enterprise` parses
+///   them today; dropping them here would break the distributed edition mid-bump.
 pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
     let (status, body) = match err.downcast_ref::<BackendUnavailable>() {
         Some(b) => (
             StatusCode::SERVICE_UNAVAILABLE,
             serde_json::json!({
+                "errors": [{
+                    "code": StatusCode::SERVICE_UNAVAILABLE.as_str(),
+                    "type": crate::response::ErrorKind::BackendUnavailable.slug(),
+                    "message": format!("{}: {}", b.feature, b.detail),
+                    "feature": b.feature,
+                    "detail": b.detail,
+                }],
                 "error": "backendUnavailable",
                 "feature": b.feature,
                 "detail": b.detail,
@@ -87,6 +105,11 @@ pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
         None => (
             StatusCode::INTERNAL_SERVER_ERROR,
             serde_json::json!({
+                "errors": [{
+                    "code": StatusCode::INTERNAL_SERVER_ERROR.as_str(),
+                    "type": crate::response::ErrorKind::InternalError.slug(),
+                    "message": format!("{err:#}"),
+                }],
                 "error": "internalError",
                 // "{err:#}" keeps the whole context chain — the outermost message alone
                 // rarely says why ("Redis GET failed" without the refused connection).
@@ -151,9 +174,33 @@ mod tests {
         assert_eq!(resp.status(), hyper::StatusCode::SERVICE_UNAVAILABLE);
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        // Legacy top-level keys (issue #800 AC2): byte-identical to 0.15.0. Deprecated in 0.16.0
+        // and removed in 0.17.0 — these three assertions are what the removal issue deletes, and
+        // until then they are what stops the deprecation window closing by accident.
         assert_eq!(json["error"], "backendUnavailable");
         assert_eq!(json["feature"], "flowState");
         assert_eq!(json["detail"], "redis connection refused");
+
+        // AC1: the door now also serves the Mountebank envelope with the #797 `type` slug.
+        assert_eq!(
+            json["errors"][0]["code"], "503",
+            "code is the status string, not a slug"
+        );
+        assert_eq!(
+            json["errors"][0]["type"], "backend unavailable",
+            "a dedicated slug — generic `unavailable` would not distinguish a backend outage \
+             from any other 503, which is the whole reason this door exists"
+        );
+        assert!(
+            json["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| !m.is_empty()),
+            "message must be non-empty, got: {json}"
+        );
+        // AC3: the structured split stays machine-readable inside the envelope — `feature` names
+        // WHICH backend failed, which is the door's entire value and must not be flattened away.
+        assert_eq!(json["errors"][0]["feature"], "flowState");
+        assert_eq!(json["errors"][0]["detail"], "redis connection refused");
     }
 
     #[tokio::test]
@@ -162,7 +209,45 @@ mod tests {
         assert_eq!(resp.status(), hyper::StatusCode::INTERNAL_SERVER_ERROR);
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        // Legacy key, frozen (AC2).
         assert_eq!(json["error"], "internalError");
+        // AC1: envelope on this branch too — a generic internal error is exactly what it is.
+        assert_eq!(json["errors"][0]["code"], "500");
+        assert_eq!(json["errors"][0]["type"], "internal error");
+        assert!(
+            json["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|m| !m.is_empty()),
+            "message must carry the context chain, got: {json}"
+        );
+        // The 500 branch has no feature/detail split to preserve — it must not invent one.
+        assert!(
+            json["errors"][0]["feature"].is_null() && json["errors"][0]["detail"].is_null(),
+            "the non-backend branch has neither `feature` nor `detail` inside the envelope, \
+             got: {json}"
+        );
+    }
+
+    // Drift tripwire, not an independent equivalence proof: both shapes are populated from the
+    // same `b.feature`/`b.detail` in one `json!` literal, so this passes trivially today. Its job
+    // is to fail the moment someone edits one shape and not the other — e.g. a fix applied only to
+    // the legacy keys — which is how the two would silently start describing different failures.
+    #[tokio::test]
+    async fn legacy_and_envelope_shapes_agree_on_the_same_error() {
+        let err = anyhow::Error::new(BackendUnavailable {
+            feature: "proxyStore",
+            detail: "connection reset".to_string(),
+        });
+        let resp = backend_error_response(&err);
+        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert_eq!(json["feature"], json["errors"][0]["feature"]);
+        assert_eq!(json["detail"], json["errors"][0]["detail"]);
+        let msg = json["errors"][0]["message"].as_str().expect("message");
+        assert!(
+            msg.contains("proxyStore") && msg.contains("connection reset"),
+            "message must carry both halves of the legacy split, got: {msg}"
+        );
     }
 
     // BackendUnavailable survives an anyhow context chain (backends wrap with .context()).

--- a/crates/rift-mock-core/src/imposter/tests.rs
+++ b/crates/rift-mock-core/src/imposter/tests.rs
@@ -3851,6 +3851,11 @@ mod backend_errors {
         let body: serde_json::Value = resp.json().await.expect("json");
         assert_eq!(body["error"], "backendUnavailable");
         assert_eq!(body["feature"], "flowState");
+        // Issue #800: a real request over the wire must carry the envelope too, not just the
+        // legacy keys — the unit tests exercise the mapper, this proves it survives serialization.
+        assert_eq!(body["errors"][0]["code"], "503");
+        assert_eq!(body["errors"][0]["type"], "backend unavailable");
+        assert_eq!(body["errors"][0]["feature"], "flowState");
 
         let calls = recorder.calls.lock().clone();
         assert_eq!(calls.len(), 1);

--- a/crates/rift-mock-core/src/response/mod.rs
+++ b/crates/rift-mock-core/src/response/mod.rs
@@ -44,6 +44,7 @@ pub enum ErrorKind {
     InvalidPredicateInjection,
     InjectionTimeout,
     PredicateInjectionTimeout,
+    BackendUnavailable,
     ScriptError,
     ScriptTimeout,
     BehaviorError,
@@ -61,7 +62,7 @@ impl ErrorKind {
     /// Every variant as of writing — keep in sync by hand when adding one. The exhaustive,
     /// wildcard-free match in [`slug`](Self::slug) is the half of the guard the compiler enforces;
     /// this array is what lets the shape test iterate them.
-    pub const ALL: [ErrorKind; 20] = [
+    pub const ALL: [ErrorKind; 21] = [
         ErrorKind::BadData,
         ErrorKind::InvalidInjection,
         ErrorKind::ResourceConflict,
@@ -71,6 +72,7 @@ impl ErrorKind {
         ErrorKind::InvalidPredicateInjection,
         ErrorKind::InjectionTimeout,
         ErrorKind::PredicateInjectionTimeout,
+        ErrorKind::BackendUnavailable,
         ErrorKind::ScriptError,
         ErrorKind::ScriptTimeout,
         ErrorKind::BehaviorError,
@@ -97,6 +99,7 @@ impl ErrorKind {
             ErrorKind::InvalidPredicateInjection => "invalid predicate injection",
             ErrorKind::InjectionTimeout => "injection timeout",
             ErrorKind::PredicateInjectionTimeout => "predicate injection timeout",
+            ErrorKind::BackendUnavailable => "backend unavailable",
             ErrorKind::ScriptError => "script error",
             ErrorKind::ScriptTimeout => "script timeout",
             ErrorKind::BehaviorError => "behavior error",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -697,15 +697,30 @@ port alike — carries three fields:
 { "errors": [ { "code": "...", "type": "...", "message": "..." } ] }
 ```
 
-**One shape is not in this family.** A backend outage (an unavailable flow-store or proxy store, and
-any matcher failure that is not an injection error) is reported as:
+**One door carries extra keys.** A backend outage (an unavailable flow-store or proxy store, and any
+matcher failure that is not an injection error) serves the envelope *plus* a legacy shape it
+predates:
 
 ```json
-{ "error": "backendUnavailable", "feature": "...", "detail": "..." }
+{
+  "errors": [{
+    "code": "503",
+    "type": "backend unavailable",
+    "message": "flowState: redis connection refused",
+    "feature": "flowState",
+    "detail": "redis connection refused"
+  }],
+  "error": "backendUnavailable",
+  "feature": "flowState",
+  "detail": "redis connection refused"
+}
 ```
 
-— a different envelope with no `errors` array and no `type`. Check for the `errors` key before
-indexing into it. Unifying the two is tracked separately.
+`feature` names *which* backend failed and `detail` gives the underlying cause; both are available
+inside `errors[0]`, so nothing needs the legacy keys.
+
+> **Deprecated:** the **top-level** `error`, `feature` and `detail` keys are retained unchanged for
+> backward compatibility and will be **removed in 0.17.0**. Read `errors[0]` instead.
 
 | Field | Read it? | What it is |
 |:------|:---------|:-----------|
@@ -735,6 +750,7 @@ The rest name doors Mountebank does not have:
 |:-------|:---------------|
 | `invalid predicate injection` | 400 |
 | `injection timeout` / `predicate injection timeout` | 504 |
+| `backend unavailable` | 503 |
 | `script error` / `script timeout` | 500 / 504 |
 | `behavior error` | 500 |
 | `imposter disabled` | 503 |

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -165,9 +165,28 @@ pub struct BackendUnavailable {
 }
 ```
 
-`backend_error_response(&anyhow::Error)` maps such an error to a structured
-`503 {"error":"backendUnavailable", ...}`; any other error maps to `500`. This is how a down remote
-store becomes a clean 503 to the API caller rather than a silent fallback.
+`backend_error_response(&anyhow::Error)` maps such an error to a structured `503`; any other error
+maps to `500`. This is how a down remote store becomes a clean 503 to the API caller rather than a
+silent fallback. The body carries the standard error envelope, with `feature` naming which backend
+failed:
+
+```json
+{
+  "errors": [{
+    "code": "503",
+    "type": "backend unavailable",
+    "message": "flowState: redis connection refused",
+    "feature": "flowState",
+    "detail": "redis connection refused"
+  }],
+  "error": "backendUnavailable",
+  "feature": "flowState",
+  "detail": "redis connection refused"
+}
+```
+
+> **Deprecated:** the **top-level** `error`/`feature`/`detail` keys are retained for backward
+> compatibility and will be **removed in 0.17.0** (#801). Read `errors[0]` instead.
 
 Per-request operational metadata travels through a tokio task-local annotation scope:
 `annotate(key: &'static str, value: String)` records a `(key, value)` that a `ResponseDecorator` later


### PR DESCRIPTION
The last door still serving only its own pre-envelope shape. Every other error carries the Mountebank
envelope with the `type` slug added in #797; this one returned
`{"error":"backendUnavailable","feature":…,"detail":…}` — no `errors` array, no `type` — so a client
that followed 0.15.0's documented guidance and switched to reading `errors[0].type` got nothing here
and silently fell through to its default error mapping.

It now serves **both shapes at once**:

```json
{
  "errors": [{
    "code": "503",
    "type": "backend unavailable",
    "message": "flowState: redis connection refused",
    "feature": "flowState",
    "detail": "redis connection refused"
  }],
  "error": "backendUnavailable",
  "feature": "flowState",
  "detail": "redis connection refused"
}
```

## Two of the issue's premises were wrong, and both changed the design

**"Only reachable with a custom injected backend."** It has **15 direct call sites** plus the
`From<ImposterError>` conversion: eight scenario handlers and the recorded-requests clear on the
admin plane, several imposter-handler paths, and the matcher fall-through — which under
`--no-default-features` catches *every* predicate-injection error, since the `PredicateInjectionError`
arm is `#[cfg(feature = "javascript")]`. Any Redis-backed flow-store outage served this shape from the
plain admin API, no embedding required.

**"Blast radius probably zero."** `achird-labs/rift-enterprise` (`crates/rift-ee/src/lib.rs`) parses
`backendUnavailable` **today** — found by code search, not assumed. A hard cut would break the
distributed edition mid-bump (rift-enterprise#22). So this is staged, not breaking.

## Design choices worth stating

- **A dedicated `backend unavailable` slug**, not the generic `unavailable` the issue proposed. This
  is the door consumers most need to *discriminate* — that is the issue's own argument for fixing it
  — and a generic slug would make a backend outage indistinguishable from any other 503.
- **`feature`/`detail` stay machine-readable inside `errors[0]`**, not flattened into `message`.
  Naming *which* backend failed is the door's entire value.
- **`code` is the status string** (`"503"`/`"500"`), not a slug. #797 froze slug-`code` as a closed
  legacy set of five; every door joining the envelope afterwards uses the status form.

## Non-breaking, and enforced as such

The top-level `error`/`feature`/`detail` keys are **byte-identical to 0.15.0**, deprecated in 0.16.0,
removed in 0.17.0 by **#801** (filed, so the window has an owner rather than closing by nobody).

The two pre-existing tests were **extended, never rewritten** — every original assertion survives.
Those legacy assertions are the mechanism that keeps the window open, and #801 lists them as the
things it must delete together.

## Coverage

| Layer | What it proves |
|---|---|
| `decorate.rs` unit ×3 | envelope + frozen legacy keys on both branches; 500 branch invents no `feature`/`detail` |
| `imposter/tests.rs` (extended) | a **real request over hyper** returns the envelope — survives serialization |
| `admin_api/handlers/imposters.rs` (extended) | the **admin plane** serves it too |

A drift tripwire (`legacy_and_envelope_shapes_agree_on_the_same_error`) fails the moment someone
edits one shape and not the other. Its comment says plainly that it is drift detection, not an
independent equivalence proof — both fields come from the same variable, so it passes trivially today.

## Docs

`docs/api/index.md` — the "one shape is not in this family" note added by #797 becomes the deprecation
note. `docs/embedding/spi.md` — the **embedder-facing** description of this exact function was stale
and had no deprecation notice; an embedder reading only it would have been stranded on the removed
keys in 0.17.0. CHANGELOG under `### Fixed`.

## Verification

`cargo fmt` · `clippy --workspace --all-targets -D warnings` → **0** · same with
`--no-default-features` → **0** · CI's exact split (`--lib`, then `--tests`, `--all-features`) → **0
failures**.

Review: 2 agents, **no blockers**. The code reviewer verified the freeze byte-for-byte against
`origin/master` and confirmed the reachability claim site-by-site; its two actionable non-blockers
(stale `spi.md`, unnumbered removal issue) and all three of the test analyst's are fixed here.

## Downstream

`rift-java#164` filed: `errors[0]` on this door carries two keys beyond the usual three, and a
Jackson typed decode rejects unknown properties by default. Not known to break — but this door never
produced an `errors` array before, so it is newly exercised. Marked *check*, not *required*.

Closes #800.
