### PR TITLE
docs: list rift-java as an available SDK on the docs site

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -78,6 +78,35 @@ await server.close();
 
 See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) for complete documentation.
 
+### Java / JVM
+
+For JVM projects, add the official [rift-java](https://github.com/achird-labs/rift-java) SDK to your
+test scope:
+
+```xml
+<dependency>
+  <groupId>io.github.achird-labs</groupId>
+  <artifactId>rift-java-core</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+Usage:
+
+```java
+try (Rift rift = Rift.embedded()) {                  // or Rift.connect(uri) / Rift.spawn()
+    Imposter users = rift.create(
+        imposter("users").stub(onGet("/api/users/1").willReturn(okJson("{\"id\":1}"))));
+    users.verify(onGet("/api/users/1"), times(1));
+}
+```
+
+`Rift.embedded()` runs the engine in-process over Panama FFM, so no separate binary or container is
+needed; `Rift.spawn()` manages a downloaded binary for you, and `Rift.connect(uri)` targets any
+running admin endpoint. See the
+[rift-java documentation](https://achird-labs.github.io/rift-java/) for the JUnit 5, Spring, and
+Testcontainers integrations.
+
 ---
 
 ## Verify Installation
@@ -178,6 +207,7 @@ Example `imposters.json`:
 
 - [Quick Start Tutorial]({{ site.baseurl }}/getting-started/quickstart/) - Detailed walkthrough
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
+- [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Predicates Guide]({{ site.baseurl }}/mountebank/predicates/) - Request matching
 - [Responses Guide]({{ site.baseurl }}/mountebank/responses/) - Response configuration
 - [Migration Guide]({{ site.baseurl }}/getting-started/migration/) - Switching from Mountebank

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,34 @@ await server.close();
 
 See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) for complete documentation.
 
+### Java / JVM Integration
+
+For JVM projects, use the official [rift-java](https://github.com/achird-labs/rift-java) SDK. It runs
+the engine three ways — embedded in-process (Panama FFM, no Docker), connected to any running admin
+endpoint, or as a managed spawned binary — with a fluent DSL plus JUnit 5, Spring, and Testcontainers
+integrations.
+
+```xml
+<dependency>
+  <groupId>io.github.achird-labs</groupId>
+  <artifactId>rift-java-core</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+```java
+try (Rift rift = Rift.embedded()) {                  // or Rift.connect(uri) / Rift.spawn()
+    Imposter users = rift.create(
+        imposter("users").stub(onGet("/api/users/1").willReturn(okJson("{\"id\":1}"))));
+    // point your system under test at users.uri(), then assert:
+    users.verify(onGet("/api/users/1"), times(1));
+}
+```
+
+See the [rift-java documentation](https://achird-labs.github.io/rift-java/) for the full feature
+surface, and the [BOM](https://github.com/achird-labs/rift-java/blob/master/rift-java-bom/README.md)
+for version-pinning every module at once.
+
 ---
 
 ## Documentation
@@ -130,6 +158,7 @@ See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) 
 - [Installation]({{ site.baseurl }}/getting-started/) - Docker, binary, and build from source
 - [Quick Start]({{ site.baseurl }}/getting-started/quickstart/) - Create your first imposter
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
+- [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Migration from Mountebank]({{ site.baseurl }}/getting-started/migration/) - Switch from Mountebank to Rift
 
 ### Concepts


### PR DESCRIPTION
## The gap

The README has had a Java/JVM section since the SDK shipped, but the **published docs site never gained one**. Both `docs/index.md` and `docs/getting-started/index.md` document the Node.js package and stop there — so a reader who lands on the site rather than the repo has no indication a JVM SDK exists.

| Page | Node.js | Java / JVM (before) |
|---|---|---|
| `docs/index.md` | "Node.js Integration" section + nav entry | — |
| `docs/getting-started/index.md` | "Node.js / npm" section + next-steps entry | — |

## What changed

Adds a Java/JVM section to both pages, mirroring the existing Node.js sections rather than inventing a new shape — same placement, same install-then-usage structure, same hand-off to the SDK's own documentation — plus a Java entry in each page's link list alongside Node.js.

The engine-side text is deliberately thin: the three run modes (embedded over Panama FFM, `connect`, `spawn`) and one worked example, then a link out. The JUnit 5 / Spring / Testcontainers detail lives in rift-java's own docs, and duplicating it here would just be a second copy to keep in sync.

## Sample correctness

Every symbol was verified against rift-java `master`, not copied on faith:

- `Rift.embedded()` / `Rift.connect(URI)` / `Rift.spawn()` — all exist
- `Imposter.uri()`, `Imposter.verify(RequestMatch, VerificationTimes)` — exist
- `imposter(String)`, `onGet(String)`, `okJson(String)`, `times(int)` — all real DSL entry points
- `StubSpec implements RequestMatch`, so `verify(onGet(...), times(1))` genuinely compiles

Docs-only; no code, config, or nav-structure changes.