### PR TITLE
server: RunningServer cannot be both awaited and shut down — no &self wait seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **`RunningServer::wait(&self)` — await the embedded server without consuming it** (issue #806).
+  `join(self)` and `shutdown(self)` both moved the server, so a host could await the server *or*
+  await its own shutdown signal, never race them: the arm that won a `select!` against `join` could
+  no longer reach `shutdown`. `wait` borrows instead, so the host owns the shutdown policy — it can
+  run its own teardown between the signal and the server stopping, and still surface an admin-plane
+  failure if the accept loop dies on its own first. `RunningAdminApi::wait(&self)` is the same seam
+  one layer down.
+
+  `RunningServer::shutdown` now takes `&self` (it was `self`), which also allows holding the server
+  in an `Arc` and stopping it from another task. Method-call syntax is unchanged, so existing
+  callers keep compiling. The accept loop's error goes to the first `wait`/`join` caller; later
+  calls return `Ok(())`, since `anyhow::Error` is not `Clone`.
+
 ### Fixed
 
 - **`examples/task-management-api.json` no longer ships two dead stubs.** The document loaded

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -103,7 +103,23 @@ impl AdminApiServer {
         let cancel = CancellationToken::new();
         let tracker = TaskTracker::new();
         let (loop_cancel, loop_tracker) = (cancel.clone(), tracker.clone());
+        // The accept loop's outcome is published to a slot rather than left solely in the
+        // JoinHandle, so `wait(&self)` can observe the exit without consuming the handle that
+        // `join(self)`/`shutdown(&self)` need (issue #806).
+        let done = CancellationToken::new();
+        let outcome: Arc<Mutex<Option<anyhow::Result<()>>>> = Arc::new(Mutex::new(None));
+        let (task_done, task_outcome) = (done.clone(), Arc::clone(&outcome));
+        let release_cancel = cancel.clone();
         let task = tokio::spawn(async move {
+            // Releasing waiters from a drop guard rather than the tail of this block covers every
+            // way the loop can end — normal return, panic unwind, and `shutdown`'s abort. Firing
+            // only on the normal path would leave `wait()` blocked forever on a panicking accept
+            // loop: precisely the death it exists to report (issue #806).
+            let _release = ReleaseWaiters {
+                done: task_done,
+                outcome: Arc::clone(&task_outcome),
+                shutdown_requested: release_cancel,
+            };
             let result = accept_loop(
                 listener,
                 self.manager,
@@ -121,7 +137,10 @@ impl AdminApiServer {
             if let Err(ref e) = result {
                 tracing::error!("Admin API server error: {e:#}");
             }
-            result
+            // Published before `_release` drops, so every released waiter sees the outcome.
+            *task_outcome
+                .lock()
+                .expect("admin API outcome mutex poisoned") = Some(result);
         });
 
         Ok(RunningAdminApi {
@@ -129,6 +148,8 @@ impl AdminApiServer {
             cancel,
             tracker,
             task: Mutex::new(Some(task)),
+            done,
+            outcome,
         })
     }
 
@@ -139,13 +160,50 @@ impl AdminApiServer {
     }
 }
 
+/// Releases `RunningAdminApi::wait` callers however the accept-loop task ends (issue #806).
+///
+/// A tail-of-the-block `cancel()` would be skipped by a panic unwind or a `shutdown` abort,
+/// stranding every waiter. Running it from `Drop` also lets an *unexpected* death be reported as
+/// an error instead of a silent `Ok`, which is the whole point of `wait` for an embedder.
+struct ReleaseWaiters {
+    done: CancellationToken,
+    outcome: Arc<Mutex<Option<anyhow::Result<()>>>>,
+    /// The server's own shutdown token: when it is set, the task ending is expected, so no
+    /// synthetic error is published.
+    shutdown_requested: CancellationToken,
+}
+
+impl Drop for ReleaseWaiters {
+    fn drop(&mut self) {
+        // Recover from a poisoned lock rather than panicking: this runs during unwind, where a
+        // second panic would abort the process.
+        let mut slot = self
+            .outcome
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if slot.is_none() && !self.shutdown_requested.is_cancelled() {
+            *slot = Some(Err(anyhow::anyhow!(
+                "admin API accept loop terminated unexpectedly"
+            )));
+        }
+        drop(slot);
+        self.done.cancel();
+    }
+}
+
 /// A bound, running admin API server (issue #342). Reports its listening address and offers a
 /// graceful shutdown that does not require dropping the runtime.
 pub struct RunningAdminApi {
     local_addr: SocketAddr,
     cancel: CancellationToken,
     tracker: TaskTracker,
-    task: Mutex<Option<JoinHandle<anyhow::Result<()>>>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+    /// Fired once the accept loop has exited and its outcome is published — the signal
+    /// `wait(&self)` observes without touching `task` (issue #806).
+    done: CancellationToken,
+    /// The accept loop's result, delivered exactly once: the first caller of `wait`/`join` takes
+    /// it, later callers get `Ok(())`. `anyhow::Error` is not `Clone`, so it cannot be shared.
+    outcome: Arc<Mutex<Option<anyhow::Result<()>>>>,
 }
 
 impl RunningAdminApi {
@@ -179,17 +237,45 @@ impl RunningAdminApi {
                 "Admin API shutdown: in-flight connections did not drain within the grace period"
             );
         }
+
+        // Release any `wait(&self)` unconditionally. The abort above can kill the task before it
+        // publishes its outcome, which would otherwise strand every waiter forever (issue #806).
+        self.done.cancel();
     }
 
     /// Run until the accept loop exits (returns immediately if already shut down).
+    ///
+    /// Shares the exactly-once error delivery described on [`wait`](Self::wait): if a `wait` caller
+    /// already took the accept loop's error, `join` returns `Ok(())`.
     pub async fn join(self) -> anyhow::Result<()> {
         match take_task(&self.task) {
             Some(task) => match task.await {
-                Ok(result) => result,
+                Ok(()) => self.take_outcome(),
                 Err(join_err) => Err(anyhow::anyhow!("admin API task failed: {join_err}")),
             },
-            None => Ok(()),
+            None => self.take_outcome(),
         }
+    }
+
+    /// Wait for the accept loop to exit **without consuming the handle** — so a caller can race
+    /// "serve until the admin plane dies" against its own shutdown signal and still call
+    /// [`shutdown`](Self::shutdown) afterwards (issue #806).
+    ///
+    /// The accept loop's error is delivered to the **first** caller only; subsequent calls (and
+    /// calls after a `shutdown` that aborted the task) return `Ok(())`.
+    pub async fn wait(&self) -> anyhow::Result<()> {
+        self.done.cancelled().await;
+        self.take_outcome()
+    }
+
+    /// Take the published accept-loop result. `Ok(())` when it was already taken or when the task
+    /// was aborted before publishing.
+    fn take_outcome(&self) -> anyhow::Result<()> {
+        self.outcome
+            .lock()
+            .expect("admin API outcome mutex poisoned")
+            .take()
+            .unwrap_or(Ok(()))
     }
 }
 
@@ -466,5 +552,111 @@ mod tests {
         // Two empty strings are trivially equal — no key configured is handled
         // by the `Some(key)` guard at the call site, not here.
         assert!(api_key_matches("", ""));
+    }
+}
+
+/// Issue #806: white-box tests for the `wait` seam's failure interleavings. These construct a
+/// `RunningAdminApi` around a stand-in task rather than a real accept loop, because the paths that
+/// matter — an abort before the outcome is published, a panicking loop, and the exactly-once error
+/// hand-off — cannot be provoked through the public bind/shutdown API (a healthy loop always exits
+/// well inside the shutdown grace).
+#[cfg(test)]
+mod wait_seam_tests {
+    use super::*;
+
+    /// A `RunningAdminApi` whose "accept loop" is `task`, wired to the same release guard the real
+    /// one uses so the drop-path behaviour under test is the shipped behaviour.
+    fn running_with_task<F>(loop_body: F) -> RunningAdminApi
+    where
+        F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let cancel = CancellationToken::new();
+        let done = CancellationToken::new();
+        let outcome: Arc<Mutex<Option<anyhow::Result<()>>>> = Arc::new(Mutex::new(None));
+        let (task_done, task_outcome) = (done.clone(), Arc::clone(&outcome));
+        let release_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let _release = ReleaseWaiters {
+                done: task_done,
+                outcome: Arc::clone(&task_outcome),
+                shutdown_requested: release_cancel,
+            };
+            let result = loop_body.await;
+            *task_outcome
+                .lock()
+                .expect("admin API outcome mutex poisoned") = Some(result);
+        });
+
+        RunningAdminApi {
+            local_addr: "127.0.0.1:0".parse().expect("test addr"),
+            cancel,
+            tracker: TaskTracker::new(),
+            task: Mutex::new(Some(task)),
+            done,
+            outcome,
+        }
+    }
+
+    /// `shutdown` aborts a loop that outlives the grace window, so the task never publishes an
+    /// outcome. Waiters must still be released — this is the interleaving the release guard and
+    /// `shutdown`'s unconditional cancel both exist to cover.
+    #[tokio::test]
+    async fn wait_is_released_when_shutdown_aborts_an_unresponsive_loop() {
+        let running = running_with_task(async {
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), running.shutdown())
+            .await
+            .expect("shutdown gives up on the wedged loop within its grace bound");
+
+        let waited = tokio::time::timeout(Duration::from_secs(2), running.wait())
+            .await
+            .expect("an aborted loop must not strand waiters");
+        assert!(
+            waited.is_ok(),
+            "an abort during a requested shutdown is not an error"
+        );
+    }
+
+    /// A panicking accept loop is the death `wait` exists to report. It must resolve — and as an
+    /// error, not a silent `Ok`, since no shutdown was requested.
+    #[tokio::test]
+    async fn wait_reports_a_panicking_loop_instead_of_hanging() {
+        let running = running_with_task(async { panic!("accept loop exploded") });
+
+        let waited = tokio::time::timeout(Duration::from_secs(2), running.wait())
+            .await
+            .expect("a panicking loop must release waiters");
+        let err = waited.expect_err("an unrequested death is an error");
+        assert!(
+            err.to_string().contains("terminated unexpectedly"),
+            "error should name the unexpected termination, got: {err}"
+        );
+    }
+
+    /// The documented exactly-once contract: the accept loop's error goes to the first caller, and
+    /// later callers get `Ok(())` rather than a duplicate or a hang.
+    #[tokio::test]
+    async fn accept_loop_error_is_delivered_exactly_once() {
+        let running = running_with_task(async { Err(anyhow::anyhow!("listener died")) });
+
+        let first = tokio::time::timeout(Duration::from_secs(2), running.wait())
+            .await
+            .expect("wait resolves once the loop has returned");
+        let err = first.expect_err("the first caller receives the accept loop's error");
+        assert!(
+            err.to_string().contains("listener died"),
+            "the real error must survive, got: {err}"
+        );
+
+        let second = tokio::time::timeout(Duration::from_secs(2), running.wait())
+            .await
+            .expect("a second wait returns immediately");
+        assert!(
+            second.is_ok(),
+            "the error is delivered once; later callers get Ok"
+        );
     }
 }

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -556,12 +556,38 @@ impl RunningServer {
         self.admin.join().await
     }
 
+    /// Run until the admin API accept loop exits, **without consuming the server** (issue #806).
+    ///
+    /// This is the seam for an embedder that must race the server against its own shutdown signal:
+    /// `join` moves the server, so the signal arm could no longer reach `shutdown`.
+    ///
+    /// ```no_run
+    /// # async fn example(server: rift_http_proxy::server::RunningServer) -> anyhow::Result<()> {
+    /// # async fn termination_signal() {}
+    /// tokio::select! {
+    ///     result = server.wait() => return result,   // the admin plane died — surface it
+    ///     () = termination_signal() => {}
+    /// }
+    /// server.shutdown().await;                      // still owned, still shutdownable
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The accept loop's error is delivered to the first caller only; later calls return `Ok(())`.
+    /// Like `join`, this tracks the admin plane — the metrics server keeps serving in background.
+    pub async fn wait(&self) -> anyhow::Result<()> {
+        self.admin.wait().await
+    }
+
     /// Stop accepting on all listeners, giving in-flight connections a bounded grace. Stops
     /// whatever intercept listener is running at shutdown time, including one started over the API
     /// after this server was bound.
-    pub async fn shutdown(self) {
+    ///
+    /// Takes `&self` (issue #806) so it composes with [`wait`](Self::wait) and can be called
+    /// through a shared handle; every underlying shutdown is already idempotent.
+    pub async fn shutdown(&self) {
         self.admin.shutdown().await;
-        if let Some(metrics) = self.metrics {
+        if let Some(metrics) = &self.metrics {
             metrics.shutdown().await;
         }
         self.intercept.stop().await;

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -518,3 +518,181 @@ async fn server_builder_start_survives_metrics_bind_failure() {
         .await
         .expect("shutdown handles the None metrics branch");
 }
+
+// Issue #806: `join`/`shutdown` both consumed `self`, so an embedder could await the server OR
+// await a shutdown signal, never race them. `wait(&self)` is the seam; these cover both arms of
+// that race plus the abort path, which is what makes the seam safe rather than merely present.
+
+// AC1: wait() returns once the server is shut down from a *different* task — the borrow, not the
+// value, is what wait() holds, so the shutdown side is still reachable while wait() is in flight.
+#[tokio::test]
+async fn running_server_wait_completes_when_shutdown_from_another_task() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+    let running = Arc::new(
+        ServerBuilder::from_cli(cli)
+            .start()
+            .await
+            .expect("start returns once bound"),
+    );
+    wait_for_http(&format!("http://{}/health", running.admin_addr())).await;
+
+    let stopper = Arc::clone(&running);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        stopper.shutdown().await;
+    });
+
+    let waited = tokio::time::timeout(Duration::from_secs(5), running.wait())
+        .await
+        .expect("wait returns once the admin accept loop exits");
+    assert!(waited.is_ok(), "a shutdown-driven exit is not an error");
+}
+
+// AC2: the rift-enterprise pattern — race wait() against a termination signal. The signal wins,
+// and the arm that wins can still call shutdown(): proof the select! borrow has ended.
+#[tokio::test]
+async fn running_server_wait_loses_race_to_signal_then_shuts_down() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+    let running = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("start returns once bound");
+    let addr = running.admin_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = signal_tx.send(());
+    });
+
+    let admin_died = tokio::select! {
+        result = running.wait() => Some(result),
+        _ = signal_rx => None,
+    };
+    assert!(
+        admin_died.is_none(),
+        "the signal must win this race; the admin plane was healthy"
+    );
+
+    // The whole point of the issue: after racing wait(), the server is still owned and shutdownable.
+    tokio::time::timeout(Duration::from_secs(5), running.shutdown())
+        .await
+        .expect("shutdown is still callable after wait() was raced");
+    assert!(
+        connect_refused(addr).await,
+        "after shutdown the admin port must refuse connections"
+    );
+}
+
+// AC3: the other arm of the same race — the admin plane exits first, so wait() wins and the
+// embedder learns the server is gone instead of hanging on a signal that never comes.
+#[tokio::test]
+async fn running_server_wait_wins_race_when_admin_plane_exits() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+    let running = Arc::new(
+        ServerBuilder::from_cli(cli)
+            .start()
+            .await
+            .expect("start returns once bound"),
+    );
+    wait_for_http(&format!("http://{}/health", running.admin_addr())).await;
+
+    let stopper = Arc::clone(&running);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        stopper.shutdown().await;
+    });
+
+    // A signal that never fires: only the admin plane's exit can resolve this select.
+    let (_signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+    let admin_result = tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = running.wait() => Some(result),
+            _ = signal_rx => None,
+        }
+    })
+    .await
+    .expect("the admin-plane arm must resolve the race");
+    assert!(
+        admin_result.is_some_and(|r| r.is_ok()),
+        "wait() wins the race and reports the accept loop's outcome"
+    );
+}
+
+// AC4: wait() is safe to call after the server has already stopped — it returns immediately rather
+// than blocking on a task that will never complete. (The abort-on-grace-timeout and panicking-loop
+// interleavings need a wedged loop, so they live in the white-box `wait_seam_tests` module beside
+// the implementation.)
+#[tokio::test]
+async fn running_server_wait_after_shutdown_returns_immediately() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+    let running = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("start returns once bound");
+    wait_for_http(&format!("http://{}/health", running.admin_addr())).await;
+
+    running.shutdown().await;
+
+    for _ in 0..2 {
+        let waited = tokio::time::timeout(Duration::from_secs(2), running.wait())
+            .await
+            .expect("wait after shutdown returns immediately");
+        assert!(waited.is_ok(), "a post-shutdown wait reports Ok");
+    }
+}
+
+// AC5: the same seam one layer down, where the accept loop actually lives.
+#[tokio::test]
+async fn admin_wait_returns_after_shutdown() {
+    let manager = Arc::new(ImposterManager::new());
+    let running = AdminApiServer::new("127.0.0.1:0".parse().unwrap(), manager, None)
+        .bind()
+        .await
+        .expect("bind admin on :0");
+    let addr = running.local_addr();
+    wait_for_http(&format!("http://{addr}/health")).await;
+
+    running.shutdown().await;
+    let waited = tokio::time::timeout(Duration::from_secs(2), running.wait())
+        .await
+        .expect("admin wait returns after the accept loop exits");
+    assert!(waited.is_ok(), "wait reports the accept loop's Ok result");
+}

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -41,8 +41,9 @@ Returned by `start()`; lets the host discover bound addresses and control lifecy
 |:-------|:----------|:--------|
 | `admin_addr` | `fn admin_addr(&self) -> SocketAddr` | The bound admin API address (resolve an ephemeral `:0` to the real port). |
 | `metrics_addr` | `fn metrics_addr(&self) -> Option<SocketAddr>` | The bound metrics address, or `None` if metrics weren't started. |
-| `join` | `async fn join(self) -> anyhow::Result<()>` | Await the server until it exits. |
-| `shutdown` | `async fn shutdown(self)` | Trigger a graceful shutdown. |
+| `join` | `async fn join(self) -> anyhow::Result<()>` | Await the server until it exits, consuming it. |
+| `wait` | `async fn wait(&self) -> anyhow::Result<()>` | Await the server until it exits **without consuming it** — so you can race it against your own shutdown signal. |
+| `shutdown` | `async fn shutdown(&self)` | Trigger a graceful shutdown. |
 
 ```rust
 use rift_http_proxy::{ServerBuilder, Cli};
@@ -53,6 +54,26 @@ println!("admin listening on {}", server.admin_addr());
 // ... run your test suite against server.admin_addr() ...
 server.shutdown().await;
 ```
+
+#### Racing the server against a shutdown signal
+
+`join` moves the server, so a `select!` arm that wins against it can no longer reach `shutdown`.
+`wait` borrows instead, which is what lets a host own the shutdown policy — run its own teardown
+between the signal and the server stopping, and still surface an admin-plane failure if the server
+dies on its own first:
+
+```rust
+tokio::select! {
+    result = server.wait() => return result,   // the admin plane exited — surface why
+    () = termination_signal() => {}            // asked to stop — fall through
+}
+// your own teardown here (drain a cluster, deregister from a load balancer, ...)
+server.shutdown().await;
+```
+
+The accept loop's error is delivered to the **first** caller of `wait`/`join`; later calls return
+`Ok(())` (`anyhow::Error` is not `Clone`). `shutdown` takes `&self`, so the server can also be held
+in an `Arc` and stopped from another task.
 
 ### Injecting a custom `ImposterManager`
 
@@ -108,7 +129,8 @@ println!("admin bound to {}", running.local_addr());
 | `with_allow_injection` | `fn with_allow_injection(self, allow: bool) -> Self` | Enable JavaScript `inject` responses. |
 | `bind` | `async fn bind(self) -> anyhow::Result<RunningAdminApi>` | Bind and start serving; returns once bound. |
 
-`RunningAdminApi`: `local_addr(&self) -> SocketAddr`, `shutdown(&self)`, `join(self) -> anyhow::Result<()>`.
+`RunningAdminApi`: `local_addr(&self) -> SocketAddr`, `shutdown(&self)`, `join(self) -> anyhow::Result<()>`,
+`wait(&self) -> anyhow::Result<()>` (the non-consuming form of `join`, as above).
 
 `ConfigSource` (from `rift-http-proxy`) is either `File { path, no_parse }` (a single `--configfile`,
 with optional EJS preprocessing) or `Dir(PathBuf)` (a `--datadir` of one-imposter-per-file configs).


### PR DESCRIPTION
`RunningServer::join(self)` and `shutdown(self)` both consumed the server, making it impossible for an embedder to race the server task against its own shutdown signal—the winning `select!` arm could not reach the other method. This seam adds `wait(&self)`, which borrows instead, so the host controls shutdown policy and can orchestrate graceful teardown.

`shutdown(&self)` now also borrows, enabling Arc-shared servers. Waiters are released from a drop guard, so a panicking accept loop reports the failure immediately rather than blocking `wait` forever.

Docs updated in `docs/embedding/server.md` with a race example.

Closes #806

Milestone: none (standalone)