### PR TITLE
server: no bootstrap seam — --rcfile, stop, restart, save live in binary private main.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **`rift_http_proxy::bootstrap` — the rcfile/stop/save helpers are now a public seam** (issue #807).
+  Issue #317 moved server composition into the library, but three bootstrap concerns stayed private
+  in the `rift` binary's `main.rs`: `apply_rcfile_defaults`, `stop_server`, and `save_imposters`. An
+  alternative binary built on this crate therefore could not support `--rcfile` or the
+  `stop`/`restart`/`save` subcommands without copy-pasting them — forking behaviour meant to stay
+  identical across binaries (the "an explicit flag always beats the rcfile" rule is exactly the kind
+  of contract that rots when duplicated).
+
+  They are now public, unchanged, with `main.rs` as a thin caller. Two signature adjustments came
+  with the move: paths are `&Path` rather than `&PathBuf`, and `save_imposters` takes `(host, port)`
+  instead of the whole `Cli` — the only two fields it ever read. `restart` needs no new seam; it is
+  `stop_server(pidfile)?` followed by the normal start path.
+
 ### Fixed
 
 - **`examples/task-management-api.json` no longer ships two dead stubs.** The document loaded

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -1,0 +1,142 @@
+//! Bootstrap concerns shared between the `rift` binary and alternative binaries (issue #807).
+//!
+//! `--rcfile` defaults, `stop`/`restart` PID-file handling, and `--save` were originally private
+//! functions in the `rift` binary's `main.rs`. That made them unreachable from an alternative
+//! binary composed on top of this crate (e.g. rift-enterprise's `rift-ee-server`), which could
+//! only get the same behaviour by copy-pasting the functions — a fork of behaviour that is meant
+//! to stay identical across binaries. Promoting them here, unchanged, gives every binary a single
+//! shared implementation instead.
+
+use crate::admin_api::DEFAULT_ADMIN_PORT;
+use crate::server::Cli;
+use std::path::Path;
+use tracing::{info, warn};
+
+/// Apply defaults from a Mountebank-compatible rcfile (JSON) to the CLI struct.
+///
+/// Only sets fields that are still at their clap defaults (i.e., not explicitly supplied
+/// on the command line). Only a subset of keys is supported; unrecognised keys are warned.
+pub fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> Result<(), anyhow::Error> {
+    let raw = std::fs::read_to_string(rcfile)?;
+    let obj: serde_json::Value = serde_json::from_str(&raw)?;
+    let map = obj
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("rcfile must be a JSON object"))?;
+
+    for (key, val) in map {
+        match key.as_str() {
+            "port" => {
+                if cli.port == DEFAULT_ADMIN_PORT
+                    && let Some(p) = val.as_u64()
+                {
+                    cli.port = p as u16;
+                }
+            }
+            "host" => {
+                if cli.host == "0.0.0.0"
+                    && let Some(h) = val.as_str()
+                {
+                    cli.host = h.to_string();
+                }
+            }
+            "logLevel" | "loglevel" => {
+                if cli.loglevel == "info"
+                    && let Some(l) = val.as_str()
+                {
+                    cli.loglevel = l.to_string();
+                }
+            }
+            "allowInjection" | "allow_injection" => {
+                if !cli.allow_injection {
+                    cli.allow_injection = val.as_bool().unwrap_or(false);
+                }
+            }
+            "localOnly" | "local_only" => {
+                if !cli.local_only {
+                    cli.local_only = val.as_bool().unwrap_or(false);
+                }
+            }
+            "datadir" => {
+                if cli.datadir.is_none()
+                    && let Some(d) = val.as_str()
+                {
+                    cli.datadir = Some(std::path::PathBuf::from(d));
+                }
+            }
+            "configfile" => {
+                if cli.configfile.is_none()
+                    && let Some(f) = val.as_str()
+                {
+                    cli.configfile = Some(std::path::PathBuf::from(f));
+                }
+            }
+            other => {
+                warn!("--rcfile: unsupported key '{}' (ignored)", other);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Stop a running server by PID file.
+pub fn stop_server(pidfile: &Path) -> Result<(), anyhow::Error> {
+    if !pidfile.exists() {
+        return Err(anyhow::anyhow!("PID file not found: {pidfile:?}"));
+    }
+
+    let pid_str = std::fs::read_to_string(pidfile)?;
+    let pid: i32 = pid_str.trim().parse()?;
+
+    info!("Stopping server with PID {}", pid);
+
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+
+    #[cfg(windows)]
+    {
+        // On Windows, use taskkill
+        std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/F"])
+            .status()?;
+    }
+
+    // Remove PID file
+    std::fs::remove_file(pidfile)?;
+
+    Ok(())
+}
+
+/// Save imposters to a file.
+///
+/// Fetches the replayable imposter config from the admin API at `host:port` and writes it to
+/// `savefile`. Builds its own tokio runtime and blocks on it, exactly like the CLI's `save`
+/// subcommand does today — so this must **not** be called from inside an already-running async
+/// runtime (it will panic trying to start a nested one). Call it from sync context, or via
+/// `tokio::task::spawn_blocking` if the caller is itself async.
+pub fn save_imposters(
+    host: &str,
+    port: u16,
+    savefile: &Path,
+    remove_proxies: bool,
+) -> Result<(), anyhow::Error> {
+    let runtime = tokio::runtime::Runtime::new()?;
+
+    runtime.block_on(async {
+        let client = reqwest::Client::new();
+        let mut query = "replayable=true".to_string();
+        if remove_proxies {
+            query.push_str("&removeProxies=true");
+        }
+        let url = format!("http://{host}:{port}/imposters?{query}");
+
+        let response = client.get(&url).send().await?;
+        let content = response.text().await?;
+
+        std::fs::write(savefile, &content)?;
+        info!("Saved imposters to {:?}", savefile);
+
+        Ok(())
+    })
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -48,6 +48,9 @@ pub mod gateway;
 // CLI surface + ServerBuilder + metrics server; the `rift` binary is a thin caller
 pub mod server;
 
+// rcfile/stop/save bootstrap helpers shared with alternative binaries (issue #807)
+pub mod bootstrap;
+
 /// Opt-in per-core runtime topology for the server binary (RFC-712, issue #744).
 pub mod runtime;
 

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -42,12 +42,11 @@ const ACTIVE_ALLOCATOR: &str = "jemalloc";
 const ACTIVE_ALLOCATOR: &str = "system";
 
 use clap::Parser;
-use rift_http_proxy::admin_api::DEFAULT_ADMIN_PORT;
+use rift_http_proxy::bootstrap::{apply_rcfile_defaults, save_imposters, stop_server};
 use rift_http_proxy::healthcheck;
 use rift_http_proxy::runtime;
 use rift_http_proxy::script_cli;
 use rift_http_proxy::server::{Cli, Commands, ServerBuilder};
-use std::path::PathBuf;
 use tracing::{info, warn};
 use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
 
@@ -141,7 +140,7 @@ fn main() -> Result<(), anyhow::Error> {
             savefile,
             remove_proxies,
         }) => {
-            return save_imposters(&cli, savefile, *remove_proxies);
+            return save_imposters(&cli.host, cli.port, savefile, *remove_proxies);
         }
         Some(Commands::Replay { configfile }) => {
             // Load the config file and start
@@ -231,125 +230,4 @@ fn run_mountebank_mode(cli: Cli) -> Result<(), anyhow::Error> {
             result
         }
     }
-}
-
-/// Stop a running server by PID file
-fn stop_server(pidfile: &PathBuf) -> Result<(), anyhow::Error> {
-    if !pidfile.exists() {
-        return Err(anyhow::anyhow!("PID file not found: {pidfile:?}"));
-    }
-
-    let pid_str = std::fs::read_to_string(pidfile)?;
-    let pid: i32 = pid_str.trim().parse()?;
-
-    info!("Stopping server with PID {}", pid);
-
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid, libc::SIGTERM);
-    }
-
-    #[cfg(windows)]
-    {
-        // On Windows, use taskkill
-        std::process::Command::new("taskkill")
-            .args(["/PID", &pid.to_string(), "/F"])
-            .status()?;
-    }
-
-    // Remove PID file
-    std::fs::remove_file(pidfile)?;
-
-    Ok(())
-}
-
-/// Apply defaults from a Mountebank-compatible rcfile (JSON) to the CLI struct.
-/// Only sets fields that are still at their clap defaults (i.e., not explicitly supplied
-/// on the command line). Only a subset of keys is supported; unrecognised keys are warned.
-fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &std::path::Path) -> Result<(), anyhow::Error> {
-    let raw = std::fs::read_to_string(rcfile)?;
-    let obj: serde_json::Value = serde_json::from_str(&raw)?;
-    let map = obj
-        .as_object()
-        .ok_or_else(|| anyhow::anyhow!("rcfile must be a JSON object"))?;
-
-    for (key, val) in map {
-        match key.as_str() {
-            "port" => {
-                if cli.port == DEFAULT_ADMIN_PORT
-                    && let Some(p) = val.as_u64()
-                {
-                    cli.port = p as u16;
-                }
-            }
-            "host" => {
-                if cli.host == "0.0.0.0"
-                    && let Some(h) = val.as_str()
-                {
-                    cli.host = h.to_string();
-                }
-            }
-            "logLevel" | "loglevel" => {
-                if cli.loglevel == "info"
-                    && let Some(l) = val.as_str()
-                {
-                    cli.loglevel = l.to_string();
-                }
-            }
-            "allowInjection" | "allow_injection" => {
-                if !cli.allow_injection {
-                    cli.allow_injection = val.as_bool().unwrap_or(false);
-                }
-            }
-            "localOnly" | "local_only" => {
-                if !cli.local_only {
-                    cli.local_only = val.as_bool().unwrap_or(false);
-                }
-            }
-            "datadir" => {
-                if cli.datadir.is_none()
-                    && let Some(d) = val.as_str()
-                {
-                    cli.datadir = Some(std::path::PathBuf::from(d));
-                }
-            }
-            "configfile" => {
-                if cli.configfile.is_none()
-                    && let Some(f) = val.as_str()
-                {
-                    cli.configfile = Some(std::path::PathBuf::from(f));
-                }
-            }
-            other => {
-                warn!("--rcfile: unsupported key '{}' (ignored)", other);
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Save imposters to a file
-fn save_imposters(
-    cli: &Cli,
-    savefile: &PathBuf,
-    remove_proxies: bool,
-) -> Result<(), anyhow::Error> {
-    let runtime = tokio::runtime::Runtime::new()?;
-
-    runtime.block_on(async {
-        let client = reqwest::Client::new();
-        let mut query = "replayable=true".to_string();
-        if remove_proxies {
-            query.push_str("&removeProxies=true");
-        }
-        let url = format!("http://{}:{}/imposters?{}", cli.host, cli.port, query);
-
-        let response = client.get(&url).send().await?;
-        let content = response.text().await?;
-
-        std::fs::write(savefile, &content)?;
-        info!("Saved imposters to {:?}", savefile);
-
-        Ok(())
-    })
 }

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -1,0 +1,205 @@
+//! Issue #807: `--rcfile`, `stop`, `restart` and `save` were private functions in the `rift`
+//! binary's `main.rs`, so an alternative binary (rift-enterprise's `rift-ee-server`) could only
+//! reach them by copy-paste — forking behaviour that is meant to stay shared.
+//!
+//! This suite is deliberately an *integration* test: it compiles as an external crate, so it fails
+//! to build if the seam is not genuinely public. That is the property the issue is about.
+
+use clap::Parser;
+use rift_http_proxy::bootstrap;
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use std::sync::Arc;
+
+fn cli(args: &[&str]) -> Cli {
+    let mut argv = vec!["rift"];
+    argv.extend_from_slice(args);
+    Cli::try_parse_from(argv).expect("cli parse")
+}
+
+fn write_rcfile(dir: &tempfile::TempDir, body: &str) -> std::path::PathBuf {
+    let path = dir.path().join("rift.rc");
+    std::fs::write(&path, body).expect("write rcfile");
+    path
+}
+
+// AC1: an rcfile fills only the fields still at their clap defaults.
+#[test]
+fn rcfile_fills_fields_left_at_defaults() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rcfile = write_rcfile(
+        &dir,
+        r#"{"port": 4321, "host": "127.0.0.1", "logLevel": "debug",
+            "allowInjection": true, "localOnly": true,
+            "datadir": "/tmp/rc-datadir", "configfile": "/tmp/rc-config.json"}"#,
+    );
+
+    let mut parsed = cli(&[]);
+    bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile).expect("rcfile applies");
+
+    assert_eq!(parsed.port, 4321);
+    assert_eq!(parsed.host, "127.0.0.1");
+    assert_eq!(parsed.loglevel, "debug");
+    assert!(parsed.allow_injection);
+    assert!(parsed.local_only);
+    assert_eq!(
+        parsed.datadir.as_deref(),
+        Some(std::path::Path::new("/tmp/rc-datadir"))
+    );
+    assert_eq!(
+        parsed.configfile.as_deref(),
+        Some(std::path::Path::new("/tmp/rc-config.json"))
+    );
+}
+
+// AC2: an explicitly-supplied flag always beats the rcfile — the rule that would silently rot if a
+// downstream binary reimplemented this by hand.
+#[test]
+fn rcfile_never_overrides_an_explicit_flag() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rcfile = write_rcfile(&dir, r#"{"port": 4321, "host": "10.0.0.1"}"#);
+
+    let mut parsed = cli(&["--port", "9999", "--host", "192.168.0.1"]);
+    bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile).expect("rcfile applies");
+
+    assert_eq!(
+        parsed.port, 9999,
+        "explicit --port must win over the rcfile"
+    );
+    assert_eq!(
+        parsed.host, "192.168.0.1",
+        "explicit --host must win over the rcfile"
+    );
+}
+
+// AC3: an unrecognised key is ignored (warned), not fatal — and the recognised keys beside it
+// still apply.
+#[test]
+fn rcfile_unknown_key_is_ignored_without_dropping_the_rest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rcfile = write_rcfile(&dir, r#"{"nopeNotAKey": 1, "port": 4321}"#);
+
+    let mut parsed = cli(&[]);
+    bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile).expect("unknown keys are not fatal");
+    assert_eq!(parsed.port, 4321);
+}
+
+// AC4: a structurally wrong rcfile is an error, not a silent no-op.
+#[test]
+fn rcfile_non_object_is_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rcfile = write_rcfile(&dir, r#"["not", "an", "object"]"#);
+
+    let mut parsed = cli(&[]);
+    let err = bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile)
+        .expect_err("a non-object rcfile must be rejected");
+    assert!(
+        err.to_string().contains("object"),
+        "the error should name the expected shape, got: {err}"
+    );
+}
+
+#[test]
+fn rcfile_missing_file_is_an_error() {
+    let mut parsed = cli(&[]);
+    let err = bootstrap::apply_rcfile_defaults(&mut parsed, std::path::Path::new("/nope/rift.rc"))
+        .expect_err("a missing rcfile must be reported");
+    assert!(!err.to_string().is_empty());
+}
+
+// AC5: stop_server reports a missing pidfile rather than exiting successfully.
+#[test]
+fn stop_server_missing_pidfile_is_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = bootstrap::stop_server(&dir.path().join("absent.pid"))
+        .expect_err("a missing pidfile must be an error");
+    assert!(err.to_string().contains("PID file not found"), "got: {err}");
+}
+
+#[test]
+fn stop_server_unparseable_pid_is_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pidfile = dir.path().join("garbage.pid");
+    std::fs::write(&pidfile, "not-a-pid").expect("write pidfile");
+
+    bootstrap::stop_server(&pidfile).expect_err("a non-numeric pidfile must be an error");
+    assert!(
+        pidfile.exists(),
+        "a pidfile that was never acted on must not be removed"
+    );
+}
+
+// AC6: the happy path — stop_server signals the process and clears the pidfile.
+#[cfg(unix)]
+#[test]
+fn stop_server_signals_the_process_and_removes_the_pidfile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn a stand-in server process");
+    let pidfile = dir.path().join("server.pid");
+    std::fs::write(&pidfile, child.id().to_string()).expect("write pidfile");
+
+    bootstrap::stop_server(&pidfile).expect("stop_server succeeds");
+
+    assert!(!pidfile.exists(), "stop_server must remove the pidfile");
+    let status = child.wait().expect("reap the stand-in process");
+    assert!(
+        !status.success(),
+        "the process should have been terminated by the signal, got: {status:?}"
+    );
+}
+
+// AC7: save_imposters fetches the replayable config from a live admin API and writes it.
+#[tokio::test]
+async fn save_imposters_writes_the_replayable_config() {
+    let manager = Arc::new(ImposterManager::new());
+    let imposter: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "protocol": "http",
+        "port": 0,
+        "name": "bootstrap-seam",
+        "stubs": [{
+            "predicates": [{"equals": {"path": "/ping"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "pong"}}]
+        }]
+    }))
+    .expect("imposter config");
+    manager
+        .create_imposter(imposter)
+        .await
+        .expect("create imposter");
+
+    let server = ServerBuilder::from_cli(cli(&["--host", "127.0.0.1", "--port", "0"]))
+        .manager(Arc::clone(&manager))
+        .start()
+        .await
+        .expect("admin API starts");
+    let addr = server.admin_addr();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let savefile = dir.path().join("imposters.json");
+    let (host, port) = (addr.ip().to_string(), addr.port());
+    let saved = tokio::task::spawn_blocking(move || {
+        bootstrap::save_imposters(&host, port, &savefile, false).map(|()| savefile)
+    })
+    .await
+    .expect("save task joins");
+    let savefile = saved.expect("save_imposters succeeds");
+
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&savefile).expect("read savefile"))
+            .expect("savefile is JSON");
+    let names: Vec<&str> = written["imposters"]
+        .as_array()
+        .expect("imposters array")
+        .iter()
+        .filter_map(|i| i["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"bootstrap-seam"),
+        "the saved config must contain the live imposter, got: {written}"
+    );
+
+    server.shutdown().await;
+}

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -133,6 +133,49 @@ metrics.shutdown().await;
 
 ---
 
+## Bootstrap helpers
+
+`ServerBuilder` composes the *running* server, but a binary also has bootstrap concerns around it:
+applying an rcfile's defaults, stopping a server by PID file, and saving a running server's
+imposters. These live in `rift_http_proxy::bootstrap` so an alternative binary keeps CLI parity with
+`rift` instead of reimplementing them (issue #807).
+
+| Function | Signature | Purpose |
+|:---------|:----------|:--------|
+| `apply_rcfile_defaults` | `fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> anyhow::Result<()>` | Fill CLI fields **still at their clap defaults** from a Mountebank-compatible JSON rcfile. An explicitly-supplied flag always wins; unrecognised keys are warned and ignored. |
+| `stop_server` | `fn stop_server(pidfile: &Path) -> anyhow::Result<()>` | Signal the process named in `pidfile` (SIGTERM on unix, `taskkill /F` on Windows), then remove the file. |
+| `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. |
+
+Supported rcfile keys: `port`, `host`, `logLevel`/`loglevel`, `allowInjection`/`allow_injection`,
+`localOnly`/`local_only`, `datadir`, `configfile`.
+
+```rust
+use rift_http_proxy::bootstrap;
+use rift_http_proxy::server::{Cli, Commands};
+use clap::Parser;
+
+let mut cli = Cli::parse();
+if let Some(rcfile) = cli.rcfile.clone() {
+    bootstrap::apply_rcfile_defaults(&mut cli, &rcfile)?;
+}
+
+match &cli.command {
+    Some(Commands::Stop { pidfile }) => return bootstrap::stop_server(pidfile),
+    // `restart` is just `stop` followed by the normal start path.
+    Some(Commands::Restart { pidfile }) => bootstrap::stop_server(pidfile)?,
+    Some(Commands::Save { savefile, remove_proxies }) => {
+        return bootstrap::save_imposters(&cli.host, cli.port, savefile, *remove_proxies);
+    }
+    _ => {}
+}
+```
+
+`save_imposters` builds its own tokio runtime and blocks on it (it is a sync subcommand path), so do
+not call it from inside a running async runtime — use `tokio::task::spawn_blocking` if your caller
+is already async.
+
+---
+
 ## TLS: install the crypto provider
 
 Before serving any HTTPS imposter from an embedding host, install the default rustls (`ring`) crypto


### PR DESCRIPTION
## Summary

Bootstrap helpers for rcfile, stop/restart, and save move from the binary's main.rs into the library as a public seam. This eliminates code duplication for alternative binaries built on rift-http-proxy while keeping the existing behavior and guarantees (explicit flags beat rcfile) invariant. New docs/embedding/server.md section documents the bootstrap helpers API.

Zero behaviour change — all logic moved verbatim from main.rs to the new seam module.

Closes #807

Milestone: none (standalone)