### PR TITLE
docs: list rift-scala as an available SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,36 @@ try (Rift rift = Rift.embedded()) {                  // or Rift.connect(uri) / R
 
 See the [rift-java docs](https://achird-labs.github.io/rift-java/) for the full feature surface.
 
+### Scala
+
+For Scala 3, use the official [rift-scala](https://github.com/achird-labs/rift-scala) SDK. It is
+effect-library-native — ZIO, Cats Effect 3 / FS2, Kyo, or no effect system at all — over the same
+four transports (embedded, connect, spawn, container):
+
+```scala
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.0" % Test
+```
+
+```scala
+import rift.dsl.*
+import rift.zio.Rift
+
+for
+  users <- Rift.create(
+             imposter("users").record.stub(
+               get("/api/users/1").reply(ok.json("""{"id":1}"""))
+             )
+           )
+  _     <- callSut(users.uri)                 // point your SUT at users.uri
+  _     <- users.verify(get("/api/users/1"), 1)
+yield ()
+// .provideShared(Rift.embedded)  — or Rift.connect(uri) / Rift.spawn() / Rift.container()
+```
+
+It also ships a [zio-bdd](https://github.com/EtaCassiopeia/zio-bdd) `MockControl` adapter, certified
+against zio-bdd's published conformance catalogue. See the
+[rift-scala docs](https://achird-labs.github.io/rift-scala/).
+
 ---
 
 ## Documentation
@@ -205,6 +235,7 @@ See the [rift-java docs](https://achird-labs.github.io/rift-java/) for the full 
 - [Quick Start](https://achird-labs.github.io/rift/getting-started/quickstart) - Create your first imposter
 - [Node.js Integration](https://achird-labs.github.io/rift/getting-started/nodejs/) - npm package for Node.js
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
 - [Migration Guide](https://achird-labs.github.io/rift/getting-started/migration) - Using Rift with Mountebank configs
 
 ### Mountebank Compatibility

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -208,6 +208,7 @@ Example `imposters.json`:
 - [Quick Start Tutorial]({{ site.baseurl }}/getting-started/quickstart/) - Detailed walkthrough
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
 - [Predicates Guide]({{ site.baseurl }}/mountebank/predicates/) - Request matching
 - [Responses Guide]({{ site.baseurl }}/mountebank/responses/) - Response configuration
 - [Migration Guide]({{ site.baseurl }}/getting-started/migration/) - Switching from Mountebank

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,6 +159,7 @@ for version-pinning every module at once.
 - [Quick Start]({{ site.baseurl }}/getting-started/quickstart/) - Create your first imposter
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
 - [Migration from Mountebank]({{ site.baseurl }}/getting-started/migration/) - Switch from Mountebank to Rift
 
 ### Concepts


### PR DESCRIPTION
rift-scala released **0.1.0** to Maven Central, and nothing in this repo mentioned it — the README and docs site list Node.js and Java and stop there, so a reader had no way to discover a Scala SDK exists.

## What changed

- **README** — a `### Scala` section beside the existing `### Java / JVM` one.
- **Nav entries** in all three link lists: `README.md`, `docs/index.md`, `docs/getting-started/index.md` — placed directly after the Java entry, matching how rift-node and rift-java are already presented rather than inventing a new shape.

Kept deliberately thin: what makes it distinct (effect-library-native across ZIO, Cats Effect 3 / FS2 and Kyo; the same four transports including `container`), one worked example, and a link out to `achird-labs.github.io/rift-scala`. Per-effect detail belongs on rift-scala's own site; a second copy here is a second copy to keep in sync.

## Sample correctness

The snippet is the same one rift-scala's README carries, and that one is **compile-gated** in rift-scala's test suite (`ReadmeSampleSpec`) against the current DSL — so it typechecks rather than being written from memory. Verified symbols: `imposter(...).record.stub(...)`, `get(path).reply(ok.json(...))`, `Rift.create`, `handle.uri`, `handle.verify(match, Int)`, `Rift.embedded`.

Docs-only; no code or nav-structure changes.

> Note: the `achird-labs.github.io/rift-scala` link goes live once Pages is enabled on that repo (achird-labs/rift-scala#76 adds the site and workflow).
