### PR TITLE
fix: imposter enabled is config — persist, replicate, apply in place

### DIFF
--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -954,15 +954,18 @@ pub unsafe extern "C" fn rift_set_imposter_enabled(
             set_last_error("rift_set_imposter_enabled: null handle");
             return -1;
         };
-        let imposter = match handle.manager.get_imposter(port) {
-            Ok(i) => i,
+        // Through the manager (issue #817): the FFI door must persist and emit
+        // like the HTTP one, or embedders keep the runtime-only bug.
+        match handle
+            .runtime
+            .block_on(handle.manager.set_imposter_enabled(port, enabled != 0))
+        {
+            Ok(()) => 0,
             Err(e) => {
                 set_last_error(format!("rift_set_imposter_enabled: {e}"));
-                return -1;
+                -1
             }
-        };
-        imposter.set_enabled(enabled != 0);
-        0
+        }
     })
 }
 

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -476,9 +476,10 @@ async fn handle_set_enabled(
     enabled: bool,
     manager: Arc<ImposterManager>,
 ) -> Response<Full<Bytes>> {
-    match manager.get_imposter(port) {
-        Ok(imposter) => {
-            imposter.set_enabled(enabled);
+    // Through the manager, not the bare atomic: the toggle is config (issue
+    // #817) — it persists to datadir and emits an event.
+    match manager.set_imposter_enabled(port, enabled).await {
+        Ok(()) => {
             let state = if enabled { "enabled" } else { "disabled" };
             json_response(
                 StatusCode::OK,

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -220,6 +220,7 @@ impl Imposter {
         // `_rift.flowState` selection.
         let flow_store = Self::create_flow_store(&config, provider)?;
 
+        let enabled = config.enabled;
         Ok(Self {
             config,
             stubs_snapshot: ArcSwap::from_pointee(StubSnapshot::build(stubs)),
@@ -228,7 +229,7 @@ impl Imposter {
             event_bus: None,
             journal: journal
                 .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
-            enabled: AtomicBool::new(true),
+            enabled: AtomicBool::new(enabled),
             created_at: chrono::Utc::now(),
             shutdown_tx: None,
             serve_handles: Mutex::new(Vec::new()),

--- a/crates/rift-mock-core/src/imposter/events.rs
+++ b/crates/rift-mock-core/src/imposter/events.rs
@@ -22,6 +22,8 @@ pub enum ImposterAction {
     Created,
     Replaced,
     StubsChanged,
+    /// The serve/pause flag flipped (issue #817).
+    EnabledChanged,
     Deleted,
     AllDeleted,
 }
@@ -34,6 +36,7 @@ impl ImposterAction {
             Self::Created => "created",
             Self::Replaced => "replaced",
             Self::StubsChanged => "stubsChanged",
+            Self::EnabledChanged => "enabledChanged",
             Self::Deleted => "deleted",
             Self::AllDeleted => "allDeleted",
         }

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -503,6 +503,9 @@ impl ImposterManager {
             ImposterEvent::Created(p) => (ImposterAction::Created, Some(p)),
             ImposterEvent::Replaced(p) => (ImposterAction::Replaced, Some(p)),
             ImposterEvent::StubsChanged(p) => (ImposterAction::StubsChanged, Some(p)),
+            ImposterEvent::EnabledChanged { port, .. } => {
+                (ImposterAction::EnabledChanged, Some(port))
+            }
             ImposterEvent::Deleted(p) => (ImposterAction::Deleted, Some(p)),
             ImposterEvent::AllDeleted => (ImposterAction::AllDeleted, None),
         };
@@ -1109,7 +1112,10 @@ impl ImposterManager {
     /// Semantics per desired port: new port → create; missing port → delete; identical
     /// config → untouched; imposter-level field change or a degenerate stub diff (> 50 % of
     /// stubs changing) → wholesale replace (PUT semantics, state resets); otherwise the stub
-    /// set is patched in place and untouched slots keep their cycling state.
+    /// set is patched in place and untouched slots keep their cycling state. Exception
+    /// (issue #817): a diff whose only imposter-level change is `enabled` toggles in place —
+    /// pausing an imposter must never reset its runtime state — and is reported under
+    /// [`ApplyReport::toggled`].
     ///
     /// The whole set is validated up front — `Err` means nothing was mutated. Per-port apply
     /// failures after that (e.g. a bind failure on a freed port) land in
@@ -1157,9 +1163,20 @@ impl ImposterManager {
                 continue;
             };
 
-            if imposter_level_differs(&existing.config, &config) {
+            if imposter_level_differs_ignoring_enabled(&existing.config, &config) {
                 self.replace_imposter(port, config, &mut report).await;
                 continue;
+            }
+
+            // An enabled-only imposter-level diff applies IN PLACE (issue
+            // #817): pause/resume must never reset cursors, scenario state or
+            // recorded requests, which a wholesale replace would. Compared
+            // against the live flag, not the retained boot value.
+            if existing.is_enabled() != config.enabled {
+                if let Err(e) = self.set_imposter_enabled(port, config.enabled).await {
+                    report.failed.push((port, e));
+                }
+                report.toggled.push(port);
             }
 
             match existing.reconcile_stubs(config.stubs.clone()) {
@@ -1348,6 +1365,23 @@ impl ImposterManager {
         self.persist_imposter_checked(&imposter).await
     }
 
+    /// Enable or disable serving on `port` — a *config* write, not an
+    /// ephemeral toggle (issue #817): flips the runtime flag (the data plane
+    /// reacts immediately), emits [`ImposterEvent::EnabledChanged`], and
+    /// persists, so a restart with `--datadir` restores the operator's last
+    /// decision. Idempotent: re-asserting the current state still persists and
+    /// emits (an at-least-once contract is simpler than a read-modify-check).
+    pub async fn set_imposter_enabled(
+        &self,
+        port: u16,
+        enabled: bool,
+    ) -> Result<(), ImposterError> {
+        let imposter = self.get_imposter(port)?;
+        imposter.set_enabled(enabled);
+        self.emit(ImposterEvent::EnabledChanged { port, enabled });
+        self.persist_imposter_checked(&imposter).await
+    }
+
     /// Get a specific stub by index
     pub fn get_stub(&self, port: u16, index: usize) -> Result<Stub, ImposterError> {
         let imposter = self.get_imposter(port)?;
@@ -1374,6 +1408,10 @@ impl ImposterManager {
         };
         let mut snapshot = imposter.config.clone();
         snapshot.stubs = imposter.get_stubs();
+        // The atomic is the runtime truth; the retained config only holds the
+        // boot value. Snapshot the flag so every persist path (stub CRUD
+        // included) writes the operator's current decision.
+        snapshot.enabled = imposter.is_enabled();
         let path = datadir.join(format!("{port}.json"));
         let json = serde_json::to_string_pretty(&snapshot).map_err(|e| {
             ImposterError::PersistError(
@@ -1417,14 +1455,17 @@ impl Default for ImposterManager {
     }
 }
 
-/// Imposter-level diff for `apply_config`, comparing the configs with stubs stripped: any
-/// difference (protocol, TLS, recordRequests, name, …) replaces wholesale. A serialization
-/// failure on either side counts as "differs" — the conservative direction (worst case an
-/// unnecessary replace, never a silently skipped change).
-fn imposter_level_differs(a: &ImposterConfig, b: &ImposterConfig) -> bool {
+/// Imposter-level diff for `apply_config`, comparing the configs with stubs stripped and the
+/// `enabled` flag normalized away: any *other* difference (protocol, TLS, recordRequests,
+/// name, …) replaces wholesale, while an enabled-only diff is applied in place by the caller
+/// (issue #817 — pause/resume must not reset runtime state). A serialization failure on
+/// either side counts as "differs" — the conservative direction (worst case an unnecessary
+/// replace, never a silently skipped change).
+fn imposter_level_differs_ignoring_enabled(a: &ImposterConfig, b: &ImposterConfig) -> bool {
     let flatten = |config: &ImposterConfig| {
         let mut flat = config.clone();
         flat.stubs = Vec::new();
+        flat.enabled = true;
         serde_json::to_value(&flat)
     };
     match (flatten(a), flatten(b)) {
@@ -2229,6 +2270,129 @@ mod tests {
         assert_eq!(last["responses"][0]["is"]["body"], "z2");
 
         manager.delete_all().await;
+    }
+
+    // Issue #817: an enabled-only diff toggles in place — pausing must never
+    // reset runtime state the way a wholesale replace would.
+    #[tokio::test]
+    async fn apply_config_enabled_only_diff_toggles_in_place() {
+        let manager = ImposterManager::new();
+        let initial = imposter_cfg(json!({
+            "protocol": "http", "port": 19430, "recordRequests": true,
+            "stubs": [stub_json("a")]
+        }));
+        manager.apply_config(vec![initial]).await.expect("create");
+        let before = manager.get_imposter(19430).unwrap();
+        before.record_request(recorded("/a"));
+        assert!(before.is_enabled());
+
+        let paused = imposter_cfg(json!({
+            "protocol": "http", "port": 19430, "recordRequests": true, "enabled": false,
+            "stubs": [stub_json("a")]
+        }));
+        let report = manager.apply_config(vec![paused]).await.expect("pause");
+        assert_eq!(report.toggled, vec![19430]);
+        assert!(report.replaced.is_empty(), "never a wholesale replace");
+        assert!(report.stub_patched.is_empty());
+
+        let after = manager.get_imposter(19430).unwrap();
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "the toggle must not recreate the imposter"
+        );
+        assert!(!after.is_enabled());
+        assert_eq!(
+            after.get_recorded_requests().len(),
+            1,
+            "runtime state survives the pause"
+        );
+
+        // Resume via the (default, unserialized) enabled=true.
+        let resumed = imposter_cfg(json!({
+            "protocol": "http", "port": 19430, "recordRequests": true,
+            "stubs": [stub_json("a")]
+        }));
+        let report = manager.apply_config(vec![resumed]).await.expect("resume");
+        assert_eq!(report.toggled, vec![19430]);
+        assert!(manager.get_imposter(19430).unwrap().is_enabled());
+
+        manager.delete_all().await;
+    }
+
+    // Issue #817: the toggle is config — it persists, emits, and a reload of
+    // the persisted file restores the operator's decision.
+    #[tokio::test]
+    async fn set_imposter_enabled_persists_emits_and_reload_restores() {
+        let datadir = tempfile::tempdir().expect("tempdir");
+        let listener = Arc::new(RecordingListener(Mutex::new(Vec::new())));
+        let manager = ImposterManager::with_datadir(Some(datadir.path().to_path_buf()))
+            .with_event_listener(listener.clone());
+        let config = imposter_cfg(json!({
+            "protocol": "http", "port": 19431, "stubs": [stub_json("a")]
+        }));
+        manager.create_imposter(config).await.expect("create");
+
+        manager
+            .set_imposter_enabled(19431, false)
+            .await
+            .expect("disable");
+        assert!(!manager.get_imposter(19431).unwrap().is_enabled());
+        assert!(
+            listener.0.lock().iter().any(|e| matches!(
+                e,
+                ImposterEvent::EnabledChanged {
+                    port: 19431,
+                    enabled: false
+                }
+            )),
+            "the toggle must be observable"
+        );
+
+        let persisted =
+            std::fs::read_to_string(datadir.path().join("19431.json")).expect("persisted file");
+        assert!(persisted.contains("\"enabled\": false"), "{persisted}");
+
+        // A fresh manager loading that file restores the pause.
+        let reloaded: ImposterConfig = serde_json::from_str(&persisted).expect("parses");
+        assert!(!reloaded.enabled);
+        let fresh = ImposterManager::new();
+        // Rebind on a fresh ephemeral port to avoid racing the old listener.
+        let mut reloaded = reloaded;
+        reloaded.port = Some(19432);
+        fresh.create_imposter(reloaded).await.expect("recreate");
+        assert!(
+            !fresh.get_imposter(19432).unwrap().is_enabled(),
+            "a restart must not silently re-enable a paused imposter"
+        );
+
+        fresh.delete_all().await;
+        manager.delete_all().await;
+    }
+
+    // Issue #817: serialization stability — the (universal) enabled case emits
+    // no field, so existing configs, dumps and round-trips stay byte-identical.
+    #[test]
+    fn enabled_serialization_is_stable() {
+        let legacy: ImposterConfig =
+            serde_json::from_value(json!({ "protocol": "http", "port": 1 })).expect("parses");
+        assert!(legacy.enabled, "absent field defaults to enabled");
+        let value = serde_json::to_value(&legacy).expect("serialize");
+        assert!(
+            value.get("enabled").is_none(),
+            "enabled imposters serialize no field: {value}"
+        );
+
+        let mut paused = legacy;
+        paused.enabled = false;
+        let value = serde_json::to_value(&paused).expect("serialize");
+        assert_eq!(value["enabled"], false);
+        let back: ImposterConfig = serde_json::from_value(value).expect("round-trips");
+        assert!(!back.enabled);
+
+        assert!(
+            ImposterConfig::default().enabled,
+            "Default must agree with the serde default"
+        );
     }
 
     // AC2d: imposter-level field changes always replace wholesale.

--- a/crates/rift-mock-core/src/imposter/reconcile.rs
+++ b/crates/rift-mock-core/src/imposter/reconcile.rs
@@ -19,6 +19,10 @@ pub struct ApplyReport {
     pub created: Vec<u16>,
     pub replaced: Vec<u16>,
     pub stub_patched: Vec<u16>,
+    /// Ports whose only imposter-level change was the `enabled` flag, applied
+    /// in place — runtime state intact (pausing an imposter must never reset
+    /// its scenario state).
+    pub toggled: Vec<u16>,
     pub deleted: Vec<u16>,
     pub failed: Vec<(u16, ImposterError)>,
 }
@@ -30,6 +34,12 @@ pub enum ImposterEvent {
     Created(u16),
     Replaced(u16),
     StubsChanged(u16),
+    /// The serve/pause flag flipped (issue #817): config, not ephemera — the
+    /// toggle persists and replicates like any other config change.
+    EnabledChanged {
+        port: u16,
+        enabled: bool,
+    },
     Deleted(u16),
     AllDeleted,
 }

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -861,8 +861,17 @@ fn default_protocol() -> String {
     "http".to_string()
 }
 
+fn default_enabled() -> bool {
+    true
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde's skip_serializing_if contract
+fn is_default_enabled(enabled: &bool) -> bool {
+    *enabled
+}
+
 /// Configuration for creating an imposter
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImposterConfig {
     /// Port for the imposter. If not specified, an available port will be auto-assigned.
@@ -884,6 +893,16 @@ pub struct ImposterConfig {
     pub name: Option<String>,
     #[serde(default)]
     pub record_requests: bool,
+    /// Whether the imposter serves data-plane traffic. Toggled at runtime by
+    /// POST /imposters/:port/{enable,disable}; persisted so a restart with
+    /// --datadir restores the operator's last decision instead of silently
+    /// re-enabling a paused imposter. Serialized only when `false`, so configs
+    /// for the (universal) enabled case stay byte-identical.
+    #[serde(
+        default = "default_enabled",
+        skip_serializing_if = "is_default_enabled"
+    )]
+    pub enabled: bool,
     /// Record which stub matched each request (Mountebank compatible)
     #[serde(default)]
     pub record_matches: bool,
@@ -947,6 +966,33 @@ pub struct RiftConfig {
     /// `file:` script — not `ref:` (no chains).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub scripts: HashMap<String, RiftScriptConfig>,
+}
+
+// Hand-written (not derived) because `enabled` and `protocol` default to
+// non-zero values; the exhaustive literal makes adding a field without
+// deciding its default a compile error rather than a silent zero.
+impl Default for ImposterConfig {
+    fn default() -> Self {
+        Self {
+            port: None,
+            host: None,
+            protocol: default_protocol(),
+            cert: None,
+            key: None,
+            name: None,
+            record_requests: false,
+            enabled: default_enabled(),
+            record_matches: false,
+            stubs: Vec::new(),
+            default_response: None,
+            default_forward: None,
+            allow_cors: false,
+            strict_behaviors: false,
+            service_name: None,
+            service_info: None,
+            rift: None,
+        }
+    }
 }
 
 /// Flow state configuration for Rift extensions


### PR DESCRIPTION
Fixes #817.

`POST /imposters/:port/{enable,disable}` only flipped a runtime `AtomicBool`, so a restart with `--datadir` silently re-enabled every paused imposter, and nothing that moves `ImposterConfig` (persistence, `apply_config`, embedders) could see the flag.

- **`ImposterConfig.enabled`** — serde default `true`, serialized only when `false`: every existing config file, API payload, `GET /imposters` dump and Mountebank round-trip stays byte-identical for the (universal) enabled case. `Default` is now hand-written so the exhaustive literal makes future field additions a compile-time decision.
- **The imposter seeds its atomic from config**, and `persist_imposter_checked` snapshots the live flag — every persist path (stub CRUD included) writes the operator's current decision.
- **`ImposterManager::set_imposter_enabled`** — the write-through: flips the atomic (data plane reacts immediately), emits the new `ImposterEvent::EnabledChanged` (`enabledChanged` on the admin SSE bus), persists. The HTTP handler and the C-ABI door (`rift_set_imposter_enabled`) both route through it.
- **`apply_config` carve-out**: an imposter-level diff whose only change is `enabled` toggles **in place** — reported under the new `ApplyReport::toggled` — never a wholesale replace. Pausing an imposter must not reset its cursors, scenario state or recorded requests; the diff comparison is against the *live* flag, not the retained boot value.

Tests: enabled-only diff preserves runtime state and identity (`Arc::ptr_eq`); toggle persists + emits + a reload of the persisted file restores the pause; serialization stability (no field emitted when enabled; `Default` agrees with the serde default). Existing wholesale-replace semantics for every other imposter-level field are unchanged and still covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)