### PR TITLE
fix(rift-http-proxy): save_imposters panics in async contexts; should use async API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ record.
 
 ### Added
 
+- **`rift_http_proxy::bootstrap::save_imposters_async` — a non-panicking async form of `save_imposters`**
+  (issue #815). `save_imposters` builds its own tokio runtime and `block_on`s it, so an async
+  embedder calling it directly from an async worker thread panics with "Cannot start a runtime from
+  within a runtime". The async body is now public as `save_imposters_async`, which awaits instead of
+  nesting a runtime — call it from an embedder's own runtime. The blocking `save_imposters` is
+  unchanged (it now wraps the async form), so the `save` subcommand and existing sync callers are
+  unaffected.
+
 - **`RunningServer::wait(&self)` — await the embedded server without consuming it** (issue #806).
   `join(self)` and `shutdown(self)` both moved the server, so a host could await the server *or*
   await its own shutdown signal, never race them: the arm that won a `select!` against `join` could

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -108,13 +108,41 @@ pub fn stop_server(pidfile: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Save imposters to a file.
+/// Save imposters to a file (async form).
 ///
 /// Fetches the replayable imposter config from the admin API at `host:port` and writes it to
-/// `savefile`. Builds its own tokio runtime and blocks on it, exactly like the CLI's `save`
+/// `savefile`. This is the form to call from an embedder's own async runtime — it awaits rather
+/// than driving a nested runtime, so it is safe on an async worker thread. Sync callers (the `save`
+/// subcommand) should use [`save_imposters`], which wraps this.
+pub async fn save_imposters_async(
+    host: &str,
+    port: u16,
+    savefile: &Path,
+    remove_proxies: bool,
+) -> Result<(), anyhow::Error> {
+    let client = reqwest::Client::new();
+    let mut query = "replayable=true".to_string();
+    if remove_proxies {
+        query.push_str("&removeProxies=true");
+    }
+    let url = format!("http://{host}:{port}/imposters?{query}");
+
+    let response = client.get(&url).send().await?;
+    let content = response.text().await?;
+
+    // `tokio::fs::write` so the shared body never blocks a caller's async worker thread.
+    tokio::fs::write(savefile, &content).await?;
+    info!("Saved imposters to {:?}", savefile);
+
+    Ok(())
+}
+
+/// Save imposters to a file (blocking form).
+///
+/// Builds its own tokio runtime and drives [`save_imposters_async`], exactly like the CLI's `save`
 /// subcommand does today — so this must **not** be called from inside an already-running async
-/// runtime (it will panic trying to start a nested one). Call it from sync context, or via
-/// `tokio::task::spawn_blocking` if the caller is itself async.
+/// runtime (it will panic trying to start a nested one). Call it from sync context; from async
+/// code call [`save_imposters_async`] directly.
 pub fn save_imposters(
     host: &str,
     port: u16,
@@ -122,21 +150,5 @@ pub fn save_imposters(
     remove_proxies: bool,
 ) -> Result<(), anyhow::Error> {
     let runtime = tokio::runtime::Runtime::new()?;
-
-    runtime.block_on(async {
-        let client = reqwest::Client::new();
-        let mut query = "replayable=true".to_string();
-        if remove_proxies {
-            query.push_str("&removeProxies=true");
-        }
-        let url = format!("http://{host}:{port}/imposters?{query}");
-
-        let response = client.get(&url).send().await?;
-        let content = response.text().await?;
-
-        std::fs::write(savefile, &content)?;
-        info!("Saved imposters to {:?}", savefile);
-
-        Ok(())
-    })
+    runtime.block_on(save_imposters_async(host, port, savefile, remove_proxies))
 }

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -203,3 +203,120 @@ async fn save_imposters_writes_the_replayable_config() {
 
     server.shutdown().await;
 }
+
+// AC1 (issue #815): the regression gate for the nested-runtime panic — `save_imposters_async` is
+// called **directly** from an async worker thread (no `spawn_blocking`). This is the call that
+// panics with "Cannot start a runtime from within a runtime" if the async body is not exposed.
+#[tokio::test]
+async fn save_imposters_async_works_from_async_context() {
+    let manager = Arc::new(ImposterManager::new());
+    let imposter: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "protocol": "http",
+        "port": 0,
+        "name": "async-seam",
+        "stubs": [{
+            "predicates": [{"equals": {"path": "/ping"}}],
+            "responses": [{"is": {"statusCode": 200, "body": "pong"}}]
+        }]
+    }))
+    .expect("imposter config");
+    manager
+        .create_imposter(imposter)
+        .await
+        .expect("create imposter");
+
+    let server = ServerBuilder::from_cli(cli(&["--host", "127.0.0.1", "--port", "0"]))
+        .manager(Arc::clone(&manager))
+        .start()
+        .await
+        .expect("admin API starts");
+    let addr = server.admin_addr();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let savefile = dir.path().join("imposters.json");
+    bootstrap::save_imposters_async(&addr.ip().to_string(), addr.port(), &savefile, false)
+        .await
+        .expect("save_imposters_async succeeds from an async context");
+
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&savefile).expect("read savefile"))
+            .expect("savefile is JSON");
+    let names: Vec<&str> = written["imposters"]
+        .as_array()
+        .expect("imposters array")
+        .iter()
+        .filter_map(|i| i["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"async-seam"),
+        "the saved config must contain the live imposter, got: {written}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC3 (issue #815): `remove_proxies=true` must reach the admin API through the async form — a
+// proxy-only stub is dropped from the saved config, a normal stub is kept. Proves the query param
+// is appended and honored, not just that the call succeeds.
+#[tokio::test]
+async fn save_imposters_async_remove_proxies_strips_proxy_stubs() {
+    let manager = Arc::new(ImposterManager::new());
+    let imposter: ImposterConfig = serde_json::from_value(serde_json::json!({
+        "protocol": "http",
+        "port": 0,
+        "name": "proxy-seam",
+        "stubs": [
+            {
+                "predicates": [{"equals": {"path": "/kept"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "kept"}}]
+            },
+            {
+                "responses": [{"proxy": {
+                    "to": "http://127.0.0.1:1", "mode": "proxyOnce"
+                }}]
+            }
+        ]
+    }))
+    .expect("imposter config");
+    manager
+        .create_imposter(imposter)
+        .await
+        .expect("create imposter");
+
+    let server = ServerBuilder::from_cli(cli(&["--host", "127.0.0.1", "--port", "0"]))
+        .manager(Arc::clone(&manager))
+        .start()
+        .await
+        .expect("admin API starts");
+    let addr = server.admin_addr();
+    let (host, port) = (addr.ip().to_string(), addr.port());
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // remove_proxies=false: the proxy stub survives.
+    let with_proxy = dir.path().join("with-proxy.json");
+    bootstrap::save_imposters_async(&host, port, &with_proxy, false)
+        .await
+        .expect("save without removeProxies");
+    let with_proxy_raw = std::fs::read_to_string(&with_proxy).expect("read with-proxy");
+    assert!(
+        with_proxy_raw.contains("\"proxy\""),
+        "without removeProxies the proxy stub must be present, got: {with_proxy_raw}"
+    );
+
+    // remove_proxies=true: the proxy-only stub is stripped, the normal stub stays.
+    let stripped = dir.path().join("stripped.json");
+    bootstrap::save_imposters_async(&host, port, &stripped, true)
+        .await
+        .expect("save with removeProxies");
+    let stripped_raw = std::fs::read_to_string(&stripped).expect("read stripped");
+    assert!(
+        !stripped_raw.contains("\"proxy\""),
+        "removeProxies=true must strip the proxy-only stub, got: {stripped_raw}"
+    );
+    assert!(
+        stripped_raw.contains("/kept"),
+        "removeProxies=true must keep the non-proxy stub, got: {stripped_raw}"
+    );
+
+    server.shutdown().await;
+}

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -166,7 +166,8 @@ imposters. These live in `rift_http_proxy::bootstrap` so an alternative binary k
 |:---------|:----------|:--------|
 | `apply_rcfile_defaults` | `fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> anyhow::Result<()>` | Fill CLI fields **still at their clap defaults** from a Mountebank-compatible JSON rcfile. An explicitly-supplied flag always wins; unrecognised keys are warned and ignored. |
 | `stop_server` | `fn stop_server(pidfile: &Path) -> anyhow::Result<()>` | Signal the process named in `pidfile` (SIGTERM on unix, `taskkill /F` on Windows), then remove the file. |
-| `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. |
+| `save_imposters_async` | `async fn save_imposters_async(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. The async form — call it from an embedder's own runtime. |
+| `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Blocking wrapper over `save_imposters_async` for the sync `save` subcommand path. |
 
 Supported rcfile keys: `port`, `host`, `logLevel`/`loglevel`, `allowInjection`/`allow_injection`,
 `localOnly`/`local_only`, `datadir`, `configfile`.
@@ -193,8 +194,9 @@ match &cli.command {
 ```
 
 `save_imposters` builds its own tokio runtime and blocks on it (it is a sync subcommand path), so do
-not call it from inside a running async runtime — use `tokio::task::spawn_blocking` if your caller
-is already async.
+not call it from inside a running async runtime — it would panic starting a nested runtime. From
+async code call `save_imposters_async` directly instead; it awaits rather than driving its own
+runtime, so it is safe on an async worker thread.
 
 ---
 


### PR DESCRIPTION
Expose `save_imposters_async` for embedders calling from async worker threads.
`save_imposters` builds its own tokio runtime and blocks on it, causing a panic
when called from an async context. The async form awaits instead of nesting runtimes.

Closes #815

Milestone: none (standalone)