### PR TITLE
fix(rift-http-proxy): save_imposters writes error responses to savefile silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ record.
 
 ### Fixed
 
+- **`rift save` and `rift stop` now fail loudly instead of lying about success** (issue #816).
+  `rift save` fetched `GET /imposters` and wrote the response body without checking the status, so
+  when the admin API answered `401`/`500` (e.g. a wrong `--apikey`) the error document was written
+  verbatim to the savefile and logged as `Saved imposters to <path>` — a savefile that looks valid
+  but is an error page. It now checks the status first and writes nothing on a non-2xx response.
+  `rift stop` discarded `kill`'s return value, so any parseable pidfile reported success and had its
+  pidfile removed even when no signal was delivered; it now distinguishes a stale pidfile (process
+  already gone → cleaned up, `Ok`) from a denied or failed signal (error, pidfile kept). Note: both
+  subcommands can now exit **non-zero** where they previously always exited `0` — that is the fix;
+  scripts relying on the old always-success behavior were being misled.
+
 - **`examples/task-management-api.json` no longer ships two dead stubs.** The document loaded
   cleanly and linted clean, but two of the behaviors it advertised never fired: matching is
   first-match-wins, and the bare `GET /tasks` stub was listed before the `?status=OPEN` one (so the

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -79,6 +79,14 @@ pub fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> Result<(), anyhow:
 }
 
 /// Stop a running server by PID file.
+///
+/// Idempotent about the end state, loud about everything else: a stale pidfile (the process is
+/// already gone) is cleaned up and reported `Ok`, but a signal that is denied (the process is not
+/// ours) or fails unexpectedly is an error and the pidfile is left in place — it is not stale.
+///
+/// The unix arm inspects `kill`'s errno to make that distinction; the Windows arm only checks
+/// whether `taskkill` succeeded (it does not map "no such process" back onto the stale-pidfile
+/// policy — that exit code is undocumented-ish and untested here).
 pub fn stop_server(pidfile: &Path) -> Result<(), anyhow::Error> {
     if !pidfile.exists() {
         return Err(anyhow::anyhow!("PID file not found: {pidfile:?}"));
@@ -90,19 +98,47 @@ pub fn stop_server(pidfile: &Path) -> Result<(), anyhow::Error> {
     info!("Stopping server with PID {}", pid);
 
     #[cfg(unix)]
-    unsafe {
-        libc::kill(pid, libc::SIGTERM);
+    {
+        // SAFETY: kill(2) with a plain PID and signal number touches no memory; failure is
+        // reported via errno, which we read immediately below.
+        let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+        if rc == -1 {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::ESRCH) => {
+                    // No such process — the pidfile is stale. The desired end state already holds.
+                    warn!("process {pid} not running; removing stale PID file");
+                }
+                Some(libc::EPERM) => {
+                    return Err(anyhow::anyhow!(
+                        "not permitted to signal process {pid} (EPERM); leaving PID file in place"
+                    ));
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "failed to signal process {pid}: {err}; leaving PID file in place"
+                    ));
+                }
+            }
+        }
     }
 
     #[cfg(windows)]
     {
-        // On Windows, use taskkill
-        std::process::Command::new("taskkill")
+        // On Windows, use taskkill; a non-success exit means the process was not stopped, so the
+        // pidfile is not stale — surface the failure and keep it.
+        let output = std::process::Command::new("taskkill")
             .args(["/PID", &pid.to_string(), "/F"])
-            .status()?;
+            .output()?;
+        if !output.status.success() {
+            return Err(anyhow::anyhow!(
+                "taskkill failed to stop process {pid}: {}; leaving PID file in place",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
     }
 
-    // Remove PID file
+    // Remove PID file (success path, and the ESRCH stale-pidfile path).
     std::fs::remove_file(pidfile)?;
 
     Ok(())
@@ -127,7 +163,9 @@ pub async fn save_imposters_async(
     }
     let url = format!("http://{host}:{port}/imposters?{query}");
 
-    let response = client.get(&url).send().await?;
+    // `error_for_status` before `.text()` so a 401/500 response is a value error, not a body
+    // silently written to the user's savefile. The error carries the status and URL.
+    let response = client.get(&url).send().await?.error_for_status()?;
     let content = response.text().await?;
 
     // `tokio::fs::write` so the shared body never blocks a caller's async worker thread.

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -129,6 +129,60 @@ fn stop_server_unparseable_pid_is_an_error() {
     );
 }
 
+// AC3 (issue #816): a pidfile naming a dead process is a stale pidfile — `stop_server` cleans it
+// up and returns Ok, since the desired end state (server not running) already holds.
+// NOTE: this guards the ESRCH arm's *outcome* but does not, alone, prove the arm ran — the old
+// "ignore kill's return" code also produced Ok + removed pidfile here. It only discriminates the
+// new dispatch in tandem with `stop_server_not_permitted_keeps_pidfile` (EPERM), which would fail
+// under that old code. Keep the two together.
+#[cfg(unix)]
+#[test]
+fn stop_server_stale_pid_is_cleaned_up_with_ok() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Spawn a child, reap it, and reuse its PID — guaranteed dead. (PID reuse between reap and
+    // kill is theoretically possible but not a realistic test-time race.)
+    let mut child = std::process::Command::new("true")
+        .spawn()
+        .expect("spawn a short-lived process");
+    let dead_pid = child.id();
+    child.wait().expect("reap the process");
+
+    let pidfile = dir.path().join("stale.pid");
+    std::fs::write(&pidfile, dead_pid.to_string()).expect("write pidfile");
+
+    bootstrap::stop_server(&pidfile).expect("a stale pidfile must clean up with Ok");
+    assert!(
+        !pidfile.exists(),
+        "stop_server must remove a stale pidfile once the process is gone"
+    );
+}
+
+// AC5 (issue #816): signalling a process we do not own is EPERM — a real error, and the pidfile is
+// NOT ours to remove, so it stays. PID 1 (init) is never ours as an unprivileged user; skip when
+// running as root (containers), where the signal would not be denied.
+#[cfg(unix)]
+#[test]
+fn stop_server_not_permitted_keeps_pidfile() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping EPERM test: running as root, PID 1 would be signalable");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pidfile = dir.path().join("not-ours.pid");
+    std::fs::write(&pidfile, "1").expect("write pidfile");
+
+    let err = bootstrap::stop_server(&pidfile)
+        .expect_err("signalling a process we do not own must be an error");
+    assert!(
+        err.to_string().contains('1'),
+        "the error should name the pid, got: {err}"
+    );
+    assert!(
+        pidfile.exists(),
+        "a pidfile we were not permitted to act on must NOT be removed"
+    );
+}
+
 // AC6: the happy path — stop_server signals the process and clears the pidfile.
 #[cfg(unix)]
 #[test]
@@ -316,6 +370,40 @@ async fn save_imposters_async_remove_proxies_strips_proxy_stubs() {
     assert!(
         stripped_raw.contains("/kept"),
         "removeProxies=true must keep the non-proxy stub, got: {stripped_raw}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC1 (issue #816): a non-2xx admin response is an error, and nothing is written to the savefile —
+// the data-path swallow this fixes is a 401/500 body written verbatim and logged as a success.
+#[tokio::test]
+async fn save_imposters_rejects_non_2xx_and_writes_nothing() {
+    let manager = Arc::new(ImposterManager::new());
+
+    // Admin API guarded by an api key — a request with no Authorization header gets 401.
+    let mut guarded = cli(&["--host", "127.0.0.1", "--port", "0"]);
+    guarded.api_key = Some("secret".to_string());
+    let server = ServerBuilder::from_cli(guarded)
+        .manager(Arc::clone(&manager))
+        .start()
+        .await
+        .expect("admin API starts");
+    let addr = server.admin_addr();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let savefile = dir.path().join("imposters.json");
+    let err =
+        bootstrap::save_imposters_async(&addr.ip().to_string(), addr.port(), &savefile, false)
+            .await
+            .expect_err("a non-2xx admin response must be an error");
+    assert!(
+        err.to_string().contains("401"),
+        "the error should carry the HTTP status, got: {err}"
+    );
+    assert!(
+        !savefile.exists(),
+        "nothing must be written to the savefile on a non-2xx response, but it exists"
     );
 
     server.shutdown().await;

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -165,8 +165,8 @@ imposters. These live in `rift_http_proxy::bootstrap` so an alternative binary k
 | Function | Signature | Purpose |
 |:---------|:----------|:--------|
 | `apply_rcfile_defaults` | `fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> anyhow::Result<()>` | Fill CLI fields **still at their clap defaults** from a Mountebank-compatible JSON rcfile. An explicitly-supplied flag always wins; unrecognised keys are warned and ignored. |
-| `stop_server` | `fn stop_server(pidfile: &Path) -> anyhow::Result<()>` | Signal the process named in `pidfile` (SIGTERM on unix, `taskkill /F` on Windows), then remove the file. |
-| `save_imposters_async` | `async fn save_imposters_async(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. The async form — call it from an embedder's own runtime. |
+| `stop_server` | `fn stop_server(pidfile: &Path) -> anyhow::Result<()>` | Signal the process named in `pidfile` (SIGTERM on unix, `taskkill /F` on Windows), then remove the file. A stale pidfile (process already gone) is cleaned up as `Ok`; a denied or failed signal is an error and the pidfile is kept. |
+| `save_imposters_async` | `async fn save_imposters_async(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. The async form — call it from an embedder's own runtime. A non-2xx admin response is an error; nothing is written to `savefile`. |
 | `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Blocking wrapper over `save_imposters_async` for the sync `save` subcommand path. |
 
 Supported rcfile keys: `port`, `host`, `logLevel`/`loglevel`, `allowInjection`/`allow_injection`,


### PR DESCRIPTION
Fix two instances where error conditions silently succeeded:

1. save_imposters wrote the admin API response body to the savefile without checking status, so a 401/500 error document was saved and logged as success.
2. stop_server discarded kill's return value, so any parseable pidfile reported success and was removed even when no signal was delivered.

Both now check error_for_status before writing and handle errors appropriately. stop_server branches on errno: ESRCH (stale pidfile) is cleaned up with Ok, while EPERM or other failures keep the pidfile and propagate error.

Note: rift save/rift stop may now exit non-zero where they previously always exited 0 (this is intentional).

Closes #816
Milestone: none (standalone)