### PR TITLE
fix(rift-http-proxy): stop_server rejects pid <= 0 to prevent signal broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ record.
 
 ### Fixed
 
+- **`rift stop` refuses a pidfile with a non-positive PID** (issue #822). `stop_server` parsed the
+  pidfile's PID without a range check, so a corrupt or crafted pidfile containing `0` or a negative
+  number would reach `kill(pid, SIGTERM)` — where `kill(0, …)` signals the caller's entire process
+  group and a negative PID broadcasts to a group. `rift stop` could thus SIGTERM itself and still
+  report success. A non-positive PID is now rejected up front and the pidfile is left untouched.
+  `rift restart` goes through the same path, so it now aborts on a corrupt pidfile instead of
+  proceeding — previously it signalled its own process group and never actually restarted cleanly.
+
 - **`rift save` and `rift stop` now fail loudly instead of lying about success** (issue #816).
   `rift save` fetched `GET /imposters` and wrote the response body without checking the status, so
   when the admin API answered `401`/`500` (e.g. a wrong `--apikey`) the error document was written

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -83,6 +83,8 @@ pub fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> Result<(), anyhow:
 /// Idempotent about the end state, loud about everything else: a stale pidfile (the process is
 /// already gone) is cleaned up and reported `Ok`, but a signal that is denied (the process is not
 /// ours) or fails unexpectedly is an error and the pidfile is left in place — it is not stale.
+/// A pidfile whose PID is non-positive is rejected outright (it names a process *group*, not a
+/// process) and likewise kept.
 ///
 /// The unix arm inspects `kill`'s errno to make that distinction; the Windows arm only checks
 /// whether `taskkill` succeeded (it does not map "no such process" back onto the stale-pidfile
@@ -94,6 +96,16 @@ pub fn stop_server(pidfile: &Path) -> Result<(), anyhow::Error> {
 
     let pid_str = std::fs::read_to_string(pidfile)?;
     let pid: i32 = pid_str.trim().parse()?;
+
+    // A pidfile must name a specific process. `kill(0, ..)` signals every process in the caller's
+    // own group and `kill(-pgid, ..)` broadcasts to a group, so a corrupt or crafted pidfile with a
+    // non-positive pid could make `rift stop` SIGTERM itself. Refuse it — and keep the pidfile,
+    // since we never acted on it.
+    if pid <= 0 {
+        return Err(anyhow::anyhow!(
+            "refusing to signal non-positive pid {pid} from PID file {pidfile:?}"
+        ));
+    }
 
     info!("Stopping server with PID {}", pid);
 

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -129,6 +129,44 @@ fn stop_server_unparseable_pid_is_an_error() {
     );
 }
 
+// AC1/AC2 (issue #822): a pidfile with a non-positive pid must be rejected before any signal —
+// `kill(0, ..)` signals the caller's whole process group and `kill(-1, ..)` broadcasts, so a
+// corrupt/crafted pidfile could otherwise make `rift stop` SIGTERM its own group. The pidfile is
+// not stale, so it is left in place.
+#[test]
+fn stop_server_zero_pid_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pidfile = dir.path().join("zero.pid");
+    std::fs::write(&pidfile, "0").expect("write pidfile");
+
+    let err = bootstrap::stop_server(&pidfile).expect_err("pid 0 must be rejected");
+    assert!(
+        err.to_string().contains("non-positive pid 0"),
+        "the error should name the offending pid, got: {err}"
+    );
+    assert!(
+        pidfile.exists(),
+        "a pidfile that was never acted on must not be removed"
+    );
+}
+
+#[test]
+fn stop_server_negative_pid_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pidfile = dir.path().join("negative.pid");
+    std::fs::write(&pidfile, "-1").expect("write pidfile");
+
+    let err = bootstrap::stop_server(&pidfile).expect_err("a negative pid must be rejected");
+    assert!(
+        err.to_string().contains("non-positive pid -1"),
+        "the error should name the offending pid, got: {err}"
+    );
+    assert!(
+        pidfile.exists(),
+        "a pidfile that was never acted on must not be removed"
+    );
+}
+
 // AC3 (issue #816): a pidfile naming a dead process is a stale pidfile — `stop_server` cleans it
 // up and returns Ok, since the desired end state (server not running) already holds.
 // NOTE: this guards the ESRCH arm's *outcome* but does not, alone, prove the arm ran — the old


### PR DESCRIPTION
Rejects pidfile containing 0 or negative PID before calling kill(). The kill(0, SIGTERM) case signals the entire caller's process group; negative pids broadcast to a group. Without the guard, a corrupt pidfile could cause rift stop to SIGTERM itself and still report success. The pidfile is kept, indicating corruption rather than staleness.

This affects rift restart as well, which shares the stop path.

Closes #822
Milestone: none (standalone)