### PR TITLE
fix(admin-api): accept_loop should retry transient errors not terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@ record.
 
 ### Fixed
 
+- **A transient accept error no longer ends the admin API server** (issue #826). `accept_loop`
+  propagated any `listener.accept()` failure straight out via `?`, so a single `ECONNABORTED` — or a
+  momentary `EMFILE`/`ENFILE` under fd pressure — terminated the admin server. That was survivable
+  when the only consumer was the single-node binary, but an embedder that races
+  `RunningServer::wait()` turns it into a node leaving the cluster and exiting non-zero, making
+  fleet-wide fd pressure a correlated restart storm. The admin listener now applies the same
+  classify-and-retry policy the imposter serve loop has had since #750: transient errors retry
+  immediately, systemic ones back off (1 ms doubling to a 1 s cap) and log once per outage with a
+  suppressed-error count on recovery. The shared machinery moved from `imposter::manager` to
+  `proxy::network` and is now public (`rift_mock_core::proxy::{AcceptErrorClass,
+  classify_accept_error, AcceptBackoff, AcceptErrorLog}`) so both listeners cannot drift apart.
+
+  Retrying is not unconditional: a *broken listener* (`EBADF`/`ENOTSOCK`/`EINVAL` — the descriptor
+  is not a working socket) still ends the loop, so `RunningServer::wait()` keeps reporting a genuinely
+  dead admin plane instead of the process lingering with a control plane that can never accept. That
+  fatal class is admin-only; the shared classifier stays two-way, because a dying imposter serve loop
+  is independently recoverable through the still-live admin API.
+
 - **`rift stop` refuses a pidfile with a non-positive PID** (issue #822). `stop_server` parsed the
   pidfile's PID without a range check, so a corrupt or crafted pidfile containing `0` or a negative
   number would reach `kill(pid, SIGTERM)` — where `kill(0, …)` signals the caller's entire process

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -11,6 +11,9 @@ use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use rift_mock_core::proxy::{
+    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error,
+};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -20,7 +23,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 /// Bounded grace given to in-flight connections on `shutdown()` before the wait is abandoned.
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
@@ -283,6 +286,29 @@ fn take_task<T>(slot: &Mutex<Option<JoinHandle<T>>>) -> Option<JoinHandle<T>> {
     slot.lock().expect("admin API task mutex poisoned").take()
 }
 
+/// Whether an `accept(2)` error means the listener itself is unusable, as opposed to a transient
+/// or resource-pressure condition that retrying can clear.
+///
+/// `EBADF` / `ENOTSOCK` / `EINVAL` say the descriptor is not a working listening socket; no amount
+/// of backoff fixes that, so the admin accept loop terminates and lets
+/// [`RunningAdminApi::wait`] report the death (issue #826). Everything else — including unknown
+/// errnos — is left to the shared two-way classifier, which retries.
+///
+/// Unix-only by construction: these are POSIX errnos. On other platforms nothing is treated as
+/// fatal, matching the conservative "retry rather than die" default.
+#[cfg(unix)]
+fn is_fatal_listener_error(e: &std::io::Error) -> bool {
+    matches!(
+        e.raw_os_error(),
+        Some(libc::EBADF) | Some(libc::ENOTSOCK) | Some(libc::EINVAL)
+    )
+}
+
+#[cfg(not(unix))]
+fn is_fatal_listener_error(_e: &std::io::Error) -> bool {
+    false
+}
+
 /// Accept connections until `cancel` fires or the listener errors. Each connection is tracked
 /// so `shutdown` can wait for in-flight requests to drain.
 #[allow(clippy::too_many_arguments)]
@@ -304,6 +330,14 @@ async fn accept_loop(
         .max_connections
         .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
 
+    // Accept-error handling, identical to the data plane's (issue #750, now shared from
+    // `proxy::network`). Previously a single `accept()` failure propagated out of this loop and
+    // ended the admin server — and an embedder that races `RunningServer::wait()` turns that into
+    // a whole node leaving the cluster, so one transient ECONNABORTED or a momentary EMFILE became
+    // a fleet-wide correlated restart (issue #826).
+    let mut backoff = AcceptBackoff::new();
+    let mut error_log = AcceptErrorLog::default();
+
     loop {
         // Acquire a permit *before* accepting so a cap holds connections back in the listener
         // backlog rather than accepting-then-failing. Raced against `cancel` so a saturated cap
@@ -321,9 +355,57 @@ async fn accept_loop(
             }
             None => None,
         };
-        let (stream, _) = tokio::select! {
+        let accepted = tokio::select! {
             _ = cancel.cancelled() => break,
-            accepted = listener.accept() => accepted?,
+            accepted = listener.accept() => accepted,
+        };
+        let (stream, _) = match accepted {
+            Ok(accepted) => {
+                // Recovery: only the transition out of a systemic-error state logs and resets the
+                // backoff, so a healthy accept path pays one branch.
+                if let Some(suppressed) = error_log.on_success() {
+                    info!(
+                        suppressed,
+                        "admin API accept loop recovered after {suppressed} suppressed error(s)"
+                    );
+                    backoff.reset();
+                }
+                accepted
+            }
+            // A broken listener fd is not a blip and cannot be cured by waiting: retrying it
+            // forever would leave the process alive with a permanently dead control plane, and an
+            // embedder racing `RunningServer::wait()` would never learn (issue #826). This fatal
+            // class is deliberately **admin-only** — the shared #750 classifier stays two-way
+            // because a dying imposter serve loop is independently recoverable through the
+            // still-live admin API, whereas nothing outranks the admin plane.
+            Err(e) if is_fatal_listener_error(&e) => {
+                return Err(anyhow::anyhow!(
+                    "admin API listener is unusable, giving up: {e}"
+                ));
+            }
+            Err(e) => match classify_accept_error(&e) {
+                // Expected under load — retry immediately, no backoff, no error spam.
+                AcceptErrorClass::Transient => {
+                    debug!("transient accept error on the admin listener: {e}");
+                    continue;
+                }
+                // Systemic (fd exhaustion / unknown): log once on entry, then back off. Raced
+                // against `cancel` so a backoff sleep never delays admin-server shutdown.
+                AcceptErrorClass::Systemic => {
+                    if error_log.on_error() {
+                        error!(
+                            "accept error on the admin listener: {e}; backing off \
+                             (further errors suppressed until recovery)"
+                        );
+                    }
+                    let delay = backoff.next_delay();
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = cancel.cancelled() => break,
+                    }
+                    continue;
+                }
+            },
         };
         let io = TokioIo::new(stream);
         let manager = Arc::clone(&manager);
@@ -658,5 +740,76 @@ mod wait_seam_tests {
             second.is_ok(),
             "the error is delivered once; later callers get Ok"
         );
+    }
+}
+
+// Issue #826: pins which accept errors must NOT end the admin server (the errnos the issue names)
+// and which still must. The visibility of the shared #750 machinery is already compile-gated by
+// `accept_loop` itself using it; these assertions cover the classification decisions.
+#[cfg(test)]
+mod admin_accept_error_tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn admin_accept_error_classification() {
+        for kind in [
+            ErrorKind::ConnectionAborted,
+            ErrorKind::Interrupted,
+            ErrorKind::ConnectionReset,
+        ] {
+            assert_eq!(
+                classify_accept_error(&Error::from(kind)),
+                AcceptErrorClass::Transient,
+                "{kind:?} must retry immediately, never end the admin server"
+            );
+        }
+        // EMFILE/ENFILE are the fd-exhaustion cases from the issue: back off, never terminate.
+        for raw in [24, 23] {
+            assert_eq!(
+                classify_accept_error(&Error::from_raw_os_error(raw)),
+                AcceptErrorClass::Systemic,
+                "errno {raw} must back off, not terminate"
+            );
+        }
+    }
+
+    #[test]
+    fn admin_backoff_and_error_log_are_usable_cross_crate() {
+        let mut b = AcceptBackoff::new();
+        assert_eq!(b.next_delay(), Duration::from_millis(1));
+        assert_eq!(b.next_delay(), Duration::from_millis(2));
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_millis(1), "reset re-arms");
+
+        let mut log = AcceptErrorLog::default();
+        assert!(log.on_error(), "first systemic error logs once");
+        assert!(!log.on_error(), "subsequent errors are suppressed");
+        assert_eq!(
+            log.on_success(),
+            Some(1),
+            "recovery reports the suppressed count"
+        );
+        assert_eq!(log.on_success(), None, "steady state is silent");
+    }
+
+    // The third class the issue asks for ("terminate only on genuinely fatal errors"): a broken
+    // listener fd must still end the loop so `RunningAdminApi::wait()` reports a dead admin plane.
+    #[cfg(unix)]
+    #[test]
+    fn broken_listener_errnos_are_fatal_but_pressure_is_not() {
+        for raw in [libc::EBADF, libc::ENOTSOCK, libc::EINVAL] {
+            assert!(
+                is_fatal_listener_error(&Error::from_raw_os_error(raw)),
+                "errno {raw} means the listener is unusable; retrying forever would hide a dead admin plane"
+            );
+        }
+        // Recoverable pressure and transient blips must never be treated as fatal.
+        for raw in [libc::EMFILE, libc::ENFILE, libc::ECONNABORTED, libc::EINTR] {
+            assert!(
+                !is_fatal_listener_error(&Error::from_raw_os_error(raw)),
+                "errno {raw} is recoverable and must be retried, not fatal"
+            );
+        }
     }
 }

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -12,6 +12,9 @@ use crate::behaviors::ResponseSequencer;
 use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
 use crate::imposter::journal::RequestJournal;
+use crate::proxy::network::{
+    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error,
+};
 use crate::recording::ProxyRecordingStore;
 use arc_swap::ArcSwapOption;
 use hyper::service::service_fn;
@@ -24,100 +27,6 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 
-// ── Accept-error handling (issue #750) ───────────────────────────────────────────────────────
-//
-// A bare `accept(2)` error arm that logs and immediately retries has two coupled defects, both
-// amplified ×N under the per-core listener fan-out (#745): it spins hot on a *systemic* error
-// (fd exhaustion cannot be cured by retrying), and it logs per failed accept — the exact
-// per-event-rate logging trap the journal-cap fix (#741) removed. The pieces below fix both with
-// no cost on the happy path.
-
-/// How an `accept(2)` error should be handled.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AcceptErrorClass {
-    /// Expected under load; the next accept is likely fine — retry immediately, log at `debug`.
-    Transient,
-    /// Resource exhaustion (or an unknown error): retrying now cannot succeed until something
-    /// frees, so back off. Unknown errors land here deliberately — spinning on an unrecognized
-    /// failure is the worse outcome.
-    Systemic,
-}
-
-/// Classify via [`std::io::ErrorKind`] so no `libc` dependency is needed: only the transient
-/// classes are named (`ECONNABORTED`/`EINTR`/`ECONNRESET`); everything else — resource exhaustion
-/// like `EMFILE`/`ENFILE`/`ENOBUFS` (`Uncategorized`) or `ENOMEM` (`OutOfMemory`), and any truly
-/// unknown error — falls through `_` to systemic.
-fn classify_accept_error(e: &std::io::Error) -> AcceptErrorClass {
-    use std::io::ErrorKind::{ConnectionAborted, ConnectionReset, Interrupted};
-    match e.kind() {
-        ConnectionAborted | Interrupted | ConnectionReset => AcceptErrorClass::Transient,
-        _ => AcceptErrorClass::Systemic,
-    }
-}
-
-/// Exponential backoff for the systemic accept-error path: 1ms doubling to a 1s cap, reset on the
-/// first successful accept. Pure and clock-free so the schedule is unit-testable without sockets.
-struct AcceptBackoff {
-    current: Duration,
-}
-
-impl AcceptBackoff {
-    const INITIAL: Duration = Duration::from_millis(1);
-    const MAX: Duration = Duration::from_secs(1);
-
-    fn new() -> Self {
-        Self {
-            current: Self::INITIAL,
-        }
-    }
-
-    /// The delay to wait now; advances the schedule (double, capped) for the next call.
-    fn next_delay(&mut self) -> Duration {
-        let delay = self.current;
-        self.current = (self.current * 2).min(Self::MAX);
-        delay
-    }
-
-    fn reset(&mut self) {
-        self.current = Self::INITIAL;
-    }
-}
-
-/// Once-per-transition logging for the systemic accept-error path, mirroring the journal-cap warn
-/// fix (#741): one `error!` on entering the error state, silence while in it (counting suppressed
-/// errors), one `info!` carrying the suppressed count on recovery.
-#[derive(Default)]
-struct AcceptErrorLog {
-    in_error: bool,
-    suppressed: u64,
-}
-
-impl AcceptErrorLog {
-    /// Record a systemic error. Returns `true` **only** on the transition *into* the error state
-    /// (emit the single `error!`); later errors return `false` and bump the suppressed count.
-    fn on_error(&mut self) -> bool {
-        if self.in_error {
-            self.suppressed += 1;
-            false
-        } else {
-            self.in_error = true;
-            self.suppressed = 0;
-            true
-        }
-    }
-
-    /// Record a successful accept. Returns `Some(suppressed)` **only** on the transition *out* of
-    /// the error state (emit the single recovery `info!`); `None` in steady state, so a healthy
-    /// accept path pays just one branch.
-    fn on_success(&mut self) -> Option<u64> {
-        if self.in_error {
-            self.in_error = false;
-            Some(std::mem::take(&mut self.suppressed))
-        } else {
-            None
-        }
-    }
-}
 use tracing::{debug, error, info, warn};
 
 /// Server-level TLS defaults for HTTPS imposters that don't carry their own cert/key (issue #206).
@@ -1629,92 +1538,6 @@ mod tests {
     fn raise_fd_limit() {}
 
     // ── Accept-error handling (issue #750) ───────────────────────────────────────────────────
-    mod accept_error {
-        use super::*;
-        use std::io::{Error, ErrorKind};
-
-        #[test]
-        fn classify_transient_vs_systemic() {
-            for kind in [
-                ErrorKind::ConnectionAborted,
-                ErrorKind::Interrupted,
-                ErrorKind::ConnectionReset,
-            ] {
-                assert_eq!(
-                    classify_accept_error(&Error::from(kind)),
-                    AcceptErrorClass::Transient,
-                    "{kind:?} must be transient (retry immediately)"
-                );
-            }
-            // EMFILE (24) / ENFILE (23) map to Uncategorized -> systemic; and a named non-transient
-            // kind is systemic too. Unknown must never be treated as transient.
-            for e in [
-                Error::from_raw_os_error(24), // EMFILE
-                Error::from_raw_os_error(23), // ENFILE
-                Error::from(ErrorKind::OutOfMemory),
-                Error::from(ErrorKind::Other),
-            ] {
-                assert_eq!(
-                    classify_accept_error(&e),
-                    AcceptErrorClass::Systemic,
-                    "{e:?} must back off, not spin"
-                );
-            }
-        }
-
-        #[test]
-        fn backoff_doubles_from_1ms_caps_at_1s_and_resets() {
-            let mut b = AcceptBackoff::new();
-            assert_eq!(
-                b.next_delay(),
-                Duration::from_millis(1),
-                "first delay is 1ms, not 0"
-            );
-            assert_eq!(b.next_delay(), Duration::from_millis(2));
-            assert_eq!(b.next_delay(), Duration::from_millis(4));
-            assert_eq!(b.next_delay(), Duration::from_millis(8));
-            // Fast-forward well past the cap.
-            for _ in 0..20 {
-                b.next_delay();
-            }
-            assert_eq!(b.next_delay(), Duration::from_secs(1), "capped at 1s");
-            b.reset();
-            assert_eq!(
-                b.next_delay(),
-                Duration::from_millis(1),
-                "reset returns to 1ms"
-            );
-        }
-
-        // The log state machine backs the "exactly one error!, exactly one info! with the
-        // suppressed count" AC without sockets: on_error transitions once, on_success reports the
-        // count once, steady state stays silent.
-        #[test]
-        fn log_emits_once_per_transition_with_suppressed_count() {
-            let mut log = AcceptErrorLog::default();
-            assert!(
-                log.on_error(),
-                "first systemic error -> emit the one error!"
-            );
-            assert!(!log.on_error(), "second is suppressed");
-            assert!(!log.on_error(), "third is suppressed");
-            assert_eq!(
-                log.on_success(),
-                Some(2),
-                "recovery emits one info! carrying the 2 suppressed errors"
-            );
-            assert_eq!(log.on_success(), None, "steady state is silent");
-            assert_eq!(log.on_success(), None);
-
-            // A fresh outage re-arms: one error!, count restarts from 0.
-            assert!(log.on_error());
-            assert_eq!(
-                log.on_success(),
-                Some(0),
-                "immediate recovery suppressed nothing"
-            );
-        }
-    }
 
     #[tokio::test]
     async fn test_create_imposter_writes_to_datadir() {

--- a/crates/rift-mock-core/src/proxy/mod.rs
+++ b/crates/rift-mock-core/src/proxy/mod.rs
@@ -46,3 +46,7 @@ pub use tls::{TLS_SESSION_CACHE_SIZE, configure_session_resumption};
 // HTTP connection-builder tuning, shared with the metrics/admin accept loops in rift-http-proxy
 // (issue #716) — `network` itself stays `pub(crate)`, only this type is exposed.
 pub use network::{DEFAULT_HTTP_MAX_BUF, HttpTuning};
+// Accept-error handling shared by every listener in the workspace: the imposter serve loop
+// (issue #750) and the admin API accept loop (issue #826), which must classify-and-retry rather
+// than let one transient accept failure end the server.
+pub use network::{AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error};

--- a/crates/rift-mock-core/src/proxy/network.rs
+++ b/crates/rift-mock-core/src/proxy/network.rs
@@ -234,6 +234,108 @@ pub fn apply_stream_tuning(stream: &TcpStream, tuning: &SocketTuning) {
     }
 }
 
+// ── Accept-error handling (issue #750) ───────────────────────────────────────────────────────
+//
+// A bare `accept(2)` error arm that logs and immediately retries has two coupled defects, both
+// amplified ×N under the per-core listener fan-out (#745): it spins hot on a *systemic* error
+// (fd exhaustion cannot be cured by retrying), and it logs per failed accept — the exact
+// per-event-rate logging trap the journal-cap fix (#741) removed. The pieces below fix both with
+// no cost on the happy path.
+
+/// How an `accept(2)` error should be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptErrorClass {
+    /// Expected under load; the next accept is likely fine — retry immediately, log at `debug`.
+    Transient,
+    /// Resource exhaustion (or an unknown error): retrying now cannot succeed until something
+    /// frees, so back off. Unknown errors land here deliberately — spinning on an unrecognized
+    /// failure is the worse outcome.
+    Systemic,
+}
+
+/// Classify via [`std::io::ErrorKind`] so no `libc` dependency is needed: only the transient
+/// classes are named (`ECONNABORTED`/`EINTR`/`ECONNRESET`); everything else — resource exhaustion
+/// like `EMFILE`/`ENFILE`/`ENOBUFS` (`Uncategorized`) or `ENOMEM` (`OutOfMemory`), and any truly
+/// unknown error — falls through `_` to systemic.
+pub fn classify_accept_error(e: &std::io::Error) -> AcceptErrorClass {
+    use std::io::ErrorKind::{ConnectionAborted, ConnectionReset, Interrupted};
+    match e.kind() {
+        ConnectionAborted | Interrupted | ConnectionReset => AcceptErrorClass::Transient,
+        _ => AcceptErrorClass::Systemic,
+    }
+}
+
+/// Exponential backoff for the systemic accept-error path: 1ms doubling to a 1s cap, reset on the
+/// first successful accept. Pure and clock-free so the schedule is unit-testable without sockets.
+#[derive(Debug)]
+pub struct AcceptBackoff {
+    current: Duration,
+}
+
+impl Default for AcceptBackoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AcceptBackoff {
+    const INITIAL: Duration = Duration::from_millis(1);
+    const MAX: Duration = Duration::from_secs(1);
+
+    pub fn new() -> Self {
+        Self {
+            current: Self::INITIAL,
+        }
+    }
+
+    /// The delay to wait now; advances the schedule (double, capped) for the next call.
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = (self.current * 2).min(Self::MAX);
+        delay
+    }
+
+    pub fn reset(&mut self) {
+        self.current = Self::INITIAL;
+    }
+}
+
+/// Once-per-transition logging for the systemic accept-error path, mirroring the journal-cap warn
+/// fix (#741): one `error!` on entering the error state, silence while in it (counting suppressed
+/// errors), one `info!` carrying the suppressed count on recovery.
+#[derive(Debug, Default)]
+pub struct AcceptErrorLog {
+    in_error: bool,
+    suppressed: u64,
+}
+
+impl AcceptErrorLog {
+    /// Record a systemic error. Returns `true` **only** on the transition *into* the error state
+    /// (emit the single `error!`); later errors return `false` and bump the suppressed count.
+    pub fn on_error(&mut self) -> bool {
+        if self.in_error {
+            self.suppressed += 1;
+            false
+        } else {
+            self.in_error = true;
+            self.suppressed = 0;
+            true
+        }
+    }
+
+    /// Record a successful accept. Returns `Some(suppressed)` **only** on the transition *out* of
+    /// the error state (emit the single recovery `info!`); `None` in steady state, so a healthy
+    /// accept path pays just one branch.
+    pub fn on_success(&mut self) -> Option<u64> {
+        if self.in_error {
+            self.in_error = false;
+            Some(std::mem::take(&mut self.suppressed))
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,5 +495,93 @@ mod tests {
         assert!(!server_stream.nodelay().expect("nodelay query"));
 
         let _ = client.await.expect("join").expect("connect");
+    }
+}
+
+#[cfg(test)]
+mod accept_error {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn classify_transient_vs_systemic() {
+        for kind in [
+            ErrorKind::ConnectionAborted,
+            ErrorKind::Interrupted,
+            ErrorKind::ConnectionReset,
+        ] {
+            assert_eq!(
+                classify_accept_error(&Error::from(kind)),
+                AcceptErrorClass::Transient,
+                "{kind:?} must be transient (retry immediately)"
+            );
+        }
+        // EMFILE (24) / ENFILE (23) map to Uncategorized -> systemic; and a named non-transient
+        // kind is systemic too. Unknown must never be treated as transient.
+        for e in [
+            Error::from_raw_os_error(24), // EMFILE
+            Error::from_raw_os_error(23), // ENFILE
+            Error::from(ErrorKind::OutOfMemory),
+            Error::from(ErrorKind::Other),
+        ] {
+            assert_eq!(
+                classify_accept_error(&e),
+                AcceptErrorClass::Systemic,
+                "{e:?} must back off, not spin"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_from_1ms_caps_at_1s_and_resets() {
+        let mut b = AcceptBackoff::new();
+        assert_eq!(
+            b.next_delay(),
+            Duration::from_millis(1),
+            "first delay is 1ms, not 0"
+        );
+        assert_eq!(b.next_delay(), Duration::from_millis(2));
+        assert_eq!(b.next_delay(), Duration::from_millis(4));
+        assert_eq!(b.next_delay(), Duration::from_millis(8));
+        // Fast-forward well past the cap.
+        for _ in 0..20 {
+            b.next_delay();
+        }
+        assert_eq!(b.next_delay(), Duration::from_secs(1), "capped at 1s");
+        b.reset();
+        assert_eq!(
+            b.next_delay(),
+            Duration::from_millis(1),
+            "reset returns to 1ms"
+        );
+    }
+
+    // The log state machine backs the "exactly one error!, exactly one info! with the
+    // suppressed count" AC without sockets: on_error transitions once, on_success reports the
+    // count once, steady state stays silent.
+    #[test]
+    fn log_emits_once_per_transition_with_suppressed_count() {
+        let mut log = AcceptErrorLog::default();
+        assert!(
+            log.on_error(),
+            "first systemic error -> emit the one error!"
+        );
+        assert!(!log.on_error(), "second is suppressed");
+        assert!(!log.on_error(), "third is suppressed");
+        assert_eq!(
+            log.on_success(),
+            Some(2),
+            "recovery emits one info! carrying the 2 suppressed errors"
+        );
+        assert_eq!(log.on_success(), None, "steady state is silent");
+        assert_eq!(log.on_success(), None);
+
+        // A fresh outage re-arms: one error!, count restarts from 0.
+        assert!(log.on_error());
+        assert_eq!(
+            log.on_success(),
+            Some(0),
+            "immediate recovery suppressed nothing"
+        );
     }
 }


### PR DESCRIPTION
A transient accept error (ECONNABORTED, EMFILE under fd pressure) terminated the admin API server, causing any embedder racing RunningServer::wait() to see a node leaving the cluster — making fd pressure a correlated restart storm across a fleet.

The admin listener now applies the same three-way classify-and-retry policy the imposter serve loop has had since #750: transient errors retry immediately, systemic ones back off (1ms doubling to 1s cap) and log once per outage, and genuinely broken listeners (EBADF/ENOTSOCK/EINVAL) still terminate so wait() reports a dead admin plane instead of lingering forever.

The shared machinery (AcceptBackoff, AcceptErrorLog, classify_accept_error) moved from imposter::manager to proxy::network and is now public (rift_mock_core::proxy::*) so both listeners cannot drift apart. The data plane behavior is unchanged.

Closes #826

Milestone: none (standalone)