### PR TITLE
fix(bootstrap): restart with global --pidfile makes the process SIGTERM itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@ record.
 
 ### Fixed
 
+- **`rift restart` no longer makes the process SIGTERM itself** (issue #827). `--pidfile` existed as
+  two separate clap bindings — a top-level `Option<PathBuf>` and a `pidfile` field on each of `stop`
+  and `restart` — and the PID file was written *before* subcommand dispatch. So
+  `rift --pidfile p restart` wrote its own PID to `p` and then signalled it (exit 143, no server
+  started); `rift restart --pidfile p` stopped the old server but the new one wrote no PID file; and
+  `rift --pidfile p save` overwrote a running server's PID with the short-lived save process's.
+  `--pidfile` is now a single `global` flag that binds before or after the subcommand, and the PID
+  file is written only on the serving path. `restart` also now treats a missing PID file as
+  "nothing to stop, start fresh" (new `bootstrap::stop_for_restart`), while bare `stop` keeps its
+  hard error. The `stop`/`restart` fallback is `bootstrap::DEFAULT_PIDFILE` (`rift.pid`), applied at
+  dispatch — a plain `rift` start still writes no PID file unless asked.
+
 - **`rift stop` refuses a pidfile with a non-positive PID** (issue #822). `stop_server` parsed the
   pidfile's PID without a range check, so a corrupt or crafted pidfile containing `0` or a negative
   number would reach `kill(pid, SIGTERM)` — where `kill(0, …)` signals the caller's entire process

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -78,6 +78,27 @@ pub fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> Result<(), anyhow:
     Ok(())
 }
 
+/// Default PID file for the `stop`/`restart` subcommands when `--pidfile` is not given.
+///
+/// Deliberately applied at the dispatch site rather than as a clap `default_value` on the global
+/// `--pidfile`: a default on the flag itself would make every plain `rift` start write a PID file
+/// it never wrote before (issue #827).
+pub const DEFAULT_PIDFILE: &str = "rift.pid";
+
+/// Stop a running server for `restart`: a missing PID file is a satisfied precondition.
+///
+/// `restart` means "end up running". If there is no PID file there is nothing to stop and the
+/// desired end state already holds, so this reports `Ok` and lets the caller start — whereas bare
+/// [`stop_server`] keeps its hard error, since a `stop` with nothing to stop is a user error
+/// (issue #827).
+pub fn stop_for_restart(pidfile: &Path) -> Result<(), anyhow::Error> {
+    if !pidfile.exists() {
+        info!("no PID file at {pidfile:?}; nothing to stop, starting fresh");
+        return Ok(());
+    }
+    stop_server(pidfile)
+}
+
 /// Stop a running server by PID file.
 ///
 /// Idempotent about the end state, loud about everything else: a stale pidfile (the process is

--- a/crates/rift-http-proxy/src/main.rs
+++ b/crates/rift-http-proxy/src/main.rs
@@ -42,7 +42,9 @@ const ACTIVE_ALLOCATOR: &str = "jemalloc";
 const ACTIVE_ALLOCATOR: &str = "system";
 
 use clap::Parser;
-use rift_http_proxy::bootstrap::{apply_rcfile_defaults, save_imposters, stop_server};
+use rift_http_proxy::bootstrap::{
+    DEFAULT_PIDFILE, apply_rcfile_defaults, save_imposters, stop_for_restart, stop_server,
+};
 use rift_http_proxy::healthcheck;
 use rift_http_proxy::runtime;
 use rift_http_proxy::script_cli;
@@ -60,9 +62,10 @@ fn main() -> Result<(), anyhow::Error> {
         return script_cli::dispatch(action);
     }
 
-    // Same treatment for `healthcheck` (issue #664), and for a second reason beyond skipping the
-    // bootstrap: the path below writes `--pidfile`, which would clobber the running server's PID
-    // file with the probe's own — every container health check.
+    // Same treatment for `healthcheck` (issue #664): skip the server bootstrap entirely. (It used
+    // to matter for a second reason — the path below wrote `--pidfile`, clobbering the running
+    // server's PID file with the probe's own — but since #827 the PID file is written only on the
+    // serving path, so a transient subcommand can no longer touch it.)
     if let Some(Commands::Healthcheck { url, timeout }) = cli.command.clone() {
         return healthcheck::dispatch(url, &cli.host, cli.port, timeout);
     }
@@ -120,20 +123,14 @@ fn main() -> Result<(), anyhow::Error> {
         .with(file_layer)
         .init();
 
-    // Write PID file if requested
-    if let Some(ref pidfile) = cli.pidfile {
-        let pid = std::process::id();
-        std::fs::write(pidfile, pid.to_string())?;
-        info!("Wrote PID {} to {:?}", pid, pidfile);
-    }
-
     // Handle subcommands
     match &cli.command {
-        Some(Commands::Stop { pidfile }) => {
-            return stop_server(pidfile);
+        Some(Commands::Stop) => {
+            return stop_server(&pidfile_or_default(&cli));
         }
-        Some(Commands::Restart { pidfile }) => {
-            stop_server(pidfile)?;
+        Some(Commands::Restart) => {
+            // A missing PID file is a satisfied precondition for restart, not an error (#827).
+            stop_for_restart(&pidfile_or_default(&cli))?;
             // Fall through to start
         }
         Some(Commands::Save {
@@ -178,8 +175,26 @@ fn main() -> Result<(), anyhow::Error> {
     run_mountebank_mode(cli)
 }
 
+/// The PID file `stop`/`restart` act on: the single global `--pidfile` binding, falling back to
+/// [`DEFAULT_PIDFILE`] (issue #827 — the default lives here, not on the flag).
+fn pidfile_or_default(cli: &Cli) -> std::path::PathBuf {
+    cli.pidfile
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from(DEFAULT_PIDFILE))
+}
+
 /// Run in Mountebank-compatible mode
 fn run_mountebank_mode(cli: Cli) -> Result<(), anyhow::Error> {
+    // Write the PID file here — the one place every serving entry converges (plain start, the
+    // `restart` fall-through, and `Replay`'s re-entry). Writing it before the subcommand dispatch
+    // meant `rift --pidfile p restart` recorded its OWN pid and then SIGTERMed itself, and a
+    // transient `save`/`healthcheck` clobbered a running server's file (issue #827).
+    if let Some(ref pidfile) = cli.pidfile {
+        let pid = std::process::id();
+        std::fs::write(pidfile, pid.to_string())?;
+        info!("Wrote PID {} to {:?}", pid, pidfile);
+    }
+
     // Topology selection (RFC-712, issue #744). Clap already applied RIFT_RUNTIME env fallback
     // into `cli.runtime`, so resolve() only sees the merged value; the platform gate then
     // downgrades or rejects per RFC D5 (macOS falls back with a warning, Windows refuses).

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -98,8 +98,11 @@ pub struct Cli {
     #[arg(long, value_name = "FILE")]
     pub log: Option<PathBuf>,
 
-    /// PID file path
-    #[arg(long, value_name = "FILE")]
+    /// PID file path. `global` so `stop`/`restart` bind the same value whether it is given
+    /// before or after the subcommand (issue #827). Deliberately has NO `default_value`: a default
+    /// here would make every plain `rift` start write `./rift.pid`. `stop`/`restart` apply
+    /// [`bootstrap::DEFAULT_PIDFILE`](crate::bootstrap::DEFAULT_PIDFILE) at their dispatch site.
+    #[arg(long, value_name = "FILE", global = true)]
     pub pidfile: Option<PathBuf>,
 
     /// CORS allowed origin
@@ -200,18 +203,10 @@ pub enum Commands {
     Start,
 
     /// Stop a running Rift server
-    Stop {
-        /// PID file to read for the process to stop
-        #[arg(long, default_value = "rift.pid")]
-        pidfile: PathBuf,
-    },
+    Stop,
 
     /// Restart the Rift server
-    Restart {
-        /// PID file to read for the process to restart
-        #[arg(long, default_value = "rift.pid")]
-        pidfile: PathBuf,
-    },
+    Restart,
 
     /// Save current imposters to a file
     Save {

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -446,3 +446,68 @@ async fn save_imposters_rejects_non_2xx_and_writes_nothing() {
 
     server.shutdown().await;
 }
+
+// ── issue #827: one pidfile binding, and restart tolerates a missing file ────────────────────
+
+// AC1: `--pidfile` is a single global binding — it parses before OR after the subcommand, and
+// `stop`/`restart` no longer carry their own. The `None` cases pin the deliberate absence of a
+// clap `default_value`: a default on the global flag would make every plain `rift` start write
+// `./rift.pid`, which it never did before.
+#[test]
+fn pidfile_is_one_global_binding_with_no_default() {
+    assert_eq!(
+        cli(&["stop", "--pidfile", "p"]).pidfile.as_deref(),
+        Some(std::path::Path::new("p")),
+        "--pidfile after the subcommand must bind the global field"
+    );
+    assert_eq!(
+        cli(&["--pidfile", "p", "restart"]).pidfile.as_deref(),
+        Some(std::path::Path::new("p")),
+        "--pidfile before the subcommand must bind the same field"
+    );
+    assert_eq!(
+        cli(&["stop"]).pidfile,
+        None,
+        "no --pidfile means None; the stop/restart default is applied at dispatch, not by clap"
+    );
+    assert_eq!(
+        cli(&[]).pidfile,
+        None,
+        "a plain start must not acquire a pidfile default"
+    );
+}
+
+// AC2: restart with no PID file is a satisfied precondition (nothing to stop, go start), while
+// bare `stop` keeps its hard error — the asymmetry is the point.
+#[test]
+fn stop_for_restart_missing_pidfile_is_ok_but_stop_still_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let absent = dir.path().join("absent.pid");
+
+    bootstrap::stop_for_restart(&absent).expect("restart tolerates a missing pidfile");
+    assert!(!absent.exists(), "nothing is created by the no-op path");
+
+    bootstrap::stop_server(&absent).expect_err("bare stop still errors on a missing pidfile");
+}
+
+// AC3: when a process IS named, stop_for_restart behaves exactly like stop_server.
+#[cfg(unix)]
+#[test]
+fn stop_for_restart_stops_a_live_process() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn a stand-in server process");
+    let pidfile = dir.path().join("server.pid");
+    std::fs::write(&pidfile, child.id().to_string()).expect("write pidfile");
+
+    bootstrap::stop_for_restart(&pidfile).expect("stop_for_restart succeeds");
+
+    assert!(!pidfile.exists(), "the pidfile must be removed");
+    let status = child.wait().expect("reap the stand-in process");
+    assert!(
+        !status.success(),
+        "the process should have been signalled, got: {status:?}"
+    );
+}

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -165,6 +165,8 @@ imposters. These live in `rift_http_proxy::bootstrap` so an alternative binary k
 | Function | Signature | Purpose |
 |:---------|:----------|:--------|
 | `apply_rcfile_defaults` | `fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> anyhow::Result<()>` | Fill CLI fields **still at their clap defaults** from a Mountebank-compatible JSON rcfile. An explicitly-supplied flag always wins; unrecognised keys are warned and ignored. |
+| `stop_for_restart` | `fn stop_for_restart(pidfile: &Path) -> anyhow::Result<()>` | `stop_server`, except a missing PID file is a satisfied precondition (nothing to stop) rather than an error — the `restart` semantic. |
+| `DEFAULT_PIDFILE` | `pub const DEFAULT_PIDFILE: &str` | The `rift.pid` fallback `stop`/`restart` apply when `--pidfile` is absent. Applied at the dispatch site so a plain start never writes a PID file it wasn't asked to. |
 | `stop_server` | `fn stop_server(pidfile: &Path) -> anyhow::Result<()>` | Signal the process named in `pidfile` (SIGTERM on unix, `taskkill /F` on Windows), then remove the file. A stale pidfile (process already gone) is cleaned up as `Ok`; a denied or failed signal is an error and the pidfile is kept. |
 | `save_imposters_async` | `async fn save_imposters_async(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Fetch `GET /imposters?replayable=true` from a running admin API and write it to `savefile`. The async form — call it from an embedder's own runtime. A non-2xx admin response is an error; nothing is written to `savefile`. |
 | `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Blocking wrapper over `save_imposters_async` for the sync `save` subcommand path. |
@@ -183,15 +185,23 @@ if let Some(rcfile) = cli.rcfile.clone() {
 }
 
 match &cli.command {
-    Some(Commands::Stop { pidfile }) => return bootstrap::stop_server(pidfile),
-    // `restart` is just `stop` followed by the normal start path.
-    Some(Commands::Restart { pidfile }) => bootstrap::stop_server(pidfile)?,
+    // `--pidfile` is a single global binding (issue #827): it parses before or after the
+    // subcommand, and the stop/restart default lives here, not on the flag.
+    Some(Commands::Stop) => return bootstrap::stop_server(&pidfile_or_default(&cli)),
+    // `restart` is `stop` followed by the normal start path — but a missing PID file means
+    // "nothing to stop", not an error, so it uses the restart-specific seam.
+    Some(Commands::Restart) => bootstrap::stop_for_restart(&pidfile_or_default(&cli))?,
     Some(Commands::Save { savefile, remove_proxies }) => {
         return bootstrap::save_imposters(&cli.host, cli.port, savefile, *remove_proxies);
     }
     _ => {}
 }
 ```
+
+The `rift` binary writes `--pidfile` only on the **serving** path (inside `run_mountebank_mode`),
+never before subcommand dispatch — otherwise `rift --pidfile p restart` would record its own PID and
+then signal itself, and a transient `save`/`healthcheck` would clobber a running server's file
+(issue #827). An alternative binary should keep that ordering.
 
 `save_imposters` builds its own tokio runtime and blocks on it (it is a sync subcommand path), so do
 not call it from inside a running async runtime — it would panic starting a nested runtime. From


### PR DESCRIPTION
## Summary

Fixes three related failures with the --pidfile flag:
1. `rift --pidfile p restart` wrote its own PID and then SIGTERMed itself
2. `rift restart --pidfile p` left the new server with no PID file
3. A transient `save` could clobber a running server's PID file

## Solution

Two-part fix:
- **Single global binding**: Consolidated --pidfile from two separate clap bindings (top-level Option + fields on stop/restart) into one global flag
- **Write-when-serving only**: PID file is now written only on the serving path, not before subcommand dispatch

## API Changes

- New `stop_for_restart()` seam that treats a missing PID file as nothing-to-stop (restart now starts fresh instead of erroring)
- New `bootstrap::DEFAULT_PIDFILE` constant so a plain `rift start` still writes no PID file by default
- Behavior change: `rift restart` with no --pidfile now starts a fresh server instead of failing

## Notes

docs/embedding/server.md was updated since rift-ee-server copies that snippet for its own server integration.

Closes #827

Milestone: none (standalone)