### PR TITLE
test(admin-api): expose fault-injectable RunningServer constructor for embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ record.
 
 ### Added
 
+- **`test-util` feature: fault-injectable `RunningServer` / `RunningAdminApi` constructors**
+  (issue #825). `RunningAdminApi::wait()` has exactly-once error delivery backed by a drop guard
+  that reports the accept loop dying however it dies — but the only way to *reach* that `Err` path
+  was an in-crate `#[cfg(test)]` helper, so an embedder that propagates a `RunningServer` outcome to
+  process exit could not write a regression test for it. `RunningServer::with_admin_accept_task` and
+  `RunningAdminApi::with_accept_task` build a handle whose accept loop is an arbitrary future, so a
+  downstream test can inject a failure (or a panic) and assert its reaction. Both are gated behind
+  the new `test-util` feature and bind no listener — test scaffolding, never a production
+  constructor. The in-crate test helper now delegates to the same seam, so what is tested and what
+  embedders get cannot drift.
+
 - **`rift_http_proxy::bootstrap::save_imposters_async` — a non-panicking async form of `save_imposters`**
   (issue #815). `save_imposters` builds its own tokio runtime and `block_on`s it, so an async
   embedder calling it directly from an async worker thread panics with "Cannot start a runtime from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest",
+ "rift-http-proxy",
  "rift-lint",
  "rift-mock-core",
  "rift-types",

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -99,6 +99,12 @@ sxd-xpath = "0.4"
 # JSONPath RFC 9535 support
 serde_json_path = "0.7"
 
+# The bootstrap_seam integration test exercises the #825 fault-injection seam, which is
+# feature-gated; enable it for this crate's own dev builds so CI covers it.
+[dev-dependencies.rift-http-proxy]
+path = "."
+features = ["test-util"]
+
 [dev-dependencies]
 # Turn on the failing flow-store backend for backend-outage tests (issue #318)
 rift-mock-core = { path = "../rift-mock-core", version = "0.1.0", default-features = false, features = ["test-backend"] }
@@ -133,6 +139,10 @@ mimalloc = ["dep:mimalloc"]
 # (e.g. CI's --all-features lanes) mimalloc wins by cfg precedence in main.rs — deliberately
 # NOT a compile_error! because CI builds --all-features.
 jemalloc = ["dep:tikv-jemallocator"]
+# Exposes the fault-injectable `RunningAdminApi`/`RunningServer` constructors so a downstream
+# embedder can drive the accept-loop failure path in its own tests (issue #825). Test-only surface:
+# never enable it in a production build.
+test-util = []
 
 [[bin]]
 name = "rift-verify"

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -210,6 +210,49 @@ pub struct RunningAdminApi {
 }
 
 impl RunningAdminApi {
+    /// Build a `RunningAdminApi` whose "accept loop" is an arbitrary future — the seam for testing
+    /// the failure path (issue #825).
+    ///
+    /// The real [`bind`](AdminApiServer::bind) can only fail its accept loop by genuinely breaking
+    /// the listener, so the exactly-once error delivery of [`wait`](Self::wait) / [`join`](Self::join)
+    /// — and the [`ReleaseWaiters`] drop guard behind it — is otherwise unreachable from outside this
+    /// crate. An embedder that propagates a `RunningServer` outcome to process exit (rift-enterprise
+    /// #42) needs to prove it reacts correctly, so pass a future that returns `Err`, or panics, and
+    /// assert what your code does with it.
+    ///
+    /// No listener is bound: `local_addr()` reports `127.0.0.1:0` and the tracker is empty. Gated
+    /// behind the `test-util` feature — it is test scaffolding, not a production constructor.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn with_accept_task<F>(loop_body: F) -> Self
+    where
+        F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let cancel = CancellationToken::new();
+        let done = CancellationToken::new();
+        let outcome: Arc<Mutex<Option<anyhow::Result<()>>>> = Arc::new(Mutex::new(None));
+        let (task_done, task_outcome) = (done.clone(), Arc::clone(&outcome));
+        let release_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let _release = ReleaseWaiters {
+                done: task_done,
+                outcome: Arc::clone(&task_outcome),
+                shutdown_requested: release_cancel,
+            };
+            let result = loop_body.await;
+            *task_outcome
+                .lock()
+                .expect("admin API outcome mutex poisoned") = Some(result);
+        });
+
+        Self {
+            local_addr: "127.0.0.1:0".parse().expect("test addr"),
+            cancel,
+            tracker: TaskTracker::new(),
+            task: Mutex::new(Some(task)),
+            done,
+            outcome,
+        }
+    }
     /// The actual bound address (a `:0` request resolves to the OS-assigned port here).
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
@@ -652,31 +695,9 @@ mod wait_seam_tests {
     where
         F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let cancel = CancellationToken::new();
-        let done = CancellationToken::new();
-        let outcome: Arc<Mutex<Option<anyhow::Result<()>>>> = Arc::new(Mutex::new(None));
-        let (task_done, task_outcome) = (done.clone(), Arc::clone(&outcome));
-        let release_cancel = cancel.clone();
-        let task = tokio::spawn(async move {
-            let _release = ReleaseWaiters {
-                done: task_done,
-                outcome: Arc::clone(&task_outcome),
-                shutdown_requested: release_cancel,
-            };
-            let result = loop_body.await;
-            *task_outcome
-                .lock()
-                .expect("admin API outcome mutex poisoned") = Some(result);
-        });
-
-        RunningAdminApi {
-            local_addr: "127.0.0.1:0".parse().expect("test addr"),
-            cancel,
-            tracker: TaskTracker::new(),
-            task: Mutex::new(Some(task)),
-            done,
-            outcome,
-        }
+        // Delegates to the public seam so the tested construction and the one embedders get are
+        // the same code (issue #825).
+        RunningAdminApi::with_accept_task(loop_body)
     }
 
     /// `shutdown` aborts a loop that outlives the grace window, so the task never publishes an

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -533,6 +533,27 @@ pub struct RunningServer {
 }
 
 impl RunningServer {
+    /// Build a `RunningServer` whose admin accept loop is an arbitrary future — the seam for
+    /// testing what your code does when the admin plane dies (issue #825).
+    ///
+    /// An embedder that races [`wait`](Self::wait) and propagates the outcome to process exit
+    /// (rift-enterprise #42) cannot otherwise reach that `Err` path from outside this crate: the
+    /// real accept loop only fails by genuinely breaking the listener. Pass a future returning
+    /// `Err` (or one that panics) and assert your reaction.
+    ///
+    /// No listener is bound and there is no metrics server; `admin_addr()` reports `127.0.0.1:0`.
+    /// Gated behind the `test-util` feature — test scaffolding, not a production constructor.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn with_admin_accept_task<F>(loop_body: F) -> Self
+    where
+        F: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        Self {
+            admin: crate::admin_api::RunningAdminApi::with_accept_task(loop_body),
+            metrics: None,
+            intercept: InterceptControl::default(),
+        }
+    }
     /// The bound admin API address (resolves a `:0` request to the assigned port).
     pub fn admin_addr(&self) -> SocketAddr {
         self.admin.local_addr()

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -446,3 +446,43 @@ async fn save_imposters_rejects_non_2xx_and_writes_nothing() {
 
     server.shutdown().await;
 }
+
+// ── issue #825: the fault-injection seam is reachable from OUTSIDE the crate ─────────────────
+//
+// This suite is an integration test on purpose: it compiles as an external crate, so it only
+// builds if the constructors are genuinely public under the `test-util` feature — which is the
+// property the issue is about (rift-enterprise could not reach the accept-loop Err path at all).
+
+#[tokio::test]
+async fn running_server_admin_failure_is_observable_by_an_embedder() {
+    let server = rift_http_proxy::server::RunningServer::with_admin_accept_task(async {
+        Err(anyhow::anyhow!("admin plane died"))
+    });
+
+    let err = server
+        .wait()
+        .await
+        .expect_err("a failing admin accept loop must surface as Err to the embedder");
+    assert!(
+        err.to_string().contains("admin plane died"),
+        "the embedder must see the underlying cause, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn running_admin_api_failure_is_delivered_exactly_once() {
+    let admin = rift_http_proxy::admin_api::RunningAdminApi::with_accept_task(async {
+        Err(anyhow::anyhow!("listener died"))
+    });
+
+    admin
+        .wait()
+        .await
+        .expect_err("first waiter receives the error");
+    // Exactly-once delivery: anyhow::Error is not Clone, so later waiters get Ok rather than a
+    // duplicate. Pinning it keeps the contract from silently changing under an embedder.
+    admin
+        .wait()
+        .await
+        .expect("later waiters see Ok, not a duplicate error");
+}

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -510,6 +510,7 @@ fn stop_for_restart_stops_a_live_process() {
         !status.success(),
         "the process should have been signalled, got: {status:?}"
     );
+}
 
 // ── issue #825: the fault-injection seam is reachable from OUTSIDE the crate ─────────────────
 //

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -155,6 +155,32 @@ metrics.shutdown().await;
 
 ---
 
+## Testing against a dead admin plane (`test-util`)
+
+`RunningServer::wait()` reports the admin accept loop dying, which an embedder typically propagates
+to process exit. Provoking that failure for real means breaking the listener, so the `test-util`
+feature exposes constructors whose "accept loop" is a future you supply (issue #825):
+
+```toml
+[dev-dependencies]
+rift-http-proxy = { version = "*", features = ["test-util"] }
+```
+
+```rust
+use rift_http_proxy::server::RunningServer;
+
+let server = RunningServer::with_admin_accept_task(async {
+    Err(anyhow::anyhow!("admin plane died"))
+});
+let err = server.wait().await.expect_err("the embedder must see the failure");
+```
+
+`RunningAdminApi::with_accept_task` is the same seam one layer down. Neither binds a listener
+(`admin_addr()` reports `127.0.0.1:0`), and both are test scaffolding — do not enable `test-util` in
+a production build.
+
+---
+
 ## Bootstrap helpers
 
 `ServerBuilder` composes the *running* server, but a binary also has bootstrap concerns around it:


### PR DESCRIPTION
Exposes RunningServer::with_admin_accept_task and RunningAdminApi::with_accept_task constructors, which accept a caller-supplied accept loop future, behind a new `test-util` feature gate. This allows embedders to test the reaction when the admin accept loop fails.

RunningAdminApi::wait() reports accept loop failures, but the error path was previously unreachable from outside the crate. The in-crate test helper now delegates to these seams so tested and shipped construction paths cannot drift.

Adds "Testing against a dead admin plane" section to docs/embedding/server.md.

Closes #825

Milestone: none (standalone)