### PR TITLE
feat(extensions): NoMatchInterceptor — async pre-default-response hook on the no-match path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ record.
 
 ### Added
 
+- **`NoMatchInterceptor` — a last-chance hook on the no-match path** (issue #819). There was no seam
+  between "no stub matched" and the `defaultForward`/`defaultResponse`/empty-`200` fallthrough:
+  `ImposterEventListener` observes config mutations only, and `ResponseDecorator` runs after the
+  response exists and can touch just headers. An embedder whose replicated config is momentarily
+  behind therefore had no way to wait for it and retry. `ImposterManager::with_no_match_interceptor`
+  registers a hook that is consulted **only** on a genuine no-match and may answer `Proceed`
+  (fall through unchanged) or `RetryMatch` (re-run matching exactly once; a hit is served as a normal
+  match, a second miss falls through). It fires even when a default is configured — under lag the
+  right stub may be missing and forwarding would misdirect the request. Registering no interceptor
+  leaves behaviour byte-identical on both the serve loop and the `/__rift/` gateway.
+
 - **`rift_http_proxy::bootstrap::save_imposters_async` — a non-panicking async form of `save_imposters`**
   (issue #815). `save_imposters` builds its own tokio runtime and `block_on`s it, so an async
   embedder calling it directly from an async worker thread panics with "Cannot start a runtime from

--- a/crates/rift-mock-core/src/extensions/mod.rs
+++ b/crates/rift-mock-core/src/extensions/mod.rs
@@ -13,12 +13,15 @@
 //! - **Template Functions** (`template_fn`): Declarative `{{ function args | filter }}`
 //!   response templating (issue #359)
 //! - **Routing** (`routing`): Multi-upstream routing for reverse proxy mode
+//! - **No-Match Interceptor** (`no_match`): Last-chance hook for a genuine no-match, before the
+//!   defaultForward/defaultResponse/empty-200 fallthrough (issue #819)
 
 pub mod decorate;
 pub mod fault;
 pub mod flow_state;
 pub mod matcher;
 pub mod metrics;
+pub mod no_match;
 pub mod routing;
 pub mod stub_analysis;
 pub mod template;
@@ -33,6 +36,8 @@ pub use flow_state::{CasOutcome, FlowStore, FlowStoreProvider, NoOpFlowStore, cr
 pub use matcher::{CompiledMatch, CompiledRule};
 #[allow(unused_imports)]
 pub use metrics::{collect_metrics, record_request};
+#[allow(unused_imports)]
+pub use no_match::{NoMatchContext, NoMatchDirective, NoMatchInterceptor};
 #[allow(unused_imports)]
 pub use routing::Router;
 #[allow(unused_imports)]

--- a/crates/rift-mock-core/src/extensions/no_match.rs
+++ b/crates/rift-mock-core/src/extensions/no_match.rs
@@ -1,0 +1,58 @@
+//! The no-match interceptor seam (issue #819): a last-chance hook consulted when an imposter
+//! genuinely has no stub matching an incoming request, before any of the built-in no-match
+//! fallthrough kicks in.
+
+use std::future::Future;
+
+/// What the interceptor saw. Borrowed from the in-flight request; nothing is cloned on the hot
+/// path (the hook is only ever constructed after matching has already failed).
+#[derive(Debug, Clone, Copy)]
+pub struct NoMatchContext<'a> {
+    /// The imposter's bound port.
+    pub port: u16,
+    pub method: &'a str,
+    pub path: &'a str,
+}
+
+/// The interceptor's verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoMatchDirective {
+    /// Fall through to defaultForward / defaultResponse / empty-200, unchanged.
+    Proceed,
+    /// Re-run stub matching exactly once; a hit is served as a normal match, a second miss falls
+    /// through as `Proceed` would have.
+    RetryMatch,
+}
+
+/// A last-chance hook for a request that matched no stub.
+///
+/// Design rulings (issue #819):
+///
+/// - Consulted ONLY on a genuine no-match, BEFORE the defaultForward/defaultResponse/empty-200
+///   fallthrough. Never for matched requests, disabled imposters, matcher errors, or the debug
+///   path — zero cost on the hot path.
+/// - It fires even when `defaultForward`/`defaultResponse` IS configured, deliberately: under
+///   replication lag the right stub may be momentarily missing and the request would otherwise
+///   be misdirected upstream. Rescue outranks forwarding.
+/// - Implementations must be bounded — the request is parked while this future runs.
+/// - At most ONE retry per request; a second miss falls through exactly as `Proceed` would.
+/// - Annotations (`extensions::decorate::annotate`) are visible wherever a `ResponseDecorator`
+///   is wired (the serve loop); on the `/__rift/` gateway they are inert, since that path has
+///   neither an annotation scope nor a decorator.
+/// - Out of scope: a request to a port with NO imposter never reaches any imposter handler (no
+///   listener, or the gateway 404s first), so there is nothing to hang a hook on. Embedders must
+///   cover that window with their own readiness gating.
+/// # `RetryMatch` re-runs the whole matching pass
+///
+/// "Indistinguishable from a first-try match" describes everything *downstream* of the match —
+/// the scenario FSM, the single cycler advance, and response dispatch all behave identically. It
+/// does **not** describe the match itself: a retry re-evaluates predicates, so a predicate
+/// `inject` script executes a second time and its persistent `state` mutations and `logger` output
+/// are committed twice. Worst-case matching wall-clock for a rescued request is also two
+/// `scriptEngine.timeoutMs` budgets plus however long this hook parks the request.
+pub trait NoMatchInterceptor: Send + Sync {
+    fn on_no_match<'a>(
+        &'a self,
+        ctx: NoMatchContext<'a>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = NoMatchDirective> + Send + 'a>>;
+}

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -138,6 +138,10 @@ pub struct Imposter {
     /// Admin SSE event bus (issue #461), shared from the manager so recorded requests fan out to
     /// streaming clients. `None` for a standalone imposter (no manager) — then nothing is published.
     pub(crate) event_bus: Option<Arc<super::events::AdminEventBus>>,
+    /// Last-chance no-match hook (issue #819), shared from the manager. `None` = no interceptor;
+    /// the request falls through to defaultForward/defaultResponse/empty-200 as before.
+    pub(crate) no_match_interceptor:
+        Option<Arc<dyn crate::extensions::no_match::NoMatchInterceptor>>,
     /// Recorded-request storage (issue #314); defaults to a private LocalJournal,
     /// or the embedder's shared journal injected via the manager.
     pub(crate) journal: Arc<dyn crate::imposter::journal::RequestJournal>,
@@ -227,6 +231,7 @@ impl Imposter {
             stubs_write: Mutex::new(()),
             proxy_store: Arc::new(LocalProxyStore::new(proxy_mode)),
             event_bus: None,
+            no_match_interceptor: None,
             journal: journal
                 .unwrap_or_else(|| Arc::new(crate::imposter::journal::LocalJournal::default())),
             enabled: AtomicBool::new(enabled),

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -19,6 +19,7 @@ use crate::behaviors::{
 use crate::extensions::decorate::{
     ResponseDecorator, ResponsePhase, backend_error_response, with_annotation_scope,
 };
+use crate::extensions::no_match::{NoMatchContext, NoMatchDirective};
 use crate::extensions::template::{RequestData, has_template_variables, process_template};
 use crate::scripting::{
     FaultDecision, ScriptCtxExtras, ScriptRequest, ScriptStubContext, resolve_script_timeout_ms,
@@ -584,7 +585,7 @@ async fn handle_request_inner(
     // Get client address info for requestFrom, ip predicates
     let request_from = client_addr.to_string();
     let client_ip = client_addr.ip().to_string();
-    let matched = match imposter
+    let mut matched = match imposter
         .find_matching_stub_with_client_bounded(
             method_str,
             path_str,
@@ -603,6 +604,42 @@ async fn handle_request_inner(
         // serve the wrong response).
         Err(e) => return Ok(matcher_error_response(&e)),
     };
+
+    // Issue #819: on a genuine no-match, give a registered interceptor one last chance before
+    // falling through to defaultForward/defaultResponse/empty-200 — deliberately even when a
+    // default IS configured, since under replication lag the right stub may be momentarily
+    // missing and the request would otherwise be misdirected upstream (rescue outranks
+    // forwarding). A `RetryMatch` re-runs matching exactly once with the identical arguments; a
+    // rescued hit is indistinguishable from a first-try match to everything downstream. A second
+    // miss falls through exactly as `Proceed` would.
+    if matched.is_none()
+        && let Some(interceptor) = &imposter.no_match_interceptor
+    {
+        let ctx = NoMatchContext {
+            port: imposter.config.port.unwrap_or(0),
+            method: method_str,
+            path: path_str,
+        };
+        if interceptor.on_no_match(ctx).await == NoMatchDirective::RetryMatch {
+            matched = match imposter
+                .find_matching_stub_with_client_bounded(
+                    method_str,
+                    path_str,
+                    &headers_clone,
+                    query_opt,
+                    body_string.as_deref(),
+                    Some(&request_from),
+                    Some(&client_ip),
+                    script_timeout,
+                )
+                .await
+            {
+                Ok(m) => m,
+                Err(e) => return Ok(matcher_error_response(&e)),
+            };
+        }
+    }
+
     if let Some((stub_state, stub_index)) = matched {
         // Scenario FSM: apply the matched stub's newScenarioState transition (no-op unless set).
         // Resolve flow_id from the same single-value header map the matcher used (headers_clone)

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -11,6 +11,7 @@ use super::types::{ImposterConfig, ImposterError, Stub};
 use crate::behaviors::ResponseSequencer;
 use crate::extensions::decorate::ResponseDecorator;
 use crate::extensions::flow_state::FlowStoreProvider;
+use crate::extensions::no_match::NoMatchInterceptor;
 use crate::imposter::journal::RequestJournal;
 use crate::proxy::network::{
     AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error,
@@ -247,6 +248,8 @@ pub struct ImposterManager {
     request_journal: Option<Arc<dyn RequestJournal>>,
     /// Pluggable proxy-recording backend (issue #315); None = per-imposter LocalProxyStore.
     proxy_store: Option<Arc<dyn ProxyRecordingStore>>,
+    /// Last-chance no-match hook (issue #819); None = no interceptor, unchanged fallthrough.
+    no_match_interceptor: Option<Arc<dyn NoMatchInterceptor>>,
     /// Per-core accept runtimes (RFC-712, issue #745). When set, every imposter port binds one
     /// SO_REUSEPORT listener per runtime and each accept loop runs pinned to its runtime; the
     /// kernel spreads connections across them by 4-tuple hash. `None` (the default) keeps
@@ -287,6 +290,7 @@ impl ImposterManager {
             sequencer: None,
             request_journal: None,
             proxy_store: None,
+            no_match_interceptor: None,
             accept_runtimes: None,
             conn_drain: DEFAULT_CONN_DRAIN,
             event_bus: Arc::new(super::events::AdminEventBus::new()),
@@ -398,6 +402,16 @@ impl ImposterManager {
     #[must_use]
     pub fn with_proxy_store(mut self, store: Arc<dyn ProxyRecordingStore>) -> Self {
         self.proxy_store = Some(store);
+        self
+    }
+
+    /// Register a last-chance no-match interceptor (issue #819), consulted for every imposter
+    /// request that matches no stub, before the defaultForward/defaultResponse/empty-200
+    /// fallthrough — including when a default IS configured, since a `RetryMatch` rescue must
+    /// outrank forwarding. See [`NoMatchInterceptor`] for the full contract.
+    #[must_use]
+    pub fn with_no_match_interceptor(mut self, interceptor: Arc<dyn NoMatchInterceptor>) -> Self {
+        self.no_match_interceptor = Some(interceptor);
         self
     }
 
@@ -549,6 +563,11 @@ impl ImposterManager {
 
         // Share the admin event bus so recorded requests fan out to the SSE stream (issue #461).
         imposter.event_bus = Some(Arc::clone(&self.event_bus));
+
+        // Inject the shared no-match interceptor, if one is registered (issue #819).
+        if let Some(interceptor) = &self.no_match_interceptor {
+            imposter.no_match_interceptor = Some(Arc::clone(interceptor));
+        }
 
         // Create shutdown channel for this imposter
         let (shutdown_tx, _) = broadcast::channel(1);
@@ -4202,6 +4221,314 @@ mod tests {
                 .expect("create succeeds once the conflict clears");
             manager.delete_imposter(19603).await.expect("delete");
             rts.shutdown();
+        }
+    }
+
+    // =========================================================================
+    // Issue #819: NoMatchInterceptor — last-chance hook on the no-match path
+    // =========================================================================
+    mod no_match_interceptor {
+        use super::*;
+        use crate::extensions::no_match::{NoMatchContext, NoMatchDirective, NoMatchInterceptor};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Counts calls and returns a fixed directive; optionally installs a matching stub the
+        /// first time it is consulted, standing in for "the replicated config caught up".
+        struct Spy {
+            calls: AtomicUsize,
+            directive: NoMatchDirective,
+            /// The stub the rescue installs when consulted.
+            rescue_stub: serde_json::Value,
+            /// Set AFTER the manager is built (the manager needs the spy at construction), so
+            /// the rescue adds its stub to the very manager serving the request.
+            rescue_with: Mutex<Option<(Arc<ImposterManager>, u16)>>,
+            seen: Mutex<Vec<(u16, String, String)>>,
+        }
+
+        impl Spy {
+            fn new(directive: NoMatchDirective) -> Arc<Self> {
+                Arc::new(Self {
+                    calls: AtomicUsize::new(0),
+                    directive,
+                    rescue_with: Mutex::new(None),
+                    rescue_stub: serde_json::Value::Null,
+                    seen: Mutex::new(Vec::new()),
+                })
+            }
+
+            fn rescuing() -> Arc<Self> {
+                Self::rescuing_with_stub(json!({
+                    "predicates": [{"equals": {"path": "/late"}}],
+                    "responses": [{"is": {"statusCode": 200, "body": "rescued"}}]
+                }))
+            }
+
+            fn rescuing_with_stub(stub: serde_json::Value) -> Arc<Self> {
+                Arc::new(Self {
+                    calls: AtomicUsize::new(0),
+                    directive: NoMatchDirective::RetryMatch,
+                    rescue_with: Mutex::new(None),
+                    rescue_stub: stub,
+                    seen: Mutex::new(Vec::new()),
+                })
+            }
+
+            fn arm_rescue(&self, manager: Arc<ImposterManager>, port: u16) {
+                *self.rescue_with.lock() = Some((manager, port));
+            }
+
+            fn calls(&self) -> usize {
+                self.calls.load(Ordering::SeqCst)
+            }
+        }
+
+        impl NoMatchInterceptor for Spy {
+            fn on_no_match<'a>(
+                &'a self,
+                ctx: NoMatchContext<'a>,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = NoMatchDirective> + Send + 'a>>
+            {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.seen
+                    .lock()
+                    .push((ctx.port, ctx.method.to_string(), ctx.path.to_string()));
+                let rescue = self.rescue_with.lock().clone();
+                let stub_json = self.rescue_stub.clone();
+                let directive = self.directive;
+                Box::pin(async move {
+                    if let Some((manager, port)) = rescue {
+                        let stub: Stub = serde_json::from_value(stub_json).expect("late stub");
+                        manager
+                            .add_stub(port, stub, None)
+                            .await
+                            .expect("add late stub");
+                    }
+                    directive
+                })
+            }
+        }
+
+        async fn get(port: u16, path: &str) -> (u16, String, bool) {
+            let resp = reqwest::get(format!("http://127.0.0.1:{port}{path}"))
+                .await
+                .expect("request");
+            let status = resp.status().as_u16();
+            let no_match = resp.headers().contains_key("x-rift-no-match");
+            (status, resp.text().await.unwrap_or_default(), no_match)
+        }
+
+        // AC1: RetryMatch rescues a request once the stub appears — served as a normal match,
+        // no x-rift-no-match, interceptor consulted exactly once.
+        #[tokio::test]
+        async fn retry_match_rescues_after_stub_appears() {
+            let spy = Spy::rescuing();
+            let manager = Arc::new(
+                ImposterManager::new()
+                    .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>),
+            );
+            // Armed after construction so the rescue mutates the manager actually serving.
+            spy.arm_rescue(Arc::clone(&manager), 19801);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19801, "stubs": []
+                })))
+                .await
+                .expect("create");
+
+            let (status, body, no_match) = get(19801, "/late").await;
+            assert_eq!(status, 200);
+            assert_eq!(
+                body, "rescued",
+                "the rescued retry must serve the late stub"
+            );
+            assert!(
+                !no_match,
+                "a rescued request is a normal match, not a no-match"
+            );
+            assert_eq!(spy.calls(), 1, "consulted exactly once");
+            assert_eq!(
+                spy.seen.lock().first().cloned(),
+                Some((19801, "GET".to_string(), "/late".to_string())),
+                "the context must carry the bound port, method and path"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC2: a second miss falls through exactly as Proceed would — and only one retry happens.
+        #[tokio::test]
+        async fn second_miss_falls_through_and_retries_only_once() {
+            let spy = Spy::new(NoMatchDirective::RetryMatch);
+            let manager = ImposterManager::new()
+                .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19802, "stubs": []
+                })))
+                .await
+                .expect("create");
+
+            let (status, _body, no_match) = get(19802, "/nope").await;
+            assert_eq!(status, 200);
+            assert!(
+                no_match,
+                "a second miss falls through to the empty-200 no-match"
+            );
+            assert_eq!(spy.calls(), 1, "at most one retry per request — no loop");
+
+            manager.delete_all().await;
+        }
+
+        // AC3: a MATCHED request never consults the interceptor (hot path pays nothing).
+        #[tokio::test]
+        async fn matched_requests_never_consult_the_interceptor() {
+            let spy = Spy::new(NoMatchDirective::RetryMatch);
+            let manager = ImposterManager::new()
+                .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19803,
+                    "stubs": [{
+                        "predicates": [{"equals": {"path": "/hit"}}],
+                        "responses": [{"is": {"statusCode": 200, "body": "hit"}}]
+                    }]
+                })))
+                .await
+                .expect("create");
+
+            let (status, body, _) = get(19803, "/hit").await;
+            assert_eq!(status, 200);
+            assert_eq!(body, "hit");
+            assert_eq!(spy.calls(), 0, "a matched request must not reach the hook");
+
+            manager.delete_all().await;
+        }
+
+        // AC4: Proceed is inert — the response is the untouched baseline fallthrough.
+        #[tokio::test]
+        async fn proceed_serves_the_baseline_fallthrough() {
+            let spy = Spy::new(NoMatchDirective::Proceed);
+            let manager = ImposterManager::new()
+                .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19804,
+                    "stubs": [],
+                    "defaultResponse": {"statusCode": 503, "body": "default"}
+                })))
+                .await
+                .expect("create");
+
+            let (status, body, _) = get(19804, "/nope").await;
+            assert_eq!(status, 503, "Proceed must fall through to defaultResponse");
+            assert_eq!(body, "default");
+            assert_eq!(spy.calls(), 1, "Proceed is still consulted once");
+
+            manager.delete_all().await;
+        }
+
+        // AC5: a disabled imposter never consults the interceptor — the enabled gate precedes
+        // matching, so the hook is unreachable there.
+        #[tokio::test]
+        async fn disabled_imposter_never_consults_the_interceptor() {
+            let spy = Spy::new(NoMatchDirective::RetryMatch);
+            let manager = ImposterManager::new()
+                .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19805, "stubs": []
+                })))
+                .await
+                .expect("create");
+            manager
+                .set_imposter_enabled(19805, false)
+                .await
+                .expect("disable the imposter");
+
+            let _ = get(19805, "/nope").await;
+            assert_eq!(
+                spy.calls(),
+                0,
+                "the enabled gate precedes matching, so a disabled imposter never reaches the hook"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC6 (the headline design ruling, #819): the hook fires even when a default IS
+        // configured, and a rescue OUTRANKS it. Without this test, an "optimization" that only
+        // consults the interceptor when no default exists would keep every other test green while
+        // silently misdirecting lagging requests upstream.
+        #[tokio::test]
+        async fn rescue_outranks_a_configured_default_response() {
+            let spy = Spy::rescuing();
+            let manager = Arc::new(
+                ImposterManager::new()
+                    .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>),
+            );
+            spy.arm_rescue(Arc::clone(&manager), 19806);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19806,
+                    "stubs": [],
+                    "defaultResponse": {"statusCode": 503, "body": "default"}
+                })))
+                .await
+                .expect("create");
+
+            let (status, body, _) = get(19806, "/late").await;
+            assert_eq!(
+                status, 200,
+                "a rescued match must win over the configured defaultResponse"
+            );
+            assert_eq!(body, "rescued");
+            assert_eq!(spy.calls(), 1);
+
+            manager.delete_all().await;
+        }
+
+        // AC7 (#819): the retry must pass the IDENTICAL request facts as the first attempt. The
+        // rescue stub predicates on body, query and a header, so dropping any of them from the
+        // retry call (passing None/empty) fails here while a bodyless-GET-only suite would not
+        // notice.
+        #[tokio::test]
+        async fn retry_passes_the_identical_request_facts() {
+            let spy = Spy::rescuing_with_stub(json!({
+                "predicates": [{"and": [
+                    {"equals": {"path": "/echo", "method": "POST"}},
+                    {"equals": {"query": {"tenant": "acme"}}},
+                    {"equals": {"headers": {"x-trace": "abc123"}}},
+                    {"contains": {"body": "payload"}}
+                ]}],
+                "responses": [{"is": {"statusCode": 200, "body": "facts-preserved"}}]
+            }));
+            let manager = Arc::new(
+                ImposterManager::new()
+                    .with_no_match_interceptor(Arc::clone(&spy) as Arc<dyn NoMatchInterceptor>),
+            );
+            spy.arm_rescue(Arc::clone(&manager), 19807);
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http", "port": 19807, "stubs": []
+                })))
+                .await
+                .expect("create");
+
+            let resp = reqwest::Client::new()
+                .post("http://127.0.0.1:19807/echo?tenant=acme")
+                .header("x-trace", "abc123")
+                .body("a payload here")
+                .send()
+                .await
+                .expect("request");
+            assert_eq!(resp.status().as_u16(), 200);
+            assert_eq!(
+                resp.text().await.unwrap_or_default(),
+                "facts-preserved",
+                "the retry must see the same method/path/query/headers/body as the first attempt"
+            );
+
+            manager.delete_all().await;
         }
     }
 }

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -153,6 +153,61 @@ Inject with `.with_response_decorator(Arc<dyn ResponseDecorator>)`.
 
 ---
 
+## `NoMatchInterceptor` — rescue the no-match path
+
+Consulted when a request matched **no stub**, before the `defaultForward` / `defaultResponse` /
+empty-`200` fallthrough (issue #819). Its purpose is a safety net on the data plane: an embedder
+whose replicated config is momentarily behind can wait a bounded interval and retry the match once,
+paying nothing on requests that already matched.
+
+```rust
+use rift_mock_core::extensions::no_match::{
+    NoMatchContext, NoMatchDirective, NoMatchInterceptor,
+};
+
+struct WaitForCatchUp;
+
+impl NoMatchInterceptor for WaitForCatchUp {
+    fn on_no_match<'a>(
+        &'a self,
+        ctx: NoMatchContext<'a>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = NoMatchDirective> + Send + 'a>> {
+        Box::pin(async move {
+            if caught_up_within(ctx.port, Duration::from_millis(500)).await {
+                NoMatchDirective::RetryMatch
+            } else {
+                NoMatchDirective::Proceed
+            }
+        })
+    }
+}
+
+let manager = ImposterManager::new()
+    .with_no_match_interceptor(Arc::new(WaitForCatchUp));
+```
+
+Contract:
+
+- **Only on a genuine no-match.** Never for matched requests, disabled imposters, matcher errors, or
+  the debug path — the hot path pays nothing when nothing missed.
+- **It fires even when a default IS configured**, deliberately. Under replication lag the right stub
+  may be momentarily missing, and forwarding upstream would misdirect the request; rescue outranks
+  forwarding. `Proceed` then falls through exactly as today.
+- **At most one retry per request.** A rescued hit is served as a normal match — indistinguishable
+  downstream — and a second miss falls through exactly as `Proceed` would. "Downstream" is precise:
+  the retry re-evaluates predicates, so a predicate `inject` script runs a **second** time and its
+  `state` mutations and `logger` output are committed twice; a rescued request can also spend two
+  `scriptEngine.timeoutMs` budgets in matching.
+- **Implementations must be bounded**: the request is parked while the future runs.
+- **Annotations** (`extensions::decorate::annotate`) are visible wherever a `ResponseDecorator` is
+  wired — the serve loop. On the `/__rift/` gateway they are inert, since that path has neither an
+  annotation scope nor a decorator.
+- **Unbound ports are out of scope.** A request to a port with no imposter never reaches an imposter
+  handler (no listener, or the gateway `404`s first), so there is nothing to hang a hook on. Cover
+  that window with your own readiness gating.
+
+Registering no interceptor leaves behaviour byte-identical, on both the serve loop and the gateway.
+
 ## Backend errors and annotations
 
 A custom backend signals unavailability by attaching `BackendUnavailable` to a failed operation's


### PR DESCRIPTION
## Summary

Added NoMatchInterceptor hook on the no-match path with:
- New trait, NoMatchContext, and NoMatchDirective in `extensions/no_match.rs`
- Stored on Imposter and registered via `ImposterManager::with_no_match_interceptor`
- Zero-cost implementation when unregistered
- 7-test gate verifying rescue outranks configured defaultResponse
- Retry re-runs matching exactly once and preserves method/path/query/headers/body
- Retry re-runs predicate `inject` scripts (state/logger commit twice)
- `docs/embedding/spi.md` gained new documentation section

Closes #819

Milestone: none (standalone)