### PR TITLE
fix(server): metrics and proxy accept loops still terminate on any accept error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ record.
 
 ### Fixed
 
+- **The metrics and proxy listeners no longer die on a transient accept error** (issue #834). #826
+  fixed the admin API accept loop but left two siblings propagating any `listener.accept()` failure:
+  the `/metrics` listener and `ProxyServer::run`. The metrics case was the quieter of the two — its
+  task result is never joined, so a single `ECONNABORTED` killed `/metrics` with one log line and
+  scrapes simply stopped. Both now apply the same policy: transient errors retry immediately,
+  systemic ones back off (1 ms doubling to a 1 s cap) logging once per outage with a suppressed
+  count on recovery, and a genuinely broken listener (`EBADF`/`ENOTSOCK`/`EINVAL`) still terminates
+  so the owner can surface it. `is_fatal_listener_error` moved alongside the rest of the machinery
+  into `rift_mock_core::proxy`, so all four accept loops now share one implementation and their
+  policies cannot drift. The imposter serve loops keep their deliberate never-terminate behaviour —
+  a dying imposter loop is recoverable through the still-live admin API.
+
 - **A transient accept error no longer ends the admin API server** (issue #826). `accept_loop`
   propagated any `listener.accept()` failure straight out via `?`, so a single `ECONNABORTED` — or a
   momentary `EMFILE`/`ENFILE` under fd pressure — terminated the admin server. That was survivable

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -12,7 +12,7 @@ use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use rift_mock_core::proxy::{
-    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error,
+    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error, is_fatal_listener_error,
 };
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -327,29 +327,6 @@ impl RunningAdminApi {
 
 fn take_task<T>(slot: &Mutex<Option<JoinHandle<T>>>) -> Option<JoinHandle<T>> {
     slot.lock().expect("admin API task mutex poisoned").take()
-}
-
-/// Whether an `accept(2)` error means the listener itself is unusable, as opposed to a transient
-/// or resource-pressure condition that retrying can clear.
-///
-/// `EBADF` / `ENOTSOCK` / `EINVAL` say the descriptor is not a working listening socket; no amount
-/// of backoff fixes that, so the admin accept loop terminates and lets
-/// [`RunningAdminApi::wait`] report the death (issue #826). Everything else — including unknown
-/// errnos — is left to the shared two-way classifier, which retries.
-///
-/// Unix-only by construction: these are POSIX errnos. On other platforms nothing is treated as
-/// fatal, matching the conservative "retry rather than die" default.
-#[cfg(unix)]
-fn is_fatal_listener_error(e: &std::io::Error) -> bool {
-    matches!(
-        e.raw_os_error(),
-        Some(libc::EBADF) | Some(libc::ENOTSOCK) | Some(libc::EINVAL)
-    )
-}
-
-#[cfg(not(unix))]
-fn is_fatal_listener_error(_e: &std::io::Error) -> bool {
-    false
 }
 
 /// Accept connections until `cancel` fires or the listener errors. Each connection is tracked
@@ -812,25 +789,5 @@ mod admin_accept_error_tests {
             "recovery reports the suppressed count"
         );
         assert_eq!(log.on_success(), None, "steady state is silent");
-    }
-
-    // The third class the issue asks for ("terminate only on genuinely fatal errors"): a broken
-    // listener fd must still end the loop so `RunningAdminApi::wait()` reports a dead admin plane.
-    #[cfg(unix)]
-    #[test]
-    fn broken_listener_errnos_are_fatal_but_pressure_is_not() {
-        for raw in [libc::EBADF, libc::ENOTSOCK, libc::EINVAL] {
-            assert!(
-                is_fatal_listener_error(&Error::from_raw_os_error(raw)),
-                "errno {raw} means the listener is unusable; retrying forever would hide a dead admin plane"
-            );
-        }
-        // Recoverable pressure and transient blips must never be treated as fatal.
-        for raw in [libc::EMFILE, libc::ENFILE, libc::ECONNABORTED, libc::EINTR] {
-            assert!(
-                !is_fatal_listener_error(&Error::from_raw_os_error(raw)),
-                "errno {raw} is recoverable and must be retried, not fatal"
-            );
-        }
     }
 }

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -711,7 +711,10 @@ async fn metrics_accept_loop(
     use hyper::service::service_fn;
     use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
-    use rift_mock_core::proxy::HttpTuning;
+    use rift_mock_core::proxy::{
+        AcceptBackoff, AcceptErrorClass, AcceptErrorLog, HttpTuning, classify_accept_error,
+        is_fatal_listener_error,
+    };
     use std::convert::Infallible;
 
     // Read HTTP tuning once per listener, not per accepted connection.
@@ -721,6 +724,13 @@ async fn metrics_accept_loop(
     let connection_semaphore = http_tuning
         .max_connections
         .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n)));
+
+    // Accept-error handling, identical to the admin loop's (issues #826, #834). Previously any
+    // `accept()` failure propagated out and ended the metrics server — and since `RunningServer`
+    // never joins this task, the death was a single log line and `/metrics` simply stopped
+    // answering until the process restarted.
+    let mut backoff = AcceptBackoff::new();
+    let mut error_log = AcceptErrorLog::default();
 
     loop {
         // Acquire a permit *before* accepting so a cap holds connections back in the listener
@@ -741,9 +751,51 @@ async fn metrics_accept_loop(
             }
             None => None,
         };
-        let (stream, _) = tokio::select! {
+        let accepted = tokio::select! {
             _ = cancel.cancelled() => break,
-            accepted = listener.accept() => accepted?,
+            accepted = listener.accept() => accepted,
+        };
+        let (stream, _) = match accepted {
+            Ok(accepted) => {
+                // Recovery: only the transition out of a systemic-error state logs and resets the
+                // backoff, so a healthy accept path pays one branch.
+                if let Some(suppressed) = error_log.on_success() {
+                    info!(
+                        suppressed,
+                        "metrics accept loop recovered after {suppressed} suppressed error(s)"
+                    );
+                    backoff.reset();
+                }
+                accepted
+            }
+            // A broken listener fd cannot be cured by waiting; end the loop so the failure reaches
+            // the `Metrics server error` log rather than spinning forever (issue #834).
+            Err(e) if is_fatal_listener_error(&e) => {
+                return Err(anyhow::anyhow!(
+                    "metrics listener is unusable, giving up: {e}"
+                ));
+            }
+            Err(e) => match classify_accept_error(&e) {
+                AcceptErrorClass::Transient => {
+                    debug!("transient accept error on the metrics listener: {e}");
+                    continue;
+                }
+                AcceptErrorClass::Systemic => {
+                    if error_log.on_error() {
+                        error!(
+                            "accept error on the metrics listener: {e}; backing off \
+                             (further errors suppressed until recovery)"
+                        );
+                    }
+                    // Raced against `cancel` so a backoff sleep never delays shutdown.
+                    let delay = backoff.next_delay();
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = cancel.cancelled() => break,
+                    }
+                    continue;
+                }
+            },
         };
         let io = TokioIo::new(stream);
         let conn_cancel = cancel.clone();

--- a/crates/rift-mock-core/src/proxy/mod.rs
+++ b/crates/rift-mock-core/src/proxy/mod.rs
@@ -49,4 +49,6 @@ pub use network::{DEFAULT_HTTP_MAX_BUF, HttpTuning};
 // Accept-error handling shared by every listener in the workspace: the imposter serve loop
 // (issue #750) and the admin API accept loop (issue #826), which must classify-and-retry rather
 // than let one transient accept failure end the server.
-pub use network::{AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error};
+pub use network::{
+    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error, is_fatal_listener_error,
+};

--- a/crates/rift-mock-core/src/proxy/network.rs
+++ b/crates/rift-mock-core/src/proxy/network.rs
@@ -242,6 +242,34 @@ pub fn apply_stream_tuning(stream: &TcpStream, tuning: &SocketTuning) {
 // per-event-rate logging trap the journal-cap fix (#741) removed. The pieces below fix both with
 // no cost on the happy path.
 
+/// Whether an `accept(2)` error means the listener itself is unusable, as opposed to a transient
+/// or resource-pressure condition that retrying can clear.
+///
+/// `EBADF` / `ENOTSOCK` / `EINVAL` say the descriptor is not a working listening socket; no amount
+/// of backoff fixes that, so a loop whose owner can observe its death should terminate and surface
+/// the error rather than retry forever (issues #826, #834). Everything else — including unknown
+/// errnos — is left to the two-way [`classify_accept_error`], which retries.
+///
+/// Not every loop wants this: the imposter serve loops deliberately never terminate, because a
+/// dying imposter loop is independently recoverable through the still-live admin API. Loops whose
+/// failure is the *only* signal an owner gets (the admin plane, the metrics plane, `ProxyServer::run`)
+/// consult this first.
+///
+/// Unix-only by construction: these are POSIX errnos. On other platforms nothing is treated as
+/// fatal, matching the conservative "retry rather than die" default.
+#[cfg(unix)]
+pub fn is_fatal_listener_error(e: &std::io::Error) -> bool {
+    matches!(
+        e.raw_os_error(),
+        Some(libc::EBADF) | Some(libc::ENOTSOCK) | Some(libc::EINVAL)
+    )
+}
+
+#[cfg(not(unix))]
+pub fn is_fatal_listener_error(_e: &std::io::Error) -> bool {
+    false
+}
+
 /// How an `accept(2)` error should be handled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AcceptErrorClass {
@@ -502,6 +530,26 @@ mod tests {
 mod accept_error {
     use super::*;
     use std::io::{Error, ErrorKind};
+
+    // The fatal class (#826, shared by every owner-observable loop since #834): a broken listener fd
+    // must still end the loop so its owner can report the death instead of retrying forever.
+    #[cfg(unix)]
+    #[test]
+    fn broken_listener_errnos_are_fatal_but_pressure_is_not() {
+        for raw in [libc::EBADF, libc::ENOTSOCK, libc::EINVAL] {
+            assert!(
+                is_fatal_listener_error(&Error::from_raw_os_error(raw)),
+                "errno {raw} means the listener is unusable; retrying forever would hide a dead listener from its owner"
+            );
+        }
+        // Recoverable pressure and transient blips must never be treated as fatal.
+        for raw in [libc::EMFILE, libc::ENFILE, libc::ECONNABORTED, libc::EINTR] {
+            assert!(
+                !is_fatal_listener_error(&Error::from_raw_os_error(raw)),
+                "errno {raw} is recoverable and must be retried, not fatal"
+            );
+        }
+    }
 
     #[test]
     fn classify_transient_vs_systemic() {

--- a/crates/rift-mock-core/src/proxy/server.rs
+++ b/crates/rift-mock-core/src/proxy/server.rs
@@ -30,7 +30,7 @@ use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 /// The main proxy server struct.
 pub struct ProxyServer {
@@ -288,6 +288,12 @@ impl ProxyServer {
             .max_connections
             .map(|n| Arc::new(tokio::sync::Semaphore::new(n)));
 
+        // Accept-error handling, identical to the admin loop's (issues #826, #834). Previously any
+        // `accept()` failure propagated out of `run()`, permanently ending the proxy on a single
+        // transient `ECONNABORTED` or a momentary `EMFILE`.
+        let mut backoff = super::network::AcceptBackoff::new();
+        let mut error_log = super::network::AcceptErrorLog::default();
+
         loop {
             // Acquire a permit *before* accepting so a cap holds connections back in the listener
             // backlog/kernel SYN queue rather than accepting them and then failing downstream.
@@ -300,7 +306,45 @@ impl ProxyServer {
                 },
                 None => None,
             };
-            let (stream, remote_addr) = listener.accept().await?;
+            let (stream, remote_addr) = match listener.accept().await {
+                Ok(accepted) => {
+                    // Recovery: only the transition out of a systemic-error state logs and resets
+                    // the backoff, so a healthy accept path pays one branch.
+                    if let Some(suppressed) = error_log.on_success() {
+                        info!(
+                            suppressed,
+                            "proxy accept loop recovered after {suppressed} suppressed error(s)"
+                        );
+                        backoff.reset();
+                    }
+                    accepted
+                }
+                // A broken listener fd cannot be cured by waiting. `run()` returning `Err` is the
+                // only signal an embedder gets, so surface it instead of retrying forever (#834).
+                Err(e) if super::network::is_fatal_listener_error(&e) => {
+                    return Err(anyhow::anyhow!(
+                        "proxy listener is unusable, giving up: {e}"
+                    ));
+                }
+                Err(e) => match super::network::classify_accept_error(&e) {
+                    super::network::AcceptErrorClass::Transient => {
+                        debug!("transient accept error on the proxy listener: {e}");
+                        continue;
+                    }
+                    super::network::AcceptErrorClass::Systemic => {
+                        if error_log.on_error() {
+                            error!(
+                                "accept error on the proxy listener: {e}; backing off \
+                                 (further errors suppressed until recovery)"
+                            );
+                        }
+                        // This loop has no shutdown signal to race against (see the permit
+                        // acquire above), so a plain sleep is the whole story here.
+                        tokio::time::sleep(backoff.next_delay()).await;
+                        continue;
+                    }
+                },
+            };
             super::network::apply_stream_tuning(&stream, &socket_tuning);
             let server = Arc::clone(&server);
             let tls_acceptor = tls_acceptor.clone();


### PR DESCRIPTION
Apply the accept-retry policy to two sibling accept loops: the metrics loop and the ProxyServer::run loop. Both were left propagating any listener.accept() failure after #826 fixed the admin API accept loop.

The metrics case was the quieter one: its task result is never joined, so a single ECONNABORTED killed /metrics with one log line and scrapes simply stopped. Both loops now classify and retry — transient immediately, systemic with backoff and one log per outage — while a broken listener still terminates so the owner can surface it.

Move is_fatal_listener_error alongside the rest of the machinery into rift_mock_core::proxy so all four accept loops share one implementation and their policies cannot drift. The imposter serve loops deliberately keep their never-terminate behaviour (a dying imposter loop is recoverable via the still-live admin API). The metrics loop races its backoff against cancel while the proxy loop has no cancel token so it plain-sleeps.

Closes #834

Milestone: none (standalone)