### PR TITLE
feat(observability): re-emit or expose a sustained accept-error outage instead of logging it once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ record.
 
 ### Added
 
+- **Accept-error metrics and a re-announcing outage log** (issue #838). Since #750/#826/#834 the
+  accept loops survive accept errors by classifying and retrying — which means a wedged listener
+  now stays *bound* while serving nothing, instead of closing its socket and refusing connections.
+  That is better to survive but harder to notice: probes hang until their own timeout rather than
+  failing fast, and the only local evidence was a single `error!` emitted whenever the outage began.
+  Two additions close that gap: `rift_accept_errors_total{listener, class}` and
+  `rift_accept_error_outage{listener}` (the gauge to alert on) expose the state through `/metrics`,
+  and a sustained outage now re-announces itself in the log roughly every 10 minutes instead of only
+  at onset. The reminder cadence is counted in suppressed errors, not wall-clock, so the accept-error
+  bookkeeping stays clock-free and unit-testable. The log re-emit and the metrics cover each other:
+  metrics are unreachable when the *metrics* listener is the wedged one, and logs rotate away. The
+  gauge counts how many loops are wedged rather than tracking whichever wrote last (one label covers
+  many loops — one per imposter, and one per accept runtime under per-core fan-out) and is released
+  when a loop ends mid-outage, so it can neither under-report nor stick at 1.
+
 - **`test-util` feature: fault-injectable `RunningServer` / `RunningAdminApi` constructors**
   (issue #825). `RunningAdminApi::wait()` has exactly-once error delivery backed by a drop guard
   that reports the accept loop dying however it dies — but the only way to *reach* that `Err` path

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -12,7 +12,8 @@ use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use rift_mock_core::proxy::{
-    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error, is_fatal_listener_error,
+    AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, classify_accept_error,
+    is_fatal_listener_error,
 };
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -357,6 +358,8 @@ async fn accept_loop(
     // a fleet-wide correlated restart (issue #826).
     let mut backoff = AcceptBackoff::new();
     let mut error_log = AcceptErrorLog::default();
+    // Clears its contribution on every exit path, including a cancel break or a panic (#838).
+    let mut outage = rift_mock_core::extensions::AcceptOutageGuard::new("admin");
 
     loop {
         // Acquire a permit *before* accepting so a cap holds connections back in the listener
@@ -384,6 +387,7 @@ async fn accept_loop(
                 // Recovery: only the transition out of a systemic-error state logs and resets the
                 // backoff, so a healthy accept path pays one branch.
                 if let Some(suppressed) = error_log.on_success() {
+                    outage.exit();
                     info!(
                         suppressed,
                         "admin API accept loop recovered after {suppressed} suppressed error(s)"
@@ -406,17 +410,30 @@ async fn accept_loop(
             Err(e) => match classify_accept_error(&e) {
                 // Expected under load — retry immediately, no backoff, no error spam.
                 AcceptErrorClass::Transient => {
+                    rift_mock_core::extensions::record_accept_error("admin", "transient");
                     debug!("transient accept error on the admin listener: {e}");
                     continue;
                 }
                 // Systemic (fd exhaustion / unknown): log once on entry, then back off. Raced
                 // against `cancel` so a backoff sleep never delays admin-server shutdown.
                 AcceptErrorClass::Systemic => {
-                    if error_log.on_error() {
-                        error!(
-                            "accept error on the admin listener: {e}; backing off \
-                             (further errors suppressed until recovery)"
-                        );
+                    rift_mock_core::extensions::record_accept_error("admin", "systemic");
+                    match error_log.on_error() {
+                        Some(AcceptErrorEvent::Onset) => {
+                            outage.enter();
+                            error!(
+                                "accept error on the admin listener: {e}; backing off \
+                                 (further errors suppressed until recovery)"
+                            );
+                        }
+                        Some(AcceptErrorEvent::StillDown { suppressed }) => {
+                            error!(
+                                suppressed,
+                                "admin listener still failing to accept after {suppressed} \
+                                 suppressed error(s): {e}"
+                            );
+                        }
+                        None => {}
                     }
                     let delay = backoff.next_delay();
                     tokio::select! {
@@ -781,8 +798,12 @@ mod admin_accept_error_tests {
         assert_eq!(b.next_delay(), Duration::from_millis(1), "reset re-arms");
 
         let mut log = AcceptErrorLog::default();
-        assert!(log.on_error(), "first systemic error logs once");
-        assert!(!log.on_error(), "subsequent errors are suppressed");
+        assert_eq!(
+            log.on_error(),
+            Some(AcceptErrorEvent::Onset),
+            "first systemic error logs once"
+        );
+        assert_eq!(log.on_error(), None, "subsequent errors are suppressed");
         assert_eq!(
             log.on_success(),
             Some(1),

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -712,8 +712,8 @@ async fn metrics_accept_loop(
     use hyper::{Request, Response, body::Incoming};
     use hyper_util::rt::TokioIo;
     use rift_mock_core::proxy::{
-        AcceptBackoff, AcceptErrorClass, AcceptErrorLog, HttpTuning, classify_accept_error,
-        is_fatal_listener_error,
+        AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, HttpTuning,
+        classify_accept_error, is_fatal_listener_error,
     };
     use std::convert::Infallible;
 
@@ -731,6 +731,8 @@ async fn metrics_accept_loop(
     // answering until the process restarted.
     let mut backoff = AcceptBackoff::new();
     let mut error_log = AcceptErrorLog::default();
+    // Clears its contribution on every exit path, including a cancel break or a panic (#838).
+    let mut outage = rift_mock_core::extensions::AcceptOutageGuard::new("metrics");
 
     loop {
         // Acquire a permit *before* accepting so a cap holds connections back in the listener
@@ -760,6 +762,7 @@ async fn metrics_accept_loop(
                 // Recovery: only the transition out of a systemic-error state logs and resets the
                 // backoff, so a healthy accept path pays one branch.
                 if let Some(suppressed) = error_log.on_success() {
+                    outage.exit();
                     info!(
                         suppressed,
                         "metrics accept loop recovered after {suppressed} suppressed error(s)"
@@ -777,15 +780,28 @@ async fn metrics_accept_loop(
             }
             Err(e) => match classify_accept_error(&e) {
                 AcceptErrorClass::Transient => {
+                    rift_mock_core::extensions::record_accept_error("metrics", "transient");
                     debug!("transient accept error on the metrics listener: {e}");
                     continue;
                 }
                 AcceptErrorClass::Systemic => {
-                    if error_log.on_error() {
-                        error!(
-                            "accept error on the metrics listener: {e}; backing off \
-                             (further errors suppressed until recovery)"
-                        );
+                    rift_mock_core::extensions::record_accept_error("metrics", "systemic");
+                    match error_log.on_error() {
+                        Some(AcceptErrorEvent::Onset) => {
+                            outage.enter();
+                            error!(
+                                "accept error on the metrics listener: {e}; backing off \
+                                 (further errors suppressed until recovery)"
+                            );
+                        }
+                        Some(AcceptErrorEvent::StillDown { suppressed }) => {
+                            error!(
+                                suppressed,
+                                "metrics listener still failing to accept after {suppressed} \
+                                 suppressed error(s): {e}"
+                            );
+                        }
+                        None => {}
                     }
                     // Raced against `cancel` so a backoff sleep never delays shutdown.
                     let delay = backoff.next_delay();

--- a/crates/rift-mock-core/src/extensions/metrics.rs
+++ b/crates/rift-mock-core/src/extensions/metrics.rs
@@ -4,10 +4,12 @@
 //!
 //! Tracks fault injection activity, script execution, and proxy performance.
 use lazy_static::lazy_static;
+use parking_lot::Mutex;
 use prometheus::{
     CounterVec, Encoder, GaugeVec, HistogramVec, TextEncoder, register_counter_vec,
     register_gauge_vec, register_histogram_vec,
 };
+use std::collections::HashMap;
 
 lazy_static! {
     /// Total number of requests processed
@@ -31,6 +33,29 @@ lazy_static! {
     .unwrap();
 
     /// Total number of faults injected
+    /// Accept errors, by listener and class (issue #838). Since the accept loops classify and
+    /// retry rather than terminate, a wedged listener stays bound and answers nothing — this is
+    /// the live signal that it is degraded. `class` is `transient` or `systemic`. Fatal (broken-fd)
+    /// errors are excluded on the admin, metrics and proxy listeners because they end the loop and
+    /// surface through its owner; the imposter loops have no fatal class by design (a dying imposter
+    /// loop is recoverable through the still-live admin API), so there they count as `systemic`.
+    /// Deliberately no port label: per-port cardinality is unbounded, and the logs carry the port.
+    pub static ref ACCEPT_ERRORS_TOTAL: CounterVec = register_counter_vec!(
+        "rift_accept_errors_total",
+        "Accept errors by listener and class",
+        &["listener", "class"]
+    )
+    .expect("metric can be created");
+
+    /// Whether a listener is currently in a systemic accept-error outage (1) or not (0),
+    /// issue #838 — the gauge to alert on.
+    pub static ref ACCEPT_ERROR_OUTAGE: GaugeVec = register_gauge_vec!(
+        "rift_accept_error_outage",
+        "1 while a listener is in a systemic accept-error outage, 0 otherwise",
+        &["listener"]
+    )
+    .expect("metric can be created");
+
     pub static ref FAULTS_INJECTED_TOTAL: CounterVec = register_counter_vec!(
         "rift_faults_injected_total",
         "Total number of faults injected",
@@ -178,6 +203,94 @@ pub fn record_flow_state_op(operation: &str, success: bool) {
 /// Helper to set active flows gauge
 pub fn set_active_flows(backend: &str, count: i64) {
     ACTIVE_FLOWS.with_label_values(&[backend]).set(count as f64);
+}
+
+lazy_static! {
+    /// How many accept loops are currently inside a systemic outage, per listener (issue #838).
+    ///
+    /// The gauge cannot simply be `set(0)` by whoever recovers first: one `listener` label covers
+    /// **many** loops — the imposter plane runs one accept loop per imposter *and* one per accept
+    /// runtime under per-core fan-out (SO_REUSEPORT). Systemic errors are dominated by process-wide
+    /// fd exhaustion, so those loops wedge together and recover asynchronously; a plain `set(0)`
+    /// would clear the gauge on the first recovery while the rest are still down, under-reporting
+    /// exactly the outage the gauge exists to report. Counting depth makes it "any loop wedged".
+    static ref ACCEPT_OUTAGE_DEPTH: Mutex<HashMap<&'static str, usize>> =
+        Mutex::new(HashMap::new());
+}
+
+/// Tracks one accept loop's outage state and keeps [`ACCEPT_ERROR_OUTAGE`] consistent (issue #838).
+///
+/// Held by the loop for its lifetime. `Drop` releases the outage, so **every** way a loop can end
+/// while wedged — a shutdown/cancel `break`, a fatal `return Err`, a panic unwind — clears its
+/// contribution. Without that, deleting an imposter mid-outage would leave the gauge stuck at 1
+/// forever for a listener that no longer exists, and the registry is process-global, so it would
+/// survive across embedded server lifecycles.
+#[derive(Debug)]
+pub struct AcceptOutageGuard {
+    listener: &'static str,
+    in_outage: bool,
+}
+
+impl AcceptOutageGuard {
+    /// Start tracking `listener`. Materializes the series so alerts can reference it before the
+    /// first outage ever happens (Prometheus only creates a child on first use).
+    ///
+    /// Goes through [`Self::adjust`] with a zero delta rather than writing the gauge directly: a
+    /// new loop can start while *another* loop on the same label is already wedged (per-core
+    /// fan-out starts N loops, a new imposter is created during an outage, a second embedded
+    /// server starts), and a blind `set(0)` there would clear the gauge while the depth stayed
+    /// non-zero — and stay wrong, since the gauge is only rewritten on an outage transition.
+    #[must_use]
+    pub fn new(listener: &'static str) -> Self {
+        Self::adjust(listener, 0);
+        Self {
+            listener,
+            in_outage: false,
+        }
+    }
+
+    /// This loop entered a systemic outage. Idempotent.
+    pub fn enter(&mut self) {
+        if !self.in_outage {
+            self.in_outage = true;
+            Self::adjust(self.listener, 1);
+        }
+    }
+
+    /// This loop recovered (or is ending). Idempotent.
+    pub fn exit(&mut self) {
+        if self.in_outage {
+            self.in_outage = false;
+            Self::adjust(self.listener, -1);
+        }
+    }
+
+    fn adjust(listener: &'static str, delta: isize) {
+        let mut depth = ACCEPT_OUTAGE_DEPTH.lock();
+        let entry = depth.entry(listener).or_insert(0);
+        *entry = entry.saturating_add_signed(delta);
+        let any = *entry > 0;
+        ACCEPT_ERROR_OUTAGE
+            .with_label_values(&[listener])
+            .set(if any { 1.0 } else { 0.0 });
+    }
+}
+
+impl Drop for AcceptOutageGuard {
+    fn drop(&mut self) {
+        // Runs during unwind too; `parking_lot::Mutex` never poisons, so this cannot double-panic.
+        self.exit();
+    }
+}
+
+/// Record a classified accept error for `listener` (issue #838).
+///
+/// `class` is `"transient"` or `"systemic"`. Called from the accept loops themselves rather than
+/// from `AcceptErrorLog`, which stays dependency-free and clock-free.
+pub fn record_accept_error(listener: &'static str, class: &'static str) {
+    ACCEPT_ERRORS_TOTAL
+        .with_label_values(&[listener, class])
+        .inc();
 }
 
 /// Helper to record proxy request duration
@@ -399,6 +512,98 @@ mod tests {
 
         let metrics = collect_metrics();
         assert!(metrics.contains("rift_script_errors_total"));
+    }
+
+    // Issue #838: the accept-error signals a scrape can alert on. A wedged listener stays bound
+    // and answers nothing, so these are the live evidence that it is degraded.
+    #[test]
+    fn test_record_accept_error_by_listener_and_class() {
+        record_accept_error("test-counter", "systemic");
+        record_accept_error("test-counter", "systemic");
+        record_accept_error("test-counter", "transient");
+
+        assert_eq!(
+            ACCEPT_ERRORS_TOTAL
+                .with_label_values(&["test-counter", "systemic"])
+                .get(),
+            2.0
+        );
+        assert_eq!(
+            ACCEPT_ERRORS_TOTAL
+                .with_label_values(&["test-counter", "transient"])
+                .get(),
+            1.0
+        );
+
+        let rendered = collect_metrics();
+        assert!(rendered.contains("rift_accept_errors_total"));
+    }
+
+    // Issue #838: one `listener` label covers MANY accept loops (per-core fan-out, one loop per
+    // imposter), and a process-wide EMFILE wedges them together but they recover one at a time.
+    // The gauge must mean "any loop still wedged", not "the last loop to write".
+    #[test]
+    fn test_accept_outage_gauge_tracks_depth_not_last_writer() {
+        // Unique label so this can never collide with another test's counters.
+        let listener = "test-depth";
+        let mut a = AcceptOutageGuard::new(listener);
+        let mut b = AcceptOutageGuard::new(listener);
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            0.0,
+            "the series exists at 0 before any outage, so alerts can reference it"
+        );
+
+        a.enter();
+        b.enter();
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            1.0
+        );
+
+        // A loop that starts *while* another is already wedged must not clear the gauge: per-core
+        // fan-out starts its loops independently, so this ordering is the normal case, not a race.
+        let _late = AcceptOutageGuard::new(listener);
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            1.0,
+            "constructing a guard must not zero a gauge another loop is holding up"
+        );
+
+        a.exit();
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            1.0,
+            "one loop recovering must NOT clear the gauge while another is still wedged"
+        );
+
+        b.exit();
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            0.0,
+            "the gauge clears only when the last wedged loop recovers"
+        );
+    }
+
+    // Issue #838: a loop that ends while wedged (cancel break, fatal return, panic) must not leave
+    // the gauge stuck at 1 for a listener that no longer exists — the registry is process-global.
+    #[test]
+    fn test_accept_outage_guard_clears_on_drop() {
+        let listener = "test-drop";
+        {
+            let mut g = AcceptOutageGuard::new(listener);
+            g.enter();
+            assert_eq!(
+                ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+                1.0
+            );
+            // dropped here while still in outage, as a cancel break would
+        }
+        assert_eq!(
+            ACCEPT_ERROR_OUTAGE.with_label_values(&[listener]).get(),
+            0.0,
+            "dropping a wedged loop must release its outage"
+        );
     }
 
     #[test]

--- a/crates/rift-mock-core/src/extensions/mod.rs
+++ b/crates/rift-mock-core/src/extensions/mod.rs
@@ -35,7 +35,7 @@ pub use flow_state::{CasOutcome, FlowStore, FlowStoreProvider, NoOpFlowStore, cr
 #[allow(unused_imports)]
 pub use matcher::{CompiledMatch, CompiledRule};
 #[allow(unused_imports)]
-pub use metrics::{collect_metrics, record_request};
+pub use metrics::{AcceptOutageGuard, collect_metrics, record_accept_error, record_request};
 #[allow(unused_imports)]
 pub use no_match::{NoMatchContext, NoMatchDirective, NoMatchInterceptor};
 #[allow(unused_imports)]

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -14,7 +14,7 @@ use crate::extensions::flow_state::FlowStoreProvider;
 use crate::extensions::no_match::NoMatchInterceptor;
 use crate::imposter::journal::RequestJournal;
 use crate::proxy::network::{
-    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error,
+    AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, classify_accept_error,
 };
 use crate::recording::ProxyRecordingStore;
 use arc_swap::ArcSwapOption;
@@ -704,6 +704,8 @@ impl ImposterManager {
         // (issue #750).
         let mut backoff = AcceptBackoff::new();
         let mut error_log = AcceptErrorLog::default();
+        // Clears its contribution on every exit path, including a cancel break or a panic (#838).
+        let mut outage = crate::extensions::AcceptOutageGuard::new("imposter");
         loop {
             // Acquire a permit *before* accepting so a cap holds connections back in the
             // listener backlog/kernel SYN queue rather than accepting them and then failing
@@ -737,6 +739,7 @@ impl ImposterManager {
                             // Recovery: only the transition out of a systemic-error state logs
                             // and resets the backoff, so a healthy accept path pays one branch.
                             if let Some(suppressed) = error_log.on_success() {
+                                outage.exit();
                                 info!(
                                     port,
                                     suppressed,
@@ -813,16 +816,31 @@ impl ImposterManager {
                         Err(e) => match classify_accept_error(&e) {
                             // Expected under load — retry immediately, no backoff, no error spam.
                             AcceptErrorClass::Transient => {
+                                crate::extensions::record_accept_error("imposter", "transient");
                                 debug!("transient accept error on port {port}: {e}");
                             }
-                            // Systemic (fd exhaustion / unknown): log once on entry, then back off.
+                            // Systemic (fd exhaustion / unknown): log on entry and periodically
+                            // while it persists, then back off.
                             AcceptErrorClass::Systemic => {
-                                if error_log.on_error() {
-                                    error!(
-                                        port,
-                                        "accept error on port {port}: {e}; backing off \
-                                         (further errors suppressed until recovery)"
-                                    );
+                                crate::extensions::record_accept_error("imposter", "systemic");
+                                match error_log.on_error() {
+                                    Some(AcceptErrorEvent::Onset) => {
+                                        outage.enter();
+                                        error!(
+                                            port,
+                                            "accept error on port {port}: {e}; backing off \
+                                             (further errors suppressed until recovery)"
+                                        );
+                                    }
+                                    Some(AcceptErrorEvent::StillDown { suppressed }) => {
+                                        error!(
+                                            port,
+                                            suppressed,
+                                            "port {port} still failing to accept after \
+                                             {suppressed} suppressed error(s): {e}"
+                                        );
+                                    }
+                                    None => {}
                                 }
                                 // Raced against shutdown exactly like the permit acquire above:
                                 // `delete_imposter_inner` awaits this task, so an un-raced sleep

--- a/crates/rift-mock-core/src/proxy/mod.rs
+++ b/crates/rift-mock-core/src/proxy/mod.rs
@@ -50,5 +50,6 @@ pub use network::{DEFAULT_HTTP_MAX_BUF, HttpTuning};
 // (issue #750) and the admin API accept loop (issue #826), which must classify-and-retry rather
 // than let one transient accept failure end the server.
 pub use network::{
-    AcceptBackoff, AcceptErrorClass, AcceptErrorLog, classify_accept_error, is_fatal_listener_error,
+    AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, classify_accept_error,
+    is_fatal_listener_error,
 };

--- a/crates/rift-mock-core/src/proxy/network.rs
+++ b/crates/rift-mock-core/src/proxy/network.rs
@@ -328,9 +328,25 @@ impl AcceptBackoff {
     }
 }
 
-/// Once-per-transition logging for the systemic accept-error path, mirroring the journal-cap warn
-/// fix (#741): one `error!` on entering the error state, silence while in it (counting suppressed
+/// What a systemic accept error should produce in the log (issue #838).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptErrorEvent {
+    /// The transition *into* the error state — emit the onset `error!`.
+    Onset,
+    /// Still failing after another [`AcceptErrorLog::REEMIT_EVERY`] suppressed errors — emit a
+    /// reminder carrying the running suppressed count.
+    StillDown { suppressed: u64 },
+}
+
+/// Rate-limited logging for the systemic accept-error path, mirroring the journal-cap warn fix
+/// (#741): one `error!` on entering the error state, near-silence while in it (counting suppressed
 /// errors), one `info!` carrying the suppressed count on recovery.
+///
+/// "Near-silence" rather than silence because a *sustained* outage would otherwise leave a single
+/// log line as its only evidence — possibly emitted weeks before anyone looked. Since the retry
+/// policy keeps the listener bound while it cannot serve, a wedged listener no longer refuses
+/// connections, so that one line may be the only local signal there is (issue #838). Every
+/// [`Self::REEMIT_EVERY`] suppressed errors the outage re-announces itself.
 #[derive(Debug, Default)]
 pub struct AcceptErrorLog {
     in_error: bool,
@@ -338,16 +354,35 @@ pub struct AcceptErrorLog {
 }
 
 impl AcceptErrorLog {
-    /// Record a systemic error. Returns `true` **only** on the transition *into* the error state
-    /// (emit the single `error!`); later errors return `false` and bump the suppressed count.
-    pub fn on_error(&mut self) -> bool {
+    /// How many suppressed errors pass between reminder log lines while an outage persists.
+    ///
+    /// Deliberately a **count**, not a duration: this type is pure and clock-free so its schedule
+    /// is unit-testable without sockets or a timer. The count maps onto time closely enough —
+    /// a sustained outage sits at [`AcceptBackoff::MAX`] (1 s), so ≈1 error/s puts a reminder
+    /// roughly every 10 minutes. Early in an outage the 1 ms→1 s ramp delivers errors faster and
+    /// the first reminder arrives sooner, which is the right bias.
+    pub const REEMIT_EVERY: u64 = 600;
+
+    /// Record a systemic error. Returns `Some(Onset)` on the transition *into* the error state,
+    /// `Some(StillDown { .. })` on every `REEMIT_EVERY`-th error while it persists, and `None`
+    /// otherwise (the error is counted, not logged).
+    ///
+    /// A reminder does **not** reset the suppressed count: it stays the running total for the
+    /// outage, so [`Self::on_success`] still reports the whole outage on recovery.
+    pub fn on_error(&mut self) -> Option<AcceptErrorEvent> {
         if self.in_error {
             self.suppressed += 1;
-            false
+            if self.suppressed.is_multiple_of(Self::REEMIT_EVERY) {
+                Some(AcceptErrorEvent::StillDown {
+                    suppressed: self.suppressed,
+                })
+            } else {
+                None
+            }
         } else {
             self.in_error = true;
             self.suppressed = 0;
-            true
+            Some(AcceptErrorEvent::Onset)
         }
     }
 
@@ -604,18 +639,18 @@ mod accept_error {
         );
     }
 
-    // The log state machine backs the "exactly one error!, exactly one info! with the
-    // suppressed count" AC without sockets: on_error transitions once, on_success reports the
-    // count once, steady state stays silent.
+    // The log state machine backs the "one error! on onset, one info! with the suppressed count
+    // on recovery" AC without sockets: on_error transitions once, steady state stays silent.
     #[test]
     fn log_emits_once_per_transition_with_suppressed_count() {
         let mut log = AcceptErrorLog::default();
-        assert!(
+        assert_eq!(
             log.on_error(),
+            Some(AcceptErrorEvent::Onset),
             "first systemic error -> emit the one error!"
         );
-        assert!(!log.on_error(), "second is suppressed");
-        assert!(!log.on_error(), "third is suppressed");
+        assert_eq!(log.on_error(), None, "second is suppressed");
+        assert_eq!(log.on_error(), None, "third is suppressed");
         assert_eq!(
             log.on_success(),
             Some(2),
@@ -625,11 +660,53 @@ mod accept_error {
         assert_eq!(log.on_success(), None);
 
         // A fresh outage re-arms: one error!, count restarts from 0.
-        assert!(log.on_error());
+        assert_eq!(log.on_error(), Some(AcceptErrorEvent::Onset));
         assert_eq!(
             log.on_success(),
             Some(0),
             "immediate recovery suppressed nothing"
         );
+    }
+
+    // Issue #838: a sustained outage must re-announce itself, or its only evidence is one log line
+    // emitted whenever it started. Reminders are count-based so this stays clock-free.
+    #[test]
+    fn sustained_outage_reemits_every_n_and_keeps_the_running_total() {
+        let mut log = AcceptErrorLog::default();
+        assert_eq!(log.on_error(), Some(AcceptErrorEvent::Onset));
+
+        // Everything strictly between onset and the Nth suppressed error is silent.
+        for i in 1..AcceptErrorLog::REEMIT_EVERY {
+            assert_eq!(log.on_error(), None, "suppressed error {i} must not log");
+        }
+        assert_eq!(
+            log.on_error(),
+            Some(AcceptErrorEvent::StillDown {
+                suppressed: AcceptErrorLog::REEMIT_EVERY
+            }),
+            "the REEMIT_EVERY-th suppressed error re-announces the outage"
+        );
+
+        // The reminder does NOT reset the count — the next one carries 2N, and recovery still
+        // reports the whole outage.
+        for _ in 1..AcceptErrorLog::REEMIT_EVERY {
+            assert_eq!(log.on_error(), None);
+        }
+        assert_eq!(
+            log.on_error(),
+            Some(AcceptErrorEvent::StillDown {
+                suppressed: AcceptErrorLog::REEMIT_EVERY * 2
+            }),
+            "reminders carry the running total, not a per-window count"
+        );
+        assert_eq!(
+            log.on_success(),
+            Some(AcceptErrorLog::REEMIT_EVERY * 2),
+            "recovery reports every error suppressed during the outage"
+        );
+
+        // And a fresh outage re-arms the reminder schedule from zero.
+        assert_eq!(log.on_error(), Some(AcceptErrorEvent::Onset));
+        assert_eq!(log.on_error(), None, "the new outage counts from 0 again");
     }
 }

--- a/crates/rift-mock-core/src/proxy/server.rs
+++ b/crates/rift-mock-core/src/proxy/server.rs
@@ -293,6 +293,8 @@ impl ProxyServer {
         // transient `ECONNABORTED` or a momentary `EMFILE`.
         let mut backoff = super::network::AcceptBackoff::new();
         let mut error_log = super::network::AcceptErrorLog::default();
+        // Clears its contribution on every exit path, including a cancel break or a panic (#838).
+        let mut outage = crate::extensions::AcceptOutageGuard::new("proxy");
 
         loop {
             // Acquire a permit *before* accepting so a cap holds connections back in the listener
@@ -311,6 +313,7 @@ impl ProxyServer {
                     // Recovery: only the transition out of a systemic-error state logs and resets
                     // the backoff, so a healthy accept path pays one branch.
                     if let Some(suppressed) = error_log.on_success() {
+                        outage.exit();
                         info!(
                             suppressed,
                             "proxy accept loop recovered after {suppressed} suppressed error(s)"
@@ -328,15 +331,28 @@ impl ProxyServer {
                 }
                 Err(e) => match super::network::classify_accept_error(&e) {
                     super::network::AcceptErrorClass::Transient => {
+                        crate::extensions::record_accept_error("proxy", "transient");
                         debug!("transient accept error on the proxy listener: {e}");
                         continue;
                     }
                     super::network::AcceptErrorClass::Systemic => {
-                        if error_log.on_error() {
-                            error!(
-                                "accept error on the proxy listener: {e}; backing off \
-                                 (further errors suppressed until recovery)"
-                            );
+                        crate::extensions::record_accept_error("proxy", "systemic");
+                        match error_log.on_error() {
+                            Some(super::network::AcceptErrorEvent::Onset) => {
+                                outage.enter();
+                                error!(
+                                    "accept error on the proxy listener: {e}; backing off \
+                                     (further errors suppressed until recovery)"
+                                );
+                            }
+                            Some(super::network::AcceptErrorEvent::StillDown { suppressed }) => {
+                                error!(
+                                    suppressed,
+                                    "proxy listener still failing to accept after {suppressed} \
+                                     suppressed error(s): {e}"
+                                );
+                            }
+                            None => {}
                         }
                         // This loop has no shutdown signal to race against (see the permit
                         // acquire above), so a plain sleep is the whole story here.

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -58,6 +58,8 @@ Histogram metrics expand into the usual `_bucket{le="…"}`, `_sum`, and `_count
 | `rift_proxy_request_duration_ms` | histogram | `method`, `fault_applied` | Proxy handling time, in milliseconds. |
 | `rift_upstream_request_duration_ms` | histogram | `method`, `status` | Upstream (proxied) request time, in milliseconds. |
 | `rift_accepted_connections_total` | counter | `worker` | Connections accepted per accept-loop worker slot. Under `--runtime per-core` the slot is the worker index, making SO_REUSEPORT skew observable; in the default topology everything lands on slot `0`. |
+| `rift_accept_errors_total` | counter | `listener`, `class` | Accept errors by listener (`imposter`, `admin`, `metrics`, `proxy`) and class (`transient`, `systemic`). The accept loops classify and retry rather than terminate, so a listener can stay bound while unable to serve — this is the signal that it is degraded. Fatal (broken-fd) errors are excluded on the admin, metrics and proxy listeners — they end the loop and surface through its owner. The imposter loops have no fatal class by design (a dying imposter loop is recoverable through the still-live admin API), so there a broken fd counts as `systemic`. No port label, deliberately (unbounded cardinality); the log lines carry the port. |
+| `rift_accept_error_outage` | gauge | `listener` | `1` while **any** accept loop for that listener is in a systemic outage, `0` otherwise — the imposter plane runs many loops behind one label, so this counts depth rather than tracking whichever loop wrote last. Released when a loop ends while wedged, so it cannot stick at `1`. Present at `0` from startup, so `absent()` alerts work. The one to alert on. |
 
 Example scrape output:
 


### PR DESCRIPTION
## Summary

Since the accept-loop retry policy (#750/#826/#834) began classifying errors and retrying, a wedged listener stays bound and answers nothing instead of closing its socket. This is better for survival, but harder to notice — the only local evidence was one error! log line emitted when the outage began.

This change re-announces a persisting outage every 600 suppressed errors (count-based on purpose so bookkeeping stays clock-free and unit-testable). `AcceptErrorLog::on_error()` now returns `Option<AcceptErrorEvent>` carrying either `Onset` or `StillDown`, and the signature change is safe: the type went public in #826 after v0.15.0, so it has never shipped in a release; the compiler enforced the migration of all five call sites.

New metrics `rift_accept_errors_total{listener, class}` and `rift_accept_error_outage{listener}` are now exposed and documented in `docs/features/metrics.md`.

The outage gauge is backed by a per-listener depth counter behind an RAII `AcceptOutageGuard`. This is necessary because one label covers many loops (one per imposter, one per accept runtime under per-core fan-out) that wedge together on process-wide EMFILE and recover asynchronously. The guard also releases on drop, so a loop ending mid-outage cannot leave the gauge stuck at 1.

Note: metrics are unreachable when the metrics listener is the wedged one; logs rotate away. The two mechanisms cover each other.

Closes #838
Milestone: none (standalone)