### PR TITLE
feat(flow-state): let provider-supplied stores carry their own config

### DIFF
--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -1012,6 +1012,21 @@ pub struct RiftFlowStateConfig {
     /// Flattened directly under `flowState` (issue #266). Absent ⇒ `"imposter_port"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flow_id_source: Option<String>,
+    /// Options belonging to a provider-supplied store ([`FlowStoreProvider`]).
+    ///
+    /// An embedder that plugs in its own [`FlowStore`] has, today, nowhere to put
+    /// that store's configuration: every field here describes a built-in backend,
+    /// and adding one per embedder does not scale (nor should this crate learn
+    /// their vocabulary). Unrecognised keys under `flowState` therefore collect
+    /// here instead of being dropped, and the provider parses what it owns.
+    ///
+    /// Built-in backends ignore this entirely — `"inmemory"` and `"redis"` read
+    /// only the typed fields above, so an unknown key changes nothing for them.
+    ///
+    /// [`FlowStoreProvider`]: crate::extensions::flow_state::FlowStoreProvider
+    /// [`FlowStore`]: crate::extensions::flow_state::FlowStore
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 fn default_flow_backend() -> String {
@@ -1029,6 +1044,7 @@ impl Default for RiftFlowStateConfig {
             ttl_seconds: default_flow_ttl(),
             redis: None,
             flow_id_source: None,
+            extra: serde_json::Map::new(),
         }
     }
 }
@@ -1555,6 +1571,93 @@ mod tests {
             }
             other => panic!("expected Is, got {other:?}"),
         }
+    }
+
+    // A provider's own options survive under `flowState`, verbatim, instead of
+    // being dropped on the floor as unknown keys.
+    #[test]
+    fn provider_options_collect_in_extra() {
+        let fs: RiftFlowStateConfig = serde_json::from_value(json!({
+            "backend": "inmemory",
+            "ttlSeconds": 60,
+            "readConsistency": "strong",
+            "nested": { "fsyncIntervalMs": 50 }
+        }))
+        .unwrap();
+
+        // The typed fields still bind; only what is left over collects.
+        assert_eq!(fs.backend, "inmemory");
+        assert_eq!(fs.ttl_seconds, 60);
+        assert_eq!(
+            fs.extra.get("readConsistency").and_then(|v| v.as_str()),
+            Some("strong")
+        );
+        assert_eq!(
+            fs.extra
+                .get("nested")
+                .and_then(|v| v.get("fsyncIntervalMs"))
+                .and_then(serde_json::Value::as_u64),
+            Some(50)
+        );
+        assert!(
+            !fs.extra.contains_key("backend") && !fs.extra.contains_key("ttlSeconds"),
+            "a key a typed field already claimed must not also land in extra: {:?}",
+            fs.extra
+        );
+
+        // Round-trip: provider keys come back flat, where they were written.
+        let out = serde_json::to_value(&fs).unwrap();
+        assert_eq!(
+            out.get("readConsistency").and_then(|v| v.as_str()),
+            Some("strong")
+        );
+    }
+
+    // `rename_all = "camelCase"` renames the *declared* fields; keys collected by
+    // `flatten` are data, not identifiers, and must pass through untouched.
+    #[test]
+    fn extra_keys_are_not_case_mangled() {
+        let fs: RiftFlowStateConfig = serde_json::from_value(json!({
+            "some_snake_key": 1,
+            "SCREAMING": 2,
+            "mixedCase": 3
+        }))
+        .unwrap();
+        for key in ["some_snake_key", "SCREAMING", "mixedCase"] {
+            assert!(fs.extra.contains_key(key), "{key} was renamed or dropped");
+        }
+    }
+
+    // Adding `extra` must not change the wire form of any config that exists
+    // today: an empty map contributes no keys, so a round-trip of a
+    // fully-populated built-in config is byte-identical to what it was before.
+    #[test]
+    fn an_empty_extra_adds_nothing_to_the_wire_form() {
+        let input = json!({
+            "backend": "redis",
+            "ttlSeconds": 900,
+            "redis": { "url": "redis://localhost:6379" },
+            "flowIdSource": "header:X-Flow"
+        });
+        let fs: RiftFlowStateConfig = serde_json::from_value(input.clone()).unwrap();
+        assert!(fs.extra.is_empty(), "nothing was left over: {:?}", fs.extra);
+
+        let out = serde_json::to_value(&fs).unwrap();
+        let keys: Vec<&String> = out.as_object().unwrap().keys().collect();
+        assert_eq!(keys.len(), 4, "serializing gained or lost a key: {keys:?}");
+        assert_eq!(out.get("backend"), input.get("backend"));
+        assert_eq!(out.get("ttlSeconds"), input.get("ttlSeconds"));
+        assert_eq!(out.get("flowIdSource"), input.get("flowIdSource"));
+    }
+
+    // Absent `flowState` keys entirely: `extra` defaults empty rather than
+    // failing to deserialize.
+    #[test]
+    fn extra_defaults_empty() {
+        let fs: RiftFlowStateConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(fs.extra.is_empty());
+        assert_eq!(fs.backend, "inmemory");
+        assert!(RiftFlowStateConfig::default().extra.is_empty());
     }
 
     // Issue #266: `flowIdSource` is flat under `flowState` and survives a serialize round-trip.


### PR DESCRIPTION
## The gap

`FlowStoreProvider` lets an embedder plug in its own `FlowStore`, and `provide()`
is handed the whole `ImposterConfig` precisely so the store can vary per
imposter. But there is nowhere to *configure* one: every field on
`RiftFlowStateConfig` describes a built-in backend, so a provider either
hardcodes its settings or invents a side channel outside the imposter config —
which is exactly where per-imposter settings belong.

Adding a named field per embedder does not scale, and would make this crate
learn vocabulary that is not its own.

## What this does

Unrecognised keys under `flowState` collect into a flattened map instead of being
dropped:

```rust
#[serde(flatten)]
pub extra: serde_json::Map<String, serde_json::Value>,
```

```jsonc
"_rift": { "flowState": {
    "backend": "inmemory",        // built-in fields, unchanged
    "ttlSeconds": 300,
    "readConsistency": "strong",  // -> extra, for the provider to parse
    "durability": "async"         // -> extra
}}
```

## Nothing changes for the built-ins

`"inmemory"` and `"redis"` read only the typed fields, so an unknown key is inert
to them. And an empty `extra` contributes **no keys** on serialize, so every
config that exists today round-trips byte-identically — pinned by
`an_empty_extra_adds_nothing_to_the_wire_form`, which asserts the serialized key
count as well as the values.

## Three properties pinned rather than assumed

| Test | Property |
|---|---|
| `provider_options_collect_in_extra` | typed fields still bind; only leftovers collect; a key a typed field claimed does **not** also appear in `extra` |
| `extra_keys_are_not_case_mangled` | `rename_all = "camelCase"` renames *declared* fields — keys collected by `flatten` are data, not identifiers, and pass through verbatim |
| `extra_defaults_empty` | an absent `flowState` body yields an empty map, not a deserialization error; `Default` matches |

`flatten` and `deny_unknown_fields` are mutually exclusive in serde.
`RiftFlowStateConfig` does not use the latter, so nothing is traded away here —
worth stating explicitly since that is the usual objection to `flatten`.

## The read path is deliberately untouched

`expose_flow_state` (`admin_api/handlers/imposters.rs`) is a **fail-closed
allowlist** — issue #260's design, so that a credential-bearing field added later
is excluded by default rather than leaked. `extra` is not on that list, and this
PR does not add it. A provider's auth block therefore cannot reach
`GET /imposters` merely by existing. A provider that wants a specific field
exposed should have to ask for it, in a change where that decision is visible.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
  warnings`, and `cargo test --workspace` all clean on this branch — including the
  1302-test `rift-mock-core` lib suite and every integration suite, 0 failures.
- The four new tests live beside the existing `flat_flow_id_source_round_trips`
  (issue #266), which is the closest precedent for a flat key under `flowState`.

## Who wants it

Rift Enterprise's clustered flow store needs two per-imposter knobs
(`readConsistency`, `durability`) and has nowhere to put them. The mechanism is
generic, though — any embedder with a custom store has this problem today, and
none of them can solve it without a change here.
