### PR TITLE
test: let the spawning suites run against a supplied server binary

### DIFF
--- a/crates/rift-http-proxy/tests/corpus_replay.rs
+++ b/crates/rift-http-proxy/tests/corpus_replay.rs
@@ -6,10 +6,13 @@
 //! `manifest.json` against drift from the fixtures on disk, and proves the *packaged* tarball (not
 //! just the source tree) still serves after `cp`/`jq`/re-tar.
 
+mod support;
+
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-const SERVER: &str = env!("CARGO_BIN_EXE_rift-http-proxy");
+// `rift-verify` is the reference `_verify` replayer (test harness, not the binary under test) and
+// stays pinned to the debug build; only the server is overridable, via `support::server_bin()`.
 const VERIFY: &str = env!("CARGO_BIN_EXE_rift-verify");
 /// The closed set of capability gates a fixture may declare in `manifest.json` `requires`
 /// (extended additively). An SDK CI skips a fixture only when it lacks a declared capability.
@@ -250,7 +253,7 @@ async fn serve_and_verify(corpus: &Path) {
     let log_out = log.reopen().expect("reopen log");
     let log_err = log.reopen().expect("reopen log");
 
-    let mut server = tokio::process::Command::new(SERVER)
+    let mut server = tokio::process::Command::new(support::server_bin())
         .arg("--configfile")
         .arg(tmp.path())
         .args(["--port", &admin_port.to_string(), "--allowInjection"])

--- a/crates/rift-http-proxy/tests/issue_360_script_cli.rs
+++ b/crates/rift-http-proxy/tests/issue_360_script_cli.rs
@@ -3,14 +3,10 @@
 //! check/run LOGIC directly). One happy path each, via `std::process::Command` against the
 //! checked-in fixtures.
 
+mod support;
+
 use std::path::PathBuf;
 use std::process::Command;
-
-fn rift_bin() -> PathBuf {
-    // The binary target is named `rift-http-proxy` (no `[[bin]] name = "rift"` override in
-    // Cargo.toml — the CLI itself is invoked as `rift` only once packaged/aliased downstream).
-    PathBuf::from(env!("CARGO_BIN_EXE_rift-http-proxy"))
-}
 
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -21,7 +17,7 @@ fn fixture(name: &str) -> PathBuf {
 // AC (issue #360): `rift script check` on a valid script exits 0 and prints OK.
 #[test]
 fn script_check_valid_fixture_exits_zero() {
-    let output = Command::new(rift_bin())
+    let output = Command::new(support::server_bin())
         .args(["script", "check"])
         .arg(fixture("fail-twice.rhai"))
         .output()
@@ -43,7 +39,7 @@ fn script_check_misnamed_entrypoint_fails() {
     let path = dir.path().join("bad.rhai");
     std::fs::write(&path, "fn respnod(ctx) { pass() }").expect("write fixture");
 
-    let output = Command::new(rift_bin())
+    let output = Command::new(support::server_bin())
         .args(["script", "check"])
         .arg(&path)
         .output()
@@ -63,7 +59,7 @@ fn script_check_misnamed_entrypoint_fails() {
 // the 200 (pass) branch, with no server running.
 #[test]
 fn script_run_fail_twice_attempts_2_passes() {
-    let output = Command::new(rift_bin())
+    let output = Command::new(support::server_bin())
         .args(["script", "run"])
         .arg(fixture("fail-twice.rhai"))
         .args(["--request"])
@@ -82,7 +78,7 @@ fn script_run_fail_twice_attempts_2_passes() {
 
 #[test]
 fn script_run_fail_twice_attempts_1_fails_with_503() {
-    let output = Command::new(rift_bin())
+    let output = Command::new(support::server_bin())
         .args(["script", "run"])
         .arg(fixture("fail-twice.rhai"))
         .args(["--state", "attempts=1"])

--- a/crates/rift-http-proxy/tests/mountebank_compatibility.rs
+++ b/crates/rift-http-proxy/tests/mountebank_compatibility.rs
@@ -3,6 +3,8 @@
 //! These tests verify that Rift behaves compatibly with Mountebank's HTTP imposter API.
 //! Tests are organized by feature category and require a running Rift server.
 
+mod support;
+
 use reqwest::Client;
 use serde_json::json;
 use std::time::Duration;
@@ -22,16 +24,8 @@ fn get_test_ports() -> (u16, u16) {
 
 /// Start a Rift server for testing
 async fn start_rift_server(admin_port: u16) -> tokio::process::Child {
-    let child = tokio::process::Command::new("cargo")
-        .args([
-            "run",
-            "--package",
-            "rift-http-proxy",
-            "--",
-            "--port",
-            &admin_port.to_string(),
-            "--allow-injection",
-        ])
+    let child = tokio::process::Command::new(support::server_bin())
+        .args(["--port", &admin_port.to_string(), "--allow-injection"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()

--- a/crates/rift-http-proxy/tests/rift_extensions.rs
+++ b/crates/rift-http-proxy/tests/rift_extensions.rs
@@ -3,6 +3,8 @@
 //! These tests verify that the `_rift` configuration extensions work correctly
 //! for flow state, scripting, and fault injection.
 
+mod support;
+
 use reqwest::Client;
 use serde_json::json;
 use std::time::{Duration, Instant};
@@ -23,16 +25,8 @@ fn get_test_ports() -> (u16, u16) {
 
 /// Start a Rift server for testing
 async fn start_rift_server(admin_port: u16) -> tokio::process::Child {
-    let child = tokio::process::Command::new("cargo")
-        .args([
-            "run",
-            "--package",
-            "rift-http-proxy",
-            "--",
-            "--port",
-            &admin_port.to_string(),
-            "--allow-injection",
-        ])
+    let child = tokio::process::Command::new(support::server_bin())
+        .args(["--port", &admin_port.to_string(), "--allow-injection"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()

--- a/crates/rift-http-proxy/tests/support/mod.rs
+++ b/crates/rift-http-proxy/tests/support/mod.rs
@@ -1,0 +1,55 @@
+//! Shared support for the process-spawning integration suites (`mountebank_compatibility`,
+//! `rift_extensions`, `issue_360_script_cli`, `corpus_replay`).
+//!
+//! This lives at `tests/support/mod.rs`, not `tests/support.rs`: Cargo treats every `.rs` file
+//! directly under `tests/` as its own test binary target, so a bare `tests/support.rs` would be
+//! compiled and run as an (empty) test suite in its own right. The `support/mod.rs` layout is a
+//! module, not a target, and each suite pulls it in with `#[path = "support/mod.rs"] mod support;`
+//! (or an equivalent `mod support;` alongside a `tests/support/mod.rs` file — either resolves the
+//! same way).
+
+use std::path::PathBuf;
+
+/// Path to the rift **server** binary under test (the `rift-http-proxy` process these suites spawn
+/// and drive over the admin API / CLI).
+///
+/// Resolution order:
+/// 1. `RIFT_SERVER_BIN`, if set — must name an existing, executable file. This lets any
+///    Mountebank-compatible build (a differently-packaged rift, e.g. a musl static image, or a
+///    downstream binary that composes rift's `ServerBuilder`) be driven through these suites
+///    instead of this repo's own debug build. A set-but-bad override panics rather than falling
+///    back silently: quietly testing the wrong binary is worse than failing loudly.
+/// 2. Otherwise `CARGO_BIN_EXE_rift-http-proxy` — today's behaviour, unchanged.
+///
+/// Only the **server** is overridable this way. `corpus_replay.rs` also spawns `rift-verify`
+/// (the reference `_verify` replayer); that stays pinned to `CARGO_BIN_EXE_rift-verify` — it is
+/// part of the test harness, not the binary under test, and `RIFT_SERVER_BIN` deliberately does
+/// not touch it. (Hence `RIFT_SERVER_BIN`, not a generic `RIFT_BIN`: with two binaries in play,
+/// a generic name would be ambiguous about which one it overrides.)
+pub fn server_bin() -> PathBuf {
+    if let Ok(path) = std::env::var("RIFT_SERVER_BIN") {
+        let bin = PathBuf::from(&path);
+        let executable = bin
+            .metadata()
+            .map(|m| m.is_file() && is_executable(&m))
+            .unwrap_or(false);
+        assert!(
+            executable,
+            "RIFT_SERVER_BIN={path} does not name an existing, executable file"
+        );
+        return bin;
+    }
+    PathBuf::from(env!("CARGO_BIN_EXE_rift-http-proxy"))
+}
+
+#[cfg(unix)]
+fn is_executable(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    meta.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_meta: &std::fs::Metadata) -> bool {
+    // No portable executable-bit check off Unix; existence-as-a-file is the best we can assert.
+    true
+}

--- a/docs/embedding/sdk-conformance.md
+++ b/docs/embedding/sdk-conformance.md
@@ -51,6 +51,24 @@ For each fixture, an SDK conformance suite must:
 The full contract ships in the tarball's `README.md`. See also the
 [`_verify` annotations]({{ site.baseurl }}/configuration/cli/) documented for `rift-verify`.
 
+## Replaying against an externally-supplied server
+
+`crates/rift-http-proxy/tests/corpus_replay.rs`, and the other process-spawning suites under
+`crates/rift-http-proxy/tests/` (`mountebank_compatibility.rs`, `rift_extensions.rs`,
+`issue_360_script_cli.rs`), default to spawning this repo's own debug build of `rift-http-proxy`.
+Set **`RIFT_SERVER_BIN`** to an existing, executable path to run them against any other
+Mountebank-compatible build instead — a differently-packaged rift (e.g. a musl static image) or a
+downstream binary that composes rift's `ServerBuilder`. A set-but-missing/non-executable path
+panics rather than silently falling back. Only the server is overridable this way; the reference
+`_verify` replayer `rift-verify` (used by `corpus_replay.rs`) always stays the debug build built
+alongside the tests.
+
+```sh
+cargo build -p rift-http-proxy
+RIFT_SERVER_BIN=$PWD/target/debug/rift-http-proxy \
+  cargo test -p rift-http-proxy --test corpus_replay
+```
+
 ## Adding a fixture
 
 Fixtures are numbered and append-only (`NN-name.json`, never renumbered). Add the next free number,


### PR DESCRIPTION
## Why

Four integration suites exercise rift by **spawning it** — `mountebank_compatibility`,
`rift_extensions`, `issue_360_script_cli`, `corpus_replay` — and each hardcoded how: two shell out
to `cargo run`, two use `CARGO_BIN_EXE_rift-http-proxy`. So they can only ever test *this repo's own
debug build*, even though what they assert is Mountebank-compatible **behaviour over a socket**,
which any equivalent build should satisfy.

That matters for anything packaged differently — the musl static image, or a downstream binary that
composes rift's `ServerBuilder`. Today the only way for such a build to get conformance coverage is
to hand-copy a subset of these suites, which then rots against the originals.

## What

All four now resolve the binary through one shared helper:

```rust
// crates/rift-http-proxy/tests/support/mod.rs
pub fn server_bin() -> PathBuf
```

`RIFT_SERVER_BIN` when set, otherwise `CARGO_BIN_EXE_rift-http-proxy` — **exactly today's
behaviour when unset**, which is the safety property this change rests on.

### Two decisions worth flagging for review

**A set-but-bad override panics; it does not fall back.**
```
RIFT_SERVER_BIN=/nonexistent/rift does not name an existing, executable file
```
Falling back would mean the suite quietly tests a *different binary than the operator asked for*,
passes, and means nothing. Loud is the only safe option here.

**`RIFT_SERVER_BIN`, not `RIFT_BIN`.** `scripts/verify-docs-examples.sh` already uses `RIFT_BIN`
for the same "reuse a prebuilt binary" idea, so the generic name was the obvious candidate — but
`corpus_replay` spawns **two** binaries. Only the server is overridable; `rift-verify` stays on its
own `CARGO_BIN_EXE_` because it is part of the harness, not the thing under test. A generic name
cannot express that distinction, and the helper's doc comment says so explicitly.

**`tests/support/mod.rs`, not `tests/support.rs`** — Cargo compiles every `.rs` directly under
`tests/` as its own test target, so the flat form would run as an empty suite of its own. This is
the crate's first shared test-support module.

## Verification

The override was proven **in both directions**, which is what rules out it being silently ignored:

| | result |
|---|---|
| `RIFT_SERVER_BIN` unset | 4 suites pass — default path unchanged |
| pointed at the real debug binary | passes |
| pointed at a nonexistent path | **every test fails** with the named message |

`cargo test -p rift-http-proxy --test mountebank_compatibility --test rift_extensions --test
issue_360_script_cli --test corpus_replay` → exit 0 (the `#[ignore]`d cases in the two big suites
are pre-existing and unaffected). `cargo fmt --check` and `cargo clippy --all-targets -D warnings`
clean. `scripts/verify-docs-coverage.sh` → *OK: 40 flags, 30 env vars, 7 subcommands documented* —
`RIFT_SERVER_BIN` is documented in `docs/embedding/sdk-conformance.md`, which already covers the
replay flow, rather than the CLI table: it is a test-harness selector, not a server runtime knob.

## Downstream

This unblocks rift-enterprise#37, which wants to run these suites against `rift-ee-server` with
`--cluster` off to verify composition parity — currently asserted by construction and spot-checked
by two local tests, but never verified against the behaviour rift itself guarantees.
