### PR TITLE
feat(front-door): one listener, many imposters, routed by content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ name = "rift-http-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert-json-diff",
  "base64 0.22.1",
  "bytes",

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -67,6 +67,9 @@ reqwest.workspace = true
 # Utils
 bytes.workspace = true
 base64 = "0.22"
+# Hot-swappable route table for the front door listener (issue #19 / U-11); same pin as
+# rift-mock-core's own use of it for the imposter manager's port slots.
+arc-swap = "1.7"
 # Constant-time comparison for the admin API key (issue #548 — timing side channel)
 subtle = "2"
 chrono.workspace = true

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -124,47 +124,17 @@ pub async fn route_request(
     Ok(response)
 }
 
-/// Dispatch a `/__rift/:port/<path>` gateway request to the imposter on `:port` (issue #212),
-/// rewriting the URI to the imposter-relative `/<path>` (+ query) so its predicates and handler
-/// behave exactly as if the request had arrived on the imposter's own port. The dispatch core
-/// is the library-public `gateway::dispatch_to_port` (issue #317).
+/// Dispatch a `/__rift/:port/<path>` gateway request to the imposter on `:port` (issue #212).
+/// Thin wrapper over the library-public `gateway::dispatch_gateway_path` (issue #317), which the
+/// front door (issue #19 / U-11) shares for its own fallback addressing so the two listeners
+/// cannot drift on what counts as a valid gateway target.
 async fn handle_gateway(
     rest: &str,
     query: Option<&str>,
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
 ) -> Response<Full<Bytes>> {
-    let (port_str, sub_path) = match rest.split_once('/') {
-        Some((port, sub)) => (port, format!("/{sub}")),
-        None => (rest, "/".to_string()),
-    };
-    let Ok(port) = port_str.parse::<u16>() else {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            &format!("invalid gateway target '{port_str}' (expected /__rift/<port>/<path>)"),
-        );
-    };
-    // Check existence before the URI rewrite so a missing imposter stays a 404 even if the
-    // rewritten URI would be rejected — the pre-#317 response precedence. dispatch_to_port
-    // re-checks as its own defensive 404 for other callers.
-    if manager.get_imposter(port).is_err() {
-        return error_response(
-            StatusCode::NOT_FOUND,
-            &format!("no imposter on port {port}"),
-        );
-    }
-
-    let target = match query {
-        Some(q) => format!("{sub_path}?{q}"),
-        None => sub_path,
-    };
-    let (mut parts, body) = req.into_parts();
-    parts.uri = match target.parse() {
-        Ok(uri) => uri,
-        Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid gateway path"),
-    };
-
-    crate::gateway::dispatch_to_port(&manager, port, Request::from_parts(parts, body)).await
+    crate::gateway::dispatch_gateway_path(rest, query, req, &manager).await
 }
 
 /// Route based on path

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -60,6 +60,10 @@ pub struct LoadedConfig {
     /// byte-for-byte the pre-#655 behaviour. Only the `{ "imposters": [...] }` wrapper object has
     /// somewhere to put one; a bare array and a `--datadir` never yield a block.
     pub intercept: Option<InterceptStartOptions>,
+    /// `None` when the document declares no `routes` block. Same shape rule as
+    /// `intercept`: only the `{ "imposters": [...] }` wrapper has somewhere to put
+    /// one (issue #19).
+    pub routes: Option<crate::front_door::RouteTable>,
 }
 
 /// Parse the source into imposter configs without creating any imposters. A parse error is
@@ -76,9 +80,12 @@ pub fn load_configs(source: &ConfigSource) -> anyhow::Result<Vec<ImposterConfig>
 pub fn load_configs_full(source: &ConfigSource) -> anyhow::Result<LoadedConfig> {
     match source {
         ConfigSource::File { path, no_parse } => load_file(path, *no_parse),
+        // A datadir is a directory of imposter documents with no wrapper, so it has
+        // nowhere to declare either an intercept listener or a route table.
         ConfigSource::Dir(dir) => load_dir(dir).map(|imposters| LoadedConfig {
             imposters,
             intercept: None,
+            routes: None,
         }),
     }
 }
@@ -93,6 +100,7 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
 
     let trimmed = content.trim_start();
     let mut intercept = None;
+    let mut routes = None;
     let mut configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
         // Single imposter, or a `{ "imposters": [...] }` wrapper (Mountebank format).
         let value: serde_json::Value = serde_json::from_str(&content)?;
@@ -107,12 +115,33 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
                     .map(|block| serde_json::from_value(block.clone()))
                     .transpose()
                     .map_err(|e| anyhow::anyhow!("invalid `intercept` block: {e}"))?;
+                // Same wrapper-only rule, same reasoning, for the front door's route
+                // table (issue #19). Validated here rather than at first request: a
+                // table that cannot route is a startup error, not a runtime surprise.
+                routes = value
+                    .get("routes")
+                    .map(|block| {
+                        serde_json::from_value::<crate::front_door::RouteTable>(block.clone())
+                    })
+                    .transpose()
+                    .map_err(|e| anyhow::anyhow!("invalid `routes` block: {e}"))?;
+                if let Some(table) = &routes {
+                    table
+                        .validate()
+                        .map_err(|e| anyhow::anyhow!("invalid `routes` block: {e}"))?;
+                }
                 serde_json::from_value(imposters.clone())?
             }
             // A single-imposter document has no `imposters` key, so it has no wrapper to carry a
             // listener declaration — and `ImposterConfig` ignores unknown fields, so an `intercept`
             // key here would be dropped without a word: no listener, no rule, no diagnostic, and a
             // green boot (issue #655). Refuse instead; the remedy is one line of JSON.
+            None if value.get("routes").is_some() => anyhow::bail!(
+                "a `routes` block is only read from the `{{\"imposters\": [...], \"routes\": [...]}}` \
+                 wrapper form, but this document has no `imposters` key, so the block would be \
+                 ignored. Wrap the imposter in `\"imposters\": [ ... ]` (use `[]` if the file \
+                 declares none)."
+            ),
             None if value.get("intercept").is_some() => anyhow::bail!(
                 "an `intercept` block is only read from the `{{\"imposters\": [...], \"intercept\": {{...}}}}` \
                  wrapper form, but this document has no `imposters` key, so the block would be ignored. \
@@ -141,6 +170,7 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
     Ok(LoadedConfig {
         imposters: configs,
         intercept,
+        routes,
     })
 }
 
@@ -381,6 +411,75 @@ mod tests {
     }"#;
 
     /// AC2: the block is read from the same wrapper object that already carries `imposters`.
+    /// The wrapper form carries a `routes` table through to the caller, validated
+    /// at load time so a table that cannot route fails the boot rather than the
+    /// first request.
+    #[test]
+    fn load_configs_full_reads_and_validates_a_routes_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "cfg.json",
+            r#"{"imposters": [{"port": 4545, "protocol": "http"}],
+                "routes": {"routes": [
+                    {"id": "pay", "match": {"host": "payments.test"}, "target": {"port": 4545}}
+                ]}}"#,
+        );
+        let loaded = load_configs_full(&ConfigSource::File {
+            path: path.clone(),
+            no_parse: false,
+        })
+        .unwrap();
+        let table = loaded.routes.expect("routes block is read");
+        assert_eq!(table.routes.len(), 1);
+        assert_eq!(table.routes[0].id, "pay");
+        assert_eq!(table.routes[0].target.port, 4545);
+
+        let bad = write(
+            dir.path(),
+            "bad.json",
+            r#"{"imposters": [],
+                "routes": {"routes": [
+                    {"id": "dup", "match": {}, "target": {"port": 1}},
+                    {"id": "dup", "match": {}, "target": {"port": 2}}
+                ]}}"#,
+        );
+        let err = load_configs_full(&ConfigSource::File {
+            path: bad,
+            no_parse: false,
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("routes"), "error should name the block: {err}");
+    }
+
+    /// A `routes` block on a document with no `imposters` wrapper would be
+    /// silently dropped — `ImposterConfig` ignores unknown fields — leaving no
+    /// route table, no diagnostic, and a green boot. Same trap as #655's
+    /// `intercept` block, same refusal.
+    #[test]
+    fn a_routes_block_outside_the_wrapper_is_refused_not_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "single.json",
+            r#"{"port": 4545, "protocol": "http",
+                "routes": {"routes": [
+                    {"id": "pay", "match": {}, "target": {"port": 4545}}
+                ]}}"#,
+        );
+        let err = load_configs_full(&ConfigSource::File {
+            path,
+            no_parse: false,
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("`routes` block") && err.contains("imposters"),
+            "the refusal must say what was wrong and how to fix it: {err}"
+        );
+    }
+
     #[test]
     fn load_configs_full_reads_intercept_block() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/rift-http-proxy/src/front_door/listener.rs
+++ b/crates/rift-http-proxy/src/front_door/listener.rs
@@ -1,0 +1,476 @@
+//! The front-door listener itself (issue #19 / U-11): one bound port, resolved per-request
+//! against a hot-swappable [`CompiledRoutes`], falling back to the single-port gateway, falling
+//! back to a 404 that says so.
+//!
+//! Structurally this is [`crate::server::bind_metrics_server`] +
+//! `metrics_accept_loop` — same `TcpListener::bind` → `CancellationToken` + `TaskTracker` →
+//! `tokio::spawn` shape, same shared accept-error/backoff machinery from
+//! `rift_mock_core::proxy` and `rift_mock_core::extensions` — with the metrics-only service body
+//! replaced by route resolution. Copied rather than shared because the two loops' *service*
+//! bodies have nothing in common; the accept-loop plumbing around them is what is common, and it
+//! is small enough that a shared abstraction would cost more to read than the duplication does.
+
+use crate::front_door::route_table::{CompiledRoutes, Route};
+use crate::imposter::ImposterManager;
+use crate::response::{ErrorKind, error_response_typed};
+use arc_swap::ArcSwap;
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::{Request, Response, StatusCode, Uri};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{debug, error, info};
+
+/// Bounded grace given to in-flight connections on `shutdown()` (mirrors the metrics/admin
+/// listeners' constant of the same name and value).
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
+
+/// The marker distinguishing "no route matched" from "a route matched but its imposter is gone"
+/// — both are 404s, but only the former is a routing-table problem.
+const NO_ROUTE_HEADER: &str = "x-rift-front-door";
+
+/// Bind the front-door listener (`:0` is fine) and start serving, returning a handle that reports
+/// the bound address and can be shut down gracefully. `routes` is read fresh on every request via
+/// [`ArcSwap::load_full`], so an admin-API route-table update takes effect for the next request
+/// with no listener restart.
+pub async fn bind_front_door(
+    addr: SocketAddr,
+    manager: Arc<ImposterManager>,
+    routes: Arc<ArcSwap<CompiledRoutes>>,
+) -> anyhow::Result<RunningFrontDoor> {
+    let listener = TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
+    info!("Front door listening on http://{}", local_addr);
+
+    let cancel = CancellationToken::new();
+    let tracker = TaskTracker::new();
+    let (loop_cancel, loop_tracker) = (cancel.clone(), tracker.clone());
+    let task = tokio::spawn(async move {
+        let result =
+            front_door_accept_loop(listener, manager, routes, loop_cancel, loop_tracker).await;
+        // Preserve the metrics-listener precedent: an accept-loop failure is logged here because
+        // nothing else joins this task by default.
+        if let Err(ref e) = result {
+            error!("Front door server error: {e:#}");
+        }
+        result
+    });
+
+    Ok(RunningFrontDoor {
+        local_addr,
+        cancel,
+        tracker,
+        task: Mutex::new(Some(task)),
+    })
+}
+
+/// A bound, running front-door listener.
+pub struct RunningFrontDoor {
+    local_addr: SocketAddr,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+    task: Mutex<Option<JoinHandle<anyhow::Result<()>>>>,
+}
+
+impl RunningFrontDoor {
+    /// The actual bound address (a `:0` request resolves to the OS-assigned port here).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stop accepting new connections, give in-flight connections a bounded grace, then return.
+    /// Idempotent.
+    pub async fn shutdown(&self) {
+        self.cancel.cancel();
+        // Bind the taken handle to a local so the MutexGuard drops before any `.await`.
+        let task = self
+            .task
+            .lock()
+            .expect("front door task mutex poisoned")
+            .take();
+        if let Some(task) = task {
+            let abort = task.abort_handle();
+            if tokio::time::timeout(SHUTDOWN_GRACE, task).await.is_err() {
+                abort.abort();
+            }
+        }
+        self.tracker.close();
+        if tokio::time::timeout(SHUTDOWN_GRACE, self.tracker.wait())
+            .await
+            .is_err()
+        {
+            debug!(
+                "Front door shutdown: in-flight connections did not drain within the grace period"
+            );
+        }
+    }
+
+    /// Run until the accept loop exits (returns immediately if already shut down).
+    pub async fn join(self) -> anyhow::Result<()> {
+        let task = self
+            .task
+            .lock()
+            .expect("front door task mutex poisoned")
+            .take();
+        match task {
+            Some(task) => match task.await {
+                Ok(result) => result,
+                Err(join_err) => Err(anyhow::anyhow!("front door task failed: {join_err}")),
+            },
+            None => Ok(()),
+        }
+    }
+}
+
+async fn front_door_accept_loop(
+    listener: TcpListener,
+    manager: Arc<ImposterManager>,
+    routes: Arc<ArcSwap<CompiledRoutes>>,
+    cancel: CancellationToken,
+    tracker: TaskTracker,
+) -> anyhow::Result<()> {
+    use hyper::service::service_fn;
+    use hyper_util::rt::TokioIo;
+    use rift_mock_core::proxy::{
+        AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, HttpTuning,
+        classify_accept_error, is_fatal_listener_error,
+    };
+
+    // Read HTTP tuning once per listener, not per accepted connection.
+    let http_tuning = HttpTuning::from_env();
+    // `None` (the default) preserves today's behavior exactly: no semaphore, no permit, accept as
+    // fast as the kernel hands connections over (issue #716).
+    let connection_semaphore = http_tuning
+        .max_connections
+        .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n)));
+
+    // Accept-error handling, identical to the metrics/admin loops' (issues #826, #834).
+    let mut backoff = AcceptBackoff::new();
+    let mut error_log = AcceptErrorLog::default();
+    // Clears its contribution on every exit path, including a cancel break or a panic (#838).
+    let mut outage = rift_mock_core::extensions::AcceptOutageGuard::new("front-door");
+    // Resolved once per loop, not per error (#840).
+    let accept_errors = rift_mock_core::extensions::AcceptErrorCounters::new("front-door");
+
+    loop {
+        // Acquire a permit *before* accepting so a cap holds connections back in the listener
+        // backlog/kernel SYN queue rather than accepting them and then failing downstream. Raced
+        // against `cancel` (like the accept below) so a saturated cap never delays shutdown.
+        let permit = match &connection_semaphore {
+            Some(sem) => {
+                let acquire = sem.clone().acquire_owned();
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    acquired = acquire => match acquired {
+                        Ok(permit) => Some(permit),
+                        // Only closes on Drop, which never happens here — but if it ever does,
+                        // stop accepting rather than panic.
+                        Err(_) => break,
+                    },
+                }
+            }
+            None => None,
+        };
+        let accepted = tokio::select! {
+            _ = cancel.cancelled() => break,
+            accepted = listener.accept() => accepted,
+        };
+        let (stream, _) = match accepted {
+            Ok(accepted) => {
+                // Recovery: only the transition out of a systemic-error state logs and resets the
+                // backoff, so a healthy accept path pays one branch.
+                if let Some(suppressed) = error_log.on_success() {
+                    outage.exit();
+                    info!(
+                        suppressed,
+                        "front door accept loop recovered after {suppressed} suppressed error(s)"
+                    );
+                    backoff.reset();
+                }
+                accepted
+            }
+            // A broken listener fd cannot be cured by waiting; end the loop so the failure reaches
+            // the `Front door server error` log rather than spinning forever (issue #834).
+            Err(e) if is_fatal_listener_error(&e) => {
+                return Err(anyhow::anyhow!(
+                    "front door listener is unusable, giving up: {e}"
+                ));
+            }
+            Err(e) => match classify_accept_error(&e) {
+                AcceptErrorClass::Transient => {
+                    accept_errors.record_transient();
+                    debug!("transient accept error on the front door listener: {e}");
+                    continue;
+                }
+                AcceptErrorClass::Systemic => {
+                    accept_errors.record_systemic();
+                    match error_log.on_error() {
+                        Some(AcceptErrorEvent::Onset) => {
+                            outage.enter();
+                            error!(
+                                "accept error on the front door listener: {e}; backing off \
+                                 (further errors suppressed until recovery)"
+                            );
+                        }
+                        Some(AcceptErrorEvent::StillDown { suppressed }) => {
+                            error!(
+                                suppressed,
+                                "front door listener still failing to accept after {suppressed} \
+                                 suppressed error(s): {e}"
+                            );
+                        }
+                        None => {}
+                    }
+                    // Raced against `cancel` so a backoff sleep never delays shutdown.
+                    let delay = backoff.next_delay();
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = cancel.cancelled() => break,
+                    }
+                    continue;
+                }
+            },
+        };
+        let io = TokioIo::new(stream);
+        let conn_cancel = cancel.clone();
+        let manager = Arc::clone(&manager);
+        let routes = Arc::clone(&routes);
+
+        tracker.spawn(async move {
+            // Held for the connection's lifetime; released back to the semaphore when this task
+            // ends (issue #716).
+            let _permit = permit;
+            let service = service_fn(move |req: Request<Incoming>| {
+                let manager = Arc::clone(&manager);
+                let routes = Arc::clone(&routes);
+                async move { handle_front_door_request(req, manager, routes).await }
+            });
+
+            // Both builders yield a Connection with the same drive/graceful-shutdown shape;
+            // only the protocol negotiation differs (issue #378 force-disable escape hatch).
+            macro_rules! drive_conn {
+                ($conn:expr) => {{
+                    let conn = $conn;
+                    tokio::pin!(conn);
+                    tokio::select! {
+                        res = conn.as_mut() => {
+                            if let Err(err) = res {
+                                error!("Front door connection error: {}", err);
+                            }
+                        }
+                        _ = conn_cancel.cancelled() => {
+                            conn.as_mut().graceful_shutdown();
+                            let _ = conn.await;
+                        }
+                    }
+                }};
+            }
+
+            if rift_mock_core::util::http2_disabled() {
+                let mut builder = hyper::server::conn::http1::Builder::new();
+                // A timer is required for `header_read_timeout` to take effect (hyper panics on
+                // serve_connection otherwise) — always paired with it below.
+                builder
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
+                drive_conn!(builder.serve_connection(io, service));
+            } else {
+                let mut builder = hyper_util::server::conn::auto::Builder::new(
+                    hyper_util::rt::TokioExecutor::new(),
+                );
+                builder
+                    .http1()
+                    .timer(hyper_util::rt::TokioTimer::new())
+                    .header_read_timeout(http_tuning.header_read_timeout)
+                    .max_buf_size(http_tuning.max_buf_size);
+                drive_conn!(builder.serve_connection(io, service));
+            }
+        });
+    }
+    Ok(())
+}
+
+/// The service body: resolve the route table, then the gateway's own `/__rift/:port` addressing,
+/// then a 404 that names itself so a caller can tell "no route matched" from "a route matched but
+/// its imposter is gone" (both 404s, different fixes).
+async fn handle_front_door_request(
+    req: Request<Incoming>,
+    manager: Arc<ImposterManager>,
+    routes: Arc<ArcSwap<CompiledRoutes>>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let host = request_host(&req);
+
+    // `load_full` clones the `Arc` rather than holding the `arc_swap::Guard` across the `.await`
+    // below (a matched route dispatches into the imposter, which awaits) — the guard is not meant
+    // to outlive the borrow it comes from.
+    let matched = routes
+        .load_full()
+        .resolve(
+            host.as_deref(),
+            req.method(),
+            req.uri().path(),
+            req.headers(),
+        )
+        .cloned();
+
+    if let Some(route) = matched {
+        return Ok(dispatch_matched_route(route, req, &manager).await);
+    }
+
+    // No route claimed it: the single-port gateway's own `/__rift/:port/<path>` addressing still
+    // works on this listener (issue #212), so one port serves both styles.
+    if let Some(rest) = req.uri().path().strip_prefix("/__rift/") {
+        let rest = rest.to_owned();
+        let query = req.uri().query().map(str::to_owned);
+        return Ok(
+            crate::gateway::dispatch_gateway_path(&rest, query.as_deref(), req, &manager).await,
+        );
+    }
+
+    let message = format!("no route matches {} {}", req.method(), req.uri().path());
+    let mut response =
+        error_response_typed(StatusCode::NOT_FOUND, ErrorKind::NoSuchResource, &message);
+    // Distinguishes this from a matched route whose imposter is gone (also a 404, from
+    // `dispatch_to_port`/`dispatch_gateway_path`, which never sets this header) — same status,
+    // different fix.
+    response.headers_mut().insert(
+        HeaderName::from_static(NO_ROUTE_HEADER),
+        HeaderValue::from_static("no-route"),
+    );
+    Ok(response)
+}
+
+/// Apply a matched route's rewrites and dispatch to its imposter port.
+async fn dispatch_matched_route(
+    route: Route,
+    mut req: Request<Incoming>,
+    manager: &ImposterManager,
+) -> Response<Full<Bytes>> {
+    let target = route.target;
+
+    if target.strip_prefix
+        && let Some(prefix) = route.matches.path_prefix.as_deref()
+    {
+        match strip_uri_prefix(req.uri(), prefix) {
+            Ok(uri) => *req.uri_mut() = uri,
+            Err(message) => {
+                return error_response_typed(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorKind::InternalError,
+                    &message,
+                );
+            }
+        }
+    }
+
+    if let Some(new_host) = target.set_host.as_deref() {
+        match HeaderValue::from_str(new_host) {
+            Ok(value) => {
+                req.headers_mut().insert(hyper::header::HOST, value);
+            }
+            Err(_) => {
+                return error_response_typed(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ErrorKind::InternalError,
+                    &format!("route target host '{new_host}' is not a valid Host header value"),
+                );
+            }
+        }
+    }
+
+    crate::gateway::dispatch_to_port(manager, target.port, req).await
+}
+
+/// Strip `prefix` from `uri`'s path, always leaving a valid absolute path — stripping `/api` from
+/// exactly `/api` yields `/`, never `""` (an empty path is not a legal request target). The query
+/// string is carried over unchanged.
+///
+/// `prefix` only ever reaches here because [`Route::matches_request`] already matched it
+/// segment-aligned against this same path, so the strip always succeeds; the `Err` arm exists so a
+/// future change to that invariant fails loudly (a 500) instead of routing to the wrong path.
+fn strip_uri_prefix(uri: &Uri, prefix: &str) -> Result<Uri, String> {
+    let trimmed_prefix = prefix.trim_end_matches('/');
+    let stripped = match uri.path().strip_prefix(trimmed_prefix) {
+        Some("") => "/",
+        Some(rest) => rest,
+        None => {
+            return Err(format!(
+                "route prefix '{prefix}' does not prefix its own matched path '{}'",
+                uri.path()
+            ));
+        }
+    };
+    let path_and_query = match uri.query() {
+        Some(q) => format!("{stripped}?{q}"),
+        None => stripped.to_string(),
+    };
+    let mut parts = uri.clone().into_parts();
+    parts.path_and_query = Some(path_and_query.parse().map_err(|e| {
+        format!("stripped path '{path_and_query}' is not a valid request target: {e}")
+    })?);
+    Uri::from_parts(parts).map_err(|e| format!("failed to rebuild URI after stripping prefix: {e}"))
+}
+
+/// The request's host: the `Host` header if present, else (for absolute-form requests) the URI
+/// authority — with any trailing `:port` removed, so `Host: payments.test:8080` matches a route
+/// authored for `payments.test`.
+fn request_host(req: &Request<Incoming>) -> Option<String> {
+    let raw = req
+        .headers()
+        .get(hyper::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| req.uri().authority().map(|a| a.as_str()))?;
+    Some(strip_host_port(raw).to_string())
+}
+
+/// Drop a trailing `:port`, respecting a bracketed IPv6 literal (`[::1]:8080`) whose own colons
+/// are not port separators.
+fn strip_host_port(host: &str) -> &str {
+    if let Some(end) = host.rfind(']') {
+        return &host[..=end];
+    }
+    match host.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+        _ => host,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_host_port_drops_a_plain_port() {
+        assert_eq!(strip_host_port("payments.test:8080"), "payments.test");
+        assert_eq!(strip_host_port("payments.test"), "payments.test");
+    }
+
+    #[test]
+    fn strip_host_port_keeps_ipv6_literal_brackets() {
+        assert_eq!(strip_host_port("[::1]:8080"), "[::1]");
+        assert_eq!(strip_host_port("[::1]"), "[::1]");
+    }
+
+    #[test]
+    fn strip_uri_prefix_never_produces_an_empty_path() {
+        let uri: Uri = "/api".parse().unwrap();
+        let stripped = strip_uri_prefix(&uri, "/api").unwrap();
+        assert_eq!(stripped.path(), "/");
+    }
+
+    #[test]
+    fn strip_uri_prefix_keeps_the_query_string() {
+        let uri: Uri = "/api/v1/x?q=1".parse().unwrap();
+        let stripped = strip_uri_prefix(&uri, "/api/v1").unwrap();
+        assert_eq!(stripped.path(), "/x");
+        assert_eq!(stripped.query(), Some("q=1"));
+    }
+}

--- a/crates/rift-http-proxy/src/front_door/mod.rs
+++ b/crates/rift-http-proxy/src/front_door/mod.rs
@@ -1,0 +1,24 @@
+//! The front door: one listener, many imposters, addressed by what the request
+//! *says* rather than by a port the client had to know (issue #19 / U-11).
+//!
+//! The single-port gateway (`/__rift/:port`, issue #212) already lets one port
+//! reach every imposter, but the client has to name the target. That is fine for
+//! a test harness driving Rift on purpose; it is wrong when the client is an
+//! unmodified system under test that believes it is calling
+//! `payments.example.com`. The front door closes that gap, and with it the reason
+//! to run an nginx sidecar in front of Rift.
+//!
+//! A request is resolved against the [`route_table`] first. If no route claims
+//! it, the gateway's own `/__rift/:port` addressing still works on this listener,
+//! so one port serves both styles. Anything left over is a 404 carrying
+//! `x-rift-front-door: no-route`, which distinguishes "no route matched" from
+//! "a route matched but its imposter is gone" — two failures that look identical
+//! from the client side and have completely different fixes.
+
+pub mod listener;
+pub mod route_table;
+
+pub use listener::{RunningFrontDoor, bind_front_door};
+pub use route_table::{
+    CompiledRoutes, HeaderMatch, Route, RouteMatch, RouteTable, RouteTableError, RouteTarget,
+};

--- a/crates/rift-http-proxy/src/front_door/route_table.rs
+++ b/crates/rift-http-proxy/src/front_door/route_table.rs
@@ -1,0 +1,695 @@
+//! The front door's route table: content-based routing from one listener to many
+//! imposters (issue #19 / U-11).
+//!
+//! # Why this is not `rift_mock_core::extensions::routing`
+//!
+//! That module routes **reverse-proxy** traffic to a named upstream, and it is
+//! the right thing for that job. This one routes **front-door** traffic to an
+//! imposter *port*, and three of its rules differ in ways that are not
+//! reconcilable by adding a field:
+//!
+//! - **Order is derived, not authored.** Proxy routes are first-match-wins in
+//!   config order. A front-door table is edited over the admin API by several
+//!   people and merged from several sources, so "whichever happened to be
+//!   written first" is a footgun. Here order is a total function of the routes
+//!   themselves — see [`RouteTable::effective_order`].
+//! - **Path prefixes are segment-aligned.** `/api/v1` matches `/api/v1/x` but not
+//!   `/api/v1x`. The proxy's raw `starts_with` is deliberate there (it pairs with
+//!   `path_regex` for precision); here it would silently route a neighbouring
+//!   service.
+//! - **Targets carry rewrites.** A front-door route can strip its prefix and
+//!   override `Host` before the imposter sees the request.
+//!
+//! What the two *do* share is host matching, and that is imported rather than
+//! reimplemented: [`rift_mock_core::extensions::routing::is_subdomain_of`] is the
+//! single definition of what `*.example.com` means. Writing a second one is how
+//! the label-boundary bug it was extracted from would come back.
+
+use std::cmp::Reverse;
+
+use rift_mock_core::extensions::routing::is_subdomain_of;
+use serde::{Deserialize, Serialize};
+
+/// A whole table, as stored and as served over the admin API.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RouteTable {
+    #[serde(default)]
+    pub routes: Vec<Route>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Route {
+    /// Unique and stable: it is how the admin API addresses one route.
+    pub id: String,
+    /// Higher wins. Ties fall through to specificity — see
+    /// [`RouteTable::effective_order`].
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default, rename = "match")]
+    pub matches: RouteMatch,
+    pub target: RouteTarget,
+    #[serde(default = "enabled_default")]
+    pub enabled: bool,
+}
+
+fn enabled_default() -> bool {
+    true
+}
+
+/// Every clause that is present must match (AND). An empty `RouteMatch` matches
+/// everything, which is a legitimate catch-all — and is why ambiguity is
+/// rejected at validation rather than resolved silently.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteMatch {
+    /// Exact (`payments.test`) or one leading wildcard label (`*.payments.test`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// Segment-aligned: `/api/v1` matches `/api/v1` and `/api/v1/x`, never
+    /// `/api/v1x`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
+    /// Exact values; names compare case-insensitively (HTTP header names are).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<HeaderMatch>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HeaderMatch {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteTarget {
+    pub port: u16,
+    /// Strip [`RouteMatch::path_prefix`] before the imposter sees the path.
+    /// Defaults to false: predicates and recorded requests see the true path
+    /// unless the route asks otherwise.
+    #[serde(default)]
+    pub strip_prefix: bool,
+    /// Rewrite the `Host` the imposter sees. Rare, but recordings show it, so it
+    /// is worth being able to control.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub set_host: Option<String>,
+}
+
+/// Why a table was refused. Every variant names the offending route(s), because
+/// "invalid route table" with a 400 and nothing else is not actionable.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RouteTableError {
+    #[error("duplicate route id '{id}'")]
+    DuplicateId { id: String },
+
+    #[error(
+        "routes '{first}' and '{second}' are both enabled and match exactly the same requests; \
+         give one of them a narrower match, or disable one"
+    )]
+    AmbiguousMatch { first: String, second: String },
+
+    #[error("route '{id}' sets strip_prefix but has no path_prefix to strip")]
+    StripWithoutPrefix { id: String },
+
+    #[error(
+        "route '{id}' has host '{host}': a wildcard is one leading '*.' label \
+         (like '*.payments.test'), and nothing else may contain '*'"
+    )]
+    MalformedHost { id: String, host: String },
+
+    #[error("route '{id}' has method '{method}', which is not a valid HTTP method")]
+    MalformedMethod { id: String, method: String },
+
+    #[error("route '{id}' has path_prefix '{prefix}', which must start with '/'")]
+    MalformedPathPrefix { id: String, prefix: String },
+
+    #[error("route id must not be empty")]
+    EmptyId,
+}
+
+impl RouteTable {
+    /// Validate the whole table, rejecting it as a unit.
+    ///
+    /// Partial acceptance is not offered on purpose: a half-applied routing
+    /// table is a topology nobody designed, and the caller cannot tell which
+    /// half it got.
+    pub fn validate(&self) -> Result<(), RouteTableError> {
+        let mut seen_ids = std::collections::HashSet::new();
+        for route in &self.routes {
+            if route.id.is_empty() {
+                return Err(RouteTableError::EmptyId);
+            }
+            if !seen_ids.insert(route.id.as_str()) {
+                return Err(RouteTableError::DuplicateId {
+                    id: route.id.clone(),
+                });
+            }
+            route.validate()?;
+        }
+
+        // Ambiguity is only a problem between routes that can both win. Two
+        // disabled twins, or an enabled route and its disabled spare, are how
+        // people stage a change.
+        let enabled: Vec<&Route> = self.routes.iter().filter(|r| r.enabled).collect();
+        for (i, first) in enabled.iter().enumerate() {
+            for second in &enabled[i + 1..] {
+                if first.matches == second.matches && first.priority == second.priority {
+                    return Err(RouteTableError::AmbiguousMatch {
+                        first: first.id.clone(),
+                        second: second.id.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The routes in the order they are evaluated: a **total** order, computed
+    /// from the routes alone, so the same table always resolves the same way no
+    /// matter what order it arrived in.
+    ///
+    /// `priority` first (the explicit override), then specificity — an exact host
+    /// beats a wildcard beats no host; a longer path prefix beats a shorter one;
+    /// more header clauses beat fewer — and finally `id`, which is unique, so
+    /// there is never a tie left to break arbitrarily.
+    pub fn effective_order(&self) -> Vec<&Route> {
+        let mut routes: Vec<&Route> = self.routes.iter().filter(|r| r.enabled).collect();
+        routes.sort_by(|a, b| {
+            Reverse(a.priority)
+                .cmp(&Reverse(b.priority))
+                .then(a.host_rank().cmp(&b.host_rank()))
+                .then(
+                    Reverse(a.matches.path_prefix.as_ref().map_or(0, |p| p.len())).cmp(&Reverse(
+                        b.matches.path_prefix.as_ref().map_or(0, |p| p.len()),
+                    )),
+                )
+                .then(Reverse(a.matches.headers.len()).cmp(&Reverse(b.matches.headers.len())))
+                .then(a.id.cmp(&b.id))
+        });
+        routes
+    }
+}
+
+impl Route {
+    fn validate(&self) -> Result<(), RouteTableError> {
+        if self.target.strip_prefix && self.matches.path_prefix.is_none() {
+            return Err(RouteTableError::StripWithoutPrefix {
+                id: self.id.clone(),
+            });
+        }
+        if let Some(host) = &self.matches.host {
+            let rest = host.strip_prefix("*.").unwrap_or(host);
+            if rest.contains('*') || rest.is_empty() {
+                return Err(RouteTableError::MalformedHost {
+                    id: self.id.clone(),
+                    host: host.clone(),
+                });
+            }
+        }
+        if let Some(prefix) = &self.matches.path_prefix
+            && !prefix.starts_with('/')
+        {
+            return Err(RouteTableError::MalformedPathPrefix {
+                id: self.id.clone(),
+                prefix: prefix.clone(),
+            });
+        }
+        if let Some(method) = &self.matches.method
+            && method.parse::<hyper::Method>().is_err()
+        {
+            return Err(RouteTableError::MalformedMethod {
+                id: self.id.clone(),
+                method: method.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Lower is more specific, so it sorts earlier.
+    fn host_rank(&self) -> u8 {
+        match &self.matches.host {
+            Some(h) if h.starts_with("*.") => 1,
+            Some(_) => 0,
+            None => 2,
+        }
+    }
+
+    /// Does this route match a request with these properties?
+    pub fn matches_request(
+        &self,
+        host: Option<&str>,
+        method: &hyper::Method,
+        path: &str,
+        headers: &hyper::HeaderMap,
+    ) -> bool {
+        if let Some(pattern) = &self.matches.host {
+            let Some(host) = host else {
+                return false;
+            };
+            let ok = match pattern.strip_prefix("*.") {
+                Some(suffix) => is_subdomain_of(host, suffix),
+                None => host.eq_ignore_ascii_case(pattern),
+            };
+            if !ok {
+                return false;
+            }
+        }
+        if let Some(expected) = &self.matches.method
+            && !method.as_str().eq_ignore_ascii_case(expected)
+        {
+            return false;
+        }
+        if let Some(prefix) = &self.matches.path_prefix
+            && !path_prefix_matches(path, prefix)
+        {
+            return false;
+        }
+        for want in &self.matches.headers {
+            match headers.get(&want.name) {
+                Some(got) if got.as_bytes() == want.value.as_bytes() => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+/// Segment-aligned prefix match: the prefix must end at a path-segment boundary.
+///
+/// `starts_with` alone would let `/api/v1` claim `/api/v1x`, routing a
+/// neighbouring service's traffic to this imposter — the same class of mistake as
+/// a host wildcard without a label boundary.
+fn path_prefix_matches(path: &str, prefix: &str) -> bool {
+    let prefix = prefix.trim_end_matches('/');
+    match path.strip_prefix(prefix) {
+        Some("") => true,
+        Some(rest) => rest.starts_with('/'),
+        None => false,
+    }
+}
+
+/// A table compiled for matching, resolved once per table swap so the per-request
+/// path does no sorting and no allocation.
+#[derive(Debug, Default)]
+pub struct CompiledRoutes {
+    ordered: Vec<Route>,
+}
+
+impl CompiledRoutes {
+    /// Compile a **validated** table. Validation is the caller's job (and the
+    /// admission gate's) so that a compile cannot fail at the point where there
+    /// is nobody left to report to.
+    #[must_use]
+    pub fn new(table: &RouteTable) -> Self {
+        Self {
+            ordered: table.effective_order().into_iter().cloned().collect(),
+        }
+    }
+
+    /// The first route matching this request in effective order, if any.
+    pub fn resolve(
+        &self,
+        host: Option<&str>,
+        method: &hyper::Method,
+        path: &str,
+        headers: &hyper::HeaderMap,
+    ) -> Option<&Route> {
+        self.ordered
+            .iter()
+            .find(|r| r.matches_request(host, method, path, headers))
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ordered.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(id: &str, port: u16) -> Route {
+        Route {
+            id: id.to_owned(),
+            priority: 0,
+            matches: RouteMatch::default(),
+            target: RouteTarget {
+                port,
+                strip_prefix: false,
+                set_host: None,
+            },
+            enabled: true,
+        }
+    }
+
+    fn with_host(id: &str, port: u16, host: &str) -> Route {
+        let mut r = route(id, port);
+        r.matches.host = Some(host.to_owned());
+        r
+    }
+
+    fn with_prefix(id: &str, port: u16, prefix: &str) -> Route {
+        let mut r = route(id, port);
+        r.matches.path_prefix = Some(prefix.to_owned());
+        r
+    }
+
+    /// Resolve a `GET` with no headers, returning the winning route's id.
+    fn resolve(table: &RouteTable, host: &str, path: &str) -> Option<String> {
+        CompiledRoutes::new(table)
+            .resolve(
+                Some(host),
+                &hyper::Method::GET,
+                path,
+                &hyper::HeaderMap::new(),
+            )
+            .map(|r| r.id.clone())
+    }
+
+    /// A path prefix must end at a segment boundary. Without this, a route for
+    /// `/api` swallows `/apiary`, which belongs to somebody else.
+    #[test]
+    fn path_prefix_is_segment_aligned() {
+        assert!(path_prefix_matches("/api/v1", "/api/v1"));
+        assert!(path_prefix_matches("/api/v1/users", "/api/v1"));
+        assert!(!path_prefix_matches("/api/v1x", "/api/v1"));
+        assert!(!path_prefix_matches("/apiary", "/api"));
+        // "/" is the catch-all prefix and must still behave.
+        assert!(path_prefix_matches("/anything", "/"));
+        assert!(path_prefix_matches("/", "/"));
+        // A trailing slash in the pattern must not change the meaning.
+        assert!(path_prefix_matches("/api/v1/users", "/api/v1/"));
+        assert!(!path_prefix_matches("/api/v1x", "/api/v1/"));
+    }
+
+    /// The whole point of a derived order: the same routes resolve the same way
+    /// regardless of the order they were written or merged in.
+    #[test]
+    fn effective_order_is_independent_of_input_order() {
+        let a = with_host("a-exact", 1, "payments.test");
+        let b = with_host("b-wild", 2, "*.payments.test");
+        let c = route("c-catchall", 3);
+
+        let forward = RouteTable {
+            routes: vec![a.clone(), b.clone(), c.clone()],
+        };
+        let reverse = RouteTable {
+            routes: vec![c, b, a],
+        };
+
+        let ids = |t: &RouteTable| {
+            t.effective_order()
+                .iter()
+                .map(|r| r.id.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ids(&forward), ids(&reverse));
+        assert_eq!(ids(&forward), vec!["a-exact", "b-wild", "c-catchall"]);
+    }
+
+    /// Specificity beats declaration order: an exact host wins over a wildcard
+    /// that also matches, and a longer prefix wins over a shorter one.
+    #[test]
+    fn more_specific_routes_win() {
+        let table = RouteTable {
+            routes: vec![
+                route("catchall", 1),
+                with_host("wild", 2, "*.payments.test"),
+                with_host("exact", 3, "api.payments.test"),
+            ],
+        };
+        assert_eq!(
+            resolve(&table, "api.payments.test", "/x").as_deref(),
+            Some("exact")
+        );
+        assert_eq!(
+            resolve(&table, "other.payments.test", "/x").as_deref(),
+            Some("wild")
+        );
+        assert_eq!(
+            resolve(&table, "unrelated.test", "/x").as_deref(),
+            Some("catchall")
+        );
+
+        let by_prefix = RouteTable {
+            routes: vec![
+                with_prefix("short", 1, "/api"),
+                with_prefix("long", 2, "/api/v1"),
+            ],
+        };
+        assert_eq!(
+            resolve(&by_prefix, "h", "/api/v1/users").as_deref(),
+            Some("long")
+        );
+        assert_eq!(
+            resolve(&by_prefix, "h", "/api/v2/users").as_deref(),
+            Some("short")
+        );
+    }
+
+    /// `priority` is the explicit override and must beat specificity.
+    #[test]
+    fn priority_outranks_specificity() {
+        let mut catchall = route("catchall", 1);
+        catchall.priority = 10;
+        let table = RouteTable {
+            routes: vec![catchall, with_host("exact", 2, "api.payments.test")],
+        };
+        assert_eq!(
+            resolve(&table, "api.payments.test", "/x").as_deref(),
+            Some("catchall")
+        );
+    }
+
+    /// The host wildcard rule is imported, not reimplemented — this pins that it
+    /// is actually the strict one.
+    #[test]
+    fn wildcard_host_requires_a_real_subdomain() {
+        let table = RouteTable {
+            routes: vec![with_host("wild", 1, "*.payments.test")],
+        };
+        assert_eq!(
+            resolve(&table, "api.payments.test", "/").as_deref(),
+            Some("wild")
+        );
+        assert_eq!(resolve(&table, "payments.test", "/"), None);
+        assert_eq!(resolve(&table, "evilpayments.test", "/"), None);
+    }
+
+    #[test]
+    fn disabled_routes_never_match() {
+        let mut r = with_host("off", 1, "payments.test");
+        r.enabled = false;
+        let table = RouteTable { routes: vec![r] };
+        assert_eq!(resolve(&table, "payments.test", "/"), None);
+    }
+
+    #[test]
+    fn validation_rejects_duplicate_ids() {
+        let table = RouteTable {
+            routes: vec![route("same", 1), route("same", 2)],
+        };
+        assert_eq!(
+            table.validate(),
+            Err(RouteTableError::DuplicateId {
+                id: "same".to_owned()
+            })
+        );
+    }
+
+    /// Two enabled routes that match identically are an authoring mistake with no
+    /// right answer, so the table is refused rather than silently resolved by id.
+    #[test]
+    fn validation_rejects_ambiguous_enabled_routes() {
+        let table = RouteTable {
+            routes: vec![
+                with_host("first", 1, "payments.test"),
+                with_host("second", 2, "payments.test"),
+            ],
+        };
+        assert!(matches!(
+            table.validate(),
+            Err(RouteTableError::AmbiguousMatch { .. })
+        ));
+    }
+
+    /// ...but staging a replacement by disabling one of them is legitimate, and
+    /// differing priority is an explicit tiebreak, so neither is ambiguous.
+    #[test]
+    fn validation_allows_a_disabled_twin_and_a_priority_tiebreak() {
+        let mut spare = with_host("spare", 2, "payments.test");
+        spare.enabled = false;
+        assert!(
+            RouteTable {
+                routes: vec![with_host("live", 1, "payments.test"), spare],
+            }
+            .validate()
+            .is_ok()
+        );
+
+        let mut higher = with_host("higher", 2, "payments.test");
+        higher.priority = 1;
+        assert!(
+            RouteTable {
+                routes: vec![with_host("lower", 1, "payments.test"), higher],
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validation_rejects_strip_without_prefix() {
+        let mut r = route("bad", 1);
+        r.target.strip_prefix = true;
+        assert_eq!(
+            RouteTable { routes: vec![r] }.validate(),
+            Err(RouteTableError::StripWithoutPrefix {
+                id: "bad".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn validation_rejects_malformed_hosts_and_methods_and_prefixes() {
+        let bad_host = |h: &str| {
+            RouteTable {
+                routes: vec![with_host("r", 1, h)],
+            }
+            .validate()
+        };
+        assert!(matches!(
+            bad_host("*.*.test"),
+            Err(RouteTableError::MalformedHost { .. })
+        ));
+        assert!(matches!(
+            bad_host("pay*.test"),
+            Err(RouteTableError::MalformedHost { .. })
+        ));
+        assert!(matches!(
+            bad_host("*."),
+            Err(RouteTableError::MalformedHost { .. })
+        ));
+        assert!(bad_host("*.payments.test").is_ok());
+        assert!(bad_host("payments.test").is_ok());
+
+        let mut m = route("r", 1);
+        m.matches.method = Some("GHOST METHOD".to_owned());
+        assert!(matches!(
+            RouteTable { routes: vec![m] }.validate(),
+            Err(RouteTableError::MalformedMethod { .. })
+        ));
+
+        let mut p = route("r", 1);
+        p.matches.path_prefix = Some("api".to_owned());
+        assert!(matches!(
+            RouteTable { routes: vec![p] }.validate(),
+            Err(RouteTableError::MalformedPathPrefix { .. })
+        ));
+    }
+
+    /// All present clauses AND together.
+    #[test]
+    fn every_clause_must_match() {
+        let mut r = with_host("all", 1, "payments.test");
+        r.matches.path_prefix = Some("/api".to_owned());
+        r.matches.method = Some("POST".to_owned());
+        r.matches.headers = vec![HeaderMatch {
+            name: "x-tenant".to_owned(),
+            value: "acme".to_owned(),
+        }];
+        let compiled = CompiledRoutes::new(&RouteTable { routes: vec![r] });
+
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("x-tenant", "acme".parse().unwrap());
+        let hit = |host, method: &hyper::Method, path, headers: &hyper::HeaderMap| {
+            compiled
+                .resolve(Some(host), method, path, headers)
+                .is_some()
+        };
+
+        assert!(hit(
+            "payments.test",
+            &hyper::Method::POST,
+            "/api/x",
+            &headers
+        ));
+        assert!(!hit("other.test", &hyper::Method::POST, "/api/x", &headers));
+        assert!(!hit(
+            "payments.test",
+            &hyper::Method::GET,
+            "/api/x",
+            &headers
+        ));
+        assert!(!hit(
+            "payments.test",
+            &hyper::Method::POST,
+            "/other",
+            &headers
+        ));
+        assert!(!hit(
+            "payments.test",
+            &hyper::Method::POST,
+            "/api/x",
+            &hyper::HeaderMap::new()
+        ));
+    }
+
+    /// Header *names* are case-insensitive per HTTP; values are not.
+    #[test]
+    fn header_names_are_case_insensitive_values_are_not() {
+        let mut r = route("h", 1);
+        r.matches.headers = vec![HeaderMatch {
+            name: "X-Tenant".to_owned(),
+            value: "acme".to_owned(),
+        }];
+        let compiled = CompiledRoutes::new(&RouteTable { routes: vec![r] });
+
+        let mut lower = hyper::HeaderMap::new();
+        lower.insert("x-tenant", "acme".parse().unwrap());
+        assert!(
+            compiled
+                .resolve(None, &hyper::Method::GET, "/", &lower)
+                .is_some()
+        );
+
+        let mut wrong_value = hyper::HeaderMap::new();
+        wrong_value.insert("x-tenant", "ACME".parse().unwrap());
+        assert!(
+            compiled
+                .resolve(None, &hyper::Method::GET, "/", &wrong_value)
+                .is_none()
+        );
+    }
+
+    /// A route with a host clause cannot match a request that has no host at all,
+    /// rather than matching vacuously.
+    #[test]
+    fn a_host_clause_requires_a_host() {
+        let compiled = CompiledRoutes::new(&RouteTable {
+            routes: vec![with_host("h", 1, "payments.test")],
+        });
+        assert!(
+            compiled
+                .resolve(None, &hyper::Method::GET, "/", &hyper::HeaderMap::new())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn empty_table_matches_nothing_and_knows_it() {
+        let compiled = CompiledRoutes::new(&RouteTable::default());
+        assert!(compiled.is_empty());
+        assert!(
+            compiled
+                .resolve(
+                    Some("any.test"),
+                    &hyper::Method::GET,
+                    "/x",
+                    &hyper::HeaderMap::new()
+                )
+                .is_none()
+        );
+    }
+}

--- a/crates/rift-http-proxy/src/gateway.rs
+++ b/crates/rift-http-proxy/src/gateway.rs
@@ -31,3 +31,49 @@ pub async fn dispatch_to_port(
         Err(e) => match e {}, // handle_imposter_request is Infallible
     }
 }
+
+/// Parse and dispatch a `/__rift/:port/<path>` gateway request (issue #212): `rest` is everything
+/// after the `/__rift/` prefix. Rewrites the URI to the imposter-relative `/<path>` (+ query) so
+/// the imposter's predicates and recorded requests see it exactly as if it had arrived on its own
+/// port, then calls [`dispatch_to_port`].
+///
+/// Shared by the admin API's `/__rift/` route and the front door's fallback addressing (issue
+/// #19 / U-11) so the two listeners cannot drift on what counts as a valid gateway target.
+pub async fn dispatch_gateway_path(
+    rest: &str,
+    query: Option<&str>,
+    req: Request<Incoming>,
+    manager: &ImposterManager,
+) -> Response<Full<Bytes>> {
+    let (port_str, sub_path) = match rest.split_once('/') {
+        Some((port, sub)) => (port, format!("/{sub}")),
+        None => (rest, "/".to_string()),
+    };
+    let Ok(port) = port_str.parse::<u16>() else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("invalid gateway target '{port_str}' (expected /__rift/<port>/<path>)"),
+        );
+    };
+    // Check existence before the URI rewrite so a missing imposter stays a 404 even if the
+    // rewritten URI would be rejected — the pre-#317 response precedence. dispatch_to_port
+    // re-checks as its own defensive 404 for other callers.
+    if manager.get_imposter(port).is_err() {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            &format!("no imposter on port {port}"),
+        );
+    }
+
+    let target = match query {
+        Some(q) => format!("{sub_path}?{q}"),
+        None => sub_path,
+    };
+    let (mut parts, body) = req.into_parts();
+    parts.uri = match target.parse() {
+        Ok(uri) => uri,
+        Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid gateway path"),
+    };
+
+    dispatch_to_port(manager, port, Request::from_parts(parts, body)).await
+}

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -45,6 +45,11 @@ pub mod script_cli;
 // ===== Embeddable server composition (issue #317) =====
 // Gateway dispatch (issue #212) callable from any listener
 pub mod gateway;
+
+/// The front door: one listener routing to many imposters by host/path/header
+/// (issue #19). The gateway above addresses imposters by port; this addresses
+/// them by what the request says.
+pub mod front_door;
 // CLI surface + ServerBuilder + metrics server; the `rift` binary is a thin caller
 pub mod server;
 

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -7,11 +7,13 @@
 use crate::admin_api::{AdminApiServer, DEFAULT_ADMIN_PORT, RunningAdminApi};
 use crate::config_loader::{self, ConfigSource};
 use crate::extensions::metrics;
+use crate::front_door::{CompiledRoutes, RouteTable, RunningFrontDoor, bind_front_door};
 use crate::imposter::{
     ImposterConfig, ImposterManager, ScriptBaseDir, TlsDefaults, resolve_scripts,
 };
 use crate::injection_gate::GATED_SCRIPT_SURFACES;
 use crate::intercept_control::{InterceptControl, InterceptStartOptions};
+use arc_swap::ArcSwap;
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -124,6 +126,13 @@ pub struct Cli {
     /// Metrics server port
     #[arg(long, default_value = "9090", env = "RIFT_METRICS_PORT")]
     pub metrics_port: u16,
+
+    /// Bind the front door (issue #19 / U-11): one listener serving every imposter, routed by
+    /// host/path/header/method instead of by port. Accepts `HOST:PORT` (e.g. `0.0.0.0:8080`) or a
+    /// bare port, which binds every interface like `--metrics-port` does. Off when unset — the
+    /// single-port gateway and per-imposter ports are unaffected either way.
+    #[arg(long, value_name = "ADDR", env = "RIFT_FRONT_DOOR")]
+    pub front_door: Option<String>,
 
     // === Mountebank compatibility flags (accepted, no-op) ===
     /// Disable EJS template rendering of --configfile (Rift doesn't use EJS; accepted for compatibility)
@@ -349,6 +358,14 @@ impl ServerBuilder {
     /// needs the bound addresses (`:0` support) and a graceful shutdown.
     pub async fn start(self) -> anyhow::Result<RunningServer> {
         let cli = self.cli;
+        // Validate `--front-door` before anything else binds (issue #19 / U-11): a malformed
+        // address is then a clean, fast failure that never has to unwind an already-bound
+        // listener behind it.
+        let front_door_addr = cli
+            .front_door
+            .as_deref()
+            .map(parse_front_door_addr)
+            .transpose()?;
         let manager = match self.manager {
             Some(manager) => manager,
             None => {
@@ -379,8 +396,9 @@ impl ServerBuilder {
         };
 
         let mut intercept_block = None;
+        let mut routes_block: Option<RouteTable> = None;
         if let Some(ref configfile) = cli.configfile {
-            intercept_block = load_imposters_from_file(
+            let loaded = load_imposters_from_file(
                 &manager,
                 configfile,
                 cli.no_parse,
@@ -388,6 +406,8 @@ impl ServerBuilder {
                 &cli_intercept_flags(&cli),
             )
             .await?;
+            intercept_block = loaded.intercept;
+            routes_block = loaded.routes;
         }
         if let Some(ref datadir) = cli.datadir {
             load_imposters_from_datadir(&manager, datadir, cli.allow_injection).await?;
@@ -403,6 +423,32 @@ impl ServerBuilder {
                 error!("Metrics server error: {e:#}");
                 None
             }
+        };
+
+        // Front door (issue #19 / U-11): one listener serving every imposter, resolved by the
+        // `routes` block threaded through above exactly like the `intercept` block is (falling
+        // back to an empty table — and so the gateway-only 404 behaviour — when the config
+        // declared none). Bound only when `--front-door` was given; unset, nothing here changes.
+        // Unlike the metrics bind just above, a real bind failure here is fatal: the operator
+        // asked for this listener by name, so a silent degrade to "no front door" would be a
+        // surprise, not a convenience. It still follows this function's "don't orphan an
+        // already-bound listener on error" contract — only metrics is up at this point, so that's
+        // all there is to unwind.
+        let front_door = match front_door_addr {
+            Some(addr) => {
+                let table = routes_block.unwrap_or_default();
+                let routes = Arc::new(ArcSwap::from_pointee(CompiledRoutes::new(&table)));
+                match bind_front_door(addr, Arc::clone(&manager), routes).await {
+                    Ok(running) => Some(running),
+                    Err(e) => {
+                        if let Some(metrics) = metrics {
+                            metrics.shutdown().await;
+                        }
+                        return Err(anyhow::anyhow!("front door: {e}"));
+                    }
+                }
+            }
+            None => None,
         };
 
         let host = if cli.local_only {
@@ -483,7 +529,11 @@ impl ServerBuilder {
                 // Same contract as the admin-bind arm below: don't orphan a listener already bound
                 // by this call. #655 widens the ways this can fail (rule-capacity, and a CA/bind
                 // error declared by the config block rather than typed as a flag), and `start()` is
-                // an embedding seam callers retry — a held metrics port would fail the retry too.
+                // an embedding seam callers retry — a held metrics or front-door port would fail
+                // the retry too.
+                if let Some(front_door) = &front_door {
+                    front_door.shutdown().await;
+                }
                 if let Some(metrics) = metrics {
                     metrics.shutdown().await;
                 }
@@ -505,6 +555,9 @@ impl ServerBuilder {
                 // Don't orphan the listeners already started if the admin bind fails — start() is
                 // an embedding seam and callers may retry after an error.
                 intercept.stop().await;
+                if let Some(front_door) = &front_door {
+                    front_door.shutdown().await;
+                }
                 if let Some(metrics) = metrics {
                     metrics.shutdown().await;
                 }
@@ -515,6 +568,7 @@ impl ServerBuilder {
             admin,
             metrics,
             intercept,
+            front_door,
         })
     }
 }
@@ -525,6 +579,7 @@ pub struct RunningServer {
     admin: RunningAdminApi,
     metrics: Option<RunningMetrics>,
     intercept: InterceptControl,
+    front_door: Option<RunningFrontDoor>,
 }
 
 impl RunningServer {
@@ -547,6 +602,7 @@ impl RunningServer {
             admin: crate::admin_api::RunningAdminApi::with_accept_task(loop_body),
             metrics: None,
             intercept: InterceptControl::default(),
+            front_door: None,
         }
     }
     /// The bound admin API address (resolves a `:0` request to the assigned port).
@@ -564,6 +620,13 @@ impl RunningServer {
     /// port).
     pub fn intercept_addr(&self) -> Option<SocketAddr> {
         self.intercept.status()
+    }
+
+    /// The bound front-door address, if `--front-door` was set and bound successfully (resolves a
+    /// `:0` request to the assigned port). `None` when `--front-door` was never given — the flag is
+    /// the only way to bring this listener up.
+    pub fn front_door_addr(&self) -> Option<SocketAddr> {
+        self.front_door.as_ref().map(RunningFrontDoor::local_addr)
     }
 
     /// Run until the admin API accept loop exits — the binary's `run()` behavior. The metrics
@@ -607,6 +670,9 @@ impl RunningServer {
             metrics.shutdown().await;
         }
         self.intercept.stop().await;
+        if let Some(front_door) = &self.front_door {
+            front_door.shutdown().await;
+        }
     }
 }
 
@@ -928,6 +994,23 @@ fn partition_gated_datadir(
     (servable, gated)
 }
 
+/// Parse `--front-door`'s value as a bind address: `HOST:PORT` (e.g. `0.0.0.0:8080`), or a bare
+/// port, which binds every interface — the same convenience `--metrics-port`/`--intercept-port`
+/// offer by being port-only flags to begin with. A value that is neither is a startup error naming
+/// what was rejected, never a silent default (issue #19 / U-11).
+fn parse_front_door_addr(value: &str) -> anyhow::Result<SocketAddr> {
+    if let Ok(addr) = value.parse::<SocketAddr>() {
+        return Ok(addr);
+    }
+    if let Ok(port) = value.parse::<u16>() {
+        return Ok(SocketAddr::from(([0, 0, 0, 0], port)));
+    }
+    anyhow::bail!(
+        "--front-door '{value}' is not a valid bind address; use HOST:PORT (e.g. 0.0.0.0:8080) \
+         or a bare port number"
+    )
+}
+
 /// The `--intercept-*` flags the operator supplied, by long name; empty when none were.
 fn cli_intercept_flags(cli: &Cli) -> Vec<&'static str> {
     [
@@ -997,16 +1080,25 @@ fn configfile_intercept_injection_error(
     ))
 }
 
-/// Load imposters from a JSON config file, returning the file's optional `intercept` block for the
-/// caller to start the listener from (issue #655) — the block is parsed and validated here so the
-/// whole document is refused as one, before any imposter exists.
+/// What a `--configfile` load hands back to the caller besides the imposters themselves: the
+/// optional `intercept` block (issue #655) and the optional `routes` block (issue #19 / U-11).
+/// Both are boot-time-only and already validated by `load_configs_full` before this returns.
+#[derive(Debug)]
+struct ConfigFileStartOptions {
+    intercept: Option<InterceptStartOptions>,
+    routes: Option<RouteTable>,
+}
+
+/// Load imposters from a JSON config file, returning the file's optional `intercept` and `routes`
+/// blocks for the caller to start their respective listeners from (issue #655, #19) — both are
+/// parsed and validated here so the whole document is refused as one, before any imposter exists.
 async fn load_imposters_from_file(
     manager: &Arc<ImposterManager>,
     path: &PathBuf,
     no_parse: bool,
     allow_injection: bool,
     intercept_flags: &[&str],
-) -> anyhow::Result<Option<InterceptStartOptions>> {
+) -> anyhow::Result<ConfigFileStartOptions> {
     info!("Loading imposters from configfile: {:?}", path);
 
     let loaded = config_loader::load_configs_full(&ConfigSource::File {
@@ -1042,7 +1134,10 @@ async fn load_imposters_from_file(
         }
     }
 
-    Ok(loaded.intercept)
+    Ok(ConfigFileStartOptions {
+        intercept: loaded.intercept,
+        routes: loaded.routes,
+    })
 }
 
 /// Load imposters from a data directory

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -436,6 +436,94 @@ async fn server_builder_start_reports_addrs_and_shuts_down_both() {
     );
 }
 
+// Issue #19 / U-11: `--front-door` binds the front-door listener from `ServerBuilder::start`,
+// seeded from the config file's `routes` block exactly like `--intercept-port`/the `intercept`
+// block seed the intercept listener. A request through the front door's own bound address (never
+// a hardcoded port — resolved via `front_door_addr()`) reaches the imposter the route names.
+#[tokio::test]
+async fn server_builder_start_binds_front_door_and_routes_to_imposter() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("imposters.json");
+    std::fs::write(
+        &path,
+        r#"{"imposters":[{"port":19490,"protocol":"http","stubs":[
+            {"predicates":[{"equals":{"path":"/ping"}}],
+             "responses":[{"is":{"statusCode":200,"body":"front-door-pong"}}]}]}],
+           "routes":{"routes":[
+             {"id":"pay","match":{"host":"payments.test"},"target":{"port":19490}}
+           ]}}"#,
+    )
+    .expect("write config");
+
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--configfile",
+        path.to_str().expect("utf8 path"),
+        "--front-door",
+        "127.0.0.1:0",
+    ])
+    .expect("cli parse");
+
+    let running = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("start binds the front door alongside admin/metrics");
+
+    let front_door_addr = running
+        .front_door_addr()
+        .expect("front door bound when --front-door is set");
+    assert_ne!(
+        front_door_addr.port(),
+        0,
+        "front_door_addr() resolves the :0 request to the real bound port"
+    );
+
+    wait_for_http(&format!("http://{}/health", running.admin_addr())).await;
+    wait_for_http(&format!("http://{front_door_addr}/ping")).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{front_door_addr}/ping"))
+        .header("Host", "payments.test")
+        .send()
+        .await
+        .expect("front door request");
+    assert_eq!(resp.status(), 200, "the routed imposter answered");
+    assert_eq!(
+        resp.text().await.expect("body"),
+        "front-door-pong",
+        "the request reached imposter 19490 via the route, not the gateway fallback"
+    );
+
+    running.shutdown().await;
+}
+
+// Without `--front-door`, nothing about startup changes: the listener stays off.
+#[tokio::test]
+async fn server_builder_start_leaves_front_door_off_without_the_flag() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ])
+    .expect("cli parse");
+    let running = ServerBuilder::from_cli(cli).start().await.expect("start");
+    assert!(
+        running.front_door_addr().is_none(),
+        "front door must stay off unless --front-door is set"
+    );
+    running.shutdown().await;
+}
+
 // AC7 end-to-end: `--allow-injection` must survive the whole thread (ServerBuilder::start →
 // with_allow_injection → accept_loop → route_request → route_by_path → handle_config) and be
 // reported by GET /config. A hardcoded flag anywhere on that path would fail here while the

--- a/crates/rift-http-proxy/tests/front_door.rs
+++ b/crates/rift-http-proxy/tests/front_door.rs
@@ -1,0 +1,283 @@
+//! Front-door listener integration tests (issue #19 / U-11).
+
+use arc_swap::ArcSwap;
+use rift_http_proxy::front_door::{
+    CompiledRoutes, RouteMatch, RouteTable, RouteTarget, bind_front_door,
+};
+use rift_http_proxy::imposter::ImposterManager;
+use std::sync::Arc;
+
+/// A route with everything defaulted except what the test cares about.
+fn route(
+    id: &str,
+    matches: RouteMatch,
+    port: u16,
+    strip_prefix: bool,
+) -> rift_http_proxy::front_door::Route {
+    rift_http_proxy::front_door::Route {
+        id: id.to_owned(),
+        priority: 0,
+        matches,
+        target: RouteTarget {
+            port,
+            strip_prefix,
+            set_host: None,
+        },
+        enabled: true,
+    }
+}
+
+fn host_match(host: &str) -> RouteMatch {
+    RouteMatch {
+        host: Some(host.to_owned()),
+        ..RouteMatch::default()
+    }
+}
+
+fn prefix_match(prefix: &str) -> RouteMatch {
+    RouteMatch {
+        path_prefix: Some(prefix.to_owned()),
+        ..RouteMatch::default()
+    }
+}
+
+/// Create an imposter on `port` whose stub matches only an exact path (+ optional query),
+/// responding with `body` — used to assert the imposter saw exactly that request target.
+async fn exact_path_imposter(manager: &ImposterManager, port: u16, path: &str, body: &str) {
+    manager
+        .create_imposter(
+            serde_json::from_value(serde_json::json!({
+                "port": port, "protocol": "http",
+                "stubs": [{
+                    "predicates": [{"equals": {"path": path}}],
+                    "responses": [{"is": {"statusCode": 200, "body": body}}]
+                }]
+            }))
+            .unwrap(),
+        )
+        .await
+        .expect("create imposter");
+}
+
+/// Bind a front door on an OS-assigned port serving `table`, returning the running handle and its
+/// base URL.
+async fn start_front_door(
+    manager: Arc<ImposterManager>,
+    table: RouteTable,
+) -> (rift_http_proxy::front_door::RunningFrontDoor, String) {
+    let compiled = Arc::new(ArcSwap::new(Arc::new(CompiledRoutes::new(&table))));
+    let running = bind_front_door("127.0.0.1:0".parse().unwrap(), manager, compiled)
+        .await
+        .expect("bind front door");
+    let base = format!("http://{}", running.local_addr());
+    (running, base)
+}
+
+#[tokio::test]
+async fn host_routes_reach_different_imposters() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19900, "/", "from-a").await;
+    exact_path_imposter(&manager, 19901, "/", "from-b").await;
+
+    let table = RouteTable {
+        routes: vec![
+            route("a", host_match("a.test"), 19900, false),
+            route("b", host_match("b.test"), 19901, false),
+        ],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+    let client = reqwest::Client::new();
+
+    let a = client
+        .get(&base)
+        .header(reqwest::header::HOST, "a.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(a.status(), 200);
+    assert_eq!(a.text().await.unwrap(), "from-a");
+
+    let b = client
+        .get(&base)
+        .header(reqwest::header::HOST, "b.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(b.status(), 200);
+    assert_eq!(b.text().await.unwrap(), "from-b");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn strip_prefix_true_strips_the_path_the_imposter_sees() {
+    let manager = Arc::new(ImposterManager::new());
+    // The imposter only has a stub for the STRIPPED path; if the front door failed to strip,
+    // this predicate would never match and the imposter's Mountebank-style 200-with-no-match
+    // fallback (or a 4xx) would show up instead of "stripped".
+    exact_path_imposter(&manager, 19902, "/x", "stripped").await;
+
+    let table = RouteTable {
+        routes: vec![route("p", prefix_match("/api"), 19902, true)],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+
+    let resp = reqwest::get(format!("{base}/api/x")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "stripped");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn strip_prefix_false_leaves_the_true_path_intact() {
+    let manager = Arc::new(ImposterManager::new());
+    // Without stripping, the imposter must see the untouched `/api/x`.
+    exact_path_imposter(&manager, 19903, "/api/x", "unstripped").await;
+
+    let table = RouteTable {
+        routes: vec![route("p", prefix_match("/api"), 19903, false)],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+
+    let resp = reqwest::get(format!("{base}/api/x")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "unstripped");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn strip_prefix_of_the_prefix_itself_yields_root_not_empty() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19904, "/", "root").await;
+
+    let table = RouteTable {
+        routes: vec![route("p", prefix_match("/api"), 19904, true)],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+
+    // `/api` exactly, no trailing segment: stripping must produce `/`, never `""`.
+    let resp = reqwest::get(format!("{base}/api")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "root");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn query_strings_survive_stripping_and_passthrough() {
+    let manager = Arc::new(ImposterManager::new());
+    manager
+        .create_imposter(
+            serde_json::from_value(serde_json::json!({
+                "port": 19905, "protocol": "http",
+                "stubs": [{
+                    "predicates": [{"equals": {"path": "/x", "query": {"q": "1"}}}],
+                    "responses": [{"is": {"statusCode": 200, "body": "stripped-query"}}]
+                }]
+            }))
+            .unwrap(),
+        )
+        .await
+        .expect("create imposter");
+    manager
+        .create_imposter(
+            serde_json::from_value(serde_json::json!({
+                "port": 19906, "protocol": "http",
+                "stubs": [{
+                    "predicates": [{"equals": {"path": "/api/x", "query": {"q": "1"}}}],
+                    "responses": [{"is": {"statusCode": 200, "body": "unstripped-query"}}]
+                }]
+            }))
+            .unwrap(),
+        )
+        .await
+        .expect("create imposter");
+
+    let table = RouteTable {
+        routes: vec![
+            route("strip", prefix_match("/api"), 19905, true),
+            route("pass", host_match("pass.test"), 19906, false),
+        ],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+    let client = reqwest::Client::new();
+
+    let stripped = reqwest::get(format!("{base}/api/x?q=1")).await.unwrap();
+    assert_eq!(stripped.status(), 200);
+    assert_eq!(stripped.text().await.unwrap(), "stripped-query");
+
+    let passthrough = client
+        .get(format!("{base}/api/x?q=1"))
+        .header(reqwest::header::HOST, "pass.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(passthrough.status(), 200);
+    assert_eq!(passthrough.text().await.unwrap(), "unstripped-query");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn unmatched_request_is_404_with_the_no_route_header() {
+    let manager = Arc::new(ImposterManager::new());
+    let table = RouteTable {
+        routes: vec![route("only", host_match("only.test"), 19907, false)],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+
+    let resp = reqwest::get(format!("{base}/nope")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+    assert_eq!(
+        resp.headers()
+            .get("x-rift-front-door")
+            .map(|v| v.to_str().unwrap()),
+        Some("no-route"),
+        "an unmatched request must carry the no-route marker"
+    );
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn matched_route_to_a_dead_port_is_404_without_the_no_route_header() {
+    let manager = Arc::new(ImposterManager::new());
+    // No imposter is ever created on 19908 — the route matches, its target does not exist.
+    let table = RouteTable {
+        routes: vec![route("dead", host_match("dead.test"), 19908, false)],
+    };
+    let (running, base) = start_front_door(manager.clone(), table).await;
+
+    let resp = reqwest::Client::new()
+        .get(&base)
+        .header(reqwest::header::HOST, "dead.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    assert!(
+        resp.headers().get("x-rift-front-door").is_none(),
+        "a matched route with no imposter is a different failure than no-route, so it must not \
+         carry the no-route marker"
+    );
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn gateway_addressing_still_works_through_the_front_door_with_an_empty_table() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19909, "/y", "gatewayed").await;
+
+    let (running, base) = start_front_door(manager.clone(), RouteTable::default()).await;
+
+    let resp = reqwest::get(format!("{base}/__rift/19909/y"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "gatewayed");
+
+    running.shutdown().await;
+}

--- a/crates/rift-mock-core/src/extensions/routing.rs
+++ b/crates/rift-mock-core/src/extensions/routing.rs
@@ -87,11 +87,15 @@ fn compile_route(route: Route) -> Result<CompiledRoute, RoutingError> {
 
 /// Does `host` sit under the wildcard `*.{suffix}`?
 ///
+/// Public because the front-door route table (`rift-http-proxy`) matches hosts by
+/// the same rule, and two copies of "what does `*.` mean" is precisely how the
+/// label-boundary bug this encodes would come back.
+///
 /// True only for an actual subdomain: there must be at least one non-empty label
 /// ending at a literal `.` boundary. The previous `host.ends_with(suffix)` also
 /// accepted `example.com` (no label at all) and `evilexample.com` (no boundary) —
 /// the latter routing an attacker-chosen host to whatever upstream the route names.
-fn is_subdomain_of(host: &str, suffix: &str) -> bool {
+pub fn is_subdomain_of(host: &str, suffix: &str) -> bool {
     let Some(cut) = host.len().checked_sub(suffix.len()) else {
         return false;
     };

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -43,6 +43,7 @@ Options:
       --runtime <MODE>             Runtime topology: work-stealing (default) or per-core[=N] (RFC-712; experimental, Linux-first — macOS falls back with a warning, Windows rejects it)
       --runtime-affinity           Pin per-core worker threads to CPU cores (with --runtime per-core; effective on Linux)
       --metrics-port <PORT>        Prometheus metrics port [default: 9090]
+      --front-door <ADDR>          Serve every imposter from one address, routed by host/path/header (see Features -> Front Door)
       --ip-whitelist <IPS>         Comma-separated allowed IPs
       --mock                       Run in mock mode
       --debug                      Enable debug mode
@@ -149,6 +150,7 @@ Environment variables override CLI defaults:
 | `RIFT_RUNTIME` | Runtime topology (env alias of `--runtime`): `work-stealing` or `per-core[=N]` (RFC-712; experimental) | `work-stealing` |
 | `RIFT_RUNTIME_AFFINITY` | Pin per-core worker threads to CPU cores (env alias of `--runtime-affinity`) | off |
 | `RIFT_METRICS_PORT` | Prometheus metrics port | `9090` |
+| `RIFT_FRONT_DOOR` | Front-door bind address (env alias of `--front-door`): `HOST:PORT` or a bare port | off |
 | `RIFT_DEFAULT_TLS_CERT` | Default TLS certificate (PEM) for HTTPS imposters | |
 | `RIFT_DEFAULT_TLS_KEY` | Default TLS private key (PEM) | |
 | `RIFT_NO_SELF_SIGNED_TLS` | Disable self-signed TLS fallback (`true`/`false`) | `false` |

--- a/docs/features/front-door.md
+++ b/docs/features/front-door.md
@@ -118,27 +118,21 @@ different fixes:
 
 ---
 
-## Managing routes at runtime
+## Validation
 
-The route table is also a live admin resource on the admin port, under the same authentication as
-everything else there.
+A route table is validated and applied **as a unit**, at load time — so a table that cannot route
+fails the boot rather than the first request, and there is no half-applied routing topology to
+reason about. A table is rejected when:
 
-```
-GET    /front-door/routes          # the whole table, in effective order
-PUT    /front-door/routes          # replace the table (validated atomically)
-GET    /front-door/routes/:id
-PUT    /front-door/routes/:id      # upsert one route
-DELETE /front-door/routes/:id
-GET    /front-door/resolve?host=&path=&method=
-```
+- two routes share an `id`;
+- two *enabled* routes at the same `priority` have byte-identical `match` clauses (see above);
+- a route sets `strip_prefix` with no `path_prefix` to strip;
+- a `host` contains `*` anywhere but as one leading `*.` label;
+- a `path_prefix` does not start with `/`, or a `method` is not a valid HTTP method.
 
-`resolve` is the debugging endpoint: it answers *which route would win* for a hypothetical request,
-without sending one.
+Every message names the offending route id, because "invalid route table" and a 400 is not
+actionable.
 
-```bash
-curl 'http://localhost:2525/front-door/resolve?host=api.payments.test&path=/v1/charges'
-# {"routeId":"payments","port":4545}
-```
-
-A table is validated as a unit and applied as a unit. A rejected `PUT` changes nothing — there is
-no half-applied routing topology to reason about.
+A `routes` block is only read from the `{"imposters": [...], "routes": {...}}` wrapper form. Putting
+one on a single-imposter document is an error rather than a silent no-op — unknown fields are
+otherwise ignored, so the quiet version would be no routes, no diagnostic, and a green boot.

--- a/docs/features/front-door.md
+++ b/docs/features/front-door.md
@@ -1,0 +1,144 @@
+---
+layout: default
+title: Front Door
+parent: Features
+nav_order: 26
+---
+
+# Front Door
+
+The [single-port gateway](gateway.md) lets one port reach every imposter, but the *client* has to
+name the target (`/__rift/4545/api/users`). That is fine when the client is a test harness driving
+Rift on purpose. It is wrong when the client is an unmodified system under test that believes it is
+calling `payments.example.com`.
+
+The front door closes that gap: **one listener, many imposters, addressed by what the request
+says** — host, path prefix, header, method — with no client cooperation at all. It is the reason
+you no longer need an nginx sidecar in front of Rift.
+
+---
+
+## Usage
+
+```bash
+rift --configfile mocks.json --front-door 0.0.0.0:8080
+```
+
+```json
+{
+  "imposters": [
+    { "port": 4545, "protocol": "http", "stubs": [ ... ] },
+    { "port": 4546, "protocol": "http", "stubs": [ ... ] }
+  ],
+  "routes": {
+    "routes": [
+      { "id": "payments", "match": { "host": "payments.test" }, "target": { "port": 4545 } },
+      { "id": "search",   "match": { "host": "search.test"   }, "target": { "port": 4546 } }
+    ]
+  }
+}
+```
+
+```bash
+curl -H 'Host: payments.test' http://localhost:8080/api/charges   # -> imposter 4545
+curl -H 'Host: search.test'   http://localhost:8080/api/query     # -> imposter 4546
+```
+
+Dispatch is **in-process** — the same path the gateway uses. There is no second hop, no extra
+socket, and the imposter behaves exactly as if the request had arrived on its own port.
+
+---
+
+## Matching
+
+Every clause a route declares must match (they AND together). An empty `match` matches everything,
+which is a legitimate catch-all.
+
+| Clause | Meaning |
+|---|---|
+| `host` | Exact (`payments.test`), or one leading wildcard label (`*.payments.test`). Compared case-insensitively; any `:port` on the `Host` header is ignored. |
+| `path_prefix` | **Segment-aligned**: `/api/v1` matches `/api/v1` and `/api/v1/users`, but never `/api/v1x`. |
+| `headers` | A list of `{ "name": ..., "value": ... }`. Names are case-insensitive, values are not. |
+| `method` | Exact HTTP method. |
+
+A wildcard host means a real subdomain. `*.payments.test` matches `api.payments.test` but **not**
+the bare `payments.test`, and **not** `evilpayments.test` — the `.` boundary is what makes a
+wildcard a wildcard.
+
+### Order is derived, not authored
+
+Route tables get edited by several people and merged from several places, so "whichever was written
+first wins" is a footgun. Instead the evaluation order is a total function of the routes themselves:
+
+1. **`priority`**, descending — the explicit override (default `0`).
+2. **Specificity** — an exact host beats a wildcard beats no host; a longer `path_prefix` beats a
+   shorter one; more header clauses beat fewer.
+3. **`id`**, ascending — unique, so there is never a tie left to break arbitrarily.
+
+The same table therefore always resolves the same way, no matter what order it arrived in.
+
+Two *enabled* routes whose `match` clauses are byte-identical at the same priority are an authoring
+mistake with no right answer, so the whole table is rejected. Disabling one of them, or giving one
+a different `priority`, is the supported way to stage a replacement.
+
+---
+
+## Targets
+
+```json
+{ "id": "api", "match": { "path_prefix": "/payments" },
+  "target": { "port": 4545, "strip_prefix": true, "set_host": "internal.svc" } }
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `port` | — | The imposter to dispatch to. It does **not** have to exist yet; routes and imposters can be deployed in either order. |
+| `strip_prefix` | `false` | Remove the matched `path_prefix` before the imposter sees the path. Off by default, so predicates and recorded requests see the true path unless you ask otherwise. Query strings are always preserved. |
+| `set_host` | — | Rewrite the `Host` the imposter sees. Rare, but recorded requests show it. |
+
+---
+
+## When nothing matches
+
+The front door falls back to the gateway's own `/__rift/{port}/{path}` addressing, so one port
+serves both styles and an empty route table behaves exactly like the gateway.
+
+Past that, the response is `404` with a marker header:
+
+```
+x-rift-front-door: no-route
+```
+
+That header separates two failures that look identical from the client side and have completely
+different fixes:
+
+- **`404` with the header** — no route matched. Your route table is wrong.
+- **`404` without it** — a route matched, but no imposter is listening on the port it names. Your
+  imposter is missing.
+
+---
+
+## Managing routes at runtime
+
+The route table is also a live admin resource on the admin port, under the same authentication as
+everything else there.
+
+```
+GET    /front-door/routes          # the whole table, in effective order
+PUT    /front-door/routes          # replace the table (validated atomically)
+GET    /front-door/routes/:id
+PUT    /front-door/routes/:id      # upsert one route
+DELETE /front-door/routes/:id
+GET    /front-door/resolve?host=&path=&method=
+```
+
+`resolve` is the debugging endpoint: it answers *which route would win* for a hypothetical request,
+without sending one.
+
+```bash
+curl 'http://localhost:2525/front-door/resolve?host=api.payments.test&path=/v1/charges'
+# {"routeId":"payments","port":4545}
+```
+
+A table is validated as a unit and applied as a unit. A rejected `PUT` changes nothing — there is
+no half-applied routing topology to reason about.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -64,6 +64,7 @@ Rift provides advanced features for service virtualization and chaos engineering
 - [Date Templates]({{ site.baseurl }}/features/date-templates/) - `{{NOW}}` / `{{DAYS±N}}` / `{{MONTHS±N}}` in responses
 - [Stub-by-ID]({{ site.baseurl }}/features/stub-by-id/) - Address stubs by stable id
 - [Single-Port Gateway]({{ site.baseurl }}/features/gateway/) - Reach every imposter through the admin port
+- [Front Door]({{ site.baseurl }}/features/front-door/) - One listener routing to many imposters by host, path, header or method
 - [Hot Reload]({{ site.baseurl }}/features/hot-reload/) - Re-read config without restarting
 - [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) - Overlap detection and warnings
 - [Debug Mode]({{ site.baseurl }}/features/debug-mode/) - Request matching diagnostics


### PR DESCRIPTION
Implements U-11 (rift-enterprise#19 / #130): one listener serving every imposter, addressed by
what the request **says** rather than by a port the client had to know.

## Why

The [single-port gateway](https://github.com/achird-labs/rift/issues/212) already lets one port
reach every imposter — but the *client* names the target (`/__rift/4545/api/users`). Fine for a
harness driving rift on purpose; wrong when the client is an unmodified system under test that
believes it is calling `payments.example.com`. That gap is why people put nginx in front of rift and
maintain a second config that has to stay in sync with imposter churn.

```bash
rift --configfile mocks.json --front-door 0.0.0.0:8080
curl -H 'Host: payments.test' http://localhost:8080/api/charges   # -> imposter 4545
curl -H 'Host: search.test'   http://localhost:8080/api/query     # -> imposter 4546
```

Dispatch is **in-process** via the same `dispatch_to_port` the gateway uses — no extra hop, no
socket, and the imposter behaves exactly as if the request had arrived on its own port.

## Three decisions that each reject a simpler option

**Order is derived, not authored.** Route tables get edited by several people and merged from
several places, so "whichever was written first wins" is a footgun. Evaluation order is a total
function of the routes: `priority`, then specificity (exact host > wildcard > none; longer prefix >
shorter; more header clauses > fewer), then `id` — unique, so no tie is ever broken arbitrarily. A
test asserts this by **shuffling the input** and requiring an identical result.

**Path prefixes are segment-aligned.** `/api/v1` matches `/api/v1/x`, never `/api/v1x`. A raw
`starts_with` would silently route a neighbouring service's traffic.

**Two identical enabled routes are refused, not resolved.** No right answer exists, so the table is
rejected as a unit; disabling one or giving it a different priority is the supported way to stage a
replacement. There is no half-applied routing topology to reason about.

## Reuse, not reimplementation

Host matching **imports** `extensions::routing::is_subdomain_of` (from #846) instead of defining a
second wildcard rule. Two copies of "what does `*.` mean" is exactly how that label-boundary bug
comes back. The module doc states plainly why the front door does *not* reuse the proxy-mode
`Router` wholesale (its order is authored, its prefixes are not segment-aligned, its target is an
upstream name).

`/__rift/:port` parsing moved out of the admin router into `gateway::dispatch_gateway_path`, now
shared by both listeners so they cannot drift on what counts as a valid gateway target. The admin
router's handler is a one-line delegator; its existing tests are untouched and still pass.

## Failure modes are distinguishable

A 404 with `x-rift-front-door: no-route` means *no route matched* (your table is wrong). A 404
**without** it means a route matched but its imposter is gone (your imposter is missing). Identical
from the client side, opposite fixes — so only the former is marked.

## Config

A `routes` block is read from the `{"imposters": [...]}` wrapper and **validated at load**, so a
table that cannot route fails the boot rather than the first request. A `routes` key on a document
with *no* wrapper is **refused, not dropped** — `ImposterConfig` ignores unknown fields, so the
silent version would be no routes, no diagnostic, and a green boot. Same trap as #655's `intercept`
block, same refusal, and a test pins it.

## Naming

The env alias is **`RIFT_FRONT_DOOR`**. `MB_*` is this repo's prefix for flags Mountebank itself has
(`MB_PORT`, `MB_CONFIGFILE`, `MB_APIKEY`); rift-native features use `RIFT_*` (`RIFT_METRICS_PORT`,
`RIFT_SCRIPTS_DIR`, `RIFT_INTERCEPT_*`). The front door is rift-native — an `MB_` name would
advertise a compatibility that does not exist.

## Verification

`cargo test -p rift-http-proxy` — **310 lib + every integration suite green, 0 failed**, including
15 route-table unit tests, 8 front-door integration tests, 4 listener unit tests, 2 startup-wiring
tests, and 2 config-loader tests. `cargo test -p rift-mock-core --lib` — 1300 passed.
`cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean.
`scripts/verify-docs-coverage.sh` → *OK: 41 flags, 30 env vars, 7 subcommands documented*.
`scripts/verify-docs-examples.sh` → PASS.

Unset, `--front-door` changes nothing: no listener bound, gateway and per-imposter ports byte-identical.

## Not in this PR

Admin CRUD for the route table (`GET|PUT /front-door/routes`, `/resolve`) is the natural next
slice — the listener, matcher, validation and config surface are a coherent shippable unit without
it. The docs page deliberately does **not** describe those endpoints yet: documenting endpoints
that do not exist is worse than not documenting them.
