### PR TITLE
test_response_cycling_with_rift_extensions asserts a client-dispatch order that concurrent requests don't guarantee

### DIFF
--- a/crates/rift-http-proxy/tests/rift_extensions.rs
+++ b/crates/rift-http-proxy/tests/rift_extensions.rs
@@ -572,21 +572,20 @@ async fn test_response_cycling_with_rift_extensions() {
 
     create_imposter(&client, admin_port, config).await;
 
-    // Verify response cycling works
-    let bodies: Vec<String> = futures::future::join_all((0..6).map(|_| {
-        let c = client.clone();
-        let port = imposter_port;
-        async move {
-            c.get(format!("{ADMIN_URL}:{port}/test"))
-                .send()
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap()
-        }
-    }))
-    .await;
+    // Sequential dispatch: concurrent requests reach the round-robin counter in
+    // nondeterministic order, which makes the ordering assertion below unsound.
+    let mut bodies: Vec<String> = Vec::with_capacity(6);
+    for _ in 0..6 {
+        let body = client
+            .get(format!("{ADMIN_URL}:{imposter_port}/test"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        bodies.push(body);
+    }
 
     assert_eq!(
         bodies,


### PR DESCRIPTION
`test_response_cycling_with_rift_extensions` dispatched its 6 requests concurrently via `futures::future::join_all`, then asserted a strict round-robin body order. `join_all` preserves input order in its result, not the order requests reach the server's round-robin counter — so the test was asserting the client's dispatch order, which nothing guarantees. It failed 10/10 runs locally, each with the correct multiset in a scrambled order.

Each response is now awaited before the next request is sent. The strict-order assertion is kept rather than relaxed to a multiset count: ordering is exactly what round-robin cycling promises, and a count-only check would still pass an order regression like `first, first, second, second, third, third`. Cursor concurrency-safety is separately covered by `cycler.rs::concurrent_strict_handoff_preserves_cycling`, so nothing is lost.

Verified: 10/10 red before the change, 10/10 green after; the full `rift_extensions` suite passes with `--include-ignored`; `cargo test --workspace --all-features --tests` green (2221 passed, 0 failed); clippy `-D warnings` clean.

Note: this test is `#[ignore = "requires running server"]`, so this repo's CI does not run it — it is exercised by downstream parity jobs.

Closes #849

Milestone: none (standalone fix)
