### PR TITLE
feat(sources): load imposters from a URI, not only a path (U-12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3287,12 +3288,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -4966,6 +4969,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -62,7 +62,9 @@ lazy_static = "1.4"
 clap = { workspace = true, features = ["env"] }
 
 # HTTP client (for save command)
-reqwest.workspace = true
+# `stream` (U-12): the https imposter source enforces its size cap while reading, not from a
+# Content-Length header the source itself supplies. No new crate — reqwest is already here.
+reqwest = { workspace = true, features = ["stream"] }
 
 # Utils
 bytes.workspace = true

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -139,7 +139,7 @@ fn reload_is_gated(configs: &[crate::imposter::ImposterConfig], allow_injection:
 /// requests, scenario state, response cyclers); only changed ports are patched or replaced.
 pub async fn handle_reload(
     manager: Arc<ImposterManager>,
-    config_source: Option<Arc<crate::config_loader::ConfigSource>>,
+    config_source: Option<crate::sources::ReloadSource>,
     allow_injection: bool,
 ) -> Response<Full<Bytes>> {
     let Some(source) = config_source else {
@@ -149,30 +149,76 @@ pub async fn handle_reload(
         );
     };
 
-    // Parse before touching state — a bad config leaves the running imposters intact.
+    // Parse/fetch before touching state — a bad config leaves the running imposters intact.
     //
     // On the blocking pool (issue #550): `load_configs` is synchronous — many small `std::fs`
     // reads plus EJS/regex/serde work — and unlike startup, reload is network-triggered and
     // repeatable, so a large datadir or a stalled mount would pin a runtime worker for the whole
     // read. Awaited here, so the parse still completes before anything mutates.
-    let loaded =
-        match tokio::task::spawn_blocking(move || crate::config_loader::load_configs_full(&source))
+    let (loaded, all_unchanged) = match source {
+        crate::sources::ReloadSource::Legacy(source) => {
+            match tokio::task::spawn_blocking(move || {
+                crate::config_loader::load_configs_full(&source)
+            })
             .await
-        {
-            Ok(Ok(loaded)) => loaded,
-            Ok(Err(e)) => {
+            {
+                Ok(Ok(loaded)) => (loaded, false),
+                Ok(Err(e)) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &format!("Reload failed (imposters unchanged): {e}"),
+                    );
+                }
+                Err(e) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &format!("Reload task failed: {e}"),
+                    );
+                }
+            }
+        }
+        // U-12: each source's own fetch is already async and does its own I/O budgeting
+        // (`FileSource` hops to the blocking pool; `HttpSource` is non-blocking), so this arm
+        // must not be wrapped in `spawn_blocking`.
+        crate::sources::ReloadSource::Sources(set) => match set.fetch_all().await {
+            Ok(merged) => {
+                let unchanged = merged.all_unchanged;
+                (
+                    crate::config_loader::LoadedConfig {
+                        imposters: merged.imposters,
+                        // Boot-only blocks; reload deliberately does not re-apply them, and the
+                        // warning below is driven off `intercept` being present in the document.
+                        intercept: merged.intercept,
+                        routes: merged.routes,
+                    },
+                    unchanged,
+                )
+            }
+            Err(e) => {
                 return error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     &format!("Reload failed (imposters unchanged): {e}"),
                 );
             }
-            Err(e) => {
-                return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("Reload task failed: {e}"),
-                );
-            }
-        };
+        },
+    };
+
+    // Every source proved its content unmoved (an HTTP 304, a matching sha), so there is nothing
+    // to apply. Returning early is not just an optimisation: `apply_config` on an identical
+    // document is still a diff pass over every imposter, and a poller doing that on a fixed
+    // interval is exactly the churn `ETag` support exists to avoid.
+    if all_unchanged {
+        return json_response(
+            StatusCode::OK,
+            &serde_json::json!({
+                "message": "No source changed; imposters left as they are",
+                "created": 0,
+                "replaced": 0,
+                "stubPatched": 0,
+                "deleted": 0,
+            }),
+        );
+    }
 
     // The `intercept` block is applied at boot only (issue #655): re-seeding would duplicate or
     // clobber rules added at runtime, and rebinding the listener is a lifecycle change reload does
@@ -349,10 +395,12 @@ mod tests {
             ]}"#,
         )
         .expect("write config");
-        let source = Arc::new(crate::config_loader::ConfigSource::File {
-            path,
-            no_parse: false,
-        });
+        let source = crate::sources::ReloadSource::Legacy(Arc::new(
+            crate::config_loader::ConfigSource::File {
+                path,
+                no_parse: false,
+            },
+        ));
 
         let manager = Arc::new(ImposterManager::new());
         let resp = handle_reload(manager.clone(), Some(source), false).await;
@@ -398,10 +446,12 @@ mod tests {
         )
         .expect("write config");
 
-        let source = Arc::new(crate::config_loader::ConfigSource::File {
-            path: config_path,
-            no_parse: false,
-        });
+        let source = crate::sources::ReloadSource::Legacy(Arc::new(
+            crate::config_loader::ConfigSource::File {
+                path: config_path,
+                no_parse: false,
+            },
+        ));
 
         let manager = Arc::new(ImposterManager::new());
 
@@ -465,10 +515,12 @@ mod tests {
             ]}]}"#,
         )
         .expect("write clean config");
-        let source = Arc::new(crate::config_loader::ConfigSource::File {
-            path: path.clone(),
-            no_parse: false,
-        });
+        let source = crate::sources::ReloadSource::Legacy(Arc::new(
+            crate::config_loader::ConfigSource::File {
+                path: path.clone(),
+                no_parse: false,
+            },
+        ));
 
         let manager = Arc::new(ImposterManager::new());
         let resp = handle_reload(manager.clone(), Some(source.clone()), false).await;
@@ -527,10 +579,12 @@ mod tests {
             ]}]}"#,
         )
         .expect("write scripted config");
-        let source = Arc::new(crate::config_loader::ConfigSource::File {
-            path,
-            no_parse: false,
-        });
+        let source = crate::sources::ReloadSource::Legacy(Arc::new(
+            crate::config_loader::ConfigSource::File {
+                path,
+                no_parse: false,
+            },
+        ));
 
         let manager = Arc::new(ImposterManager::new());
         let resp = handle_reload(manager.clone(), Some(source), true).await;

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -4,9 +4,9 @@
 
 use crate::admin_api::handlers::{imposters, intercept, scenarios, stubs, system};
 use crate::admin_api::types::{error_response, get_base_url, not_found};
-use crate::config_loader::ConfigSource;
 use crate::imposter::ImposterManager;
 use crate::intercept_control::InterceptControl;
+use crate::sources::ReloadSource;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming;
@@ -75,7 +75,7 @@ impl ImposterRoute {
 pub async fn route_request(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
-    config_source: Option<Arc<ConfigSource>>,
+    config_source: Option<ReloadSource>,
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
@@ -146,7 +146,7 @@ async fn route_by_path(
     req: Request<Incoming>,
     base_url: &str,
     manager: Arc<ImposterManager>,
-    config_source: Option<Arc<ConfigSource>>,
+    config_source: Option<ReloadSource>,
     allow_injection: bool,
     scripts_dir: Option<Arc<PathBuf>>,
 ) -> Response<Full<Bytes>> {

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -6,6 +6,7 @@ use crate::config_loader::ConfigSource;
 use crate::extensions::decorate::{ResponsePhase, with_annotation_scope};
 use crate::imposter::ImposterManager;
 use crate::intercept_control::InterceptControl;
+use crate::sources::{ReloadSource, SourceSet};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::service::service_fn;
@@ -34,7 +35,7 @@ pub struct AdminApiServer {
     addr: SocketAddr,
     manager: Arc<ImposterManager>,
     api_key: Option<Arc<String>>,
-    config_source: Option<Arc<ConfigSource>>,
+    config_source: Option<ReloadSource>,
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
@@ -58,7 +59,15 @@ impl AdminApiServer {
     /// (issue #197). Without it, reload is a no-op.
     #[must_use]
     pub fn with_config_source(mut self, source: ConfigSource) -> Self {
-        self.config_source = Some(Arc::new(source));
+        self.config_source = Some(ReloadSource::Legacy(Arc::new(source)));
+        self
+    }
+
+    /// Set the `--imposters` source set so `POST /admin/reload` re-fetches every source (U-12).
+    /// Replaces any previously-set config source: a server reloads from one place.
+    #[must_use]
+    pub fn with_imposter_sources(mut self, sources: Arc<SourceSet>) -> Self {
+        self.config_source = Some(ReloadSource::Sources(sources));
         self
     }
 
@@ -337,7 +346,7 @@ async fn accept_loop(
     listener: TcpListener,
     manager: Arc<ImposterManager>,
     api_key: Option<Arc<String>>,
-    config_source: Option<Arc<ConfigSource>>,
+    config_source: Option<ReloadSource>,
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -42,6 +42,23 @@ static EJS_STMT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?s)<%[^=].*?%>").expect("EJS statement pattern is a valid constant regex")
 });
 
+/// Whether EJS tags that read the local filesystem are honoured.
+///
+/// `--configfile` documents are authored by someone who already has filesystem access, so
+/// `<% include %>` / `<%- stringify %>` are resolved verbatim — the same rationale that makes
+/// [`ScriptBaseDir::ConfigRelative`] unrestricted. A document fetched over the network (U-12's
+/// `https:` source) has no such author, so those two tags are refused rather than resolved:
+/// honouring them would let whoever serves the document read arbitrary local files. `<%=
+/// process.env.X %>` still substitutes in both — env is deployment config the operator chose to
+/// expose to their own process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EjsFileAccess {
+    /// Local document: `include` and `stringify` resolve against the document's directory.
+    Allowed,
+    /// Remote document: `include` and `stringify` are a load error naming the tag.
+    Denied,
+}
+
 /// Where the running imposters were loaded from, retained so reload can re-read the same source.
 #[derive(Debug, Clone)]
 pub enum ConfigSource {
@@ -95,15 +112,46 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
     let content = if no_parse {
         raw
     } else {
-        preprocess_ejs(&raw, path)?
+        preprocess_ejs(&raw, path, EjsFileAccess::Allowed)?
     };
 
+    // `_rift.script` `file:`/`ref:` sources (issue #356) resolve relative to the config file's
+    // own directory, so a parse error and a resolve error are both surfaced up front, and
+    // hot-reload (which re-runs this loader) automatically picks up edits to referenced scripts.
+    let base = ScriptBaseDir::ConfigRelative(
+        path.parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf(),
+    );
+    parse_document(&content, &base)
+}
+
+/// Parse a document fetched from a source that is not the local filesystem (U-12's `https:`
+/// built-in, and any third-party [`crate::sources::ImposterSource`]).
+///
+/// Format sniffing, the wrapper/single/array shapes, and the `intercept`/`routes` block rules are
+/// the *same* code the `--configfile` path runs, so a document behaves identically whichever
+/// source delivered it. The two deliberate differences are both fail-closed, and both exist
+/// because a remote document's author is not someone who already has local access:
+/// - EJS `include`/`stringify` are refused ([`EjsFileAccess::Denied`]);
+/// - `_rift.script` `file:` references are refused ([`ScriptBaseDir::Unconfigured`]).
+///
+/// `uri` is used only to name the source in error messages.
+pub fn parse_remote_document(content: &str, uri: &str) -> anyhow::Result<LoadedConfig> {
+    let processed = preprocess_ejs(content, Path::new(uri), EjsFileAccess::Denied)?;
+    parse_document(&processed, &ScriptBaseDir::Unconfigured)
+}
+
+/// The shared parse path: format sniffing, the Mountebank document shapes, and script resolution
+/// against whatever base the caller's source implies. Everything above this function differs per
+/// source (bytes off a disk, bytes off a socket); everything below it must not.
+fn parse_document(content: &str, base: &ScriptBaseDir) -> anyhow::Result<LoadedConfig> {
     let trimmed = content.trim_start();
     let mut intercept = None;
     let mut routes = None;
     let mut configs: Vec<ImposterConfig> = if trimmed.starts_with('{') {
         // Single imposter, or a `{ "imposters": [...] }` wrapper (Mountebank format).
-        let value: serde_json::Value = serde_json::from_str(&content)?;
+        let value: serde_json::Value = serde_json::from_str(content)?;
         match value.get("imposters") {
             Some(imposters) => {
                 // Only the wrapper carries siblings, so this is the one shape with somewhere to
@@ -150,22 +198,13 @@ fn load_file(path: &Path, no_parse: bool) -> anyhow::Result<LoadedConfig> {
             None => vec![serde_json::from_value(value)?],
         }
     } else if trimmed.starts_with('[') {
-        serde_json::from_str(&content)?
+        serde_json::from_str(content)?
     } else {
-        serde_yaml::from_str(&content)?
+        serde_yaml::from_str(content)?
     };
 
-    // Resolve `_rift.script` `file:`/`ref:` sources (issue #356) relative to the config file's
-    // own directory, before the configs are handed to the caller — so a parse error and a
-    // resolve error are both surfaced up front, and hot-reload (which re-runs this loader)
-    // automatically picks up edits to referenced script files.
-    let base = ScriptBaseDir::ConfigRelative(
-        path.parent()
-            .unwrap_or_else(|| Path::new("."))
-            .to_path_buf(),
-    );
     for config in &mut configs {
-        resolve_scripts(config, &base)?;
+        resolve_scripts(config, base)?;
     }
     Ok(LoadedConfig {
         imposters: configs,
@@ -204,9 +243,34 @@ fn load_dir(dir: &Path) -> anyhow::Result<Vec<ImposterConfig>> {
 ///
 /// Any other `<%= expr %>` token is replaced with an empty string and logged as a warning.
 /// `<% expr %>` (without `=`) statements (e.g., `<% for (...) %>`) are removed and logged.
-fn preprocess_ejs(content: &str, config_path: &Path) -> anyhow::Result<String> {
+fn preprocess_ejs(
+    content: &str,
+    config_path: &Path,
+    file_access: EjsFileAccess,
+) -> anyhow::Result<String> {
     if !content.contains("<%") {
         return Ok(content.to_string());
+    }
+
+    // Fail closed before any resolution: a remote document that names a local file is refused
+    // outright, naming the tag, rather than having it quietly stripped by the `<% ... %>`
+    // catch-all further down (which would produce a silently different config, not an error).
+    if file_access == EjsFileAccess::Denied {
+        for (re, tag) in [
+            (&*EJS_INCLUDE_RE, "<% include ... %>"),
+            (&*EJS_STRINGIFY_RE, "<%- stringify(...) %>"),
+        ] {
+            if let Some(cap) = re.captures(content) {
+                anyhow::bail!(
+                    "`{tag}` reads a local file and is not honoured in a document fetched from \
+                     {} — it names '{}'. Only local `--configfile` documents may include local \
+                     files; use `--configfile` if the template must, or inline the content at \
+                     the source.",
+                    config_path.display(),
+                    &cap[1],
+                );
+            }
+        }
     }
 
     let config_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
@@ -667,7 +731,10 @@ mod tests {
     fn test_ejs_no_tokens_passthrough() {
         let content = r#"{"imposters": []}"#;
         let path = PathBuf::from("config.json");
-        assert_eq!(preprocess_ejs(content, &path).unwrap(), content);
+        assert_eq!(
+            preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap(),
+            content
+        );
     }
 
     #[test]
@@ -675,7 +742,7 @@ mod tests {
         unsafe { std::env::set_var("RIFT_TEST_HOST", "myhost") };
         let content = r#"{"body": "<%= process.env.RIFT_TEST_HOST %>"}"#;
         let path = PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
+        let result = preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap();
         assert_eq!(result, r#"{"body": "myhost"}"#);
         unsafe { std::env::remove_var("RIFT_TEST_HOST") };
     }
@@ -685,7 +752,7 @@ mod tests {
         unsafe { std::env::remove_var("RIFT_TEST_UNSET_VAR") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_UNSET_VAR || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
+        let result = preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap();
         assert_eq!(result, r#"{"port": "4545"}"#);
     }
 
@@ -694,7 +761,7 @@ mod tests {
         unsafe { std::env::set_var("RIFT_TEST_PORT", "8080") };
         let content = r#"{"port": "<%= process.env.RIFT_TEST_PORT || '4545' %>"}"#;
         let path = PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path).unwrap();
+        let result = preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap();
         assert_eq!(result, r#"{"port": "8080"}"#);
         unsafe { std::env::remove_var("RIFT_TEST_PORT") };
     }
@@ -705,7 +772,7 @@ mod tests {
         std::fs::write(dir.path().join("partial.json"), r#"{"key": "value"}"#).unwrap();
         let content = r#"<% include 'partial.json' %>"#.to_string();
         let config_path = dir.path().join("config.ejs");
-        let result = preprocess_ejs(&content, &config_path).unwrap();
+        let result = preprocess_ejs(&content, &config_path, EjsFileAccess::Allowed).unwrap();
         assert_eq!(result, r#"{"key": "value"}"#);
     }
 
@@ -715,7 +782,7 @@ mod tests {
         std::fs::write(dir.path().join("partial.json"), r#"[1,2,3]"#).unwrap();
         let content = r#"<% include partial.json %>"#;
         let config_path = dir.path().join("config.ejs");
-        let result = preprocess_ejs(content, &config_path).unwrap();
+        let result = preprocess_ejs(content, &config_path, EjsFileAccess::Allowed).unwrap();
         assert_eq!(result, "[1,2,3]");
     }
 
@@ -723,7 +790,7 @@ mod tests {
     fn test_ejs_missing_include_is_fatal_error() {
         let content = r#"<% include 'nonexistent.json' %>"#;
         let path = PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path);
+        let result = preprocess_ejs(content, &path, EjsFileAccess::Allowed);
         assert!(result.is_err(), "missing include file should return Err");
         assert!(
             result.unwrap_err().to_string().contains("nonexistent.json"),
@@ -743,7 +810,7 @@ mod tests {
         .unwrap();
         let content = r#"{"port": 9000, "protocol": "http", "stubs": [{"responses": [{"inject": "<%- stringify('inject.js') %>"}]}]}"#;
         let config_path = dir.path().join("config.ejs");
-        let processed = preprocess_ejs(content, &config_path).unwrap();
+        let processed = preprocess_ejs(content, &config_path, EjsFileAccess::Allowed).unwrap();
 
         // The substituted content must keep the surrounding JSON valid.
         let processed_value: serde_json::Value =
@@ -774,7 +841,7 @@ mod tests {
     fn ejs_stringify_missing_file_is_fatal_error() {
         let content = r#"{"inject": "<%- stringify('nope-355.js') %>"}"#;
         let path = PathBuf::from("config.json");
-        let result = preprocess_ejs(content, &path);
+        let result = preprocess_ejs(content, &path, EjsFileAccess::Allowed);
         assert!(result.is_err(), "missing stringify file should return Err");
         assert!(
             result.unwrap_err().to_string().contains("nope-355.js"),
@@ -792,7 +859,7 @@ mod tests {
         let content = r#"{"a": "<%- stringify('inject.js') %>"}<% if (x) { %><% } %>"#;
         let config_path = dir.path().join("config.ejs");
         assert_eq!(
-            preprocess_ejs(content, &config_path).unwrap(),
+            preprocess_ejs(content, &config_path, EjsFileAccess::Allowed).unwrap(),
             r#"{"a": "hi"}"#
         );
     }
@@ -801,14 +868,20 @@ mod tests {
     fn ejs_statement_blocks_are_stripped() {
         let content = r#"{"a": 1<% for (var i=0;i<3;i++) { %><% } %>}"#;
         let path = PathBuf::from("config.json");
-        assert_eq!(preprocess_ejs(content, &path).unwrap(), r#"{"a": 1}"#);
+        assert_eq!(
+            preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap(),
+            r#"{"a": 1}"#
+        );
     }
 
     #[test]
     fn ejs_statement_strip_spans_newlines() {
         let content = "{\"a\": 1<% if (x) {\n  y();\n} %>}";
         let path = PathBuf::from("config.json");
-        assert_eq!(preprocess_ejs(content, &path).unwrap(), r#"{"a": 1}"#);
+        assert_eq!(
+            preprocess_ejs(content, &path, EjsFileAccess::Allowed).unwrap(),
+            r#"{"a": 1}"#
+        );
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -39,6 +39,11 @@ pub mod intercept_control;
 // Imposter config loading (--configfile / --datadir), shared with hot-reload (issue #197)
 pub mod config_loader;
 
+/// Imposter sources (U-12): `--imposters <uri,...>` and the `ImposterSource` SPI embedders
+/// register their own schemes through. `file:`/`https:` are built in; parsing is shared with
+/// [`config_loader`] so no scheme can grow its own dialect.
+pub mod sources;
+
 // `rift script check` / `rift script run` (issue #360): scripting DX outside a running server
 pub mod script_cli;
 

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -5,7 +5,7 @@
 //! binary.
 
 use crate::admin_api::{AdminApiServer, DEFAULT_ADMIN_PORT, RunningAdminApi};
-use crate::config_loader::{self, ConfigSource};
+use crate::config_loader::ConfigSource;
 use crate::extensions::metrics;
 use crate::front_door::{CompiledRoutes, RouteTable, RunningFrontDoor, bind_front_door};
 use crate::imposter::{
@@ -13,6 +13,9 @@ use crate::imposter::{
 };
 use crate::injection_gate::GATED_SCRIPT_SURFACES;
 use crate::intercept_control::{InterceptControl, InterceptStartOptions};
+use crate::sources::{
+    self, FileSource, HttpSource, ImposterSource, SourceRef, SourceRegistry, SourceSet,
+};
 use arc_swap::ArcSwap;
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
@@ -61,6 +64,14 @@ pub struct Cli {
     /// Directory for persistent imposter storage
     #[arg(long, value_name = "DIR", env = "MB_DATADIR")]
     pub datadir: Option<PathBuf>,
+
+    /// Load imposters from one or more source URIs (U-12), comma-separated. `file:<path>` and a
+    /// bare path read the local filesystem; `https://…` fetches the document over HTTP, honouring
+    /// `ETag`. Multiple sources are merged, and a port declared by two of them is a startup error
+    /// naming both. `POST /admin/reload` re-fetches every source. `--configfile <p>` is sugar for
+    /// `--imposters file:<p>`.
+    #[arg(long, value_name = "URI[,URI...]", env = "RIFT_IMPOSTERS")]
+    pub imposters: Option<String>,
 
     /// Root directory `_rift.script` `file:` references resolve under for admin-API-created
     /// imposters (issue #356). A resolved path that escapes this root is rejected. Without it,
@@ -316,6 +327,7 @@ pub struct ServerBuilder {
     cli: Cli,
     manager: Option<Arc<ImposterManager>>,
     accept_runtimes: Vec<tokio::runtime::Handle>,
+    imposter_sources: Vec<Arc<dyn ImposterSource>>,
 }
 
 impl ServerBuilder {
@@ -326,7 +338,20 @@ impl ServerBuilder {
             cli,
             manager: None,
             accept_runtimes: Vec::new(),
+            imposter_sources: Vec::new(),
         }
+    }
+
+    /// Register an additional [`ImposterSource`] scheme (U-12).
+    ///
+    /// Repeatable. The `file:` and `https:` built-ins are always registered; claiming a scheme
+    /// that is already taken is a startup error rather than a silent override, so an embedder
+    /// that shadows a built-in finds out immediately. This is the seam the enterprise
+    /// `git:`/`s3:`/`registry:` providers attach through.
+    #[must_use]
+    pub fn imposter_source(mut self, source: Arc<dyn ImposterSource>) -> Self {
+        self.imposter_sources.push(source);
+        self
     }
 
     /// Fan imposter accept loops out across per-core worker runtimes (RFC-712, issue #745).
@@ -358,6 +383,7 @@ impl ServerBuilder {
     /// needs the bound addresses (`:0` support) and a graceful shutdown.
     pub async fn start(self) -> anyhow::Result<RunningServer> {
         let cli = self.cli;
+        let extra_sources = self.imposter_sources;
         // Validate `--front-door` before anything else binds (issue #19 / U-11): a malformed
         // address is then a clean, fast failure that never has to unwind an already-bound
         // listener behind it.
@@ -397,11 +423,13 @@ impl ServerBuilder {
 
         let mut intercept_block = None;
         let mut routes_block: Option<RouteTable> = None;
-        if let Some(ref configfile) = cli.configfile {
-            let loaded = load_imposters_from_file(
+        // `--configfile` and `--imposters` converge here: the flag is sugar for a single `file:`
+        // ref, so both spellings run the same fetch, gating and block handling (U-12).
+        let source_set = resolve_source_set(&cli, extra_sources)?;
+        if let Some(set) = &source_set {
+            let loaded = load_imposters_from_sources(
                 &manager,
-                configfile,
-                cli.no_parse,
+                set,
                 cli.allow_injection,
                 &cli_intercept_flags(&cli),
             )
@@ -485,11 +513,11 @@ impl ServerBuilder {
         if let Some(scripts_dir) = cli.scripts_dir {
             server = server.with_scripts_dir(scripts_dir);
         }
-        if let Some(configfile) = cli.configfile {
-            server = server.with_config_source(ConfigSource::File {
-                path: configfile,
-                no_parse: cli.no_parse,
-            });
+        // Reload re-runs whatever boot ran. A source set (`--imposters`, or `--configfile`
+        // desugared into one) re-fetches every source; a bare `--datadir` keeps the original
+        // synchronous directory re-read.
+        if let Some(set) = source_set {
+            server = server.with_imposter_sources(set);
         } else if let Some(datadir) = cli.datadir {
             server = server.with_config_source(ConfigSource::Dir(datadir));
         }
@@ -1089,45 +1117,77 @@ struct ConfigFileStartOptions {
     routes: Option<RouteTable>,
 }
 
-/// Load imposters from a JSON config file, returning the file's optional `intercept` and `routes`
-/// blocks for the caller to start their respective listeners from (issue #655, #19) — both are
-/// parsed and validated here so the whole document is refused as one, before any imposter exists.
-async fn load_imposters_from_file(
+/// Resolve `--imposters` / `--configfile` into the source set the server both boots from and
+/// reloads from (U-12). `Ok(None)` when neither flag was given.
+///
+/// The built-ins are registered before the embedder's own sources, so an embedder that claims
+/// `file:` or `https:` gets a startup error instead of silently shadowing a built-in.
+fn resolve_source_set(
+    cli: &Cli,
+    extra: Vec<Arc<dyn ImposterSource>>,
+) -> anyhow::Result<Option<Arc<SourceSet>>> {
+    let refs = match (&cli.imposters, &cli.configfile) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "--imposters and --configfile are two spellings of the same thing (`--configfile p` \
+             is `--imposters file:p`); pass only one"
+        ),
+        (Some(list), None) => sources::parse_uri_list(list),
+        // The sugar. Spelled `file:` explicitly so a path containing `://` cannot be re-read as
+        // some other scheme on the way back through `SourceRef::scheme`.
+        (None, Some(path)) => vec![SourceRef::new(format!("file:{}", path.display()))],
+        (None, None) => return Ok(None),
+    };
+    if refs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut registry = SourceRegistry::new();
+    registry.register(Arc::new(FileSource::new(cli.no_parse)))?;
+    registry.register(Arc::new(HttpSource::new()?))?;
+    for source in extra {
+        registry.register(source)?;
+    }
+    Ok(Some(Arc::new(SourceSet::new(refs, registry))))
+}
+
+/// Boot-time load from every `--imposters` source, with the same refusals `--configfile` has
+/// always applied — injection gating and the intercept-source conflict — evaluated across the
+/// merged set before a single imposter exists, so a rejected document cannot half-load.
+async fn load_imposters_from_sources(
     manager: &Arc<ImposterManager>,
-    path: &PathBuf,
-    no_parse: bool,
+    set: &SourceSet,
     allow_injection: bool,
     intercept_flags: &[&str],
 ) -> anyhow::Result<ConfigFileStartOptions> {
-    info!("Loading imposters from configfile: {:?}", path);
+    for source_ref in &set.refs {
+        info!("Loading imposters from source: {}", source_ref.uri);
+    }
+    let merged = set.fetch_all().await?;
 
-    let loaded = config_loader::load_configs_full(&ConfigSource::File {
-        path: path.clone(),
-        no_parse,
-    })?;
-
-    // Refuse before creating anything: a gated configfile must not half-load (issue #612). The
-    // intercept block is validated in the same breath, so a file that cannot bring up its listener
-    // never half-applies its imposters either.
-    if let Some(message) = configfile_injection_error(path, &loaded.imposters, allow_injection) {
+    // A label for the refusal messages, which were written for a single `--configfile` path.
+    let label = PathBuf::from(
+        set.refs
+            .iter()
+            .map(|r| r.uri.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    if let Some(message) = configfile_injection_error(&label, &merged.imposters, allow_injection) {
         anyhow::bail!(message);
     }
-    if let Some(block) = &loaded.intercept {
-        if let Some(message) = intercept_source_conflict_error(path, intercept_flags) {
+    if let Some(block) = &merged.intercept {
+        if let Some(message) = intercept_source_conflict_error(&label, intercept_flags) {
             anyhow::bail!(message);
         }
         if let Some(message) =
-            configfile_intercept_injection_error(path, &block.rules, allow_injection)
+            configfile_intercept_injection_error(&label, &block.rules, allow_injection)
         {
             anyhow::bail!(message);
         }
     }
 
-    for config in loaded.imposters {
-        info!(
-            "Creating imposter on port {:?} from configfile",
-            config.port
-        );
+    for config in merged.imposters {
+        info!("Creating imposter on port {:?} from source", config.port);
         match manager.create_imposter(config).await {
             Ok(port) => info!("Created imposter on port {}", port),
             Err(e) => error!("Failed to create imposter: {}", e),
@@ -1135,8 +1195,8 @@ async fn load_imposters_from_file(
     }
 
     Ok(ConfigFileStartOptions {
-        intercept: loaded.intercept,
-        routes: loaded.routes,
+        intercept: merged.intercept,
+        routes: merged.routes,
     })
 }
 
@@ -1737,12 +1797,24 @@ mod tests {
     // drive the real loaders, so dropping the gate call (or bailing after the create loop) fails
     // here even though every helper test would still pass.
 
+    /// What `--configfile <p>` desugars to, so these tests exercise the path the flag now takes.
+    fn single_file_source(path: &Path) -> SourceSet {
+        let mut registry = SourceRegistry::new();
+        registry
+            .register(Arc::new(FileSource::new(false)))
+            .expect("file source registers");
+        SourceSet::new(
+            vec![SourceRef::new(format!("file:{}", path.display()))],
+            registry,
+        )
+    }
+
     fn write_json(path: &Path, value: serde_json::Value) {
         std::fs::write(path, serde_json::to_string(&value).expect("json")).expect("write");
     }
 
     #[tokio::test]
-    async fn load_imposters_from_file_aborts_before_creating_any_imposter() {
+    async fn a_gated_file_source_aborts_before_creating_any_imposter() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("imposters.json");
         // A clean imposter listed *before* the offender: if the gate ran per-imposter inside the
@@ -1758,7 +1830,8 @@ mod tests {
         );
 
         let manager = Arc::new(ImposterManager::new());
-        let err = load_imposters_from_file(&manager, &path, false, false, &[])
+        let set = single_file_source(&path);
+        let err = load_imposters_from_sources(&manager, &set, false, &[])
             .await
             .expect_err("a gated configfile must abort startup");
         assert!(err.to_string().contains("--allowInjection"), "got: {err}");
@@ -1778,13 +1851,14 @@ mod tests {
     // The literal repro from the issue's Evidence section: the shipped example is refused by the
     // admin API without --allowInjection, and must now be refused through --configfile too.
     #[tokio::test]
-    async fn load_imposters_from_file_refuses_the_shipped_latency_example() {
+    async fn a_file_source_refuses_the_shipped_latency_example() {
         let example =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/latency-testing.json");
         assert!(example.exists(), "fixture missing: {}", example.display());
 
         let manager = Arc::new(ImposterManager::new());
-        let err = load_imposters_from_file(&manager, &example, false, false, &[])
+        let set = single_file_source(&example);
+        let err = load_imposters_from_sources(&manager, &set, false, &[])
             .await
             .expect_err("examples/latency-testing.json uses a JS-function wait; it must be gated");
         assert!(err.to_string().contains("--allowInjection"), "got: {err}");

--- a/crates/rift-http-proxy/src/sources.rs
+++ b/crates/rift-http-proxy/src/sources.rs
@@ -1,0 +1,534 @@
+//! Imposter sources (U-12): load imposters from a URI instead of only from a local path.
+//!
+//! A source is a scheme plus a way to turn a [`SourceRef`] into imposter configs. Two are built
+//! in — `file:` and `https:` — and embedders register their own with
+//! [`crate::server::ServerBuilder::imposter_source`]; that is how the enterprise `git:`/`s3:`/
+//! `registry:` providers attach without this crate knowing they exist.
+//!
+//! Two properties are load-bearing and easy to lose in a refactor:
+//!
+//! 1. **Parsing is shared.** A provider hands back *bytes*; the document shapes, format sniffing
+//!    and block rules all run in [`crate::config_loader`], so `file:` and `https:` cannot drift
+//!    into two dialects of the same config format.
+//! 2. **`--configfile` is unchanged.** It is sugar for `--imposters file:<path>`, and
+//!    [`FileSource`] delegates to the very same loader function the flag used before, so the
+//!    behaviour is identical rather than merely similar.
+
+use crate::config_loader::{self, ConfigSource, LoadedConfig};
+use crate::front_door::RouteTable;
+use crate::imposter::ImposterConfig;
+use crate::intercept_control::InterceptStartOptions;
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+/// Refuse a body larger than this. A config document is small; anything at this scale is a
+/// misconfigured URL (or a hostile one), and it would otherwise be buffered whole.
+pub const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+
+/// Whole-request budget for an `https:` fetch — connect, headers and body.
+pub const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A source URI as written on the command line: `file:mocks.json`, `https://host/imposters.json`,
+/// or a bare path (sugar for `file:`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRef {
+    pub uri: String,
+}
+
+impl SourceRef {
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self { uri: uri.into() }
+    }
+
+    /// The scheme this ref dispatches on.
+    ///
+    /// A bare path is `file`, so `--imposters mocks.json` works like `--configfile mocks.json`.
+    /// The `://` form is checked before the bare `scheme:` form so that a compound scheme such as
+    /// `git+https://…` (an enterprise provider) resolves to `git+https` rather than to `git`.
+    pub fn scheme(&self) -> &str {
+        match self.uri.split_once("://") {
+            Some((scheme, _)) => scheme,
+            None if self.uri.starts_with("file:") => "file",
+            None => "file",
+        }
+    }
+
+    /// The scheme-specific part: what `file:` should open, or the whole URI for network schemes
+    /// that need it verbatim.
+    pub fn target(&self) -> &str {
+        self.uri.strip_prefix("file:").unwrap_or(&self.uri)
+    }
+}
+
+/// What a source knows about the version it just served, used to skip redundant work.
+#[derive(Debug, Clone)]
+pub struct SourceMeta {
+    /// ETag, commit sha, content hash — whatever the provider has. `None` means "no version
+    /// information", which is always treated as changed.
+    pub version: Option<String>,
+    pub fetched_at: SystemTime,
+}
+
+/// The result of a fetch.
+#[derive(Debug)]
+pub struct FetchedImposters {
+    pub configs: Vec<ImposterConfig>,
+    /// The document's optional `intercept` block (issue #655). Carried here — not in the original
+    /// U-12 sketch — because `--configfile` is now sugar for `--imposters file:<path>`, and a
+    /// configfile that declares a block must keep starting its listener.
+    pub intercept: Option<InterceptStartOptions>,
+    /// The document's optional `routes` block (issue #19 / U-11). Same reasoning as `intercept`.
+    pub routes: Option<RouteTable>,
+    pub meta: SourceMeta,
+    /// True when the provider proved the content had not changed since its last fetch (an HTTP
+    /// 304, a matching commit sha) and `configs` therefore came from its cache without being
+    /// re-parsed.
+    ///
+    /// Not in the original U-12 sketch, but the sketch had no way to express "nothing changed",
+    /// and without it every poll re-applies an identical config — which is exactly the log growth
+    /// and state churn the ETag support exists to avoid.
+    pub unchanged: bool,
+}
+
+/// A scheme handler. Implementors fetch bytes and hand back parsed configs; they must route the
+/// parsing through [`config_loader`] rather than parsing themselves.
+pub trait ImposterSource: Send + Sync {
+    /// The schemes this source claims. Registering two sources for one scheme is a startup error.
+    fn schemes(&self) -> &'static [&'static str];
+
+    fn fetch<'a>(
+        &'a self,
+        r: &'a SourceRef,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<FetchedImposters>> + Send + 'a>>;
+}
+
+/// `file:` — the local filesystem, and the path `--configfile` takes.
+#[derive(Debug, Clone)]
+pub struct FileSource {
+    /// Mirrors `--no-parse`: skip EJS preprocessing.
+    pub no_parse: bool,
+}
+
+impl FileSource {
+    pub fn new(no_parse: bool) -> Self {
+        Self { no_parse }
+    }
+}
+
+impl ImposterSource for FileSource {
+    fn schemes(&self) -> &'static [&'static str] {
+        &["file"]
+    }
+
+    fn fetch<'a>(
+        &'a self,
+        r: &'a SourceRef,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<FetchedImposters>> + Send + 'a>> {
+        Box::pin(async move {
+            let path = PathBuf::from(r.target());
+            let no_parse = self.no_parse;
+            // The same call `--configfile` made before U-12 — including the EJS pass, the
+            // config-relative script base, and the block rules. Not a reimplementation.
+            let loaded: LoadedConfig = tokio::task::spawn_blocking(move || {
+                config_loader::load_configs_full(&ConfigSource::File { path, no_parse })
+            })
+            .await??;
+            Ok(FetchedImposters {
+                configs: loaded.imposters,
+                intercept: loaded.intercept,
+                routes: loaded.routes,
+                meta: SourceMeta {
+                    version: None,
+                    fetched_at: SystemTime::now(),
+                },
+                unchanged: false,
+            })
+        })
+    }
+}
+
+/// What [`HttpSource`] remembers per URI so a later fetch can be conditional.
+#[derive(Debug, Clone)]
+struct CachedResponse {
+    etag: String,
+    configs: Vec<ImposterConfig>,
+}
+
+/// `http:`/`https:` — fetch a document over HTTP, honouring `ETag`/`If-None-Match`.
+#[derive(Debug)]
+pub struct HttpSource {
+    client: reqwest::Client,
+    cache: Mutex<HashMap<String, CachedResponse>>,
+}
+
+impl HttpSource {
+    pub fn new() -> anyhow::Result<Self> {
+        Self::with_timeout(DEFAULT_HTTP_TIMEOUT)
+    }
+
+    pub fn with_timeout(timeout: Duration) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            // A redirect is followed only while it stays on http(s). reqwest would reject an
+            // exotic scheme on its own, but a config source is exactly the place to be explicit:
+            // a redirect chain is attacker-controlled whenever the document host is.
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                let url = attempt.url().clone();
+                if url.scheme() != "http" && url.scheme() != "https" {
+                    return attempt.error(anyhow::anyhow!(
+                        "refusing to follow a redirect to a non-http(s) URL: {url}"
+                    ));
+                }
+                if attempt.previous().len() >= 10 {
+                    return attempt.error(anyhow::anyhow!("too many redirects"));
+                }
+                attempt.follow()
+            }))
+            .build()?;
+        Ok(Self {
+            client,
+            cache: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Read the body, refusing anything past [`MAX_BODY_BYTES`].
+    ///
+    /// Enforced while streaming rather than from `Content-Length`: the header is optional under
+    /// chunked encoding and is attacker-supplied anyway, so trusting it would cap nothing.
+    async fn read_capped(response: reqwest::Response, uri: &str) -> anyhow::Result<String> {
+        use futures::StreamExt;
+
+        let mut body: Vec<u8> = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if body.len() + chunk.len() > MAX_BODY_BYTES {
+                anyhow::bail!(
+                    "imposter source {uri} exceeds the {MAX_BODY_BYTES}-byte limit; refusing to \
+                     buffer it"
+                );
+            }
+            body.extend_from_slice(&chunk);
+        }
+        String::from_utf8(body)
+            .map_err(|e| anyhow::anyhow!("imposter source {uri} is not valid UTF-8: {e}"))
+    }
+}
+
+impl ImposterSource for HttpSource {
+    fn schemes(&self) -> &'static [&'static str] {
+        &["http", "https"]
+    }
+
+    fn fetch<'a>(
+        &'a self,
+        r: &'a SourceRef,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<FetchedImposters>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut request = self.client.get(&r.uri);
+            let previous = self
+                .cache
+                .lock()
+                .map_err(|_| anyhow::anyhow!("imposter source cache poisoned"))?
+                .get(&r.uri)
+                .cloned();
+            if let Some(cached) = &previous {
+                request = request.header(reqwest::header::IF_NONE_MATCH, &cached.etag);
+            }
+
+            let response = request
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("fetching imposter source {}: {e}", r.uri))?;
+
+            // Unchanged: serve the configs parsed on the last fetch. Nothing is re-parsed, and
+            // the caller is told so it can skip re-applying an identical config.
+            if response.status() == reqwest::StatusCode::NOT_MODIFIED {
+                let Some(cached) = previous else {
+                    anyhow::bail!(
+                        "imposter source {} answered 304 Not Modified without a prior fetch to \
+                         reuse",
+                        r.uri
+                    );
+                };
+                return Ok(FetchedImposters {
+                    configs: cached.configs,
+                    // Blocks are boot-only, and a 304 can only happen on a re-fetch, which is
+                    // always past boot — so there is nothing a cached block could start.
+                    intercept: None,
+                    routes: None,
+                    meta: SourceMeta {
+                        version: Some(cached.etag),
+                        fetched_at: SystemTime::now(),
+                    },
+                    unchanged: true,
+                });
+            }
+
+            let status = response.status();
+            if !status.is_success() {
+                anyhow::bail!("imposter source {} returned HTTP {status}", r.uri);
+            }
+
+            let etag = response
+                .headers()
+                .get(reqwest::header::ETAG)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned);
+            let body = Self::read_capped(response, &r.uri).await?;
+            let loaded = config_loader::parse_remote_document(&body, &r.uri)
+                .map_err(|e| anyhow::anyhow!("imposter source {}: {e}", r.uri))?;
+
+            if let Some(etag) = &etag {
+                self.cache
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("imposter source cache poisoned"))?
+                    .insert(
+                        r.uri.clone(),
+                        CachedResponse {
+                            etag: etag.clone(),
+                            configs: loaded.imposters.clone(),
+                        },
+                    );
+            }
+
+            Ok(FetchedImposters {
+                configs: loaded.imposters,
+                intercept: loaded.intercept,
+                routes: loaded.routes,
+                meta: SourceMeta {
+                    version: etag,
+                    fetched_at: SystemTime::now(),
+                },
+                unchanged: false,
+            })
+        })
+    }
+}
+
+/// Scheme → source. Registering a scheme twice is refused at build time rather than resolved by
+/// declaration order, so an embedder that shadows a built-in finds out at startup.
+#[derive(Default)]
+pub struct SourceRegistry {
+    by_scheme: HashMap<String, Arc<dyn ImposterSource>>,
+}
+
+impl SourceRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, source: Arc<dyn ImposterSource>) -> anyhow::Result<()> {
+        for scheme in source.schemes() {
+            if self.by_scheme.contains_key(*scheme) {
+                anyhow::bail!(
+                    "two imposter sources both claim the `{scheme}:` scheme; each scheme may have \
+                     exactly one source"
+                );
+            }
+            self.by_scheme.insert((*scheme).to_string(), source.clone());
+        }
+        Ok(())
+    }
+
+    pub fn get(&self, scheme: &str) -> Option<&Arc<dyn ImposterSource>> {
+        self.by_scheme.get(scheme)
+    }
+
+    pub fn schemes(&self) -> Vec<&str> {
+        let mut schemes: Vec<&str> = self.by_scheme.keys().map(String::as_str).collect();
+        schemes.sort_unstable();
+        schemes
+    }
+}
+
+/// The resolved `--imposters` list: the refs, in the order given, and the registry that serves
+/// them. Held by the admin server so `POST /admin/reload` re-fetches the same set.
+pub struct SourceSet {
+    pub refs: Vec<SourceRef>,
+    pub registry: SourceRegistry,
+}
+
+/// What one round of fetching every source produced.
+pub struct MergedSources {
+    pub imposters: Vec<ImposterConfig>,
+    /// The `intercept` block, from whichever source declared one. Two sources declaring one is
+    /// an error, not a silent last-one-wins — there is a single listener to bring up.
+    pub intercept: Option<InterceptStartOptions>,
+    /// The `routes` block, same one-declarer rule: the front door has one route table.
+    pub routes: Option<RouteTable>,
+    /// True when *every* source reported no change, so the caller can skip applying a config it
+    /// already applied.
+    pub all_unchanged: bool,
+}
+
+impl SourceSet {
+    pub fn new(refs: Vec<SourceRef>, registry: SourceRegistry) -> Self {
+        Self { refs, registry }
+    }
+
+    /// Fetch every source and merge the results in list order.
+    ///
+    /// A port declared by two different sources is an error naming both, not a last-one-wins
+    /// silent override: the operator wrote two URIs expecting both to be served, and quietly
+    /// dropping one of them is the failure mode that is hardest to notice in a running fleet.
+    pub async fn fetch_all(&self) -> anyhow::Result<MergedSources> {
+        let mut imposters: Vec<ImposterConfig> = Vec::new();
+        // port -> the URI that claimed it.
+        let mut claimed: HashMap<u16, String> = HashMap::new();
+        let mut all_unchanged = true;
+        let mut intercept: Option<(String, InterceptStartOptions)> = None;
+        let mut routes: Option<(String, RouteTable)> = None;
+
+        for source_ref in &self.refs {
+            let scheme = source_ref.scheme();
+            let source = self.registry.get(scheme).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no imposter source is registered for the `{scheme}:` scheme (from `{}`); \
+                     known schemes: {}",
+                    source_ref.uri,
+                    self.registry.schemes().join(", ")
+                )
+            })?;
+
+            let fetched = source.fetch(source_ref).await?;
+            if !fetched.unchanged {
+                all_unchanged = false;
+            }
+
+            if let Some(block) = fetched.intercept {
+                if let Some((other, _)) = &intercept {
+                    anyhow::bail!(
+                        "imposter sources `{other}` and `{}` both declare an `intercept` block; \
+                         there is one intercept listener, so exactly one source may declare it",
+                        source_ref.uri
+                    );
+                }
+                intercept = Some((source_ref.uri.clone(), block));
+            }
+            if let Some(table) = fetched.routes {
+                if let Some((other, _)) = &routes {
+                    anyhow::bail!(
+                        "imposter sources `{other}` and `{}` both declare a `routes` block; there \
+                         is one front-door route table, so exactly one source may declare it",
+                        source_ref.uri
+                    );
+                }
+                routes = Some((source_ref.uri.clone(), table));
+            }
+
+            for config in fetched.configs {
+                // An imposter with no port is auto-assigned at creation, so it cannot collide
+                // with anything here.
+                if let Some(port) = config.port {
+                    if let Some(other) = claimed.get(&port) {
+                        anyhow::bail!(
+                            "imposter sources `{other}` and `{}` both declare port {port}; each \
+                             port may be declared by exactly one source",
+                            source_ref.uri
+                        );
+                    }
+                    claimed.insert(port, source_ref.uri.clone());
+                }
+                imposters.push(config);
+            }
+        }
+
+        Ok(MergedSources {
+            imposters,
+            intercept: intercept.map(|(_, block)| block),
+            routes: routes.map(|(_, table)| table),
+            all_unchanged,
+        })
+    }
+}
+
+/// What `POST /admin/reload` re-reads.
+///
+/// One slot, not two: a server reloads from the sources it booted from, and making
+/// "a datadir *and* a source set" representable would leave the handler picking a winner at
+/// runtime for a state the CLI cannot produce.
+#[derive(Clone)]
+pub enum ReloadSource {
+    /// A bare `--datadir`: re-read the directory synchronously, exactly as before U-12.
+    Legacy(Arc<ConfigSource>),
+    /// `--imposters`, or `--configfile` desugared into one: re-fetch every source.
+    Sources(Arc<SourceSet>),
+}
+
+/// Split a `--imposters` value into refs. Empty entries are dropped so a trailing comma is not an
+/// error.
+pub fn parse_uri_list(raw: &str) -> Vec<SourceRef> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(SourceRef::new)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_detection_covers_bare_paths_and_compound_schemes() {
+        assert_eq!(SourceRef::new("mocks.json").scheme(), "file");
+        assert_eq!(SourceRef::new("./a/b.json").scheme(), "file");
+        assert_eq!(SourceRef::new("file:mocks.json").scheme(), "file");
+        assert_eq!(SourceRef::new("https://h/i.json").scheme(), "https");
+        assert_eq!(SourceRef::new("http://h/i.json").scheme(), "http");
+        // The enterprise providers (#136) ride the same dispatch; `git+https` must not be read
+        // as `git`, or a compound scheme would collide with a plain one.
+        assert_eq!(
+            SourceRef::new("git+https://h/r#main:p").scheme(),
+            "git+https"
+        );
+        assert_eq!(SourceRef::new("s3://bucket/key").scheme(), "s3");
+    }
+
+    #[test]
+    fn target_strips_only_the_file_prefix() {
+        assert_eq!(SourceRef::new("file:mocks.json").target(), "mocks.json");
+        assert_eq!(SourceRef::new("mocks.json").target(), "mocks.json");
+        assert_eq!(
+            SourceRef::new("https://h/i.json").target(),
+            "https://h/i.json"
+        );
+    }
+
+    #[test]
+    fn uri_list_splits_and_tolerates_blanks() {
+        let refs = parse_uri_list("a.json, https://h/b.json ,");
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].uri, "a.json");
+        assert_eq!(refs[1].uri, "https://h/b.json");
+        assert!(parse_uri_list("").is_empty());
+    }
+
+    #[test]
+    fn registry_refuses_a_duplicate_scheme() {
+        let mut registry = SourceRegistry::new();
+        registry.register(Arc::new(FileSource::new(false))).unwrap();
+        let err = registry
+            .register(Arc::new(FileSource::new(false)))
+            .expect_err("a second source for `file:` must be refused");
+        assert!(
+            err.to_string().contains("file"),
+            "the error must name the contested scheme: {err}"
+        );
+    }
+
+    #[test]
+    fn registry_reports_known_schemes_for_diagnostics() {
+        let mut registry = SourceRegistry::new();
+        registry.register(Arc::new(FileSource::new(false))).unwrap();
+        registry
+            .register(Arc::new(HttpSource::new().unwrap()))
+            .unwrap();
+        assert_eq!(registry.schemes(), vec!["file", "http", "https"]);
+    }
+}

--- a/crates/rift-http-proxy/tests/imposter_sources.rs
+++ b/crates/rift-http-proxy/tests/imposter_sources.rs
@@ -1,0 +1,648 @@
+//! U-12 imposter sources: the `ImposterSource` SPI, the `file:`/`https:` built-ins, `--imposters`,
+//! and re-fetch on `POST /admin/reload`.
+//!
+//! Every test here asserts an exact observable — a counter, a surviving request count, an error
+//! naming both offenders — rather than "it didn't blow up". The `https:` tests run against a
+//! purpose-built counting server so that "fetched once", "a 304 re-applies nothing" and the
+//! hygiene limits are *measured*, not narrated.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use rift_http_proxy::sources::{
+    FileSource, HttpSource, ImposterSource, SourceRef, SourceRegistry, SourceSet,
+};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+// ===== A tiny counting HTTP/1.1 origin =====
+
+/// What the test origin should answer with.
+#[derive(Clone)]
+enum Reply {
+    /// 200 with this body and `ETag`; answers 304 when the request carries a matching
+    /// `If-None-Match`.
+    Etagged { body: String, etag: String },
+    /// 302 to an arbitrary `Location` — used to prove the redirect scheme check.
+    Redirect { location: String },
+    /// A body of `size` bytes, to prove the size cap.
+    Oversized { size: usize },
+    /// Sleep before answering, to prove the timeout.
+    Slow { delay: Duration },
+}
+
+struct Origin {
+    port: u16,
+    hits: Arc<AtomicUsize>,
+    /// Requests that arrived carrying `If-None-Match`.
+    conditional_hits: Arc<AtomicUsize>,
+    body: Arc<std::sync::Mutex<Reply>>,
+}
+
+impl Origin {
+    fn start(reply: Reply) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("origin binds");
+        let port = listener.local_addr().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let conditional_hits = Arc::new(AtomicUsize::new(0));
+        let body = Arc::new(std::sync::Mutex::new(reply));
+
+        let (h, ch, b) = (hits.clone(), conditional_hits.clone(), body.clone());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { continue };
+                let (h, ch, b) = (h.clone(), ch.clone(), b.clone());
+                std::thread::spawn(move || {
+                    let _ = serve_one(stream, &h, &ch, &b);
+                });
+            }
+        });
+        Self {
+            port,
+            hits,
+            conditional_hits,
+            body,
+        }
+    }
+
+    fn uri(&self) -> String {
+        format!("http://127.0.0.1:{}/imposters.json", self.port)
+    }
+
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+
+    fn conditional_hits(&self) -> usize {
+        self.conditional_hits.load(Ordering::SeqCst)
+    }
+
+    fn set(&self, reply: Reply) {
+        *self.body.lock().unwrap() = reply;
+    }
+}
+
+fn serve_one(
+    mut stream: TcpStream,
+    hits: &AtomicUsize,
+    conditional_hits: &AtomicUsize,
+    reply: &std::sync::Mutex<Reply>,
+) -> std::io::Result<()> {
+    let mut buf = [0u8; 8192];
+    let n = stream.read(&mut buf)?;
+    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+    hits.fetch_add(1, Ordering::SeqCst);
+
+    let if_none_match = request
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("if-none-match:"))
+        .map(|l| l.split_once(':').unwrap().1.trim().to_string());
+    if if_none_match.is_some() {
+        conditional_hits.fetch_add(1, Ordering::SeqCst);
+    }
+
+    let reply = reply.lock().unwrap().clone();
+    match reply {
+        Reply::Etagged { body, etag } => {
+            if if_none_match.as_deref() == Some(etag.as_str()) {
+                write!(
+                    stream,
+                    "HTTP/1.1 304 Not Modified\r\nETag: {etag}\r\nContent-Length: 0\r\n\r\n"
+                )?;
+            } else {
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nETag: {etag}\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\n\r\n{body}",
+                    body.len()
+                )?;
+            }
+        }
+        Reply::Redirect { location } => {
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\n\r\n"
+            )?;
+        }
+        Reply::Oversized { size } => {
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {size}\r\n\r\n"
+            )?;
+            // Written in chunks so the reader can bail part-way; a broken pipe here is the
+            // expected outcome, not a failure.
+            let chunk = vec![b'x'; 64 * 1024];
+            let mut written = 0;
+            while written < size {
+                let take = chunk.len().min(size - written);
+                if stream.write_all(&chunk[..take]).is_err() {
+                    break;
+                }
+                written += take;
+            }
+        }
+        Reply::Slow { delay } => {
+            std::thread::sleep(delay);
+            write!(stream, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n[]")?;
+        }
+    }
+    stream.flush()
+}
+
+// ===== Helpers =====
+
+fn imposter_doc(port: u16, body: &str) -> String {
+    format!(
+        r#"{{"imposters":[{{"port":{port},"protocol":"http","recordRequests":true,
+            "stubs":[{{"responses":[{{"is":{{"statusCode":200,"body":"{body}"}}}}]}}]}}]}}"#
+    )
+}
+
+fn set_of(refs: &[&str], no_parse: bool) -> SourceSet {
+    let mut registry = SourceRegistry::new();
+    registry
+        .register(Arc::new(FileSource::new(no_parse)))
+        .unwrap();
+    registry
+        .register(Arc::new(HttpSource::new().unwrap()))
+        .unwrap();
+    SourceSet::new(refs.iter().map(|u| SourceRef::new(*u)).collect(), registry)
+}
+
+fn cli(args: &[&str]) -> Cli {
+    let mut argv = vec!["rift"];
+    argv.extend_from_slice(args);
+    Cli::try_parse_from(argv).expect("cli parse")
+}
+
+// ===== AC3: a port claimed by two sources names both =====
+
+#[tokio::test]
+async fn merge_collision_names_both_sources() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.json");
+    let b = dir.path().join("b.json");
+    std::fs::write(&a, imposter_doc(21401, "from-a")).unwrap();
+    std::fs::write(&b, imposter_doc(21401, "from-b")).unwrap();
+
+    let set = set_of(
+        &[
+            &format!("file:{}", a.display()),
+            &format!("file:{}", b.display()),
+        ],
+        false,
+    );
+    let err = set
+        .fetch_all()
+        .await
+        .map(|_| ())
+        .expect_err("two sources claiming one port must be refused, not silently merged");
+    let msg = err.to_string();
+
+    // Both sources named, and the contested port — an operator must be able to fix this from the
+    // message alone. Naming only one (the "loser") is the failure mode this asserts against.
+    assert!(
+        msg.contains(&a.display().to_string()),
+        "the error must name the first source: {msg}"
+    );
+    assert!(
+        msg.contains(&b.display().to_string()),
+        "the error must name the second source: {msg}"
+    );
+    assert!(msg.contains("21401"), "the error must name the port: {msg}");
+}
+
+#[tokio::test]
+async fn distinct_ports_across_sources_merge() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.json");
+    let b = dir.path().join("b.json");
+    std::fs::write(&a, imposter_doc(21402, "from-a")).unwrap();
+    std::fs::write(&b, imposter_doc(21403, "from-b")).unwrap();
+
+    let merged = set_of(
+        &[
+            &format!("file:{}", a.display()),
+            &format!("file:{}", b.display()),
+        ],
+        false,
+    )
+    .fetch_all()
+    .await
+    .expect("distinct ports merge");
+    let mut ports: Vec<u16> = merged.imposters.iter().filter_map(|c| c.port).collect();
+    ports.sort_unstable();
+    assert_eq!(ports, vec![21402, 21403]);
+}
+
+// ===== AC2: an ETag 304 re-parses nothing and re-applies nothing =====
+
+#[tokio::test]
+async fn http_source_304_serves_cache_without_reparsing() {
+    let origin = Origin::start(Reply::Etagged {
+        body: imposter_doc(21404, "v1"),
+        etag: "\"v1\"".to_string(),
+    });
+    let source = HttpSource::new().unwrap();
+    let r = SourceRef::new(origin.uri());
+
+    let first = source.fetch(&r).await.expect("first fetch succeeds");
+    assert!(!first.unchanged, "a first fetch is always a change");
+    assert_eq!(first.configs.len(), 1);
+    assert_eq!(first.meta.version.as_deref(), Some("\"v1\""));
+    assert_eq!(origin.hits(), 1);
+    assert_eq!(
+        origin.conditional_hits(),
+        0,
+        "nothing to be conditional about yet"
+    );
+
+    // Swap the body for something that would FAIL to parse. A 304 must never reach the parser,
+    // so this is the strongest available proof that the second fetch did not re-parse: if it
+    // did, the test fails with a parse error instead of passing.
+    origin.set(Reply::Etagged {
+        body: "{ this is not valid json".to_string(),
+        etag: "\"v1\"".to_string(),
+    });
+
+    let second = source.fetch(&r).await.expect("a 304 is not an error");
+    assert!(second.unchanged, "a 304 must report unchanged");
+    assert_eq!(
+        second.configs.len(),
+        1,
+        "the cached configs are served verbatim"
+    );
+    assert_eq!(second.configs[0].port, Some(21404));
+    assert_eq!(origin.hits(), 2);
+    assert_eq!(
+        origin.conditional_hits(),
+        1,
+        "the second request must carry If-None-Match, or the ETag is doing nothing"
+    );
+}
+
+#[tokio::test]
+async fn changed_etag_refetches_and_reports_a_change() {
+    let origin = Origin::start(Reply::Etagged {
+        body: imposter_doc(21405, "v1"),
+        etag: "\"v1\"".to_string(),
+    });
+    let source = HttpSource::new().unwrap();
+    let r = SourceRef::new(origin.uri());
+
+    source.fetch(&r).await.expect("first fetch");
+    origin.set(Reply::Etagged {
+        body: imposter_doc(21406, "v2"),
+        etag: "\"v2\"".to_string(),
+    });
+
+    let second = source.fetch(&r).await.expect("second fetch");
+    assert!(!second.unchanged, "a new ETag is a change");
+    assert_eq!(second.configs[0].port, Some(21406));
+    assert_eq!(second.meta.version.as_deref(), Some("\"v2\""));
+}
+
+// ===== AC5: https hygiene — cap, timeout, redirect scheme =====
+
+#[tokio::test]
+async fn http_source_refuses_an_oversized_body() {
+    let origin = Origin::start(Reply::Oversized {
+        size: rift_http_proxy::sources::MAX_BODY_BYTES + 4096,
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a body past the cap must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("limit") || msg.contains("exceeds"),
+        "the error must say the cap was hit: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn http_source_enforces_its_timeout() {
+    let origin = Origin::start(Reply::Slow {
+        delay: Duration::from_secs(3),
+    });
+    let source = HttpSource::with_timeout(Duration::from_millis(150)).unwrap();
+    let started = std::time::Instant::now();
+    let err = source
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a stalled origin must not hang the fetch");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "the timeout must fire well before the origin answers; took {:?}",
+        started.elapsed()
+    );
+    let _ = err;
+}
+
+/// Behaviour pin, not a proof of our own line: mutation testing showed reqwest refuses a
+/// `file://` redirect on its own, so disabling our scheme check leaves this test green. It stays
+/// because the *behaviour* is what the security claim rests on, and a future change of HTTP
+/// client would silently drop it. The redirect guarantee that is genuinely ours is the chain cap
+/// below — a custom `redirect::Policy` replaces reqwest's default limit rather than adding to it.
+#[tokio::test]
+async fn http_source_refuses_a_redirect_to_a_non_http_scheme() {
+    let origin = Origin::start(Reply::Redirect {
+        location: "file:///etc/passwd".to_string(),
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a redirect off http(s) must be refused, never followed");
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("root:"),
+        "the target must never be read: {msg}"
+    );
+}
+
+/// A custom redirect policy REPLACES reqwest's default 10-hop limit, so without an explicit cap
+/// a self-referential redirect loops until the request timeout — burning the origin, and the
+/// fetch, for the whole budget. Asserted on the origin's own hit count, which is exact.
+#[tokio::test]
+async fn http_source_caps_the_redirect_chain() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("origin binds");
+    let port = listener.local_addr().unwrap().port();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let h = hits.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            h.fetch_add(1, Ordering::SeqCst);
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            // Always redirect back to ourselves: a loop that only a hop cap can stop.
+            let _ = write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/loop\r\n\
+                 Content-Length: 0\r\n\r\n"
+            );
+            let _ = stream.flush();
+        }
+    });
+
+    let source = HttpSource::with_timeout(Duration::from_secs(5)).unwrap();
+    let err = source
+        .fetch(&SourceRef::new(format!("http://127.0.0.1:{port}/loop")))
+        .await
+        .map(|_| ())
+        .expect_err("a redirect loop must terminate as an error");
+    let _ = err;
+
+    let seen = hits.load(Ordering::SeqCst);
+    assert!(
+        seen <= 12,
+        "the chain must be capped at ~10 hops; the origin saw {seen} requests"
+    );
+}
+
+// ===== D3: a remote document may not read local files =====
+
+#[tokio::test]
+async fn remote_document_refuses_ejs_include() {
+    let origin = Origin::start(Reply::Etagged {
+        body: r#"{"imposters":[<% include '/etc/passwd' %>]}"#.to_string(),
+        etag: "\"inc\"".to_string(),
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a remote document must not include a local file");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("include"),
+        "the error must name the refused tag: {msg}"
+    );
+    assert!(!msg.contains("root:"), "the file must never be read: {msg}");
+}
+
+#[tokio::test]
+async fn remote_document_refuses_ejs_stringify() {
+    let origin = Origin::start(Reply::Etagged {
+        body: r#"{"imposters":[{"port":21407,"protocol":"http","stubs":[{"responses":[{"inject":"<%- stringify('/etc/passwd') %>"}]}]}]}"#.to_string(),
+        etag: "\"str\"".to_string(),
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a remote document must not stringify a local file");
+    assert!(
+        err.to_string().contains("stringify"),
+        "the error must name the refused tag: {err}"
+    );
+}
+
+#[tokio::test]
+async fn remote_document_refuses_a_file_script_reference() {
+    let origin = Origin::start(Reply::Etagged {
+        body: r#"{"imposters":[{"port":21408,"protocol":"http","stubs":[{"responses":[
+            {"_rift":{"script":{"file":"/etc/passwd"}}}]}]}]}"#
+            .to_string(),
+        etag: "\"ref\"".to_string(),
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a remote document must not resolve a local `file:` script");
+    assert!(
+        !err.to_string().contains("root:"),
+        "the file must never be read: {err}"
+    );
+}
+
+/// The chosen half of the split: env substitution still runs for a remote document, because it is
+/// deployment configuration the operator supplied to their own process.
+#[tokio::test]
+async fn remote_document_still_substitutes_env() {
+    unsafe { std::env::set_var("RIFT_TEST_U12_BODY", "from-env") };
+    let origin = Origin::start(Reply::Etagged {
+        body: imposter_doc(21409, "<%= process.env.RIFT_TEST_U12_BODY %>"),
+        etag: "\"env\"".to_string(),
+    });
+    let fetched = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect("env substitution is honoured for remote documents");
+    let json = serde_json::to_string(&fetched.configs[0]).unwrap();
+    assert!(
+        json.contains("from-env"),
+        "the env var must have been substituted: {json}"
+    );
+    unsafe { std::env::remove_var("RIFT_TEST_U12_BODY") };
+}
+
+// ===== AC1: reload across two sources is incremental =====
+
+/// The #316 composition claim, tested rather than asserted: changing one source must not reset
+/// the imposters that came from the *other* source. Runtime state (recorded requests) is the
+/// probe, because it is exactly what a delete-and-recreate would destroy.
+#[tokio::test]
+async fn source_reload_is_incremental_across_sources() {
+    let dir = tempfile::tempdir().unwrap();
+    let changing = dir.path().join("changing.json");
+    let stable = dir.path().join("stable.json");
+    std::fs::write(&changing, imposter_doc(21410, "v1")).unwrap();
+    std::fs::write(&stable, imposter_doc(21411, "stable")).unwrap();
+
+    let server = ServerBuilder::from_cli(cli(&[
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--imposters",
+        &format!("file:{},file:{}", changing.display(), stable.display()),
+    ]))
+    .start()
+    .await
+    .expect("server starts from two file sources");
+    let admin = server.admin_addr();
+    let client = reqwest::Client::new();
+
+    // Both sources loaded.
+    for port in [21410u16, 21411] {
+        let body = client
+            .get(format!("http://127.0.0.1:{port}/"))
+            .send()
+            .await
+            .expect("imposter is serving")
+            .text()
+            .await
+            .unwrap();
+        assert!(!body.is_empty(), "imposter {port} answered");
+    }
+
+    // Give the stable imposter runtime state to lose.
+    let recorded_before = requests_for(&client, admin.port(), 21411).await;
+    assert_eq!(
+        recorded_before, 1,
+        "the probe request must have been recorded, or this test proves nothing"
+    );
+
+    // Change ONLY the first source.
+    std::fs::write(&changing, imposter_doc(21410, "v2")).unwrap();
+    let reload = client
+        .post(format!("http://127.0.0.1:{}/admin/reload", admin.port()))
+        .send()
+        .await
+        .expect("reload responds");
+    assert!(
+        reload.status().is_success(),
+        "reload failed: {}",
+        reload.text().await.unwrap_or_default()
+    );
+
+    // The changed source took effect...
+    let changed = client
+        .get("http://127.0.0.1:21410/")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(changed, "v2", "the changed source must have been applied");
+
+    // ...and the untouched source's imposter kept its runtime state. A delete-and-recreate
+    // reload — the mutant this test exists to catch — resets this to 0.
+    let recorded_after = requests_for(&client, admin.port(), 21411).await;
+    assert_eq!(
+        recorded_after, recorded_before,
+        "the sibling source's imposter must not have been recreated"
+    );
+
+    server.shutdown().await;
+}
+
+async fn requests_for(client: &reqwest::Client, admin_port: u16, imposter: u16) -> usize {
+    let body: serde_json::Value = client
+        .get(format!(
+            "http://127.0.0.1:{admin_port}/imposters/{imposter}"
+        ))
+        .send()
+        .await
+        .expect("admin responds")
+        .json()
+        .await
+        .expect("imposter body is json");
+    body.get("requests")
+        .and_then(|r| r.as_array())
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
+// ===== `--configfile` is sugar, not a second code path =====
+
+#[tokio::test]
+async fn configfile_and_imposters_are_mutually_exclusive() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("c.json");
+    std::fs::write(&f, imposter_doc(21412, "x")).unwrap();
+
+    let err = ServerBuilder::from_cli(cli(&[
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--configfile",
+        f.to_str().unwrap(),
+        "--imposters",
+        &format!("file:{}", f.display()),
+    ]))
+    .start()
+    .await
+    .map(|_| ())
+    .expect_err("passing both spellings of one thing must be refused");
+    assert!(
+        err.to_string().contains("--imposters") && err.to_string().contains("--configfile"),
+        "the error must name both flags: {err}"
+    );
+}
+
+/// An embedder's source is reachable through the same dispatch as the built-ins, and a scheme it
+/// shares with a built-in is a startup error rather than a silent shadow.
+#[test]
+fn registry_refuses_an_embedder_shadowing_a_builtin() {
+    struct Shadow;
+    impl ImposterSource for Shadow {
+        fn schemes(&self) -> &'static [&'static str] {
+            &["https"]
+        }
+        fn fetch<'a>(
+            &'a self,
+            _r: &'a SourceRef,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = anyhow::Result<rift_http_proxy::sources::FetchedImposters>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async { anyhow::bail!("unreachable") })
+        }
+    }
+
+    let mut registry = SourceRegistry::new();
+    registry
+        .register(Arc::new(HttpSource::new().unwrap()))
+        .unwrap();
+    let err = registry
+        .register(Arc::new(Shadow))
+        .expect_err("shadowing a built-in scheme must be refused");
+    assert!(
+        err.to_string().contains("https"),
+        "the error must name the contested scheme: {err}"
+    );
+}

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -24,6 +24,98 @@ rift-http-proxy --configfile imposters.json
 rift-http-proxy --port 3525
 ```
 
+
+---
+
+## Imposter Sources
+
+`--imposters` loads imposters from one or more URIs instead of a single local path. Sources are
+merged in the order given, and `POST /admin/reload` re-fetches all of them.
+
+```bash
+# A local file (these three are identical)
+rift-http-proxy --configfile mocks.json
+rift-http-proxy --imposters file:mocks.json
+rift-http-proxy --imposters mocks.json
+
+# A document served over HTTP
+rift-http-proxy --imposters https://config.example.com/imposters.json
+
+# Several sources merged into one running set
+rift-http-proxy --imposters file:base.json,https://config.example.com/team-overrides.json
+```
+
+`--configfile <p>` is sugar for `--imposters file:<p>` and behaves identically; passing both is an
+error. `RIFT_IMPOSTERS` is the environment-variable spelling.
+
+### Built-in schemes
+
+| Scheme | Form | Version token |
+|---|---|---|
+| `file:` | `file:<path>`, or a bare path | none — always re-read |
+| `http:` / `https:` | a full URL | the response `ETag` |
+
+### Merging
+
+Every source contributes its imposters to one set. A port declared by **two** sources is a
+startup error naming both — the alternative, letting the last source win, silently drops an
+imposter the operator asked for. The optional `intercept` and `routes` blocks follow the same
+rule: at most one source may declare each.
+
+### Reload and `ETag`
+
+`POST /admin/reload` re-fetches every source. An `https:` source sends `If-None-Match` with the
+`ETag` it last saw; a `304 Not Modified` is served from cache without re-parsing, and when *every*
+source reports no change the reload returns without touching the running imposters at all:
+
+```json
+{"message": "No source changed; imposters left as they are",
+ "created": 0, "replaced": 0, "stubPatched": 0, "deleted": 0}
+```
+
+When something did change, the existing incremental apply runs: unchanged imposters keep their
+recorded requests, scenario state and response cyclers; only changed ports are patched or replaced.
+
+### What a remote document may not do
+
+A document fetched over the network is not written by someone who already has access to the
+machine running Rift, so two things a local `--configfile` may do are refused for `https:`
+sources:
+
+- **`<% include 'path' %>` and `<%- stringify('path') %>`** — both read a local file. Refused with
+  an error naming the tag.
+- **`_rift.script` `file:` references** — refused, as they are for admin-API-created imposters
+  without `--scripts-dir`.
+
+`<%= process.env.VAR %>` **is** substituted for remote documents: environment is deployment
+configuration the operator supplied to their own process. Note the consequence — a remote source
+you do not control can read your process environment into an imposter response body. Point
+`--imposters` only at hosts you trust as much as the config file they replace.
+
+### Limits
+
+| Limit | Value |
+|---|---|
+| Response body | 10 MB (enforced while reading, not from `Content-Length`) |
+| Request timeout | 30 s |
+| Redirects | followed only while the target stays `http`/`https`; at most 10 hops |
+
+### Adding a scheme
+
+Embedders register their own schemes on the builder:
+
+```rust
+ServerBuilder::from_cli(cli)
+    .imposter_source(Arc::new(MyGitSource::new()))
+    .run()
+    .await
+```
+
+A source declares the schemes it claims via `ImposterSource::schemes`. Claiming a scheme that is
+already registered — including a built-in — is a startup error rather than a silent override.
+Providers return bytes; parsing goes through the same loader the built-ins use, so no scheme can
+grow its own dialect of the config format.
+
 ---
 
 ## CLI Options
@@ -34,7 +126,8 @@ rift-http-proxy [OPTIONS]
 Options:
       --port <PORT>                Admin API port [default: 2525]
       --host <HOST>                Bind hostname [default: 0.0.0.0]
-      --configfile <FILE>          Load imposters from a JSON/YAML file on startup
+      --configfile <FILE>          Load imposters from a JSON/YAML file on startup (sugar for --imposters file:<FILE>)
+      --imposters <URI[,URI...]>   Load imposters from one or more source URIs: file:<path>, a bare path, or https://… (see Imposter Sources below)
       --datadir <DIR>              Directory for persistent imposter storage
       --scripts-dir <DIR>          Root directory for admin-API `file:`/`ref:` script resolution; references that escape it are rejected (unset ⇒ file-backed scripts via the admin API are refused)
       --allow-injection            Enable JavaScript injection in responses (alias: --allowInjection)
@@ -61,7 +154,7 @@ Options:
       --intercept-ca-key <FILE>    PEM CA private key for interception (required with --intercept-ca-cert)
       --intercept-ca-cert-pem <PEM>  Inline PEM CA certificate for interception (with --intercept-ca-key-pem); mutually exclusive with file paths
       --intercept-ca-key-pem <PEM>   Inline PEM CA private key for interception (required with --intercept-ca-cert-pem)
-      --no-parse                   Disable EJS preprocessing of --configfile (alias: --noParse)
+      --no-parse                   Disable EJS preprocessing of --configfile/file: sources (alias: --noParse)
       --formatter <NAME>           Custom config formatter module (no-op; Rift auto-detects JSON/YAML)
       --protofile <FILE>           Custom protocol definitions file (no-op; custom protocols unsupported)
   -h, --help                       Print help


### PR DESCRIPTION
U-12: load imposters from a URI instead of only from a local path.

```bash
rift --imposters https://config.example.com/imposters.json
rift --imposters file:base.json,https://config.example.com/team-overrides.json
rift --configfile mocks.json          # unchanged; now sugar for --imposters file:mocks.json
```

## The two properties worth reviewing for

**Parsing is shared.** A provider hands back *bytes*; format sniffing, the Mountebank document
shapes and the `intercept`/`routes` block rules all run in `config_loader::parse_document`, which
is the same code `--configfile` has always run. `file:` and `https:` cannot drift into two
dialects. `FileSource::fetch` delegates to the very same `load_configs_full` call the flag made
before, so `--configfile` is identical rather than merely similar — and passing both spellings is
an error.

**Merging is explicit.** A port declared by two sources is a startup error naming both and the
port. Last-one-wins would silently drop an imposter the operator asked for, which is the failure
mode hardest to notice in a running fleet. `intercept` and `routes` follow the same one-declarer
rule — there is one listener and one route table.

## ETag

An `https:` source sends `If-None-Match`. A 304 is served from its cache **without re-parsing**,
and when *every* source reports no change the reload returns without touching the running
imposters:

```json
{"message": "No source changed; imposters left as they are", "created": 0, ...}
```

That is what makes a future polling caller cheap rather than a source of constant churn.

## Fetch hygiene

| Limit | How |
|---|---|
| 10 MB body | enforced **while streaming** — a `Content-Length` the source itself supplies caps nothing |
| 30 s | whole-request budget |
| redirects | http(s) only, ≤10 hops |

The hop cap is not decoration: a custom `redirect::Policy` **replaces** reqwest's default limit
rather than adding to it, so without an explicit cap a self-referential redirect loops until the
timeout. Measured: 40,245 origin requests without it, 11 with it.

## What a remote document may not do

The issue lists EJS among the behaviours `file:` and `https:` should share. It is split here
instead, deliberately:

- `<% include 'p' %>` and `<%- stringify('p') %>` **read a local file** → refused for remote
  documents, with an error naming the tag.
- `_rift.script` `file:` references → refused (`ScriptBaseDir::Unconfigured`, the existing
  admin-API-without-`--scripts-dir` rule).
- `<%= process.env.X %>` → **still substituted**. Environment is deployment configuration the
  operator supplied to their own process.

The consequence of that last one is stated plainly in the docs rather than left implicit: a remote
source you do not control can read your process environment into an imposter response body. Point
`--imposters` only at hosts you trust as much as the config file they replace.

## Shape

`ConfigSource` and `load_configs{,_full}` keep their exact signatures — `rift-ffi` and `script_cli`
are on them. The admin server's reload slot becomes a `ReloadSource` enum (`Legacy(ConfigSource)` |
`Sources(SourceSet)`) instead of gaining a parallel field, so "a datadir *and* a source set" is
unrepresentable rather than resolved by a runtime tiebreak.

`load_imposters_from_file` is deleted — `--configfile` no longer routes through it. Its two gate
tests (all-or-nothing injection refusal; the shipped latency example) are repointed at
`load_imposters_from_sources` so the guarantee stays tested on the path that now runs.

## Verification

15 new tests in `tests/imposter_sources.rs`, against a purpose-built counting origin so the claims
are measured rather than narrated. Load-bearing ones are mutation-proven:

| Mutant | Test | Result |
|---|---|---|
| 304 reports "changed" | `http_source_304_serves_cache_without_reparsing` | RED |
| cross-source collision ignored | `merge_collision_names_both_sources` | RED |
| remote EJS gate removed | `remote_document_refuses_ejs_include` | RED |
| reload doesn't re-fetch | `source_reload_is_incremental_across_sources` | RED |
| redirect hop cap removed | `http_source_caps_the_redirect_chain` | RED (40,245 hits) |
| redirect scheme check removed | `http_source_refuses_a_redirect_to_a_non_http_scheme` | **SURVIVED** |

The last row is reported rather than hidden: reqwest refuses a `file://` redirect on its own, so
that check is belt-and-braces and the test is a behaviour pin, not a proof of our line. The test
carries a comment saying so.

The 304 test earns its name a second way — it swaps the origin's body for **unparseable** JSON
before the conditional request, so a re-parse fails the test instead of passing it.

`cargo clippy --workspace --all-targets -D warnings` clean; full workspace unit + integration
suites green; `scripts/verify-docs-coverage.sh` passes with `--imposters` documented.

## Downstream

`--imposters` is additive and no existing surface changed shape, so no SDK is broken. Follow-ups
for the SDK repos are filed separately as *adoption*, not compat.
