### PR TITLE
chore(deps): remove rift-mock-core's unused futures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,6 @@ dependencies = [
  "criterion",
  "crossbeam",
  "foldhash 0.2.0",
- "futures",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -23,7 +23,6 @@ foldhash = "0.2"
 tokio = { workspace = true, features = ["full"] }
 # TaskTracker for bounded connection-drain on imposter teardown (issue #596)
 tokio-util = { workspace = true, features = ["rt"] }
-futures.workspace = true
 
 # HTTP
 hyper = { version = "1.5", features = ["full"] }


### PR DESCRIPTION
`crates/rift-mock-core/Cargo.toml` declared `futures.workspace = true` with zero references to `futures::` anywhere in the crate. The declaration predates any use in the crate's history. This removes the line and regenerates `Cargo.lock`.

The workspace-root pin and `rift-http-proxy`'s own declaration stay — PR #852 reintroduced a real `futures::StreamExt` use there, so those two remain load-bearing.

Verified: `cargo check --workspace --all-targets --all-features` (exit 0), clippy `-D warnings` clean, full workspace test suite green (2241 passed, 0 failed).

Closes #851

Milestone: none (standalone fix)
