### PR TITLE
refactor(flow-state): extract the Redis flow store into an opt-in rift-store-redis crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
   # job runs the whole integration surface with `--tests`. `--workspace` covers only the six
   # `crates/*` members, so the docker-bound `rift-compatibility-tests` crate and the benchmark are
   # excluded automatically (they keep their own dedicated jobs); mountebank_compatibility spawns its
-  # own server, so it runs on the Docker-enabled runner without extra setup. redis_backend still
-  # *compiles* here but its container-backed tests are `#[ignore]`d pending #853 (they no longer
-  # start a Redis container) — that compile is what keeps the suite from bit-rotting while it is
-  # disabled. Runs on stable only (the unit surface already covers beta) to keep the heavier
-  # integration run off the critical path.
+  # own server, so it runs on the Docker-enabled runner without extra setup. The Redis suite moved to
+  # `rift-store-redis` with the store itself (#853) and is no longer `#[ignore]`d, so it both
+  # compiles and *runs* here as well as in the dedicated `redis-integration` job below. Runs on
+  # stable only (the unit surface already covers beta) to keep the heavier integration run off the
+  # critical path.
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -434,17 +434,14 @@ jobs:
       - name: Build
         run: cargo build --workspace --all-features --release
 
-  # DISABLED pending issue #853 (extract the Redis flow store into `rift-store-redis`). That change
-  # relocates this suite, so the tests in `tests/redis_backend.rs` are `#[ignore]`d and this job is
-  # gated off rather than left to run zero tests and report a green "Redis Integration Tests" —
-  # a passing job with no coverage behind it is worse than a visibly skipped one. The job body is
-  # kept intact (not deleted) so re-enabling is a one-line revert of the `if:` below, together with
-  # dropping the `#[ignore]`s. `Integration Tests` still *compiles* the suite, so API drift is
-  # caught in the meantime. Re-enable as part of #853.
+  # The container-backed Redis suite. It lives in `rift-store-redis` since #853 extracted the store
+  # there; before that it sat in rift-http-proxy and this job was gated off with `if: false` while
+  # the move was pending. Both the gate and the suite's `#[ignore]`s are gone, so this job runs the
+  # real containers again. `--all-features` is kept for symmetry with the rest of CI even though
+  # `rift-store-redis` has no features of its own — redis is unconditional there.
   redis-integration:
     name: Redis Integration Tests
     runs-on: ubuntu-latest
-    if: false # re-enable with #853
     steps:
       - uses: actions/checkout@v7
 
@@ -470,7 +467,22 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Redis integration tests
-        run: cargo test --package rift-http-proxy --test redis_backend --all-features
+        run: |
+          set -euo pipefail
+          cargo test --package rift-store-redis --test redis_backend --all-features 2>&1 \
+            | tee /tmp/redis-tests.log
+          # libtest reports success for a suite whose tests are all `#[ignore]`d, and for a filter
+          # that matches nothing — the exact shape that let this job sit green with zero coverage
+          # while #853 was pending. Assert the tests actually ran, so re-parking the suite (or a
+          # filter typo) fails loudly instead of quietly certifying nothing. The suite is 16
+          # container-backed tests plus 7 Docker-free `probe_gate` ones; the floor leaves a little
+          # slack without becoming a second copy of the test list.
+          passed=$(awk '/^test result:/ { for (i = 1; i <= NF; i++) if ($i == "passed;") s += $(i-1) } END { print s+0 }' /tmp/redis-tests.log)
+          echo "redis suite tests passed: $passed"
+          if [ "$passed" -lt 20 ]; then
+            echo "::error::the Redis suite ran only $passed tests (expected >= 20) — is it \`#[ignore]\`d again?"
+            exit 1
+          fi
 
   compatibility-test:
     name: Compatibility Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ record.
   been the supported spelling and is unchanged. A key containing spaces is still a valid key and is
   compared byte for byte, untrimmed.
 
+### Changed
+
+- **The Redis flow store moved to its own opt-in crate, `rift-store-redis`** (issue #853).
+  `rift-mock-core` now carries **no `redis`/`r2d2` dependency under any feature combination**, so
+  anyone embedding the engine — including `rift-ffi` and downstream SDKs — stops pulling a Redis
+  client and connection pool they may never use. The store reattaches through a new
+  `FlowStoreBackendFactory` seam, which adds a `_rift.flowState.backend` name and, unlike
+  `FlowStoreProvider`, has an error channel so a misconfigured backend fails imposter creation
+  instead of silently declining.
+
+  **This is behaviour-neutral for users.** The `rift` binary, the Docker images and the FFI
+  `cdylib`s all keep `redis-backend` on by default, so `_rift.flowState.backend: "redis"` works
+  exactly as before, with the same config schema and wire format. What changed is the dependency
+  graph and the error text: an unregistered backend now names the ones this build *can* serve
+  (`flowState.backend is "redis" but no such backend is registered (available: "inmemory")`), and
+  the redis case adds a `--features redis-backend` rebuild hint. `rift-mock-core` lost its
+  `redis-backend` feature entirely; the feature name survives on `rift-http-proxy` and `rift-ffi`,
+  where it now means "register the Redis backend".
+
+  Embedders assembling an `ImposterManager` by hand and wanting Redis should register it with
+  `.with_flow_store_backends(rift_http_proxy::default_flow_store_backends())` — see
+  [Embedding → SPI](docs/embedding/spi.md).
+
 ### Fixed
 
 - **Reverse-proxy `*.` host routes matched hosts they should not have.** A wildcard route's host

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,6 +3380,7 @@ dependencies = [
  "rift-http-proxy",
  "rift-lint",
  "rift-mock-core",
+ "rift-store-redis",
  "rift-types",
  "rustls",
  "rustls-pemfile",
@@ -3394,8 +3395,6 @@ dependencies = [
  "sxd-document",
  "sxd-xpath",
  "tempfile",
- "testcontainers",
- "testcontainers-modules",
  "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
@@ -3452,10 +3451,8 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "quamina",
- "r2d2",
  "rand 0.8.5",
  "rcgen",
- "redis",
  "regex",
  "regex-automata",
  "reqwest",
@@ -3485,6 +3482,21 @@ dependencies = [
  "urlencoding",
  "uuid",
  "yasna",
+]
+
+[[package]]
+name = "rift-store-redis"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "r2d2",
+ "redis",
+ "rift-mock-core",
+ "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/rift-types",
     "crates/rift-mock-core",
+    "crates/rift-store-redis",
     "crates/rift-ffi",
     "crates/rift-http-proxy",
     "crates/rift-lint",

--- a/crates/rift-ffi/Cargo.toml
+++ b/crates/rift-ffi/Cargo.toml
@@ -53,7 +53,10 @@ tracing-test = "0.2"
 default = ["redis-backend", "javascript", "quamina-matching"]
 # Engine features are forwarded to BOTH rift-mock-core and rift-http-proxy so the two share one
 # feature set (mimalloc is deliberately never forwarded — see the dependency note above).
-redis-backend = ["rift-mock-core/redis-backend", "rift-http-proxy/redis-backend"]
+# Only rift-http-proxy forwards this now: since #853 the Redis store is the separate
+# `rift-store-redis` crate, which rift-http-proxy owns registering — rift-mock-core has no
+# redis feature to forward any more.
+redis-backend = ["rift-http-proxy/redis-backend"]
 javascript = ["rift-mock-core/javascript", "rift-http-proxy/javascript"]
 # The quamina body-field candidate dimension (#767) — forwarded for the same reason as the two
 # above: without it the cdylib silently ships without the dimension (#777). Unlike mimalloc this

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -265,7 +265,13 @@ pub extern "C" fn rift_start() -> *mut RiftHandle {
         match Runtime::new() {
             Ok(runtime) => Box::into_raw(Box::new(RiftHandle {
                 runtime,
-                manager: Arc::new(ImposterManager::new()),
+                // Register the shipped flow-state backends (issue #853) so an embedded host gets
+                // the same `_rift.flowState.backend` vocabulary as the binary — `"redis"` included
+                // under the default `redis-backend` feature.
+                manager: Arc::new(
+                    ImposterManager::new()
+                        .with_flow_store_backends(rift_http_proxy::default_flow_store_backends()),
+                ),
                 admin: Mutex::new(None),
                 intercept: InterceptControl::default(),
             })),

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -2460,3 +2460,50 @@ fn ffi_serve_admin_still_enforces_a_real_api_key() {
         rift_stop(h);
     }
 }
+
+// Issue #853: the manager `rift_start` builds must register the shipped flow-state backends, so an
+// embedded host gets the same `_rift.flowState.backend` vocabulary as the binary.
+//
+// This is the C-ABI half of the same regression guard as
+// `embedded_server::server_builder_registers_the_shipped_flow_store_backends`. Without it, dropping
+// `.with_flow_store_backends(...)` from `rift_start` would compile, lint and test clean while every
+// embedded SDK lost `backend: "redis"`.
+//
+// No Redis server needed: an UNREACHABLE url discriminates the two outcomes. Registered => the
+// factory runs and fails to connect ("failed to build the Redis flow store"); not registered => the
+// registry lookup misses first ("no such backend is registered"). Both fail creation (sentinel 0),
+// so `rift_last_error` is what tells them apart.
+#[cfg(feature = "redis-backend")]
+#[test]
+fn ffi_start_registers_the_shipped_flow_store_backends() {
+    unsafe {
+        let h = rift_start();
+        assert!(!h.is_null(), "rift_start returned null");
+
+        let config = cstr(
+            r#"{"port": 19484, "protocol": "http", "stubs": [],
+                "_rift": {"flowState": {"backend": "redis",
+                                        "redis": {"url": "redis://127.0.0.1:1"}}}}"#,
+        );
+        assert_eq!(
+            rift_create_imposter(h, config.as_ptr()),
+            0,
+            "an unreachable redis must fail imposter creation, not downgrade to NoOp"
+        );
+
+        let err = rift_last_error();
+        assert!(!err.is_null(), "a failed creation must record last_error");
+        let err = take_json(err);
+        assert!(
+            err.contains("failed to build the Redis flow store"),
+            "the redis backend must be REGISTERED on the manager rift_start builds — got {err:?}, \
+             which means rift_start no longer calls default_flow_store_backends()"
+        );
+        assert!(
+            !err.contains("no such backend is registered"),
+            "redis resolved as an unknown backend, so it was never registered: {err}"
+        );
+
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/Cargo.toml
+++ b/crates/rift-http-proxy/Cargo.toml
@@ -47,6 +47,10 @@ serde_json.workspace = true
 # Shared workspace types + CLI-free engine (issue #203)
 rift-types = { path = "../rift-types", version = "0.1.0" }
 rift-mock-core = { path = "../rift-mock-core", version = "0.1.0", default-features = false }
+# The Redis flow-state backend, opt-in as its own crate (issue #853). Optional so a build
+# without `redis-backend` pulls no redis/r2d2 at all; default-on below, so shipped artifacts
+# behave exactly as before the extraction.
+rift-store-redis = { path = "../rift-store-redis", version = "0.1.0", optional = true }
 
 # Stable stub id generation for id-addressed stub ops (issue #202)
 uuid.workspace = true
@@ -121,8 +125,6 @@ rcgen = "0.13"
 # Integration testing
 reqwest = { workspace = true, features = ["http2"] }
 tokio-test = "0.4"
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["redis"] }
 assert-json-diff = "2.0"
 serial_test = "3.0"
 tracing-test = "0.2"
@@ -130,7 +132,9 @@ port_check = "0.2"
 
 [features]
 default = ["redis-backend", "javascript", "mimalloc", "quamina-matching"]
-redis-backend = ["rift-mock-core/redis-backend"]
+# Registers `rift-store-redis`'s factory so `_rift.flowState.backend: "redis"` resolves
+# (issue #853). The feature name is unchanged from when the store lived in rift-mock-core.
+redis-backend = ["dep:rift-store-redis"]
 javascript = ["rift-mock-core/javascript"]
 # The quamina body-field candidate dimension (#767). rift-mock-core is taken with
 # `default-features = false`, so a feature that is default-on THERE reaches nothing users run

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -33,14 +33,19 @@ COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
 COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 COPY crates/rift-mock-core/Cargo.toml ./crates/rift-mock-core/
 COPY crates/rift-ffi/Cargo.toml ./crates/rift-ffi/
+COPY crates/rift-store-redis/Cargo.toml ./crates/rift-store-redis/
 
-# Create dummy source files to build dependencies
+# Create dummy source files to build dependencies.
+# Every workspace member needs an entry here, even one this image does not run: cargo resolves the
+# whole workspace, so a member with no manifest/source fails the build outright.
 RUN mkdir -p crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches \
              crates/rift-mock-core/benches \
-             crates/rift-lint/src crates/rift-tui/src crates/rift-types/src crates/rift-mock-core/src crates/rift-ffi/src && \
+             crates/rift-lint/src crates/rift-tui/src crates/rift-types/src crates/rift-mock-core/src crates/rift-ffi/src \
+             crates/rift-store-redis/src && \
     echo "" > crates/rift-types/src/lib.rs && \
     echo "" > crates/rift-mock-core/src/lib.rs && \
     echo "" > crates/rift-ffi/src/lib.rs && \
+    echo "" > crates/rift-store-redis/src/lib.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/bin/verify.rs && \
     echo "fn main() {}" > crates/rift-mock-core/benches/imposter_matcher_bench.rs && \

--- a/crates/rift-http-proxy/src/lib.rs
+++ b/crates/rift-http-proxy/src/lib.rs
@@ -10,6 +10,26 @@ pub use rift_mock_core::{
     proxy, recording, response, routing, scripting, stub_analysis, template, util,
 };
 
+/// The named flow-state backends this build ships (issue #853).
+///
+/// One owner for "which backends exist in a shipped artifact", so the binary and the C-ABI cannot
+/// drift apart: both register the result of this on their `ImposterManager`. `"redis"` is present
+/// exactly when the default `redis-backend` feature is on — that feature used to enable the store
+/// inside `rift-mock-core`, and now pulls in the `rift-store-redis` crate instead, which is why
+/// the extraction is invisible to users.
+///
+/// A backend absent here is not a silent downgrade: naming it in `_rift.flowState.backend` fails
+/// imposter creation with an error listing what is available (issues #325/#377).
+#[must_use]
+pub fn default_flow_store_backends() -> extensions::flow_state::FlowStoreBackends {
+    let backends = extensions::flow_state::FlowStoreBackends::new();
+    #[cfg(feature = "redis-backend")]
+    let backends = backends.with(std::sync::Arc::new(
+        rift_store_redis::RedisFlowStoreBackendFactory,
+    ));
+    backends
+}
+
 /// Install the process-wide rustls `ring` crypto provider, idempotently (issue #343).
 ///
 /// The binary does this in `main.rs`; an embedded host (the FFI `rift_start`) must too, or an

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -421,7 +421,8 @@ impl ServerBuilder {
                 Arc::new(
                     ImposterManager::with_datadir(cli.datadir.clone())
                         .with_tls_defaults(tls_defaults)
-                        .with_accept_runtimes(self.accept_runtimes),
+                        .with_accept_runtimes(self.accept_runtimes)
+                        .with_flow_store_backends(crate::default_flow_store_backends()),
                 )
             }
         };

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -187,6 +187,58 @@ async fn delete_flow_state_clears_whole_flow() {
     let _ = manager.delete_imposter(19780).await;
 }
 
+// Issue #853: a `flowState.backend` no build serves is rejected with 400 over the real admin
+// surface, and the body names both the rejected backend and the ones that ARE selectable — so an
+// operator whose binary lacks a feature can tell a typo from a missing build. This is the HTTP-level
+// proof of the #325/#377 contract: never a silent NoOpFlowStore downgrade.
+#[tokio::test]
+async fn create_imposter_rejects_an_unregistered_flow_state_backend() {
+    let manager = std::sync::Arc::new(
+        ImposterManager::new()
+            .with_flow_store_backends(rift_http_proxy::default_flow_store_backends()),
+    );
+    let admin_addr = "127.0.0.1:12604".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12604";
+    let r = c
+        .post(format!("{admin}/imposters"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "port": 19782, "protocol": "http", "stubs": [],
+                "_rift": { "flowState": { "backend": "postgres" } }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(
+        r.status(),
+        400,
+        "an unregistered flowState.backend must be rejected at creation"
+    );
+    let body = r.text().await.expect("body");
+    assert!(
+        body.contains("postgres"),
+        "the 400 must name the rejected backend, got: {body}"
+    );
+    assert!(
+        body.contains("inmemory"),
+        "the 400 must list the backends this build serves, got: {body}"
+    );
+    // This test build has `redis-backend` on (a default feature), so redis is registered and must
+    // appear as available — which also proves `default_flow_store_backends()` actually registered it.
+    assert!(
+        body.contains("redis"),
+        "a redis-enabled build must advertise redis as available, got: {body}"
+    );
+}
+
 // Issue #530: creating an imposter with flowState.ttlSeconds < 1 is rejected with 400.
 #[tokio::test]
 async fn create_imposter_rejects_non_positive_ttl_seconds() {

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -87,6 +87,71 @@ async fn server_builder_with_injected_manager_serves_admin_api() {
     manager.delete_all().await;
 }
 
+// Issue #853: the manager `ServerBuilder` builds ITSELF must register the shipped flow-state
+// backends. Deliberately no `.manager(...)` here — injecting one would test the wrong object.
+//
+// Why this guard exists: `default_flow_store_backends()` is unit-tested, and the admin API is
+// tested against a manager the test builds by hand, so if a refactor dropped
+// `.with_flow_store_backends(...)` from `ServerBuilder`, everything would still compile, clippy
+// would pass, `verify-feature-propagation.sh` would pass (it checks the Cargo feature chain, not
+// the registration call) — and every `rift` binary user with `backend: "redis"` would get
+// "no such backend is registered". That is the #777 shape moved from the manifest to the code.
+//
+// The probe needs no Redis server: an UNREACHABLE url separates the two outcomes. Registered ⇒ the
+// factory runs and fails to connect ("failed to build the Redis flow store"); not registered ⇒ the
+// registry lookup misses first ("no such backend is registered"). Both are 400, so the body is what
+// discriminates.
+#[cfg(feature = "redis-backend")]
+#[tokio::test]
+async fn server_builder_registers_the_shipped_flow_store_backends() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "12611",
+        "--metrics-port",
+        "19483",
+    ])
+    .expect("cli parse");
+
+    tokio::spawn(ServerBuilder::from_cli(cli).run());
+    wait_for_http("http://127.0.0.1:12611/health").await;
+
+    let response = reqwest::Client::new()
+        .post("http://127.0.0.1:12611/imposters")
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "port": 19482, "protocol": "http", "stubs": [],
+                "_rift": { "flowState": {
+                    "backend": "redis",
+                    "redis": { "url": "redis://127.0.0.1:1" }
+                }}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("post imposter");
+
+    assert_eq!(
+        response.status(),
+        400,
+        "an unreachable redis must fail imposter creation, not downgrade to NoOp"
+    );
+    let body = response.text().await.expect("body");
+    assert!(
+        body.contains("failed to build the Redis flow store"),
+        "the redis backend must be REGISTERED on the manager ServerBuilder builds — got {body:?}, \
+         which means ServerBuilder no longer calls default_flow_store_backends()"
+    );
+    assert!(
+        !body.contains("no such backend is registered"),
+        "redis resolved as an unknown backend, so it was never registered: {body}"
+    );
+}
+
 // AC2: run_metrics_server on an explicit loopback SocketAddr serves /metrics (and 404s
 // elsewhere). Fixed port rather than :0 — the function never returns, so a :0 bind gives
 // the caller no way to learn the assigned port.

--- a/crates/rift-lint/Dockerfile
+++ b/crates/rift-lint/Dockerfile
@@ -25,12 +25,16 @@ COPY crates/rift-tui/Cargo.toml ./crates/rift-tui/
 COPY crates/rift-types/Cargo.toml ./crates/rift-types/
 COPY crates/rift-mock-core/Cargo.toml ./crates/rift-mock-core/
 COPY crates/rift-ffi/Cargo.toml ./crates/rift-ffi/
+COPY crates/rift-store-redis/Cargo.toml ./crates/rift-store-redis/
 
-# Create dummy source files to build dependencies
-RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src crates/rift-types/src crates/rift-mock-core/src crates/rift-ffi/src && \
+# Create dummy source files to build dependencies.
+# Every workspace member needs an entry here, even one this image does not run: cargo resolves the
+# whole workspace, so a member with no manifest/source fails the build outright.
+RUN mkdir -p crates/rift-lint/src crates/rift-http-proxy/src/bin crates/rift-http-proxy/benches crates/rift-tui/src crates/rift-types/src crates/rift-mock-core/src crates/rift-ffi/src crates/rift-store-redis/src && \
     echo "" > crates/rift-types/src/lib.rs && \
     echo "" > crates/rift-mock-core/src/lib.rs && \
     echo "" > crates/rift-ffi/src/lib.rs && \
+    echo "" > crates/rift-store-redis/src/lib.rs && \
     echo "pub fn lint() {}" > crates/rift-lint/src/lib.rs && \
     echo "fn main() {}" > crates/rift-lint/src/main.rs && \
     echo "fn main() {}" > crates/rift-http-proxy/src/main.rs && \

--- a/crates/rift-mock-core/Cargo.toml
+++ b/crates/rift-mock-core/Cargo.toml
@@ -50,10 +50,6 @@ rift-types = { path = "../rift-types", version = "0.1.0" }
 rhai.workspace = true
 boa_engine = { version = "0.20", optional = true }
 
-# State storage
-redis = { version = "0.26", default-features = false, optional = true }
-r2d2 = { version = "0.8", optional = true }
-
 # Logging & Observability
 tracing.workspace = true
 prometheus = "0.13"
@@ -130,8 +126,11 @@ name = "response_serve_bench"
 harness = false
 
 [features]
-default = ["redis-backend", "javascript", "quamina-matching"]
-redis-backend = ["redis", "r2d2"]
+default = ["javascript", "quamina-matching"]
+# NOTE: there is deliberately no `redis-backend` feature here any more (issue #853). The Redis flow
+# store lives in the `rift-store-redis` crate and attaches through `FlowStoreBackendFactory`, so
+# this crate cannot pull `redis`/`r2d2` under any feature combination. The feature name survives on
+# `rift-http-proxy` and `rift-ffi`, where it now means "register the redis backend".
 javascript = ["boa_engine"]
 # Quamina-backed body-field candidate dimension (issue #767). Off ⇒ the dimension
 # compiles to a no-op that never prunes; Stage-2 still evaluates every body predicate.

--- a/crates/rift-mock-core/src/backends/mod.rs
+++ b/crates/rift-mock-core/src/backends/mod.rs
@@ -1,9 +1,10 @@
+//! Built-in [`FlowStore`](crate::extensions::flow_state::FlowStore) backends.
+//!
+//! Only the in-memory store lives here. The Redis backend moved to the `rift-store-redis` crate
+//! (issue #853) and attaches at runtime through
+//! [`FlowStoreBackendFactory`](crate::extensions::flow_state::FlowStoreBackendFactory), which is
+//! what keeps `redis`/`r2d2` out of this crate's dependency graph entirely.
+
 pub mod inmemory;
 
-#[cfg(feature = "redis-backend")]
-pub mod redis;
-
 pub use inmemory::InMemoryFlowStore;
-
-#[cfg(feature = "redis-backend")]
-pub use redis::RedisFlowStore;

--- a/crates/rift-mock-core/src/extensions/flow_state.rs
+++ b/crates/rift-mock-core/src/extensions/flow_state.rs
@@ -125,6 +125,120 @@ pub trait FlowStoreProvider: Send + Sync {
     fn provide(&self, config: &crate::imposter::ImposterConfig) -> Option<Arc<dyn FlowStore>>;
 }
 
+/// A backend selectable by name through `_rift.flowState.backend` (issue #853).
+///
+/// This is how a store lives outside `rift-mock-core` while still being chosen by config: the
+/// `"redis"` backend ships in the separate `rift-store-redis` crate and registers here, so the
+/// core engine carries no redis dependency. Distinct from [`FlowStoreProvider`] in two ways that
+/// matter:
+///
+/// - **It has an error channel.** `provide` returns `Option`, so a provider can only *decline* —
+///   a misconfigured backend would silently fall through to a built-in. A factory returns
+///   `Result`, so a bad URL or missing config block fails imposter creation loudly (issue #325).
+/// - **It is selected by the config, not imposed on it.** A provider overrides any
+///   `_rift.flowState`; a factory is only consulted when the config names it.
+pub trait FlowStoreBackendFactory: Send + Sync {
+    /// The `_rift.flowState.backend` string this factory serves, e.g. `"redis"`.
+    fn name(&self) -> &'static str;
+
+    /// Build a store for this imposter's `flowState` block. An `Err` fails imposter creation
+    /// (fail-loud, #325) — never a silent downgrade to [`NoOpFlowStore`].
+    fn build(&self, config: &crate::imposter::RiftFlowStateConfig) -> Result<Arc<dyn FlowStore>>;
+}
+
+/// The named flow-store backends a build can serve, beyond the always-present `"inmemory"`
+/// (issue #853). Register with
+/// [`ImposterManager::with_flow_store_backends`](crate::imposter::ImposterManager::with_flow_store_backends).
+///
+/// Empty by default: `rift-mock-core` alone serves only `"inmemory"`, and any other name fails
+/// construction with an error listing what *is* available. The `rift` binary and the C-ABI
+/// register `"redis"` (from `rift-store-redis`) when built with the `redis-backend` feature, so
+/// shipped artifacts behave exactly as before.
+#[derive(Clone, Default)]
+pub struct FlowStoreBackends {
+    factories: Vec<Arc<dyn FlowStoreBackendFactory>>,
+}
+
+impl FlowStoreBackends {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `factory` under its own [`FlowStoreBackendFactory::name`].
+    ///
+    /// Lookup scans in registration order, so the **first** registration of a name wins and a
+    /// second one is unreachable rather than an override. That is a caller mistake with a
+    /// well-defined outcome, so it warns rather than panicking — a builder in a library has no
+    /// business aborting the host process over it, but it should not be silent either.
+    ///
+    /// Built-in names also take precedence over the registry: both selection sites match
+    /// `"inmemory"` (and the `test-backend` `"failing"` store) before consulting it, so registering
+    /// a factory under one of those names has no effect.
+    #[must_use]
+    pub fn with(mut self, factory: Arc<dyn FlowStoreBackendFactory>) -> Self {
+        if self.get(factory.name()).is_some() {
+            tracing::warn!(
+                backend = factory.name(),
+                "flow-state backend registered twice; the first registration wins and this one is unreachable"
+            );
+        }
+        self.factories.push(factory);
+        self
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Arc<dyn FlowStoreBackendFactory>> {
+        self.factories.iter().find(|f| f.name() == name)
+    }
+
+    /// Registered backend names, for the fail-loud "available:" list.
+    #[must_use]
+    pub fn names(&self) -> Vec<&'static str> {
+        self.factories.iter().map(|f| f.name()).collect()
+    }
+}
+
+impl std::fmt::Debug for FlowStoreBackends {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlowStoreBackends")
+            .field("backends", &self.names())
+            .finish()
+    }
+}
+
+/// The fail-loud error for a `flowState.backend` this build cannot serve (issues #325/#377/#853).
+///
+/// Names the requested backend *and* everything selectable, so an operator whose binary was built
+/// without a feature learns what to rebuild with — instead of a silent `NoOpFlowStore` downgrade
+/// that only shows up later as state that never persists. The `test-backend` `"failing"` store is
+/// deliberately not advertised: it is a test fixture, not an operator choice.
+pub(crate) fn unknown_backend_error(backend: &str, backends: &FlowStoreBackends) -> anyhow::Error {
+    let mut available = vec!["inmemory"];
+    for name in backends.names() {
+        // A name can legitimately appear twice in the registry (first registration wins), but
+        // showing an operator `available: "inmemory", "redis", "redis"` would just look broken.
+        if !available.contains(&name) {
+            available.push(name);
+        }
+    }
+    let list = available
+        .iter()
+        .map(|n| format!("\"{n}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // Only reached when `backend` resolved to no factory, so an unregistered redis needs no
+    // second lookup to confirm it.
+    let hint = if backend == "redis" {
+        " — this build has no redis backend registered (rebuild with --features redis-backend)"
+    } else {
+        ""
+    };
+    anyhow!(
+        "flowState.backend is \"{backend}\" but no such backend is registered (available: {list}){hint}"
+    )
+}
+
 /// No-op flow store that does nothing
 ///
 /// This is used when flow_state is not configured but scripts are enabled.
@@ -173,71 +287,49 @@ impl FlowStore for NoOpFlowStore {
     }
 }
 
-/// Create a FlowStore based on configuration
+/// Create a server-level FlowStore from the `flowState` block of a proxy config file.
 ///
-/// # Arguments
-/// * `config` - FlowStateConfig from proxy configuration
-///
-/// # Returns
-/// * `Arc<dyn FlowStore>` - Backend-appropriate flow store
-///
-/// # Example
-/// ```ignore
-/// use rift_http_proxy::config::FlowStateConfig;
-/// use rift_http_proxy::flow_state::create_flow_store;
-///
-/// let config = FlowStateConfig::default(); // inmemory
-/// let store = create_flow_store(&config).await?;
-/// ```
-pub fn create_flow_store(config: &crate::config::FlowStateConfig) -> Result<Arc<dyn FlowStore>> {
+/// `"inmemory"` is built in; every other name is resolved through `backends` (issue #853), so a
+/// backend living outside this crate — `"redis"`, from `rift-store-redis` — is selectable without
+/// `rift-mock-core` depending on it. An unregistered name is an error listing what is available,
+/// never a silent downgrade to [`NoOpFlowStore`] (issues #325/#377).
+pub fn create_flow_store(
+    config: &crate::config::FlowStateConfig,
+    backends: &FlowStoreBackends,
+) -> Result<Arc<dyn FlowStore>> {
     match config.backend.as_str() {
         "inmemory" => {
             use crate::backends::InMemoryFlowStore;
             tracing::info!("Using InMemory FlowStore (ttl={}s)", config.ttl_seconds);
             Ok(Arc::new(InMemoryFlowStore::new(config.ttl_seconds as u64)))
         }
-        "redis" => {
-            // Validate config presence in *all* builds so the "no redis config" error is returned
-            // even without the backend feature (a test locks this in); the value is only *consumed*
-            // when the backend is compiled in, hence the unused-var allow for the minimal build.
-            // `Context` is likewise only used inside the feature block, so it's imported there (#599).
-            #[cfg_attr(not(feature = "redis-backend"), allow(unused_variables))]
-            let redis_config = config
-                .redis
-                .as_ref()
-                .ok_or_else(|| anyhow!("Redis backend selected but no redis config provided"))?;
+        other => match backends.get(other) {
+            Some(factory) => factory.build(&server_flow_state_config(config)),
+            None => Err(unknown_backend_error(other, backends)),
+        },
+    }
+}
 
-            #[cfg(feature = "redis-backend")]
-            {
-                use anyhow::Context;
-
-                use crate::backends::RedisFlowStore;
-
-                let store = RedisFlowStore::new(
-                    &redis_config.url,
-                    redis_config.pool_size,
-                    redis_config.key_prefix.clone(),
-                    config.ttl_seconds,
-                )
-                .context("Failed to create Redis backend")?;
-
-                tracing::info!(
-                    "Using redis FlowStore (url={}, ttl={}s)",
-                    redis_config.url,
-                    config.ttl_seconds
-                );
-
-                Ok(Arc::new(store))
-            }
-
-            #[cfg(not(feature = "redis-backend"))]
-            {
-                Err(anyhow!(
-                    "Redis backend not available. Compile with --features redis-backend"
-                ))
-            }
-        }
-        other => Err(anyhow!("Unknown backend type: {other}")),
+/// Adapt the server-level `flowState` block to the per-imposter shape a
+/// [`FlowStoreBackendFactory`] takes, so both config surfaces reach one factory implementation
+/// rather than each backend having to understand two config types (issue #853). `flow_id_source`
+/// and `extra` have no server-level equivalent.
+fn server_flow_state_config(
+    config: &crate::config::FlowStateConfig,
+) -> crate::imposter::RiftFlowStateConfig {
+    crate::imposter::RiftFlowStateConfig {
+        backend: config.backend.clone(),
+        ttl_seconds: config.ttl_seconds,
+        redis: config
+            .redis
+            .as_ref()
+            .map(|r| crate::imposter::RiftRedisConfig {
+                url: r.url.clone(),
+                pool_size: r.pool_size,
+                key_prefix: r.key_prefix.clone(),
+            }),
+        flow_id_source: None,
+        extra: serde_json::Map::new(),
     }
 }
 
@@ -361,7 +453,7 @@ mod tests {
             ttl_seconds: 300,
             redis: None,
         };
-        let store = create_flow_store(&config);
+        let store = create_flow_store(&config, &FlowStoreBackends::new());
         assert!(store.is_ok());
     }
 
@@ -373,36 +465,231 @@ mod tests {
             ttl_seconds: 7200,
             redis: None,
         };
-        let store = create_flow_store(&config);
+        let store = create_flow_store(&config, &FlowStoreBackends::new());
         assert!(store.is_ok());
     }
 
-    #[test]
-    fn test_create_flow_store_unknown_backend() {
-        use crate::config::FlowStateConfig;
-        let config = FlowStateConfig {
-            backend: "unknown".to_string(),
-            ttl_seconds: 300,
-            redis: None,
-        };
-        let result = create_flow_store(&config);
-        assert!(result.is_err());
-        let err_msg = result.err().unwrap().to_string();
-        assert!(err_msg.contains("Unknown backend type"));
+    /// `Arc<dyn FlowStore>` is not `Debug`, so `expect_err` is unavailable — unwrap the error
+    /// message explicitly instead.
+    fn build_error(result: Result<Arc<dyn FlowStore>>, what: &str) -> String {
+        match result {
+            Ok(_) => panic!("{what}"),
+            Err(e) => e.to_string(),
+        }
     }
 
+    /// A fake out-of-crate backend: proves the registry seam works with NO redis dependency in
+    /// `rift-mock-core`, which is the whole point of issue #853.
+    struct FakeBackend;
+
+    impl FlowStoreBackendFactory for FakeBackend {
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+        fn build(
+            &self,
+            _config: &crate::imposter::RiftFlowStateConfig,
+        ) -> Result<Arc<dyn FlowStore>> {
+            Ok(Arc::new(NoOpFlowStore))
+        }
+    }
+
+    /// A backend whose construction fails — the error channel `FlowStoreProvider` lacks (#853).
+    struct BrokenBackend;
+
+    impl FlowStoreBackendFactory for BrokenBackend {
+        fn name(&self) -> &'static str {
+            "broken"
+        }
+        fn build(
+            &self,
+            _config: &crate::imposter::RiftFlowStateConfig,
+        ) -> Result<Arc<dyn FlowStore>> {
+            Err(anyhow!("cannot reach the thing"))
+        }
+    }
+
+    // Issue #853 AC3: an explicitly-named backend that nothing registered must fail with an error
+    // naming it AND listing what IS selectable — never a silent NoOp downgrade (#325/#377). This
+    // covers "redis" specifically, since after the extraction core registers nothing itself.
     #[test]
-    fn test_create_flow_store_redis_without_config() {
+    fn create_flow_store_unregistered_backend_names_the_available_ones() {
+        use crate::config::FlowStateConfig;
+        for backend in ["redis", "unknown"] {
+            let config = FlowStateConfig {
+                backend: backend.to_string(),
+                ttl_seconds: 300,
+                redis: None,
+            };
+            let err = build_error(
+                create_flow_store(&config, &FlowStoreBackends::new()),
+                "an unregistered backend must fail, not downgrade to NoOp",
+            );
+            assert!(
+                err.contains(backend) && err.contains("no such backend is registered"),
+                "the error must name the requested backend, got: {err}"
+            );
+            assert!(
+                err.contains("available: \"inmemory\""),
+                "the error must list what IS selectable, got: {err}"
+            );
+        }
+    }
+
+    // Issue #853: the redis case earns a rebuild hint, because a missing feature (not a typo) is
+    // overwhelmingly the reason it is absent.
+    #[test]
+    fn create_flow_store_unregistered_redis_hints_at_the_feature() {
         use crate::config::FlowStateConfig;
         let config = FlowStateConfig {
             backend: "redis".to_string(),
             ttl_seconds: 300,
             redis: None,
         };
-        let result = create_flow_store(&config);
-        assert!(result.is_err());
-        let err_msg = result.err().unwrap().to_string();
-        assert!(err_msg.contains("redis config"));
+        let err = build_error(
+            create_flow_store(&config, &FlowStoreBackends::new()),
+            "redis is not registered in core",
+        );
+        assert!(
+            err.contains("--features redis-backend"),
+            "an absent redis backend must say how to get one, got: {err}"
+        );
+    }
+
+    // Issue #853: a registered factory is consulted for its own name, and its registered name
+    // shows up in the fail-loud list for other names.
+    #[test]
+    fn create_flow_store_consults_a_registered_backend() {
+        use crate::config::FlowStateConfig;
+        let backends = FlowStoreBackends::new().with(Arc::new(FakeBackend));
+        let config = FlowStateConfig {
+            backend: "fake".to_string(),
+            ttl_seconds: 300,
+            redis: None,
+        };
+        assert!(
+            create_flow_store(&config, &backends).is_ok(),
+            "a registered backend must be built through its factory"
+        );
+
+        let missing = FlowStateConfig {
+            backend: "nope".to_string(),
+            ttl_seconds: 300,
+            redis: None,
+        };
+        let err = build_error(create_flow_store(&missing, &backends), "unregistered");
+        assert!(
+            err.contains("\"inmemory\", \"fake\""),
+            "the available list must include registered backends, got: {err}"
+        );
+    }
+
+    // Issue #853: a factory's build error propagates — this is the error channel that made a
+    // factory the right seam instead of `FlowStoreProvider` (whose `provide` returns Option).
+    #[test]
+    fn create_flow_store_propagates_a_factory_build_failure() {
+        use crate::config::FlowStateConfig;
+        let backends = FlowStoreBackends::new().with(Arc::new(BrokenBackend));
+        let config = FlowStateConfig {
+            backend: "broken".to_string(),
+            ttl_seconds: 300,
+            redis: None,
+        };
+        let err = build_error(
+            create_flow_store(&config, &backends),
+            "a failing factory must fail the build",
+        );
+        assert!(
+            err.contains("cannot reach the thing"),
+            "the factory's own error must survive, got: {err}"
+        );
+    }
+
+    // Issue #853: registration order is the contract — the FIRST factory for a name wins, so a
+    // duplicate cannot silently displace a backend that is already installed.
+    #[test]
+    fn the_first_registration_of_a_name_wins() {
+        struct Named(&'static str, &'static str);
+        impl FlowStoreBackendFactory for Named {
+            fn name(&self) -> &'static str {
+                self.0
+            }
+            fn build(
+                &self,
+                _config: &crate::imposter::RiftFlowStateConfig,
+            ) -> Result<Arc<dyn FlowStore>> {
+                Err(anyhow!("built by {}", self.1))
+            }
+        }
+
+        let backends = FlowStoreBackends::new()
+            .with(Arc::new(Named("dup", "first")))
+            .with(Arc::new(Named("dup", "second")));
+        assert_eq!(backends.names(), vec!["dup", "dup"]);
+
+        let config = crate::config::FlowStateConfig {
+            backend: "dup".to_string(),
+            ttl_seconds: 300,
+            redis: None,
+        };
+        let err = build_error(create_flow_store(&config, &backends), "always errors");
+        assert!(
+            err.contains("built by first"),
+            "the first registration must be the one consulted, got: {err}"
+        );
+    }
+
+    // Issue #853: built-ins are matched before the registry is consulted, so a factory claiming a
+    // built-in name is inert. Pinned so a future reorder of the match cannot silently start letting
+    // an embedder replace `"inmemory"`.
+    #[test]
+    fn a_factory_cannot_shadow_the_builtin_inmemory_backend() {
+        struct Hijack;
+        impl FlowStoreBackendFactory for Hijack {
+            fn name(&self) -> &'static str {
+                "inmemory"
+            }
+            fn build(
+                &self,
+                _config: &crate::imposter::RiftFlowStateConfig,
+            ) -> Result<Arc<dyn FlowStore>> {
+                Err(anyhow!("the hijacking factory must never be consulted"))
+            }
+        }
+
+        let backends = FlowStoreBackends::new().with(Arc::new(Hijack));
+        let config = crate::config::FlowStateConfig {
+            backend: "inmemory".to_string(),
+            ttl_seconds: 300,
+            redis: None,
+        };
+        assert!(
+            create_flow_store(&config, &backends).is_ok(),
+            "the built-in inmemory backend must win over a registered factory of the same name"
+        );
+    }
+
+    // Issue #853: the server-level `redis` block must reach the factory — otherwise a config-file
+    // deployment would hand the backend an empty config and fail for the wrong reason.
+    #[test]
+    fn server_level_redis_block_reaches_the_factory() {
+        use crate::config::{FlowStateConfig, RedisConfig};
+        let config = FlowStateConfig {
+            backend: "redis".to_string(),
+            ttl_seconds: 900,
+            redis: Some(RedisConfig {
+                url: "redis://example:6379".to_string(),
+                pool_size: 7,
+                key_prefix: "pfx:".to_string(),
+            }),
+        };
+        let adapted = server_flow_state_config(&config);
+        assert_eq!(adapted.backend, "redis");
+        assert_eq!(adapted.ttl_seconds, 900);
+        let redis = adapted.redis.expect("the redis block must carry over");
+        assert_eq!(redis.url, "redis://example:6379");
+        assert_eq!(redis.pool_size, 7);
+        assert_eq!(redis.key_prefix, "pfx:");
     }
 
     // ============================================

--- a/crates/rift-mock-core/src/extensions/mod.rs
+++ b/crates/rift-mock-core/src/extensions/mod.rs
@@ -31,7 +31,10 @@ pub mod template_fn;
 #[allow(unused_imports)]
 pub use fault::{FaultDecision, create_error_response, decide_fault};
 #[allow(unused_imports)]
-pub use flow_state::{CasOutcome, FlowStore, FlowStoreProvider, NoOpFlowStore, create_flow_store};
+pub use flow_state::{
+    CasOutcome, FlowStore, FlowStoreBackendFactory, FlowStoreBackends, FlowStoreProvider,
+    NoOpFlowStore, create_flow_store,
+};
 #[allow(unused_imports)]
 pub use matcher::{CompiledMatch, CompiledRule};
 #[allow(unused_imports)]

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Maximum allowed proxy response body size (10 MB)
 const MAX_PROXY_RESPONSE_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -212,6 +212,31 @@ impl Imposter {
         sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
         journal: Option<Arc<dyn crate::imposter::journal::RequestJournal>>,
     ) -> anyhow::Result<Self> {
+        Self::new_with_hooks_journal_and_backends(
+            config,
+            provider,
+            sequencer,
+            journal,
+            &crate::extensions::flow_state::FlowStoreBackends::new(),
+        )
+    }
+
+    /// Create a new imposter with all embedder hooks, including the named flow-store backend
+    /// registry (issue #853).
+    ///
+    /// `backends` supplies every `_rift.flowState.backend` beyond the built-in `"inmemory"` — most
+    /// importantly `"redis"`, which lives in the separate `rift-store-redis` crate. With an empty
+    /// registry (what [`Self::new_with_hooks_and_journal`] passes) a config naming `"redis"` fails
+    /// construction with an error listing what *is* available, rather than downgrading to
+    /// `NoOpFlowStore`. The `rift` binary and the C-ABI register the shipped backends, so their
+    /// behaviour is unchanged.
+    pub fn new_with_hooks_journal_and_backends(
+        config: ImposterConfig,
+        provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
+        sequencer: Option<Arc<dyn crate::behaviors::ResponseSequencer>>,
+        journal: Option<Arc<dyn crate::imposter::journal::RequestJournal>>,
+        backends: &crate::extensions::flow_state::FlowStoreBackends,
+    ) -> anyhow::Result<Self> {
         let stubs: Vec<Arc<StubState>> = config
             .stubs
             .iter()
@@ -222,7 +247,7 @@ impl Imposter {
 
         // Initialize flow store: a registered provider wins; otherwise the built-in
         // `_rift.flowState` selection.
-        let flow_store = Self::create_flow_store(&config, provider)?;
+        let flow_store = Self::create_flow_store(&config, provider, backends)?;
 
         let enabled = config.enabled;
         Ok(Self {
@@ -322,6 +347,7 @@ impl Imposter {
     fn create_flow_store(
         config: &ImposterConfig,
         provider: Option<&Arc<dyn crate::extensions::flow_state::FlowStoreProvider>>,
+        backends: &crate::extensions::flow_state::FlowStoreBackends,
     ) -> anyhow::Result<Arc<dyn FlowStore>> {
         if let Some(provider) = provider
             && let Some(store) = provider.provide(config)
@@ -363,17 +389,21 @@ impl Imposter {
                         flow_state_config.ttl_seconds as u64,
                     )))
                 }
-                "redis" => Self::create_redis_flow_store(flow_state_config),
                 #[cfg(feature = "test-backend")]
                 "failing" => {
                     info!("Creating deliberately failing FlowStore (test-backend feature)");
                     Ok(Arc::new(crate::extensions::flow_state::FailingFlowStore))
                 }
-                // An explicitly-set but unrecognized backend is a config error, not a reason to
-                // silently downgrade to NoOp (issue #377) — fail construction like the redis arm.
-                other => anyhow::bail!(
-                    "flowState.backend is \"{other}\" but no such backend exists (expected \"inmemory\" or \"redis\")"
-                ),
+                // Any other name is resolved through the registered backends (issue #853) — that
+                // is how `"redis"`, which now lives in the `rift-store-redis` crate, is selected
+                // without this crate depending on it. An unregistered name is a config error, not
+                // a reason to silently downgrade to NoOp (issue #377).
+                other => match backends.get(other) {
+                    Some(factory) => factory.build(flow_state_config),
+                    None => Err(crate::extensions::flow_state::unknown_backend_error(
+                        other, backends,
+                    )),
+                },
             };
         }
 
@@ -476,53 +506,6 @@ impl Imposter {
     /// magic `config.port.unwrap_or(0)` at every script call site.
     pub(crate) fn script_state_key(&self) -> u16 {
         self.config.port.unwrap_or(0)
-    }
-
-    /// Create Redis flow store if configured and available.
-    ///
-    /// An explicitly-requested `"redis"` backend that cannot be built must fail imposter
-    /// construction rather than silently downgrade to `NoOpFlowStore` (issue #325).
-    #[allow(unused_variables)]
-    fn create_redis_flow_store(
-        flow_state_config: &crate::imposter::types::RiftFlowStateConfig,
-    ) -> anyhow::Result<Arc<dyn FlowStore>> {
-        #[cfg(feature = "redis-backend")]
-        {
-            let Some(ref redis_config) = flow_state_config.redis else {
-                error!("Redis backend selected but no redis config provided");
-                anyhow::bail!(
-                    "flowState.backend is \"redis\" but no redis config block was provided"
-                );
-            };
-
-            use crate::backends::RedisFlowStore;
-            match RedisFlowStore::new(
-                &redis_config.url,
-                redis_config.pool_size,
-                redis_config.key_prefix.clone(),
-                flow_state_config.ttl_seconds,
-            ) {
-                Ok(store) => {
-                    info!(
-                        "Created Redis FlowStore for imposter (url={}, ttl={}s)",
-                        redis_config.url, flow_state_config.ttl_seconds
-                    );
-                    Ok(Arc::new(store))
-                }
-                Err(e) => {
-                    error!("Failed to create Redis FlowStore: {e:#}");
-                    anyhow::bail!("failed to build the Redis flow store: {e}");
-                }
-            }
-        }
-
-        #[cfg(not(feature = "redis-backend"))]
-        {
-            error!("Redis backend not available (compile with --features redis-backend)");
-            anyhow::bail!(
-                "flowState.backend is \"redis\" but this binary was built without the redis-backend feature (rebuild with --features redis-backend)"
-            );
-        }
     }
 
     /// Extract proxy mode from stubs
@@ -682,53 +665,105 @@ mod tests {
         );
     }
 
-    // Issue #325: an explicitly-requested redis backend that can't be built must fail imposter
-    // construction loudly, not silently downgrade to NoOp. Constructed at the ctor level (no port
-    // bind needed). `redis-backend` is a default feature, so the first case runs in `cargo test`.
-    #[cfg(feature = "redis-backend")]
+    // Issue #853 (was #325): with the Redis store extracted to `rift-store-redis`, this crate
+    // registers no `"redis"` backend at all — so an imposter naming it must fail construction with
+    // an error that names the backend and lists what IS selectable, never a silent NoOp downgrade
+    // (#377). This is the "factory absent" half of the old cfg-gated pair.
     #[test]
-    fn explicit_redis_without_config_block_fails_construction() {
-        let cfg = serde_json::from_value(json!({
-            "port": 0, "protocol": "http", "stubs": [],
-            "_rift": { "flowState": { "backend": "redis" } }
-        }))
-        .expect("valid imposter config");
-        let result = Imposter::new_with_hooks_and_journal(cfg, None, None, None);
-        assert!(
-            result.is_err(),
-            "redis backend requested with no redis config block must fail construction, not NoOp"
-        );
-    }
-
-    #[cfg(not(feature = "redis-backend"))]
-    #[test]
-    fn explicit_redis_without_feature_fails_construction() {
+    fn explicit_redis_without_a_registered_factory_fails_construction() {
         let cfg = serde_json::from_value(json!({
             "port": 0, "protocol": "http", "stubs": [],
             "_rift": { "flowState": { "backend": "redis", "redis": { "url": "redis://localhost:6379" } } }
         }))
         .expect("valid imposter config");
-        let result = Imposter::new_with_hooks_and_journal(cfg, None, None, None);
+        let err = match Imposter::new_with_hooks_and_journal(cfg, None, None, None) {
+            Ok(_) => panic!("an unregistered redis backend must fail construction, not NoOp"),
+            Err(e) => format!("{e:#}"),
+        };
         assert!(
-            result.is_err(),
-            "redis backend without the redis-backend feature must fail construction, not NoOp"
+            err.contains("redis") && err.contains("no such backend is registered"),
+            "the error must name the missing backend, got: {err}"
+        );
+        assert!(
+            err.contains("available: \"inmemory\""),
+            "the error must list what IS selectable, got: {err}"
         );
     }
 
-    // Issue #325/#358: an unreachable redis URL must fail imposter creation loudly (via
-    // `RedisFlowStore::new`'s eager PING), not silently downgrade to NoOp/in-memory.
-    #[cfg(feature = "redis-backend")]
+    // Issue #853: the "factory registered" half. A registered backend is built through its factory
+    // — proving the seam works with no redis dependency anywhere in this crate.
     #[test]
-    fn redis_unreachable_url_fails_construction() {
+    fn a_registered_backend_factory_is_consulted_for_its_name() {
+        use crate::extensions::flow_state::{
+            FlowStore, FlowStoreBackendFactory, FlowStoreBackends,
+        };
+
+        struct CountingFactory(std::sync::atomic::AtomicUsize);
+        impl FlowStoreBackendFactory for CountingFactory {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+            fn build(
+                &self,
+                _config: &crate::imposter::RiftFlowStateConfig,
+            ) -> anyhow::Result<Arc<dyn FlowStore>> {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Arc::new(crate::backends::InMemoryFlowStore::new(60)))
+            }
+        }
+
+        let factory = Arc::new(CountingFactory(std::sync::atomic::AtomicUsize::new(0)));
+        let backends = FlowStoreBackends::new().with(Arc::clone(&factory) as Arc<_>);
         let cfg = serde_json::from_value(json!({
             "port": 0, "protocol": "http", "stubs": [],
-            "_rift": { "flowState": { "backend": "redis", "redis": { "url": "redis://127.0.0.1:1" } } }
+            "_rift": { "flowState": { "backend": "counting" } }
         }))
         .expect("valid imposter config");
-        let result = Imposter::new_with_hooks_and_journal(cfg, None, None, None);
+
+        Imposter::new_with_hooks_journal_and_backends(cfg, None, None, None, &backends)
+            .expect("a registered backend must build");
+        assert_eq!(
+            factory.0.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the factory must be consulted exactly once for its own backend name"
+        );
+    }
+
+    // Issue #853: a factory whose build fails must fail imposter construction — the error channel
+    // that made a named factory the right seam rather than `FlowStoreProvider` (#325).
+    #[test]
+    fn a_failing_backend_factory_fails_construction() {
+        use crate::extensions::flow_state::{
+            FlowStore, FlowStoreBackendFactory, FlowStoreBackends,
+        };
+
+        struct Broken;
+        impl FlowStoreBackendFactory for Broken {
+            fn name(&self) -> &'static str {
+                "broken"
+            }
+            fn build(
+                &self,
+                _config: &crate::imposter::RiftFlowStateConfig,
+            ) -> anyhow::Result<Arc<dyn FlowStore>> {
+                anyhow::bail!("the backend is unreachable")
+            }
+        }
+
+        let backends = FlowStoreBackends::new().with(Arc::new(Broken));
+        let cfg = serde_json::from_value(json!({
+            "port": 0, "protocol": "http", "stubs": [],
+            "_rift": { "flowState": { "backend": "broken" } }
+        }))
+        .expect("valid imposter config");
+        let err =
+            match Imposter::new_with_hooks_journal_and_backends(cfg, None, None, None, &backends) {
+                Ok(_) => panic!("a failing factory must fail construction, not NoOp"),
+                Err(e) => format!("{e:#}"),
+            };
         assert!(
-            result.is_err(),
-            "an unreachable redis URL must fail imposter construction, not NoOp"
+            err.contains("the backend is unreachable"),
+            "the factory's own error must survive, got: {err}"
         );
     }
 

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -242,6 +242,9 @@ pub struct ImposterManager {
     response_decorator: Option<Arc<dyn ResponseDecorator>>,
     /// Embedder hook to supply a custom flow store per imposter (issue #312)
     flow_store_provider: Option<Arc<dyn FlowStoreProvider>>,
+    /// Named `_rift.flowState.backend` implementations beyond the built-in `"inmemory"`
+    /// (issue #853) — `"redis"` arrives here from the `rift-store-redis` crate.
+    flow_store_backends: crate::extensions::flow_state::FlowStoreBackends,
     /// Pluggable response-cursor backend (issue #313); None = embedded per-stub cycler.
     sequencer: Option<Arc<dyn ResponseSequencer>>,
     /// Pluggable recorded-request backend (issue #314); None = per-imposter LocalJournal.
@@ -287,6 +290,7 @@ impl ImposterManager {
             event_listener: None,
             response_decorator: None,
             flow_store_provider: None,
+            flow_store_backends: crate::extensions::flow_state::FlowStoreBackends::new(),
             sequencer: None,
             request_journal: None,
             proxy_store: None,
@@ -359,6 +363,24 @@ impl ImposterManager {
     #[must_use]
     pub fn with_flow_store_provider(mut self, provider: Arc<dyn FlowStoreProvider>) -> Self {
         self.flow_store_provider = Some(provider);
+        self
+    }
+
+    /// Register the named flow-store backends this build serves (issue #853).
+    ///
+    /// Supplies every `_rift.flowState.backend` beyond the built-in `"inmemory"` — notably
+    /// `"redis"`, which lives in the `rift-store-redis` crate so that this one carries no redis
+    /// dependency. Without it, an imposter naming an unregistered backend fails construction with
+    /// an error listing what is available (never a silent `NoOpFlowStore`, #325/#377).
+    ///
+    /// Unlike [`Self::with_flow_store_provider`], a factory does not override an imposter's
+    /// config: it is consulted only when the config names it.
+    #[must_use]
+    pub fn with_flow_store_backends(
+        mut self,
+        backends: crate::extensions::flow_state::FlowStoreBackends,
+    ) -> Self {
+        self.flow_store_backends = backends;
         self
     }
 
@@ -547,11 +569,12 @@ impl ImposterManager {
 
         info!("Imposter bound to {}:{}", bind_host, port);
         // Create imposter
-        let mut imposter = Imposter::new_with_hooks_and_journal(
+        let mut imposter = Imposter::new_with_hooks_journal_and_backends(
             config,
             self.flow_store_provider.as_ref(),
             self.sequencer.clone(),
             self.request_journal.clone(),
+            &self.flow_store_backends,
         )
         .map_err(|e| ImposterError::FlowStoreConfig(format!("{e:#}")))?;
 

--- a/crates/rift-mock-core/src/proxy/server.rs
+++ b/crates/rift-mock-core/src/proxy/server.rs
@@ -9,7 +9,7 @@ use super::network::{HttpTuning, create_reusable_listener};
 use super::tls::create_tls_acceptor;
 use crate::behaviors::{CsvCache, ResponseCycler};
 use crate::config::{Config, Protocol as RiftProtocol, Upstream};
-use crate::extensions::flow_state::{FlowStore, create_flow_store};
+use crate::extensions::flow_state::{FlowStore, FlowStoreBackends, create_flow_store};
 use crate::extensions::matcher::CompiledRule;
 use crate::extensions::routing::Router;
 use crate::proxy::context::RequestHandlerContext;
@@ -54,8 +54,21 @@ pub struct ProxyServer {
 
 impl ProxyServer {
     /// Create a new ProxyServer from configuration.
+    ///
+    /// Serves only the built-in `"inmemory"` flow-state backend; use
+    /// [`Self::new_with_backends`] to make a named backend such as `"redis"` selectable
+    /// (issue #853).
     pub async fn new(config: Config) -> Result<Self, anyhow::Error> {
-        Self::new_internal(config, None).await
+        Self::new_internal(config, None, &FlowStoreBackends::new()).await
+    }
+
+    /// Create a new ProxyServer that can serve the named flow-state backends in `backends`
+    /// (issue #853) — e.g. `"redis"` from the `rift-store-redis` crate.
+    pub async fn new_with_backends(
+        config: Config,
+        backends: &FlowStoreBackends,
+    ) -> Result<Self, anyhow::Error> {
+        Self::new_internal(config, None, backends).await
     }
 
     /// Create a new ProxyServer with a shared flow store.
@@ -63,12 +76,14 @@ impl ProxyServer {
         config: Config,
         flow_store: Arc<dyn FlowStore>,
     ) -> Result<Self, anyhow::Error> {
-        Self::new_internal(config, Some(flow_store)).await
+        // A shared store is used verbatim, so no backend is ever constructed from config here.
+        Self::new_internal(config, Some(flow_store), &FlowStoreBackends::new()).await
     }
 
     async fn new_internal(
         config: Config,
         shared_flow_store: Option<Arc<dyn FlowStore>>,
+        backends: &FlowStoreBackends,
     ) -> Result<Self, anyhow::Error> {
         // Compile rules and extract upstream filters
         let mut compiled_rules = Vec::new();
@@ -112,7 +127,7 @@ impl ProxyServer {
             store
         } else if let Some(ref fs_config) = config.flow_state {
             // Create new flow store for this worker (backward compatible mode)
-            create_flow_store(fs_config)?
+            create_flow_store(fs_config, backends)?
         } else if !config.script_rules.is_empty() {
             // Scripts are configured but no flow_state - use no-op store
             tracing::info!("Using NoOpFlowStore for scripts (flow_state not configured)");

--- a/crates/rift-store-redis/Cargo.toml
+++ b/crates/rift-store-redis/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "rift-store-redis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+
+description = "Redis-backed flow-state store for Rift, registered through the FlowStoreBackendFactory seam."
+readme = "../../README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The `FlowStore`/`FlowStoreBackendFactory` seams and the `RiftFlowStateConfig` this factory reads.
+# Taken without default features for the same reason rift-http-proxy does: a backend crate has no
+# business pulling the engine's scripting or matching feature set into the tree.
+rift-mock-core = { path = "../rift-mock-core", version = "0.1.0", default-features = false }
+
+redis = { version = "0.26", default-features = false }
+r2d2 = "0.8"
+
+anyhow.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["redis"] }

--- a/crates/rift-store-redis/src/lib.rs
+++ b/crates/rift-store-redis/src/lib.rs
@@ -1,6 +1,16 @@
-use crate::extensions::flow_state::{CasOutcome, FlowStore};
+//! The Redis [`FlowStore`] backend, as an opt-in crate (issue #853).
+//!
+//! This lived in `rift-mock-core::backends::redis` until #853 moved it out, so the core engine
+//! carries no `redis`/`r2d2` dependency under any feature combination. It reattaches through the
+//! [`FlowStoreBackendFactory`] seam, which means `_rift.flowState.backend: "redis"` still selects
+//! it exactly as before — the `rift` binary and the C-ABI register
+//! [`RedisFlowStoreBackendFactory`] when built with their default `redis-backend` feature.
+//!
+//! Nothing about the wire format, config schema or store behaviour changed in the move.
+
 use anyhow::{Context, Result};
 use redis::{Commands, Connection};
+use rift_mock_core::extensions::flow_state::{CasOutcome, FlowStore};
 use serde_json::Value;
 use std::sync::Mutex;
 
@@ -149,8 +159,8 @@ fn escape_glob(s: &str) -> String {
 /// #318): annotate the failed op, then attach `BackendUnavailable`. Serde failures are
 /// NOT wrapped — malformed stored data is corruption, not backend unavailability.
 fn backend_err(op: &'static str, err: impl std::fmt::Display) -> anyhow::Error {
-    crate::extensions::decorate::annotate(op, err.to_string());
-    anyhow::Error::new(crate::extensions::decorate::BackendUnavailable {
+    rift_mock_core::extensions::decorate::annotate(op, err.to_string());
+    anyhow::Error::new(rift_mock_core::extensions::decorate::BackendUnavailable {
         feature: "flowState",
         detail: format!("{op}: {err}"),
     })
@@ -434,18 +444,107 @@ fn scan_batch(
         .map_err(|e| backend_err(op, e))
 }
 
-/// Health check for Redis connection
-#[allow(dead_code, private_interfaces)]
-pub(crate) fn health_check(pool: &r2d2::Pool<RedisConnectionManager>) -> Result<bool> {
-    let conn = pool.get().context("Failed to get connection from pool")?;
+/// Registers [`RedisFlowStore`] under the `_rift.flowState.backend` name `"redis"` (issue #853).
+///
+/// Construction is eager and fail-loud: a missing `redis` config block, an unparseable URL or an
+/// unreachable server all fail imposter creation (surfacing as a 400) rather than silently
+/// downgrading to a no-op store (issues #325/#377).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RedisFlowStoreBackendFactory;
 
-    let mut guard = lock_recover(&conn);
-    match redis::cmd("PING").query::<String>(&mut *guard) {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            tracing::warn!("Redis health check failed: {}", e);
-            Ok(false)
+impl rift_mock_core::extensions::flow_state::FlowStoreBackendFactory
+    for RedisFlowStoreBackendFactory
+{
+    fn name(&self) -> &'static str {
+        "redis"
+    }
+
+    fn build(
+        &self,
+        config: &rift_mock_core::imposter::RiftFlowStateConfig,
+    ) -> Result<std::sync::Arc<dyn FlowStore>> {
+        let Some(ref redis_config) = config.redis else {
+            tracing::error!("Redis backend selected but no redis config provided");
+            anyhow::bail!("flowState.backend is \"redis\" but no redis config block was provided");
+        };
+
+        match RedisFlowStore::new(
+            &redis_config.url,
+            redis_config.pool_size,
+            redis_config.key_prefix.clone(),
+            config.ttl_seconds,
+        ) {
+            Ok(store) => {
+                // No "for imposter" here: since #853 this one factory also serves the server-level
+                // config-file path, where that wording would be wrong.
+                tracing::info!(
+                    "Created Redis FlowStore (url={}, ttl={}s)",
+                    redis_config.url,
+                    config.ttl_seconds
+                );
+                Ok(std::sync::Arc::new(store))
+            }
+            Err(e) => {
+                tracing::error!("Failed to create Redis FlowStore: {e:#}");
+                anyhow::bail!("failed to build the Redis flow store: {e}");
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod factory_tests {
+    use super::*;
+    use rift_mock_core::extensions::flow_state::FlowStoreBackendFactory;
+    use rift_mock_core::imposter::{RiftFlowStateConfig, RiftRedisConfig};
+
+    fn config(redis: Option<RiftRedisConfig>) -> RiftFlowStateConfig {
+        RiftFlowStateConfig {
+            backend: "redis".to_string(),
+            ttl_seconds: 300,
+            redis,
+            flow_id_source: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn factory_serves_the_redis_backend_name() {
+        assert_eq!(RedisFlowStoreBackendFactory.name(), "redis");
+    }
+
+    // Issue #325: the no-config-block case must fail construction, not decline silently. This is
+    // the error that used to live in `Imposter::create_redis_flow_store`; the wording is preserved
+    // because it is operator-facing.
+    #[test]
+    fn factory_without_a_redis_block_fails_loudly() {
+        let err = match RedisFlowStoreBackendFactory.build(&config(None)) {
+            Ok(_) => panic!("a redis backend with no redis block must fail"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("no redis config block was provided"),
+            "got: {err}"
+        );
+    }
+
+    // Issue #325/#358: an unreachable URL must fail at construction (the eager PING), never
+    // succeed and fail later on first use.
+    #[test]
+    fn factory_with_an_unreachable_url_fails_construction() {
+        let cfg = config(Some(RiftRedisConfig {
+            url: "redis://127.0.0.1:1".to_string(),
+            pool_size: 1,
+            key_prefix: "rift:".to_string(),
+        }));
+        let err = match RedisFlowStoreBackendFactory.build(&cfg) {
+            Ok(_) => panic!("an unreachable redis URL must fail construction"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("failed to build the Redis flow store"),
+            "got: {err}"
+        );
     }
 }
 
@@ -478,7 +577,7 @@ mod tests {
     fn backend_err_is_downcastable_to_backend_unavailable() {
         let err = backend_err("flowStore.get", "connection refused");
         let unavailable = err
-            .downcast_ref::<crate::extensions::decorate::BackendUnavailable>()
+            .downcast_ref::<rift_mock_core::extensions::decorate::BackendUnavailable>()
             .expect("typed error");
         assert_eq!(unavailable.feature, "flowState");
         assert!(unavailable.detail.contains("flowStore.get"));

--- a/crates/rift-store-redis/tests/redis_backend.rs
+++ b/crates/rift-store-redis/tests/redis_backend.rs
@@ -1,31 +1,24 @@
-//! Integration tests for RedisFlowStore using testcontainers.
+//! Integration tests for [`RedisFlowStore`] using testcontainers.
 //!
-//! # Currently disabled (issue #853)
+//! These moved here from `rift-http-proxy` with the store itself (issue #853) and are **live
+//! again**: the ignore attributes and the `redis-integration` CI job's `if: false` that parked the
+//! suite during the extraction are both gone. `redis` is not optional in this crate, so the suite
+//! needs no feature gate either.
 //!
-//! Every container-backed test below is `#[ignore]`d, and the dedicated `redis-integration` CI
-//! job is switched off, until #853 extracts `RedisFlowStore` into the `rift-store-redis` crate —
-//! that change relocates this suite, so running it in the interim only re-litigates behaviour the
-//! extraction is about to move. They are `#[ignore]`d rather than deleted or `#[cfg]`d out so the
-//! file still **compiles** in the `Integration Tests` job: API drift in `RedisFlowStore` or
-//! `FlowStore` still breaks the build here, it just doesn't spend a Docker container per PR.
-//! Re-enable by removing these attributes and the CI job's `if: false` (see #853's checklist).
-//! Run them meanwhile with `cargo test -p rift-http-proxy --test redis_backend -- --ignored`.
-//!
-//! The `probe_gate` unit tests at the bottom are deliberately **not** ignored — they are pure
-//! classification logic (issue #649) and need no Docker.
+//! The `probe_gate` unit tests at the bottom need no Docker — they are pure classification logic
+//! (issue #649).
 //!
 //! These tests start a throwaway Redis container via testcontainers, so **Docker must be
 //! running**. When Docker is not available they are **skipped** locally (with a note on stderr)
-//! rather than hanging and failing — so `cargo test -p rift-http-proxy` is green on a dev machine
-//! without Docker. In CI (`CI`/`GITHUB_ACTIONS` set) a *definitively* absent Docker is a hard
-//! failure, so coverage is never silently lost; a probe that merely times out under load proceeds
-//! and lets testcontainers decide (issue #649). To run them locally, start Docker (e.g.
-//! `colima start` or Docker Desktop) and re-run.
+//! rather than hanging and failing — so `cargo test` is green on a dev machine without Docker. In
+//! CI (`CI`/`GITHUB_ACTIONS` set) a *definitively* absent Docker is a hard failure, so coverage is
+//! never silently lost; a probe that merely times out under load proceeds and lets testcontainers
+//! decide (issue #649). To run them locally, start Docker (e.g. `colima start` or Docker Desktop)
+//! and re-run.
 
-#[cfg(feature = "redis-backend")]
 mod tests {
-    use rift_http_proxy::backends::RedisFlowStore;
-    use rift_http_proxy::flow_state::FlowStore;
+    use rift_mock_core::extensions::flow_state::FlowStore;
+    use rift_store_redis::RedisFlowStore;
     use serde_json::json;
     use std::time::{Duration, Instant};
     use testcontainers::runners::AsyncRunner;
@@ -110,6 +103,15 @@ mod tests {
     /// Docker is a hard failure (so CI never silently loses Redis coverage). A probe timeout
     /// in CI is not treated as absence; see [`DockerProbe::disposition`].
     async fn setup(ttl: i64) -> Option<(testcontainers::ContainerAsync<Redis>, RedisFlowStore)> {
+        let (container, url) = setup_container().await?;
+        let store = RedisFlowStore::new(&url, 5, "test:".to_string(), ttl).unwrap();
+        Some((container, store))
+    }
+
+    /// Start a Redis container and return it with its URL, for tests that need to build the store
+    /// through a higher layer (the factory, the backend registry) rather than calling
+    /// [`RedisFlowStore::new`] directly. Same Docker disposition rules as [`setup`].
+    async fn setup_container() -> Option<(testcontainers::ContainerAsync<Redis>, String)> {
         let in_ci = std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok();
         match docker_probe().disposition(in_ci) {
             Disposition::Proceed => {}
@@ -125,18 +127,100 @@ mod tests {
         }
         let container = Redis::default().start().await.unwrap();
         let port = container.get_host_port_ipv4(6379).await.unwrap();
-        let store = RedisFlowStore::new(
-            &format!("redis://127.0.0.1:{port}"),
-            5,
-            "test:".to_string(),
-            ttl,
-        )
-        .unwrap();
-        Some((container, store))
+        Some((container, format!("redis://127.0.0.1:{port}")))
+    }
+
+    /// A `flowState` block selecting redis at `url`, as an imposter config carries it.
+    fn redis_flow_state(url: &str) -> rift_mock_core::imposter::RiftFlowStateConfig {
+        rift_mock_core::imposter::RiftFlowStateConfig {
+            backend: "redis".to_string(),
+            ttl_seconds: 300,
+            redis: Some(rift_mock_core::imposter::RiftRedisConfig {
+                url: url.to_string(),
+                pool_size: 5,
+                key_prefix: "factory:".to_string(),
+            }),
+            flow_id_source: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    // Issue #853 AC2: the factory's SUCCESS path against a real Redis. Every other factory test
+    // covers a failure branch, and the rest of this suite calls `RedisFlowStore::new` directly —
+    // so without this, the adapter the extraction introduces is never proven to produce a working
+    // store, and a field-mapping slip in `build()` (ttl for pool size, say) would pass everything.
+    #[tokio::test]
+    async fn factory_builds_a_working_store_against_a_real_redis() {
+        use rift_mock_core::extensions::flow_state::FlowStoreBackendFactory;
+
+        let Some((_container, url)) = setup_container().await else {
+            return;
+        };
+
+        let store = rift_store_redis::RedisFlowStoreBackendFactory
+            .build(&redis_flow_state(&url))
+            .expect("the factory must build a store against a reachable redis");
+
+        store.set("flow-f", "k", json!({"via": "factory"})).unwrap();
+        assert_eq!(
+            store.get("flow-f", "k").unwrap(),
+            Some(json!({"via": "factory"})),
+            "a store built through the factory must round-trip values"
+        );
+        assert!(
+            store.is_blocking(),
+            "the redis store blocks, and the request path relies on that to offload (issue #475)"
+        );
+    }
+
+    // Issue #853 AC2, the composition that "behaviour-neutral" actually means: an imposter whose
+    // config names `"redis"` resolves it through the backend registry to a real Redis store. This
+    // is the whole seam end to end — registry -> `Imposter::create_flow_store` -> factory -> store
+    // — which fakes cannot prove.
+    #[tokio::test]
+    async fn an_imposter_resolves_redis_through_the_backend_registry() {
+        use rift_mock_core::extensions::flow_state::FlowStoreBackends;
+        use rift_mock_core::imposter::Imposter;
+
+        let Some((_container, url)) = setup_container().await else {
+            return;
+        };
+
+        let backends = FlowStoreBackends::new().with(std::sync::Arc::new(
+            rift_store_redis::RedisFlowStoreBackendFactory,
+        ));
+        let config: rift_mock_core::imposter::ImposterConfig = serde_json::from_value(json!({
+            "port": 0,
+            "protocol": "http",
+            "stubs": [],
+            "_rift": { "flowState": {
+                "backend": "redis",
+                "ttlSeconds": 300,
+                "redis": { "url": url, "keyPrefix": "imposter:" }
+            }}
+        }))
+        .expect("valid imposter config");
+
+        let imposter =
+            Imposter::new_with_hooks_journal_and_backends(config, None, None, None, &backends)
+                .expect("an imposter naming a registered backend must build");
+
+        imposter
+            .flow_store
+            .set("flow-i", "k", json!("through the registry"))
+            .unwrap();
+        assert_eq!(
+            imposter.flow_store.get("flow-i", "k").unwrap(),
+            Some(json!("through the registry")),
+            "the imposter's store must be the real Redis one, reached via the registry"
+        );
+        assert!(
+            imposter.flow_store.is_blocking(),
+            "resolving through the registry must not lose the blocking-store property (#475)"
+        );
     }
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_get_set() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -150,7 +234,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_increment() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -169,7 +252,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_ttl() {
         let Some((_container, store)) = setup(2).await else {
             return;
@@ -185,7 +267,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_exists_delete() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -200,10 +281,9 @@ mod tests {
 
     // ===== compare_and_set (issue #311) — single-round-trip Lua CAS =====
 
-    use rift_http_proxy::flow_state::CasOutcome;
+    use rift_mock_core::extensions::flow_state::CasOutcome;
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_cas_expected_absent_applies() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -221,7 +301,6 @@ mod tests {
     // SETEX inside the CAS script must carry the store TTL: a CAS-applied key expires
     // like a set() key (a dropped TTL arg would mean unbounded key growth in Redis).
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_cas_applied_key_expires() {
         let Some((_container, store)) = setup(2).await else {
             return;
@@ -244,7 +323,6 @@ mod tests {
     // Issue #475: increment_by folds INCRBY + EXPIRE into one EVAL. Mirror the CAS-expiry test to
     // pin that the EXPIRE arg isn't dropped — a lost EXPIRE would mean unbounded key growth.
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_increment_by_key_expires() {
         let Some((_container, store)) = setup(2).await else {
             return;
@@ -262,7 +340,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_cas_expected_present_and_conflict() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -303,7 +380,6 @@ mod tests {
     // extend every key's TTL via SCAN + EXPIRE. With a 2s store default, extending to 100s must keep
     // the keys alive past a 3s wait (before the fix they'd expire at 2s and be gone).
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_set_ttl_extends_all_keys() {
         let Some((_container, store)) = setup(2).await else {
             return;
@@ -335,7 +411,6 @@ mod tests {
 
     // Flow-level ttl(<=0) expires every current key (Redis EXPIRE semantics), matching in-memory.
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_set_ttl_zero_expires_flow() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -350,7 +425,6 @@ mod tests {
 
     // Per-key ttl mirrors Redis EXPIRE: true when the key exists, false when absent; <=0 deletes.
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_set_key_ttl() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -383,7 +457,6 @@ mod tests {
 
     // clear_flow removes only the target flow's keys.
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_clear_flow() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -416,7 +489,6 @@ mod tests {
     // literally by clear_flow's SCAN MATCH — it must NOT wipe sibling flows whose ids the glob would
     // otherwise match. Here clear_flow("a*") must clear only the literal flow "a*", leaving "abc".
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_clear_flow_does_not_glob_across_flows() {
         let Some((_container, store)) = setup(300).await else {
             return;
@@ -449,7 +521,6 @@ mod tests {
 
     // Per-key ttl on an already-expired key reports false (the key is absent), on Redis too.
     #[tokio::test]
-    #[ignore = "disabled pending #853: the Redis flow store moves to the rift-store-redis crate; re-enable as part of that change"]
     async fn test_redis_set_key_ttl_on_expired_key_is_false() {
         let Some((_container, store)) = setup(2).await else {
             return;

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -56,7 +56,7 @@ The engines and allocator are feature-gated. Relevant features:
 
 | Feature | Default (`rift-http-proxy`) | Default (`rift-ffi`) | Effect |
 |:--------|:----------------------------|:---------------------|:-------|
-| `redis-backend` | on | on | Redis flow-store backend |
+| `redis-backend` | on | on | Redis flow-store backend. The store itself lives in the separate `rift-store-redis` crate; this feature pulls it in and registers it under `_rift.flowState.backend: "redis"`. `rift-mock-core` has **no** redis feature and never depends on `redis`/`r2d2`, so embedders taking the engine alone do not carry them. |
 | `javascript` | on | on | JavaScript scripting engine (Boa) |
 | `mimalloc` | on | **never forwarded** | mimalloc global allocator (a `cdylib` must not impose an allocator on its host, so `rift-ffi` deliberately never enables it) |
 | `jemalloc` | off | n/a | Opt-in alternative allocator, kept for the #717 bake-off. If both `mimalloc` and `jemalloc` are enabled (as in CI's `--all-features` lanes), **mimalloc wins** — this is resolved by `cfg` precedence, not an error. mimalloc remains the shipped default. |
@@ -66,7 +66,9 @@ The engines and allocator are feature-gated. Relevant features:
 > each engine feature above must be explicitly forwarded to reach what actually ships.
 > `scripts/verify-feature-propagation.sh` enforces that in CI, so a feature cannot be default-on for
 > the library and silently absent from the binary — which is what
-> [#777](https://github.com/achird-labs/rift/issues/777) fixed.
+> [#777](https://github.com/achird-labs/rift/issues/777) fixed. `redis-backend` is checked by the
+> same script along a different chain, since it is no longer a `rift-mock-core` feature: it must
+> enable `dep:rift-store-redis` in `rift-http-proxy`, and `rift-ffi` must forward it from there.
 
 ---
 

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -46,6 +46,54 @@ pub trait FlowStoreProvider: Send + Sync {
 
 Inject with `.with_flow_store_provider(Arc<dyn FlowStoreProvider>)`.
 
+A provider **overrides** the imposter's own `_rift.flowState` selection, and it cannot report a
+failure — `provide` returns `Option`, so declining falls through to the built-ins. When you want a
+store the *config* selects by name, and misconfiguration to fail loudly, use
+`FlowStoreBackendFactory` below instead.
+
+---
+
+## `FlowStoreBackendFactory` — a named flow-state backend
+
+Adds a `_rift.flowState.backend` name the config can select, with an error channel. This is how the
+Redis backend ships: it lives in the separate `rift-store-redis` crate, so `rift-mock-core` itself
+carries no `redis`/`r2d2` dependency under any feature combination.
+
+```rust
+pub trait FlowStoreBackendFactory: Send + Sync {
+    /// The `_rift.flowState.backend` string this factory serves, e.g. "redis".
+    fn name(&self) -> &'static str;
+
+    /// Build a store for this imposter's flowState block. An `Err` fails imposter creation.
+    fn build(&self, config: &RiftFlowStateConfig) -> anyhow::Result<Arc<dyn FlowStore>>;
+}
+```
+
+Register with `.with_flow_store_backends(FlowStoreBackends)`:
+
+```rust
+use rift_mock_core::extensions::flow_state::FlowStoreBackends;
+
+let backends = FlowStoreBackends::new().with(Arc::new(MyBackend));
+let manager = ImposterManager::new().with_flow_store_backends(backends);
+```
+
+The `rift` binary and the C-ABI register their shipped backends automatically — with the default
+`redis-backend` feature that means `"redis"`, so `_rift.flowState.backend: "redis"` works out of the
+box. `rift_http_proxy::default_flow_store_backends()` returns that set if you are assembling a
+manager yourself and want the same vocabulary.
+
+Choosing between the two seams:
+
+| | `FlowStoreProvider` | `FlowStoreBackendFactory` |
+|---|---|---|
+| Selected by | the embedder, for every imposter | the imposter's `flowState.backend` name |
+| Precedence | overrides `_rift.flowState` | only consulted when the config names it |
+| On failure | can only decline (`None`) → falls through | returns `Err` → imposter creation fails with `400` |
+
+A backend name that nothing registered is a config error, never a silent downgrade to a no-op store:
+creation fails with an error listing the names this build does serve.
+
 ## `ResponseSequencer` — custom response cycling
 
 Owns the per-stub cursor that drives multiple-response cycling and `repeat` (see

--- a/docs/features/flow-state.md
+++ b/docs/features/flow-state.md
@@ -41,10 +41,12 @@ With `backend: "redis"` you may also set `url`, `poolSize` (default 10), and `ke
 An explicit `flowState` block that can't be honored now **fails imposter creation** with
 `400 Bad Request` rather than silently downgrading to a no-op store:
 
-- An **unknown backend** string (anything other than `inmemory` or `redis`) is rejected at
-  construction.
+- An **unregistered backend** string is rejected at construction. The error names the backend and
+  lists the ones this build can serve, e.g. `flowState.backend is "mystore" but no such backend is
+  registered (available: "inmemory", "redis")`.
 - A **`redis` backend that can't be created** — no redis config block, a connection/pool failure, or
-  a binary built without the `redis-backend` feature — fails creation too.
+  a binary built without the `redis-backend` feature — fails creation too. In the last case the
+  error also tells you to rebuild with `--features redis-backend`.
 - A **non-positive `ttlSeconds`** (`< 1`) is rejected: a zero/negative default TTL would expire every
   write the instant it lands (and errors on the first Redis `SETEX`), so it's caught up front rather
   than misbehaving later.

--- a/scripts/verify-feature-propagation.sh
+++ b/scripts/verify-feature-propagation.sh
@@ -28,10 +28,23 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST="${MANIFEST:-$repo_root/Cargo.toml}"
 
-# Features intentionally NOT forwarded, as "crate:feature=reason". Empty today.
+# Features intentionally NOT forwarded, as "crate:feature=reason".
 # (`mimalloc` is NOT here: it is a `rift-http-proxy` feature, not a `rift-mock-core` one, so it is
 # outside this invariant entirely.)
-DELIBERATELY_NOT_FORWARDED=()
+#
+# The invariant this gate encodes is "on by default in the library means on by default in what
+# ships", and it finds dependents structurally — anything taking rift-mock-core with
+# default-features = false. `rift-store-redis` (issue #853) matches that shape without being
+# something users run: it is a leaf *backend* crate, pulled in BY rift-http-proxy, and it needs core
+# only for the `FlowStore`/`FlowStoreBackendFactory` seams and the `RiftFlowStateConfig` type.
+# Nobody builds the engine through it, so forwarding the engine's own features would be inert — and
+# taking core with default features instead would drag boa_engine and quamina into a Redis client
+# crate, which is the dependency bloat #853 exists to remove. The propagation that does matter for
+# redis is checked by CHAINS below.
+DELIBERATELY_NOT_FORWARDED=(
+  "rift-store-redis:javascript=leaf backend crate (#853), not a shipped artifact; needs core only for the FlowStore seams"
+  "rift-store-redis:quamina-matching=leaf backend crate (#853), not a shipped artifact; needs core only for the FlowStore seams"
+)
 
 check() {
   local manifest="$1"
@@ -80,6 +93,38 @@ for feat in lib_defaults:
                 f"{dep}: forwards '{feat}' via {forwarding} but none of those are in its "
                 f"default = [...], so it is off unless a caller opts in.")
 
+# A feature can also be default-on in the library layer WITHOUT being one of rift-mock-core's own
+# features, in which case the loop above cannot see it at all. `redis-backend` became exactly that
+# in issue #853: the Redis store moved to the `rift-store-redis` crate, so rift-mock-core has no
+# such feature any more and the invariant above stopped covering redis entirely — silently
+# reopening the #777 blind spot it exists to close. These chains restore the coverage by naming the
+# hop explicitly: each entry is "crate:feature -> what it must enable".
+CHAINS = [
+    # The feature must actually pull the backend crate in, not just exist.
+    ("rift-http-proxy", "redis-backend", "dep:rift-store-redis"),
+    # ...and the C-ABI must forward it, since rift-ffi is what embedded SDKs load.
+    ("rift-ffi", "redis-backend", "rift-http-proxy/redis-backend"),
+]
+
+for crate, feat, required in CHAINS:
+    if crate not in pkgs:
+        failures.append(f"{crate}: not in the workspace — has it been renamed?")
+        continue
+    feats = pkgs[crate]["features"]
+    if feat not in feats:
+        failures.append(
+            f"{crate}: has no '{feat}' feature at all.\n"
+            f"    Expected:  {feat} = [\"{required}\"]\n"
+            f"    Effect today: nothing users run can select that backend.")
+        continue
+    if required not in feats[feat]:
+        failures.append(
+            f"{crate}: '{feat}' does not enable '{required}' (it enables {feats[feat]}).\n"
+            f"    Effect today: the feature name exists but reaches nothing — the #777 shape.")
+    if feat not in feats.get("default", []):
+        failures.append(
+            f"{crate}: '{feat}' is not in its default = [...], so it is off unless a caller opts in.")
+
 if failures:
     print("Feature-propagation gate FAILED:\n", file=sys.stderr)
     for f in failures:
@@ -89,7 +134,8 @@ if failures:
     sys.exit(1)
 
 print(f"Feature propagation OK: {LIB} defaults {lib_defaults} "
-      f"forwarded and default-on in {sorted(set(dependents))}.")
+      f"forwarded and default-on in {sorted(set(dependents))}; "
+      f"chains OK: {[f'{c}:{f}' for c, f, _ in CHAINS]}.")
 PY
 }
 


### PR DESCRIPTION
Extracts `RedisFlowStore` out of `rift-mock-core` into a new opt-in `rift-store-redis` crate, wired back in through a new named-backend factory seam. `rift-mock-core` ends up with **zero** redis/r2d2 dependencies under any feature combination; the shipped `rift` binary, Docker images and `rift-ffi` cdylibs keep `redis-backend` default-on, so this release is **behaviour-neutral** for users.

## Why a factory and not `FlowStoreProvider`

`FlowStoreProvider::provide` returns `Option` — no error channel — so a misconfigured redis block could only decline and silently fall through to a built-in. A misconfigured backend must fail imposter creation (#325/#377). `FlowStoreBackendFactory` returns `Result`, and is consulted only when the config names it rather than overriding the config.

## Verification

- `cargo tree -p rift-mock-core --all-features` — 0 `redis`, 0 `r2d2` (AC1)
- **The relocated Redis integration suite runs green against a real Redis** — 16 container-backed tests + 7 Docker-free `probe_gate` tests
- `cargo test --workspace --all-features` — 65 suites, 0 failures
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, plus the minimal `--no-default-features` cdylib lane
- `scripts/verify-feature-propagation.sh` green
- Opt-in proven both ways: the rift-ffi tree has 3 redis-related crates with `redis-backend`, 0 without

## Gates added, and proven to bite

Two of the new guards were mutation-tested rather than merely observed passing:

- **Wiring guards** at both shipped registration sites (`ServerBuilder` and the C-ABI `rift_start`). `default_flow_store_backends()` being unit-tested is not enough: dropping the registration call would compile, lint and test clean while every user of `backend: "redis"` broke. Removing the call at either site now fails its test (verified).
- **Feature-propagation chain.** `rift-mock-core` losing `redis-backend` made the existing gate stop covering redis entirely, silently reopening the #777 blind spot it exists to close. Added an explicit chain check (`rift-http-proxy:redis-backend -> dep:rift-store-redis`, `rift-ffi` forwards it), verified against four planted breaks.

`rift-store-redis` is exempted from the core-default-forwarding invariant with a recorded reason: it is a leaf backend crate, not a shipped artifact, and taking core with default features would drag Boa and Quamina into a Redis client — the bloat this change removes.

## Docs

`docs/embedding/spi.md` documents the new seam beside `FlowStoreProvider` with a table for choosing between them; `docs/features/flow-state.md` and `docs/embedding/index.md` updated; CHANGELOG entry under Changed.

Closes #853
Milestone: standalone
