### PR TITLE
admin API: an empty --apikey enables the auth gate and then authenticates everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ record.
 
 ## [Unreleased]
 
+### Security
+
+- **An empty `--api-key` enabled the admin auth gate and then authenticated everyone** (issue #844).
+  `Some("")` is `Some`, so the gate switched on; a request with no `Authorization` header degrades
+  to `""`, and comparing two empty strings matched. The admin API — which can create imposters and
+  drive the TLS intercept proxy — reported as protected while being fully open, on the configuration
+  that most looks like it should fail closed.
+
+  A blank key (empty or whitespace) is now refused where it is configured: at CLI startup, before
+  anything binds, and in `rift_serve_admin`, which is the boundary every language SDK reaches the
+  admin plane through — so this is fixed once for the CLI and all SDKs rather than in four guards
+  that can each drift. Rejecting rather than silently downgrading to "no auth" is deliberate: a
+  downgrade would leave the operator believing a key is in force. As defence in depth, the key
+  comparison itself now fails closed on a blank configured key.
+
+  The realistic trigger was ordinary plumbing — an unset-but-defaulted `MB_APIKEY`, a Helm value
+  that renders empty, or an SDK passing `apiKey(getProperty("rift.apikey", ""))`. **If you were
+  relying on `--api-key ""` to mean "no authentication", omit the flag instead**; that has always
+  been the supported spelling and is unchanged. A key containing spaces is still a valid key and is
+  compared byte for byte, untrimmed.
+
 ### Fixed
 
 - **Reverse-proxy `*.` host routes matched hosts they should not have.** A wildcard route's host

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1844,6 +1844,10 @@ async fn build_admin_plane_inner(
 ) -> anyhow::Result<(AdminPlane, String)> {
     let host = opts.host.as_deref().unwrap_or("127.0.0.1");
     let port = opts.port.unwrap_or(0);
+    // Refuse a blank `apiKey` before any side effect (issue #844): it would enable the auth gate
+    // and then authenticate every request. This is the boundary every SDK reaches the admin plane
+    // through, so rejecting here covers all of them at once.
+    rift_http_proxy::admin_api::validate_admin_api_key(opts.api_key.as_deref())?;
     let api_key = opts.api_key.clone();
     let allow_injection = opts.allow_injection.unwrap_or(false);
 

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -2386,3 +2386,77 @@ fn ffi_serve_admin_failure_after_intercept_start_leaves_no_listener() {
         drop(occupied);
     }
 }
+
+// Issue #844: a blank `apiKey` used to switch the auth gate ON and then authenticate every
+// anonymous request. This is the boundary that matters most for the SDKs: they all reach the admin
+// plane through `rift_serve_admin`, and the realistic trigger is plumbing rather than intent —
+// `apiKey(getProperty("rift.apikey", ""))`, or a Helm value that renders empty. Rejecting here
+// fixes it once for all four SDKs instead of four guards that can each drift.
+#[test]
+fn ffi_serve_admin_rejects_a_blank_api_key() {
+    unsafe {
+        for blank in ["", "   "] {
+            let h = rift_start();
+            let opts = cstr(&format!(
+                r#"{{"host":"127.0.0.1","port":0,"apiKey":{}}}"#,
+                serde_json::json!(blank)
+            ));
+            assert!(
+                rift_serve_admin(h, opts.as_ptr()).is_null(),
+                "a blank apiKey must be refused, not accepted as a key that matches everyone"
+            );
+
+            let err = rift_last_error();
+            assert!(!err.is_null(), "a refused blank apiKey records last_error");
+            let msg = take_json(err);
+            assert!(
+                msg.contains("api-key") || msg.contains("apiKey"),
+                "the rejection must name the option an embedder would fix, got: {msg}"
+            );
+
+            rift_stop(h);
+        }
+    }
+}
+
+// Issue #844 AC4: a real key over the same path still works and is still enforced — the fix must
+// not weaken the configuration that was already correct.
+#[test]
+fn ffi_serve_admin_still_enforces_a_real_api_key() {
+    unsafe {
+        let h = rift_start();
+        let started = serve_admin(
+            h,
+            r#"{"host":"127.0.0.1","port":0,"apiKey":"s3cret-token"}"#,
+        );
+        let admin_url = started["adminUrl"].as_str().expect("adminUrl").to_string();
+
+        let anonymous = rt().block_on(async {
+            reqwest::Client::new()
+                .get(format!("{admin_url}/imposters"))
+                .send()
+                .await
+                .expect("request")
+                .status()
+                .as_u16()
+        });
+        assert_eq!(anonymous, 401, "anonymous must still be rejected");
+
+        let authorized = rt().block_on(async {
+            reqwest::Client::new()
+                .get(format!("{admin_url}/imposters"))
+                .header("authorization", "s3cret-token")
+                .send()
+                .await
+                .expect("request")
+                .status()
+                .as_u16()
+        });
+        assert_eq!(
+            authorized, 200,
+            "the configured key must still authenticate"
+        );
+
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -15,7 +15,7 @@ mod server;
 pub mod types;
 
 pub use handlers::imposters::{filter_proxy_responses, filter_proxy_stubs};
-pub use server::{AdminApiServer, RunningAdminApi};
+pub use server::{AdminApiServer, RunningAdminApi, validate_admin_api_key};
 
 /// Default port for the Mountebank-compatible admin API.
 pub const DEFAULT_ADMIN_PORT: u16 = 2525;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -102,6 +102,13 @@ impl AdminApiServer {
     /// Bind the listener (`:0` is fine) and start serving on the current runtime, returning a
     /// handle that reports the bound address and can be shut down gracefully (issue #342).
     pub async fn bind(self) -> anyhow::Result<RunningAdminApi> {
+        // The third door onto this server, after the CLI and the C-ABI: an embedder building an
+        // `AdminApiServer` directly (documented in docs/embedding/server.md). Without this check a
+        // blank key here is caught only by `api_key_matches` failing closed, which is safe but
+        // silent — the embedder would get a server that 401s everything while the log below claims
+        // authentication is enabled. Checking at the one point all three doors converge on makes
+        // the diagnosis loud wherever the key came from (issue #844).
+        validate_admin_api_key(self.api_key.as_deref().map(String::as_str))?;
         let listener = TcpListener::bind(self.addr).await?;
         let local_addr = listener.local_addr()?;
         info!(
@@ -588,7 +595,42 @@ async fn accept_loop(
 /// (issue #548). `ConstantTimeEq` compares every byte regardless of where the
 /// mismatch is; the length check it performs first is not secret.
 fn api_key_matches(provided: &str, expected: &str) -> bool {
+    // Fail closed on a blank configured key (issue #844). A request with no `authorization` header
+    // reaches here as `""`, so comparing it against a blank key returns true and authenticates
+    // everyone — on the configuration that most looks like it should fail closed. A classifier that
+    // cannot tell callers apart must treat them as unauthenticated.
+    //
+    // This early return branches only on the SERVER's configured key, never on the caller-supplied
+    // one, so it leaks nothing about the secret and leaves the constant-time property from #548
+    // intact for the comparison that matters.
+    if expected.trim().is_empty() {
+        return false;
+    }
     provided.as_bytes().ct_eq(expected.as_bytes()).into()
+}
+
+/// Reject a blank admin API key where it is configured (issue #844).
+///
+/// A blank key is a misconfiguration, not a key: `Some("")` switches the auth gate on, and a
+/// request with no `Authorization` header also degrades to `""`, so the gate then matches everyone.
+/// Rejecting rather than normalising to "no auth" is deliberate — a silent downgrade leaves the
+/// operator believing a key is in force. Whitespace-only counts as blank; a key that merely
+/// *contains* spaces is valid and is never trimmed for comparison.
+///
+/// See the CHANGELOG entry and `docs/configuration/cli.md` for the operator-facing account of how
+/// a blank value gets configured in the first place.
+pub fn validate_admin_api_key(api_key: Option<&str>) -> anyhow::Result<()> {
+    if let Some(key) = api_key
+        && key.trim().is_empty()
+    {
+        anyhow::bail!(
+            "the admin API key (`--api-key` / `MB_APIKEY` / `apiKey`) is set to a blank value. \
+             That would enable the auth gate and then accept every unauthenticated request, \
+             leaving the admin API open while reporting as protected. Set a real token, or omit \
+             it entirely to run the admin API explicitly unauthenticated."
+        );
+    }
+    Ok(())
 }
 
 /// Box a `Full<Bytes>` response into the streaming-unified `AdminBody` (issue #461), so the normal
@@ -679,9 +721,73 @@ mod tests {
     #[test]
     fn api_key_matches_rejects_empty_against_nonempty() {
         assert!(!api_key_matches("", "s3cret-token"));
-        // Two empty strings are trivially equal — no key configured is handled
-        // by the `Some(key)` guard at the call site, not here.
-        assert!(api_key_matches("", ""));
+    }
+
+    // Issue #844: this used to assert the OPPOSITE — that two empty strings match — on the
+    // reasoning that "no key configured is handled by the `Some(key)` guard at the call site".
+    // `Some("")` is `Some`, so that guard does not fire: the gate switched ON and then
+    // authenticated every anonymous request, because a missing `authorization` header also
+    // degrades to `""`. A security classifier that cannot identify a caller must fail closed, so a
+    // blank configured key now matches nothing. `validate_admin_api_key` rejects that config long
+    // before a request arrives; this is the backstop for an entry point that forgets to call it.
+    #[test]
+    fn api_key_matches_fails_closed_on_a_blank_expected_key() {
+        assert!(
+            !api_key_matches("", ""),
+            "a blank configured key must not authenticate an anonymous request"
+        );
+        assert!(!api_key_matches("anything", ""));
+        assert!(!api_key_matches("", "   "));
+        assert!(
+            !api_key_matches("   ", "   "),
+            "a whitespace-only key is blank too, and must not authenticate its own echo"
+        );
+    }
+
+    // Issue #844 AC1/AC2: the shared validator both config boundaries use. A blank key is a
+    // misconfiguration to reject loudly, never a key and never a silent downgrade to "no auth" —
+    // downgrading would leave the operator believing a key is in force.
+    #[test]
+    fn blank_api_key_is_rejected() {
+        // `\u{00a0}` (non-breaking space) is included deliberately: `str::trim` uses
+        // `char::is_whitespace`, so it counts as blank — and a non-breaking space is exactly the
+        // kind of thing that survives a copy-paste out of a rendered config or a wiki page.
+        for blank in ["", " ", "   ", "\t", "\n", " \t\n ", "\u{00a0}"] {
+            let err = validate_admin_api_key(Some(blank))
+                .expect_err("a blank api key must be rejected")
+                .to_string();
+            assert!(
+                err.contains("--api-key"),
+                "the error must name the flag an operator would fix, got: {err}"
+            );
+        }
+    }
+
+    // Issue #844 AC4: the fix must not change either working configuration — a real key, or no key
+    // at all (explicitly unauthenticated).
+    #[test]
+    fn a_real_or_absent_api_key_is_accepted() {
+        assert!(validate_admin_api_key(Some("s3cret-token")).is_ok());
+        assert!(
+            validate_admin_api_key(Some(" padded ")).is_ok(),
+            "a key with surrounding spaces is unusual but not blank; it stays a valid key"
+        );
+        assert!(
+            validate_admin_api_key(None).is_ok(),
+            "no key at all remains a supported, explicitly unauthenticated configuration"
+        );
+    }
+
+    // Issue #844: a key that is not blank keeps matching exactly as before, including the
+    // surrounding-whitespace case — the validator allows it, so the comparison must too, byte for
+    // byte and without trimming.
+    #[test]
+    fn a_padded_key_still_matches_byte_for_byte() {
+        assert!(api_key_matches(" padded ", " padded "));
+        assert!(
+            !api_key_matches("padded", " padded "),
+            "the comparison must not trim; a trimmed guess is a different key"
+        );
     }
 }
 

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -384,6 +384,11 @@ impl ServerBuilder {
     pub async fn start(self) -> anyhow::Result<RunningServer> {
         let cli = self.cli;
         let extra_sources = self.imposter_sources;
+        // Refuse a blank `--api-key` before anything binds (issue #844). Same reasoning as the
+        // front-door check below, with a security edge: a blank key enables the auth gate and then
+        // authenticates every request, so the admin plane must never reach the accept loop in that
+        // state.
+        crate::admin_api::validate_admin_api_key(cli.api_key.as_deref())?;
         // Validate `--front-door` before anything else binds (issue #19 / U-11): a malformed
         // address is then a clean, fast failure that never has to unwind an already-bound
         // listener behind it.

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -784,3 +784,116 @@ async fn admin_wait_returns_after_shutdown() {
         .expect("admin wait returns after the accept loop exits");
     assert!(waited.is_ok(), "wait reports the accept loop's Ok result");
 }
+
+// Issue #844: `--api-key ""` used to switch the auth gate ON and then authenticate every anonymous
+// request, so the admin plane reported as protected while being fully open. It must now be a loud
+// startup failure instead.
+//
+// Driven through `ServerBuilder::start` rather than the validator directly, because the property
+// that matters is that a real startup refuses: an empty value arrives here from ordinary config
+// plumbing (a Helm value that renders empty, `MB_APIKEY=` unset-but-defaulted, an SDK passing
+// `getProperty("rift.apikey", "")`), not from someone typing `--api-key ""` on purpose.
+#[tokio::test]
+async fn server_builder_rejects_a_blank_api_key() {
+    for blank in ["", "   "] {
+        let cli = Cli::try_parse_from([
+            "rift",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--api-key",
+            blank,
+        ])
+        .expect("cli parse");
+
+        let err = match ServerBuilder::from_cli(cli).start().await {
+            Ok(_) => {
+                panic!("a blank --api-key must fail startup, not silently authenticate everyone")
+            }
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            err.contains("--api-key"),
+            "the failure must name the flag an operator would fix, got: {err}"
+        );
+    }
+}
+
+// Issue #844 AC4: the same path with a real key still starts and still enforces the key — the fix
+// must reject blank keys without weakening the working configuration.
+#[tokio::test]
+async fn server_builder_still_accepts_and_enforces_a_real_api_key() {
+    let cli = Cli::try_parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "12614",
+        "--metrics-port",
+        "19491",
+        "--api-key",
+        "s3cret-token",
+    ])
+    .expect("cli parse");
+
+    tokio::spawn(ServerBuilder::from_cli(cli).run());
+    // Readiness only: `wait_for_http` needs *any* HTTP response, and with a key configured this
+    // probe gets a 401 — `/health` is behind the auth gate like everything except the `/__rift/`
+    // gateway. That 401 is itself evidence the gate is on; the assertions below are what test it.
+    wait_for_http("http://127.0.0.1:12614/health").await;
+
+    let client = reqwest::Client::new();
+    let anonymous = client
+        .get("http://127.0.0.1:12614/imposters")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(
+        anonymous.status(),
+        401,
+        "an anonymous request must still be rejected when a real key is configured"
+    );
+
+    let authorized = client
+        .get("http://127.0.0.1:12614/imposters")
+        .header("authorization", "s3cret-token")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(
+        authorized.status(),
+        200,
+        "the configured key must still authenticate"
+    );
+}
+
+// Issue #844: the third door onto the admin server — an embedder constructing `AdminApiServer`
+// directly, as documented in docs/embedding/server.md. Without a check here a blank key is caught
+// only by `api_key_matches` failing closed: safe, but the embedder gets a server that 401s
+// everything while the startup log says authentication is enabled. `bind()` is where all three
+// doors converge, so the diagnosis is loud wherever the key came from.
+#[tokio::test]
+async fn admin_api_server_bind_rejects_a_blank_api_key() {
+    let manager = Arc::new(ImposterManager::new());
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+
+    let err = match AdminApiServer::new(addr, manager.clone(), Some(String::new()))
+        .bind()
+        .await
+    {
+        Ok(_) => panic!("a blank api key must fail bind, not serve a deny-all admin plane"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        err.contains("api-key"),
+        "the failure must name the option to fix, got: {err}"
+    );
+
+    // AC4 at this door too: a real key still binds and still serves.
+    let running = AdminApiServer::new(addr, manager, Some("s3cret-token".to_string()))
+        .bind()
+        .await
+        .expect("a real key must bind");
+    running.shutdown().await;
+}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -25,6 +25,9 @@ When Rift is started with `--api-key <TOKEN>` (or `MB_APIKEY`), every admin API 
 token in the `Authorization` header. Requests without a matching token receive `401 Unauthorized`.
 Data-plane traffic — direct imposter ports and the `/__rift/:port/...` gateway — is not gated.
 
+A blank token is a startup error, not a key: it would enable this gate and then authenticate every
+request. Omit the option to run the admin API explicitly unauthenticated.
+
 ```bash
 curl -H "Authorization: <TOKEN>" http://localhost:2525/imposters
 ```

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -183,6 +183,17 @@ is a startup error rather than a silent precedence guess, so pick one. (Each fla
 `Authorization` header. Data-plane traffic — direct imposter ports and the `/__rift/:port/...`
 gateway — is **not** gated by this key.
 
+A **blank** value is refused at startup rather than accepted as a key:
+
+```
+the admin API key (`--api-key` / `MB_APIKEY` / `apiKey`) is set to a blank value. …
+```
+
+`--api-key ""` (or `MB_APIKEY=` set-but-empty) would otherwise enable the auth gate and then match
+every unauthenticated request, leaving the admin API open while reporting as protected. Whitespace
+counts as blank. Omit the flag entirely to run the admin API explicitly unauthenticated; a key that
+merely *contains* spaces is still a valid key and is compared exactly as given.
+
 ```bash
 rift-http-proxy --api-key s3cr3t
 curl -H "Authorization: s3cr3t" http://localhost:2525/imposters

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -110,6 +110,11 @@ rift_free(result);
   `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false}`.
   `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
   `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
+- **`apiKey`**: a blank string is rejected — `rift_serve_admin` returns `NULL` and records the
+  reason in `rift_last_error`. A blank key would enable the admin auth gate and then authenticate
+  every request, and the realistic way to send one is plumbing rather than intent
+  (`apiKey(getProperty("rift.apikey", ""))`, a config value that renders empty). Pass a real token,
+  or omit the field to leave the admin plane unauthenticated.
 - **`allowInjection`** (default `false`): whether Rift admits script/`inject` imposters
   (`inject`/`decorate`/`shellTransform`/JS-function `wait`/`_rift.script`), mirroring the
   `--allowInjection` CLI flag. Leave it `false` unless you intend to permit them.


### PR DESCRIPTION
An empty-string admin api key was treated as "authentication enabled" and then matched every unauthenticated request, so the admin plane reported as protected while being fully open.

`Some("")` is `Some` ⇒ the gate switches on. A request with no `Authorization` header falls to `.unwrap_or("")`. `api_key_matches("", "")` is `ct_eq` over two empty slices ⇒ **true**.

## The fix

A blank key (empty **or whitespace**) is refused where it is configured, rather than normalised to "no auth" — a silent downgrade would leave the operator believing a key is in force. Three doors, one validator:

| Door | Where |
|---|---|
| CLI / `MB_APIKEY` | `ServerBuilder::start`, before anything binds |
| C-ABI `rift_serve_admin` | `build_admin_plane_inner`, before any side effect |
| Direct embedding (`docs/embedding/server.md`) | `AdminApiServer::bind()` |

Every language SDK reaches the admin plane through the CLI or the C-ABI, so this fixes it once for all of them instead of four per-SDK guards that can each drift. As **defence in depth**, `api_key_matches` now fails closed on a blank configured key, so an entry point added later that forgets to validate still cannot authenticate anonymous traffic.

A key that merely *contains* spaces is still a valid key, compared byte for byte and never trimmed.

## A test that pinned the bug

`api_key_matches_rejects_empty_against_nonempty` asserted `api_key_matches("", "")` is **true**, justified by *"no key configured is handled by the `Some(key)` guard at the call site, not here."* `Some("")` is not "no key configured" — that comment was the bug's premise. The assertion is inverted; the test's other, genuine assertion is kept.

## Verification

- `cargo test --workspace --all-features` — 63 suites, 0 failures
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; docs coverage gate green
- **Mutation-proofed** — each guard was checked to actually fail without the fix: reverting the validator trips four tests; reverting only the fail-closed branch trips exactly its own test; reverting only the CLI call site trips only the CLI test (confirmed by an actual revert-and-run), and likewise for the FFI call site.

## Breaking change

`--api-key ""` previously "worked" as a no-op auth and is now a startup error naming all three spellings and both remedies. **Omit the flag** to run the admin API explicitly unauthenticated — that spelling is unchanged. Called out under `### Security` in the CHANGELOG.

## Out of scope

The issue's second half — `--host 0.0.0.0` with no `--apikey` — is explicitly separate and lower priority there, and is not touched here.

Closes #844