### PR TITLE
bench: WireMock benchmark suite (bench_wiremock.py) reusing the direct-bench fixture

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -17,6 +17,14 @@ npm install --prefix ~/bench-mb mountebank@2.9.1  # reference engine
 # python3 is used to orchestrate the runs
 ```
 
+For the WireMock suite (optional — only needed for `bench_wiremock.py`) you also need a JRE 11+
+(use an LTS, 17 or 21) and the standalone jar:
+
+```bash
+mkdir -p ~/bench-wiremock && curl -Lo ~/bench-wiremock/wiremock-standalone.jar \
+  https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+```
+
 > `oha` initialises a TLS stack that reads the macOS keychain even for plain-HTTP
 > targets — run these outside a restricted sandbox.
 
@@ -154,6 +162,59 @@ done   # -> direct_rift_{work-stealing,per-core}_cores{2,4,8}_rep{1,2,3}.csv
 Linux only (`taskset`/`lscpu`). Note the ceiling this implies: on an M-vCPU box the generator
 needs its own cores, so the engine tops out well below M — an ≥8-*physical*-core point needs a
 bigger box or an off-box generator, and any verdict quoting these numbers should say so.
+
+### WireMock comparison (issue #861)
+
+WireMock is the most widely used JVM mock server, so the published comparison covers both reference
+engines people actually migrate from. It lives in its own suite because it cannot consume imposter
+JSON — different stub schema, and one port per JVM with admin under `/__admin` on that same port:
+
+```bash
+cd tests/benchmark
+
+# Bench WireMock alone -> results/direct_wiremock.csv
+python3 scripts/bench_wiremock.py --run-all --duration 20s --warmup 10s --connections 50
+
+# Combine whatever CSVs exist from the SAME box and settings -> WIREMOCK_BENCHMARK_REPORT.md
+python3 scripts/bench_wiremock.py --report --connections 50
+```
+
+- **Same fixture, same gates.** The suite *imports* `IMPOSTERS`/`SCENARIOS`/`EXPECT_BODY` from
+  `bench_direct` and generates WireMock mappings from them, so the two can never drift. The same 13
+  scenarios, oha settings and `verify_body` marker assertion apply, and a non-2xx distribution
+  aborts the run — a mistranslated stub falls through to the no-match default and is caught rather
+  than published as a fast number.
+- **`bench_direct.py` is untouched**, so the rift-vs-mb stability contract is unaffected by
+  construction.
+- **Engines stay on disjoint ports:** rift +0, mb +100, wiremock +200 (4745–4760), one engine at a
+  time.
+- **`--warmup 10s`, not 3s.** 3s is thin for a JIT. For a like-for-like table, quote rift/mb numbers
+  measured with the same warmup.
+- **Response templating stays off** so `${request.path}` is served literally, exactly as Mountebank
+  does — otherwise the `template` scenario would compare two different behaviours.
+- **The request journal stays off** (`--no-request-journal`). WireMock records every request by
+  default, unbounded; Rift and Mountebank are both measured with recording *off*, and journaling is
+  a separate additive scenario in the Rift suite because it is a distinct cost. Leaving it on would
+  compare WireMock-with-recording against Rift-without, and would also make the four scenarios
+  sharing the API instance non-comparable with each other.
+
+Two honest caveats the generated report repeats, because a reader will otherwise over-read the
+table:
+
+- **`complex_predicate` is not a pure predicate comparison.** WireMock has no OR across two
+  *different* headers within one stub, so those 50 stubs become 101 mappings and the measured
+  request matches the 50th candidate where Rift/MB match the 25th — roughly twice the scan. That is
+  a genuine cost of expressing this workload in WireMock, but it is not like-for-like.
+- **The all-2xx gate is weaker for WireMock.** The catch-all that reproduces Rift/MB's empty-200
+  no-match default also means every request returns 200, so the status-distribution check cannot
+  detect a fall-through here. The per-scenario body-marker assertion is the gate that does.
+- `--report` refuses to combine CSVs whose `connections`/`mode` disagree (stale-artefact guard), and
+  renders Mountebank columns as `n/a` when `direct_mb.csv` is absent.
+
+Translator logic is gate-tested in `scripts/test_bench_wiremock.py` (golden mappings per stub
+generator, priority ordering, the `or`-split, the catch-all, and a completeness test that runs
+*every* stub in the live fixture through the translator so a new generator in `bench_direct.py`
+cannot ship silently untranslated).
 
 ### Matching-dimension scenarios (Rift-only, additive)
 

--- a/tests/benchmark/scripts/bench_wiremock.py
+++ b/tests/benchmark/scripts/bench_wiremock.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""WireMock benchmark suite (issue #861) — the third engine in the published comparison.
+
+`bench_direct.py` compares Rift against Mountebank on byte-identical imposter JSON. WireMock cannot
+consume that JSON: it has its own stub-mapping schema and a different process model (one port per
+JVM, admin under `/__admin` on that same port). So this is a **separate suite** rather than a third
+engine inside `bench_direct.py`, for one specific reason: the rift-vs-mb default run is a stability
+contract (`DefaultRunUnchanged`) that must stay byte-comparable with previously published numbers,
+and leaving `bench_direct.py` untouched makes that risk zero by construction.
+
+The two suites still share one source of truth. This module **imports** the canonical fixture
+(`IMPOSTERS`, `SCENARIOS`, `EXPECT_BODY`) and the shared plumbing (`run_oha`/`metric`,
+`verify_body`, `launch`/`stop`/`free_ports`, the CSV writers) from `bench_direct`; WireMock
+mappings are *generated* from `IMPOSTERS` by the translator below. Hand-written parallel fixtures
+would drift, and a drifted fixture publishes a number that compares two different workloads.
+
+Known fidelity gaps, recorded rather than hidden — none affects a matched request in the current
+fixture, but a future generator could walk into one:
+
+- **Case sensitivity.** Mountebank/Rift predicates are case-*insensitive* by default; WireMock's
+  `equalTo`/`contains`/`urlPath` are case-sensitive. Every request the fixture measures matches
+  exactly, and the difference makes WireMock do strictly *less* string work, so it cannot flatter
+  Rift — but it is not like-for-like.
+- **`complex_predicate` scans twice as far** under WireMock (see `wiremock_mappings`), which the
+  generated report states in its own caveat.
+
+Run:
+    python3 bench_wiremock.py --run-all          # bench WireMock alone -> direct_wiremock.csv
+    python3 bench_wiremock.py --report           # combine whatever CSVs exist -> 3-way report
+
+Prerequisites: a JRE (WireMock 3 needs 11+; use an LTS, 17 or 21) and the WireMock standalone jar.
+    mkdir -p ~/bench-wiremock && curl -Lo ~/bench-wiremock/wiremock-standalone.jar \\
+      https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(__file__))
+from bench_direct import (  # noqa: E402
+    IMPOSTERS, RESULTS_DIR, SCENARIOS,
+    free_ports, launch, load_rift_csv, metric, mode_label,
+    parse_conn_list, run_oha, stop, verify_body, write_results_csv,
+)
+
+# rift = offset 0, mb = offset 100 (bench_direct), wiremock = offset 200. Disjoint ranges are what
+# let the engines run one at a time without cross-talk; 200 keeps 4745-4760 clear of both.
+WIREMOCK_OFFSET = 200
+
+# WireMock resolves competing stubs by `priority` (lower wins), falling back to most-recently-added.
+# The catch-all must lose to every translated mapping, so it sits at the far end of that ordering.
+CATCH_ALL_PRIORITY = 999_999
+
+MIN_JAVA_MAJOR = 11
+DEFAULT_JAR = os.path.expanduser("~/bench-wiremock/wiremock-standalone.jar")
+DEFAULT_WIREMOCK_VERSION = "3.9.1"
+
+
+# --------------------------------------------------------------------------------------------
+# Stub translator
+# --------------------------------------------------------------------------------------------
+
+def _fail(msg):
+    """Abort translation.
+
+    Deliberately fatal rather than "skip the stub I don't understand": a silently dropped stub still
+    passes most scenarios and corrupts exactly the one it mattered for, which is the failure mode
+    that publishes an inflated number. `verify_body` would catch it for the 13 measured scenarios,
+    but not for the hundreds of stubs that merely make the match *work harder*."""
+    raise SystemExit(f"bench_wiremock: cannot translate stub — {msg}")
+
+
+def _value_matcher_headers(fields, kind, out):
+    headers = out.setdefault("headers", {})
+    for k, v in fields.items():
+        headers[k] = {kind: v}
+
+
+def _set_url_path(out, key, value):
+    # WireMock takes exactly one URL matcher per request; two would silently drop one.
+    for other in ("urlPath", "urlPathPattern", "urlPattern", "url"):
+        if other in out and other != key:
+            _fail(f"two URL matchers on one mapping ({other} and {key})")
+    out[key] = value
+
+
+def _apply_equals_like(op, fields, out, strict_body):
+    for field, value in fields.items():
+        # `deepEquals` means "these key/value pairs and NO others" (see rift's own
+        # predicate/deep_equals.rs). WireMock's `queryParameters`/`headers` are *subset* matchers
+        # with no way to say "and nothing else", so there is no faithful translation — and an
+        # unfaithful one is worse than none here, because it would also be strictly *cheaper* than
+        # the exact-set check the other engines run, quietly flattering WireMock. The body branch
+        # below is the only field where the distinction is expressible (`ignoreExtraElements`).
+        if op == "deepEquals" and field in ("headers", "query"):
+            _fail(f"deepEquals.{field} has no faithful WireMock translation: "
+                  f"queryParameters/headers are subset matchers and cannot express "
+                  f"'and no other keys'. Translating it as a subset would measure a weaker "
+                  f"(and cheaper) predicate than Rift/Mountebank evaluate.")
+        if field == "method":
+            out["method"] = value
+        elif field == "path":
+            _set_url_path(out, "urlPath", value)
+        elif field == "headers":
+            _value_matcher_headers(value, "equalTo", out)
+        elif field == "query":
+            params = out.setdefault("queryParameters", {})
+            for k, v in value.items():
+                params[k] = {"equalTo": v}
+        elif field == "body":
+            if not isinstance(value, dict):
+                _fail(f"{op}.body must be a JSON object here, got {type(value).__name__} "
+                      f"({value!r}); a scalar body only appears under a jsonpath selector")
+            pattern = {"equalToJson": json.dumps(value, separators=(",", ":"))}
+            if not strict_body:
+                # Mountebank's `equals` on a parsed JSON body tolerates extra fields; `deepEquals`
+                # does not. Mirroring that distinction is what keeps the workloads comparable.
+                pattern["ignoreExtraElements"] = True
+            out.setdefault("bodyPatterns", []).append(pattern)
+        else:
+            _fail(f"unsupported field {field!r} under {op!r}")
+
+
+def _apply_operator(op, fields, out):
+    if op == "equals":
+        _apply_equals_like(op, fields, out, strict_body=False)
+    elif op == "deepEquals":
+        _apply_equals_like(op, fields, out, strict_body=True)
+    elif op == "matches":
+        for field, value in fields.items():
+            if field != "path":
+                _fail(f"unsupported field {field!r} under 'matches'")
+            # MB `matches` is an unanchored regex *search*; `urlPathPattern` anchors the full
+            # path. Every pattern in the fixture spans the whole path, so the two agree today. The
+            # leading-'/' check below is a cheap prefix sanity check, NOT a proof of equivalence:
+            # a pattern that is anchored at the start but open at the end (`/v1/[0-9]+`) still
+            # matches `/v1/123/details` under MB and not under WireMock. Deciding that in general
+            # is not tractable here, so the guard catches the obvious case and this comment owns
+            # the rest — revisit if a generator ever adds a genuinely partial-path pattern.
+            if not value.startswith("/"):
+                _fail(f"'matches.path' pattern {value!r} is not anchored at '/': WireMock's "
+                      f"urlPathPattern matches the whole path, so translating an unanchored "
+                      f"MB search would change its meaning")
+            _set_url_path(out, "urlPathPattern", value)
+    elif op == "startsWith":
+        for field, value in fields.items():
+            if field != "path":
+                _fail(f"unsupported field {field!r} under 'startsWith'")
+            _set_url_path(out, "urlPathPattern", re.escape(value) + ".*")
+    elif op == "contains":
+        for field, value in fields.items():
+            if field == "path":
+                _set_url_path(out, "urlPathPattern", ".*" + re.escape(value) + ".*")
+            elif field == "headers":
+                _value_matcher_headers(value, "contains", out)
+            else:
+                _fail(f"unsupported field {field!r} under 'contains'")
+    else:
+        _fail(f"unsupported predicate operator {op!r}")
+
+
+def _apply_selector_predicate(pred, out):
+    """A predicate carrying a `jsonpath`/`xpath` selector: the operator applies to the *selected*
+    value, not the raw body, so it becomes a body pattern rather than a request field."""
+    if "jsonpath" in pred:
+        selector = pred["jsonpath"].get("selector")
+        if selector is None:
+            _fail("jsonpath predicate without a selector")
+        ops = [k for k in pred if k not in ("jsonpath", "caseSensitive")]
+        if ops != ["equals"] or list(pred["equals"]) != ["body"]:
+            _fail(f"jsonpath selector supports only `equals.body`, got {ops} / {list(pred.get('equals', {}))}")
+        out.setdefault("bodyPatterns", []).append(
+            {"matchesJsonPath": {"expression": selector, "equalTo": pred["equals"]["body"]}})
+        return
+    selector = pred["xpath"].get("selector")
+    if selector is None:
+        _fail("xpath predicate without a selector")
+    ops = [k for k in pred if k not in ("xpath", "caseSensitive")]
+    if ops != ["exists"] or pred["exists"] != {"body": True}:
+        _fail(f"xpath selector supports only `exists.body: true`, got {ops} / {pred.get('exists')}")
+    out.setdefault("bodyPatterns", []).append({"matchesXPath": selector})
+
+
+def _apply_predicate(pred, variants):
+    """Fold one imposter predicate into every request variant, returning the new variant list.
+
+    Variants exist for `or`: WireMock's criteria within one mapping are implicitly ANDed and its
+    `or` operator combines *value matchers against a single value*, not criteria across different
+    fields. `complex_stubs` needs an OR over two different headers, so the only faithful
+    translation is one mapping per branch. Folding over a list and cross-producting on `or` makes
+    the nested `and[..., or[...]]` shape fall out without a special case."""
+    if "jsonpath" in pred or "xpath" in pred:
+        for v in variants:
+            _apply_selector_predicate(pred, v)
+        return variants
+
+    ops = list(pred)
+    if len(ops) != 1:
+        _fail(f"expected exactly one operator per predicate, got {ops}")
+    op = ops[0]
+
+    if op == "and":
+        for sub in pred["and"]:
+            variants = _apply_predicate(sub, variants)
+        return variants
+
+    if op == "or":
+        branches = pred["or"]
+        if not branches:
+            _fail("empty `or` predicate")
+        out = []
+        for branch in branches:
+            # Each branch gets its own deep copy of every variant so far.
+            out.extend(_apply_predicate(branch, [json.loads(json.dumps(v)) for v in variants]))
+        return out
+
+    for v in variants:
+        _apply_operator(op, pred[op], v)
+    return variants
+
+
+def _translate_response(stub):
+    responses = stub.get("responses", [])
+    if len(responses) != 1:
+        _fail(f"expected exactly one response per stub, got {len(responses)}")
+    resp = responses[0]
+    if list(resp) != ["is"]:
+        _fail(f"only `is` responses are translatable, got {list(resp)}")
+    is_ = resp["is"]
+    unknown = set(is_) - {"statusCode", "headers", "body"}
+    if unknown:
+        _fail(f"unsupported `is` response fields {sorted(unknown)}")
+    out = {"status": is_.get("statusCode", 200)}
+    if "headers" in is_:
+        out["headers"] = dict(is_["headers"])
+    if "body" in is_:
+        out["body"] = is_["body"]
+    return out
+
+
+def catch_all_mapping():
+    """Rift/MB answer an unmatched request with an empty 200; WireMock answers 404 with diagnostic
+    text. Without this, `no_match` would fail its empty-body assertion AND trip the all-2xx gate —
+    so the comparison needs WireMock to adopt the other engines' no-match behaviour."""
+    return {
+        "priority": CATCH_ALL_PRIORITY,
+        "request": {"urlPattern": ".*"},
+        "response": {"status": 200, "body": ""},
+    }
+
+
+def wiremock_mappings(stubs):
+    """Translate imposter stubs into WireMock mappings, preserving first-match-wins.
+
+    Rift/MB take the first matching stub in declaration order. WireMock resolves by `priority`
+    (lower wins) and otherwise by most-recently-added — so equal priorities would *invert* the
+    intended order. The counter below is therefore strictly increasing across emitted mappings,
+    including across an `or`-split; it coincides with the 1-based stub index until the first split.
+    """
+    out = []
+    priority = 0
+    for stub in stubs:
+        predicates = stub.get("predicates", [])
+        variants = [{}]
+        for pred in predicates:
+            variants = _apply_predicate(pred, variants)
+        response = _translate_response(stub)
+        for request in variants:
+            priority += 1
+            if priority >= CATCH_ALL_PRIORITY:
+                _fail(f"too many mappings ({priority}); would collide with the catch-all priority")
+            out.append({"priority": priority, "request": request,
+                        "response": json.loads(json.dumps(response))})
+    out.append(catch_all_mapping())
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Java preflight + process model
+# --------------------------------------------------------------------------------------------
+
+def parse_java_major(version_output):
+    """Major version from `java -version` output, or None if unparseable.
+
+    Handles both the legacy `1.8.0_x` spelling and the modern `17.0.13` one."""
+    m = re.search(r'version "(\d+)(?:\.(\d+))?', version_output)
+    if not m:
+        return None
+    major = int(m.group(1))
+    if major == 1 and m.group(2):
+        return int(m.group(2))
+    return major
+
+
+def java_preflight():
+    """Fail once, actionably, instead of as 14 cryptic instance-launch failures."""
+    try:
+        out = subprocess.run(["java", "-version"], capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        raise SystemExit(
+            "bench_wiremock: `java` not found. WireMock 3 needs a JRE 11+ (use an LTS, 17 or 21). "
+            "This suite is native-process by design, so the official WireMock container is not a "
+            "substitute.")
+    text = (out.stderr or "") + (out.stdout or "")
+    major = parse_java_major(text)
+    if major is None:
+        raise SystemExit(f"bench_wiremock: could not parse `java -version` output: {text.strip()[:200]}")
+    if major < MIN_JAVA_MAJOR:
+        raise SystemExit(
+            f"bench_wiremock: java {major} is too old — WireMock 3 needs {MIN_JAVA_MAJOR}+ "
+            f"(use an LTS, 17 or 21).")
+    return major, text.strip().splitlines()[0] if text.strip() else f"java {major}"
+
+
+def instance_ports():
+    return [port + WIREMOCK_OFFSET for port, _, _ in IMPOSTERS]
+
+
+def wiremock_cmd(jar, port):
+    """WireMock's argv for one imposter port.
+
+    `--no-request-journal` is a fairness requirement, not a tuning knob. WireMock records every
+    incoming request by default and the journal is unbounded, so a JVM under 30s of load retains
+    hundreds of thousands of `LoggedRequest` objects (headers and body copied). Rift and Mountebank
+    are measured with recording OFF — `bench_direct.load_imposters` posts no `recordRequests`, and
+    journaling is a deliberately *separate*, additive, Rift-only scenario (`RECORDING_SCENARIO`)
+    precisely because it is a distinct cost. Leaving WireMock's journal on would compare
+    WireMock-with-recording against Rift-without, and would also make the four scenarios sharing
+    the API instance non-comparable with each other, since each is measured against a progressively
+    fuller journal. Nothing in this suite reads `/__admin/requests`, so disabling it costs nothing.
+    """
+    return ["java", "-jar", jar, "--port", str(port), "--disable-banner",
+            "--no-request-journal"]
+
+
+def admin_ready(port, tries=240):
+    """Readiness is `GET /__admin/mappings` answering 200 — there is no separate 2525-style admin
+    port, and a bare TCP accept would race the admin servlet coming up."""
+    url = f"http://localhost:{port}/__admin/mappings"
+    for _ in range(tries):
+        try:
+            with urllib.request.urlopen(url, timeout=2) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def load_mappings(port, mappings):
+    """Bulk-import one instance's mappings.
+
+    `/__admin/mappings/import` in one request rather than a POST per mapping: the fixture is ~1000
+    stubs across 14 instances, so per-mapping POSTs would be ~14k round trips of pure setup."""
+    body = json.dumps({"mappings": mappings}).encode()
+    req = urllib.request.Request(f"http://localhost:{port}/__admin/mappings/import",
+                                 data=body, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req, timeout=120).close()
+    except urllib.error.HTTPError as e:
+        # urlopen raises on >=400, so this is the real failure path — a bare traceback here would
+        # bury a stub-validation rejection (422) that the operator needs to read.
+        detail = e.read().decode("utf-8", "replace")[:400]
+        raise SystemExit(f"bench_wiremock: mapping import failed on {port}: "
+                         f"HTTP {e.code}: {detail}")
+
+    # Verify the count landed. An import that silently drops a mapping is the same class of failure
+    # `_fail` exists to prevent: the 13 measured scenarios would still pass while the surrounding
+    # stubs — the ones that make the match *work* — quietly went missing, inflating the number.
+    with urllib.request.urlopen(f"http://localhost:{port}/__admin/mappings?limit=0",
+                                timeout=60) as r:
+        total = json.loads(r.read()).get("meta", {}).get("total")
+    if total != len(mappings):
+        raise SystemExit(f"bench_wiremock: {port} reports {total} mappings, expected "
+                         f"{len(mappings)} — the import dropped some; measuring this would be bogus")
+
+
+def probe_wiremock_version(port, fallback):
+    """WireMock does not guarantee an admin version endpoint across 2.x/3.x, so treat it as
+    best-effort and fall back to the pinned CLI value rather than failing a whole run over a
+    reporting detail."""
+    try:
+        with urllib.request.urlopen(f"http://localhost:{port}/__admin/version", timeout=5) as r:
+            text = r.read().decode("utf-8", "replace").strip()
+        if text:
+            try:
+                parsed = json.loads(text)
+                return parsed.get("version", text) if isinstance(parsed, dict) else text
+            except json.JSONDecodeError:
+                return text
+    except Exception:
+        pass
+    return fallback
+
+
+def launch_instances(jar, logdir, procs):
+    """Spawn one JVM per imposter and wait for each to answer on its admin path.
+
+    `procs` is an out-parameter the caller owns, appended to as each process is spawned. That is
+    deliberate: if instance 3 never becomes ready, the caller's `finally` still has to see
+    instances 1..14 to shut them down. Returning the list instead would strand every already-spawned
+    JVM on the readiness failure — and a JVM still in startup is not yet listening, so `free_ports`
+    cannot rescue it either; it would bind its port moments later and poison the next run."""
+    os.makedirs(logdir, exist_ok=True)
+    # All 14, including the four (DeepEquals/Literal/MethodMix/BodyField) that only appear in
+    # bench_direct's Rift-only DIMENSION_SCENARIOS: rift and mb hold those imposters during their
+    # runs too, so loading them keeps the resident-stub count comparable across engines.
+    for (base_port, name, stubs) in IMPOSTERS:
+        port = base_port + WIREMOCK_OFFSET
+        log = os.path.join(logdir, f"wiremock-{name}-{port}.log")
+        procs.append((name, port, launch(wiremock_cmd(jar, port), log), log, stubs))
+    for i, (name, port, _proc, log, _stubs) in enumerate(procs, 1):
+        if not admin_ready(port):
+            raise SystemExit(f"bench_wiremock: instance {name} on {port} never became ready "
+                             f"(see {log})")
+        print(f"    [{i}/{len(procs)}] {name} ready on {port}")
+    return procs
+
+
+def load_all_mappings(procs):
+    for name, port, _proc, _log, stubs in procs:
+        mappings = wiremock_mappings(stubs)
+        t0 = time.time()
+        load_mappings(port, mappings)
+        print(f"    {name} port={port} mappings={len(mappings)} in {time.time() - t0:.2f}s")
+
+
+def stop_instances(procs):
+    for _name, port, proc, _log, _stubs in procs:
+        stop(proc, [port])
+
+
+# --------------------------------------------------------------------------------------------
+# Bench loop
+# --------------------------------------------------------------------------------------------
+
+def bench_wiremock(duration, warmup, conn_list, csv_suffix=""):
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    mode = mode_label(None)
+    rows = []
+    for conns in conn_list:
+        for name, base_port, method, path, body, headers in SCENARIOS:
+            url = f"http://localhost:{base_port + WIREMOCK_OFFSET}{path}"
+            # The same two gates bench_direct uses, and the reason a wrong translation cannot be
+            # published as a fast number: the body marker proves the intended mapping served the
+            # request, and a non-2xx distribution aborts the run.
+            verify_body("wiremock", name, method, url, body, headers)
+            run_oha(url, method, body, headers, warmup, conns)
+            m = metric(run_oha(url, method, body, headers, duration, conns))
+            total = sum(m["codes"].values())
+            good = all(c.startswith("2") for c in m["codes"])
+            status = "ok" if good and total > 0 else f"BAD codes={m['codes']}"
+            print(f"  {name:20s} c={conns:<4d} {m['rps']:>10.1f} rps  "
+                  f"p50={m['p50_ms']}ms p99={m['p99_ms']}ms p999={m['p999_ms']}ms  {status}")
+            if not (good and total > 0):
+                raise SystemExit(f"wiremock/{name}: unexpected status distribution {m['codes']} — aborting")
+            rows.append((name, conns, mode, m))
+    path = write_results_csv("wiremock", csv_suffix, rows)
+    print(f"[wiremock] wrote {path}")
+    return path
+
+
+def run_all(jar, duration, warmup, conn_list, csv_suffix="", wiremock_version=DEFAULT_WIREMOCK_VERSION):
+    major, java_line = java_preflight()
+    print(f"[wiremock] java {major} ({java_line})")
+    if not os.path.exists(jar):
+        raise SystemExit(
+            f"bench_wiremock: WireMock jar not found at {jar}. Download it with:\n"
+            f"  mkdir -p {os.path.dirname(jar)} && curl -Lo {jar} \\\n"
+            f"    https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/"
+            f"{wiremock_version}/wiremock-standalone-{wiremock_version}.jar")
+    ports = instance_ports()
+    logdir = os.path.join(RESULTS_DIR, "logs")
+    free_ports(ports)
+    # Owned here, not returned by launch_instances, so the `finally` below can still stop every
+    # JVM that was spawned when a later one fails its readiness probe.
+    procs = []
+    try:
+        print(f"[wiremock] launching {len(IMPOSTERS)} instances at offset +{WIREMOCK_OFFSET}")
+        launch_instances(jar, logdir, procs)
+        print("[wiremock] loading mappings")
+        load_all_mappings(procs)
+        version = probe_wiremock_version(procs[0][1], wiremock_version)
+        print(f"[wiremock] version {version}")
+        bench_wiremock(duration, warmup, conn_list, csv_suffix)
+    finally:
+        stop_instances(procs)
+        free_ports(ports)
+
+
+# --------------------------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------------------------
+
+def engine_csv_path(engine, csv_suffix):
+    """Where `--report` looks for an engine's CSV.
+
+    Deliberately resolved against *this* module's `RESULTS_DIR` rather than delegating to
+    `bench_direct.results_csv_path`, which closes over its own copy. The two are the same directory
+    in a real run — the bench half writes through `write_results_csv` — but routing every read
+    through one local seam is what makes the combiner testable against a temp directory instead of
+    whatever a previous benchmark left in `results/`."""
+    return os.path.join(RESULTS_DIR, f"direct_{engine}{csv_suffix}.csv")
+
+
+def load_engine_csv(engine, csv_suffix, conns):
+    """Rows for one engine at the single closed-loop comparison point, or None if absent.
+
+    Filtering on mode+connections is the stale-artefact guard: a CSV left behind by a sweep or an
+    open-loop run holds rows that are not comparable, and blending them into the headline table
+    would be silently wrong."""
+    path = engine_csv_path(engine, csv_suffix)
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        rows = {r["scenario"]: {"rps": float(r["rps"]), "p50": r["p50_ms"], "p99": r["p99_ms"]}
+                for r in load_rift_csv(f)
+                if r["mode"] == "closed" and int(r["connections"]) == conns}
+    return rows or None
+
+
+def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix=""):
+    rift = load_engine_csv("rift", csv_suffix, conns)
+    wm = load_engine_csv("wiremock", csv_suffix, conns)
+    mb = load_engine_csv("mb", csv_suffix, conns)
+    if rift is None:
+        raise SystemExit(f"bench_wiremock: no comparable rift rows at connections={conns}, "
+                         f"mode=closed in {engine_csv_path('rift', csv_suffix)}")
+    if wm is None:
+        raise SystemExit(f"bench_wiremock: no comparable wiremock rows at connections={conns}, "
+                         f"mode=closed in {engine_csv_path('wiremock', csv_suffix)}")
+
+    order = [s[0] for s in SCENARIOS]
+    out = os.path.join(RESULTS_DIR, f"WIREMOCK_BENCHMARK_REPORT{csv_suffix}.md")
+    with open(out, "w") as f:
+        f.write("# Rift vs WireMock vs Mountebank — Direct-Process Benchmark\n\n")
+        f.write(f"- **Date:** {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"- **Rift:** {rift_ver}\n")
+        f.write(f"- **WireMock:** {wiremock_ver} (JVM: {java_ver})\n")
+        f.write(f"- **Mountebank:** {mb_ver if mb else 'not measured on this box'}\n")
+        f.write(f"- **Load generator:** oha, {conns} keep-alive connections, {duration} per scenario "
+                f"(after warmup)\n")
+        f.write("- **Method:** native processes (no Docker); engines run one at a time on disjoint "
+                "port ranges; the same 13 scenarios and the same oha settings for every engine; "
+                "each scenario's matched body is asserted before it is measured.\n")
+        f.write("- **WireMock setup:** one JVM per imposter port (14 instances), stock heap/GC and "
+                "the default 10-thread Jetty container pool. Response templating is **off**, so "
+                "`${request.path}` is served literally exactly as Mountebank serves it. The request "
+                "journal is **off** (`--no-request-journal`): it is on and unbounded by default, "
+                "and Rift and Mountebank are both measured with recording off — journaling is a "
+                "separate, additive scenario in the Rift suite precisely because it is a distinct "
+                "cost.\n")
+        f.write("- **Read `complex_predicate` with care.** WireMock cannot express an OR across two "
+                "*different* headers in one stub, so that imposter's 50 stubs become 101 mappings "
+                "and the measured request matches the 50th candidate where Rift/Mountebank match "
+                "the 25th. Its ratio therefore reflects roughly twice the candidate scan, not "
+                "predicate cost alone — a real cost of modelling this workload in WireMock, but not "
+                "a like-for-like predicate comparison.\n")
+        f.write("- **The status-distribution gate is weaker here than for Rift/MB.** WireMock 404s "
+                "an unmatched request, so this suite installs a catch-all empty-200 to reproduce "
+                "the other engines' no-match default — which also means an all-2xx distribution no "
+                "longer proves a match. The per-scenario body-marker assertion is the gate that "
+                "does.\n\n")
+
+        f.write("## Throughput (requests/sec, higher is better)\n\n")
+        f.write("| Scenario | Mountebank | WireMock | Rift | Rift/MB | Rift/WM |\n")
+        f.write("|---|--:|--:|--:|--:|--:|\n")
+        for name in order:
+            wr, rr = wm[name]["rps"], rift[name]["rps"]
+            mr = mb[name]["rps"] if mb else None
+            mb_cell = f"{mr:,.0f}" if mr is not None else "n/a"
+            mb_sp = f"{rr / mr:.1f}x" if mr else "n/a"
+            wm_sp = f"{rr / wr:.1f}x" if wr else "n/a"
+            f.write(f"| {name} | {mb_cell} | {wr:,.0f} | {rr:,.0f} | **{mb_sp}** | **{wm_sp}** |\n")
+
+        f.write("\n## Latency p99 (ms, lower is better)\n\n")
+        f.write("| Scenario | Mountebank | WireMock | Rift |\n|---|--:|--:|--:|\n")
+        for name in order:
+            mb_cell = mb[name]["p99"] if mb else "n/a"
+            f.write(f"| {name} | {mb_cell} | {wm[name]['p99']} | {rift[name]['p99']} |\n")
+    print(f"wrote {out}")
+    return out
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="WireMock benchmark suite (issue #861)")
+    ap.add_argument("--run-all", action="store_true", help="bench WireMock alone")
+    ap.add_argument("--report", action="store_true",
+                    help="combine direct_rift.csv / direct_mb.csv / direct_wiremock.csv from the "
+                         "SAME box and settings into WIREMOCK_BENCHMARK_REPORT.md")
+    ap.add_argument("--duration", default="20s")
+    ap.add_argument("--warmup", default="10s",
+                    help="3s is thin for a JIT; 10s is the recommended default for WireMock runs. "
+                         "Quote rift/mb numbers measured with the same warmup for comparability.")
+    ap.add_argument("--connections", type=int, default=50)
+    ap.add_argument("--sweep-connections", help="comma-separated connection counts")
+    ap.add_argument("--wiremock-jar", default=DEFAULT_JAR)
+    ap.add_argument("--wiremock-version", default=DEFAULT_WIREMOCK_VERSION)
+    ap.add_argument("--rift-version", default="local")
+    ap.add_argument("--mb-version", default="2.9.1")
+    ap.add_argument("--java-version", default=None,
+                    help="override the JVM string recorded in the report (default: probed)")
+    ap.add_argument("--rep", type=int, default=None,
+                    help="tag this run's CSV as _repN so several reps can be aggregated")
+    args = ap.parse_args()
+
+    suffix = f"_rep{args.rep}" if args.rep else ""
+    conn_list = parse_conn_list(args.sweep_connections) if args.sweep_connections else [args.connections]
+
+    if args.run_all:
+        run_all(args.wiremock_jar, args.duration, args.warmup, conn_list, suffix,
+                args.wiremock_version)
+    if args.report:
+        java_ver = args.java_version
+        if java_ver is None:
+            try:
+                _major, java_ver = java_preflight()
+            except SystemExit:
+                java_ver = "unknown"
+        report(args.rift_version, args.mb_version, args.wiremock_version, java_ver,
+               args.duration, args.connections, suffix)
+    if not (args.run_all or args.report):
+        ap.error("nothing to do: pass --run-all and/or --report")

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Gate tests for the WireMock suite's pure logic (issue #861).
+
+The live benchmark path (14 JVMs + oha) is not CI-runnable, so these tests pin what actually
+decides whether a published number is honest: the stub translation. A wrong translation does not
+crash — it falls through to WireMock's no-match default, which is precisely why the translator
+fails loudly on anything it does not recognise and why the completeness test below runs the *live*
+imported fixture through it.
+
+Run: python3 -m unittest test_bench_wiremock   (from tests/benchmark/scripts)
+"""
+import copy
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import bench_direct as bd  # noqa: E402
+import bench_wiremock as bw  # noqa: E402
+
+
+def _translated(stubs):
+    """Mappings without the trailing catch-all."""
+    return bw.wiremock_mappings(stubs)[:-1]
+
+
+class GoldenMappings(unittest.TestCase):
+    """One representative stub from each generator -> the exact mapping expected."""
+
+    def test_api_stub_equals_method_and_path(self):
+        m = _translated(bd.api_stubs(resources=1, per=0))
+        self.assertEqual(m[0], {
+            "priority": 1,
+            "request": {"method": "GET", "urlPath": "/api/v1/resource1"},
+            "response": {"status": 200, "headers": {"Content-Type": "application/json"},
+                         "body": json.dumps({"items": [{"id": 1}, {"id": 2}], "total": 2})},
+        })
+
+    def test_status_only_response_has_no_body_key(self):
+        # api_stubs' DELETE is a 204 with no body; emitting `"body": ""` would be a different
+        # response than the other engines send.
+        m = _translated(bd.api_stubs(resources=1, per=1))
+        delete = [x for x in m if x["request"].get("method") == "DELETE"][0]
+        self.assertEqual(delete["response"], {"status": 204})
+
+    def test_regex_stub_uses_urlPathPattern(self):
+        m = _translated(bd.regex_stubs(n=1))
+        self.assertEqual(m[0]["request"], {"urlPathPattern": "/regex/pattern1/[a-zA-Z0-9]+"})
+
+    def test_complex_stub_splits_the_or_into_two_mappings(self):
+        m = _translated(bd.complex_stubs(n=1))
+        self.assertEqual(len(m), 2, "an OR over two different headers cannot be one mapping")
+        for mapping in m:
+            self.assertEqual(mapping["request"]["method"], "POST")
+            self.assertEqual(mapping["request"]["urlPathPattern"], r"/complex/1/.*")
+        self.assertEqual(m[0]["request"]["headers"], {"X-Request-Type": {"contains": "json"}})
+        self.assertEqual(m[1]["request"]["headers"], {"Content-Type": {"contains": "application/json"}})
+        # Same response on both branches, and consecutive priorities so neither can outrank the
+        # other by WireMock's most-recently-added tiebreak.
+        self.assertEqual(m[0]["response"], m[1]["response"])
+        self.assertEqual([m[0]["priority"], m[1]["priority"]], [1, 2])
+
+    def test_json_body_stub_is_tolerant_equalToJson(self):
+        m = _translated(bd.json_body_stubs(n=1))
+        self.assertEqual(m[0]["request"], {
+            "method": "POST", "urlPath": "/json/equals/1",
+            "bodyPatterns": [{"equalToJson": '{"id":1,"type":"request"}',
+                              "ignoreExtraElements": True}],
+        })
+
+    def test_deepequals_body_stub_is_strict(self):
+        m = _translated(bd.deepequals_body_stubs(n=1))
+        pattern = m[0]["request"]["bodyPatterns"][0]
+        self.assertIn("equalToJson", pattern)
+        self.assertNotIn("ignoreExtraElements", pattern,
+                         "deepEquals must not tolerate extra fields — that is what makes it deep")
+
+    def test_jsonpath_stub_becomes_matchesJsonPath(self):
+        m = _translated(bd.jsonpath_stubs(n=1))
+        self.assertEqual(m[0]["request"], {
+            "method": "POST", "urlPath": "/jsonpath/1",
+            "bodyPatterns": [{"matchesJsonPath": {"expression": "$.user.id", "equalTo": "1"}}],
+        })
+
+    def test_xpath_stub_becomes_matchesXPath(self):
+        m = _translated(bd.xpath_stubs(n=1))
+        self.assertEqual(m[0]["request"], {
+            "method": "POST", "urlPath": "/xpath/1",
+            "bodyPatterns": [{"matchesXPath": "//item[@id='1']"}],
+        })
+
+    def test_template_stub_body_is_served_literally(self):
+        # Response templating stays disabled, so `${request.path}` must survive into the mapping
+        # verbatim — Mountebank serves it literally too, and EXPECT_BODY was chosen to match that.
+        m = _translated(bd.template_stubs(n=1))
+        self.assertIn("${request.path}", m[0]["response"]["body"])
+        self.assertEqual(m[0]["response"]["headers"]["X-Request-Path"], "${request.path}")
+
+    def test_header_stub_uses_equalTo_header_matcher(self):
+        m = _translated(bd.header_stubs(n=1))
+        self.assertEqual(m[0]["request"], {
+            "urlPath": "/headers/route", "headers": {"X-Route-Id": {"equalTo": "route-1"}},
+        })
+
+    def test_query_stub_keeps_urlPath_and_adds_queryParameters(self):
+        m = _translated(bd.query_stubs(n=1))
+        self.assertEqual(m[0]["request"], {
+            "urlPath": "/query/search",
+            "queryParameters": {"page": {"equalTo": "1"}, "size": {"equalTo": "10"}},
+        })
+
+    def test_simple_stubs(self):
+        m = _translated(bd.simple_stubs())
+        self.assertEqual(m[0]["request"], {"urlPath": "/health"})
+        self.assertEqual(m[0]["response"], {"status": 200, "body": "OK"})
+
+    def test_literal_prefix_and_contains_become_patterns(self):
+        m = _translated(bd.literal_prefix_stubs(n=1))
+        self.assertEqual(m[0]["request"]["urlPathPattern"], r"/literal/prefix1/.*")
+        self.assertEqual(m[1]["request"]["urlPathPattern"], r".*/needle1/.*")
+
+    def test_literal_matchers_escape_regex_metacharacters(self):
+        # `startsWith`/`contains` are LITERAL in Mountebank but land in a WireMock *regex*
+        # (`urlPathPattern`), so the literal must be escaped on the way in. Every path in the
+        # current fixture is metacharacter-free, which means the fixture alone cannot tell an
+        # escaping translator from a non-escaping one — this test can. Without it, a future stub
+        # path containing `.` or `+` would silently match the wrong requests.
+        starts = _translated([{"predicates": [{"startsWith": {"path": "/v1.0/items+/"}}],
+                               "responses": [{"is": {"statusCode": 200}}]}])
+        self.assertEqual(starts[0]["request"]["urlPathPattern"], re.escape("/v1.0/items+/") + ".*")
+        self.assertIn(r"\.", starts[0]["request"]["urlPathPattern"])
+        self.assertIn(r"\+", starts[0]["request"]["urlPathPattern"])
+
+        contains = _translated([{"predicates": [{"contains": {"path": "/a.b+c/"}}],
+                                 "responses": [{"is": {"statusCode": 200}}]}])
+        self.assertEqual(contains[0]["request"]["urlPathPattern"],
+                         ".*" + re.escape("/a.b+c/") + ".*")
+
+    def test_method_mix_stub_keeps_the_verb(self):
+        m = _translated(bd.method_mix_stubs(n=1))
+        self.assertEqual({x["request"]["method"] for x in m},
+                         {"PUT", "DELETE", "PATCH", "OPTIONS"})
+
+    def test_body_field_stubs_share_a_path_and_differ_only_by_body(self):
+        m = _translated(bd.body_field_stubs(n=2))
+        self.assertEqual({x["request"]["urlPath"] for x in m}, {"/orders/submit"})
+        self.assertNotEqual(m[0]["request"]["bodyPatterns"], m[1]["request"]["bodyPatterns"])
+
+
+class Ordering(unittest.TestCase):
+    """Rift/MB take the first matching stub; WireMock takes the lowest priority, breaking ties by
+    most-recently-added — so a duplicate priority silently INVERTS the intended order."""
+
+    def test_priorities_are_strictly_increasing_across_an_or_split(self):
+        stubs = bd.simple_stubs() + bd.complex_stubs(n=2) + bd.simple_stubs()
+        mappings = _translated(stubs)
+        priorities = [m["priority"] for m in mappings]
+        self.assertEqual(priorities, sorted(priorities))
+        self.assertEqual(len(priorities), len(set(priorities)), "duplicate priority inverts order")
+
+    def test_priority_matches_stub_index_when_nothing_splits(self):
+        mappings = _translated(bd.regex_stubs(n=5))
+        self.assertEqual([m["priority"] for m in mappings], [1, 2, 3, 4, 5])
+
+    def test_every_translated_mapping_outranks_the_catch_all(self):
+        mappings = bw.wiremock_mappings(bd.api_stubs())
+        self.assertEqual(mappings[-1]["priority"], bw.CATCH_ALL_PRIORITY)
+        for m in mappings[:-1]:
+            self.assertLess(m["priority"], bw.CATCH_ALL_PRIORITY)
+
+
+class CatchAll(unittest.TestCase):
+    """Rift/MB answer an unmatched request with an empty 200; WireMock answers 404 with diagnostic
+    text, which would fail `no_match`'s empty-body assertion and trip the all-2xx gate."""
+
+    def test_catch_all_is_last_and_returns_empty_200(self):
+        for _port, name, stubs in bd.IMPOSTERS:
+            with self.subTest(imposter=name):
+                last = bw.wiremock_mappings(stubs)[-1]
+                self.assertEqual(last, {
+                    "priority": bw.CATCH_ALL_PRIORITY,
+                    "request": {"urlPattern": ".*"},
+                    "response": {"status": 200, "body": ""},
+                })
+
+
+class TranslatorCompleteness(unittest.TestCase):
+    """Runs EVERY stub in the live imported fixture through the translator.
+
+    This is the anti-drift guard: because the suite imports `IMPOSTERS` rather than copying it, a
+    stub generator added to `bench_direct.py` later is seen here automatically and fails loudly if
+    it uses an operator the translator does not implement."""
+
+    def test_every_fixture_stub_translates(self):
+        for _port, name, stubs in bd.IMPOSTERS:
+            with self.subTest(imposter=name):
+                mappings = bw.wiremock_mappings(stubs)
+                self.assertGreaterEqual(len(mappings), len(stubs) + 1)
+                for m in mappings:
+                    self.assertIn("request", m)
+                    self.assertIn("response", m)
+
+    def test_every_comparison_scenario_has_an_imposter_and_a_marker(self):
+        ports = {p for p, _, _ in bd.IMPOSTERS}
+        for name, port, _method, _path, _body, _headers in bd.SCENARIOS:
+            with self.subTest(scenario=name):
+                self.assertIn(port, ports)
+                self.assertIn(name, bd.EXPECT_BODY)
+
+
+class UnknownOperator(unittest.TestCase):
+    """A silently skipped stub still passes most scenarios and corrupts the one it mattered for."""
+
+    def _expect_fail(self, stub, needle):
+        with self.assertRaises(SystemExit) as ctx:
+            bw.wiremock_mappings([stub])
+        self.assertIn(needle, str(ctx.exception))
+
+    def test_unknown_operator_raises(self):
+        self._expect_fail({"predicates": [{"endsWith": {"path": "/x"}}],
+                           "responses": [{"is": {"statusCode": 200}}]}, "endsWith")
+
+    def test_unknown_field_raises(self):
+        self._expect_fail({"predicates": [{"equals": {"protocol": "http"}}],
+                           "responses": [{"is": {"statusCode": 200}}]}, "protocol")
+
+    def test_non_is_response_raises(self):
+        self._expect_fail({"predicates": [{"equals": {"path": "/x"}}],
+                           "responses": [{"proxy": {"to": "http://x"}}]}, "proxy")
+
+    def test_unsupported_is_field_raises(self):
+        self._expect_fail({"predicates": [{"equals": {"path": "/x"}}],
+                           "responses": [{"is": {"statusCode": 200, "_behaviors": {"wait": 1}}}]},
+                          "_behaviors")
+
+    def test_multiple_responses_raise(self):
+        self._expect_fail({"predicates": [{"equals": {"path": "/x"}}],
+                           "responses": [{"is": {"statusCode": 200}}, {"is": {"statusCode": 201}}]},
+                          "exactly one response")
+
+    def test_unanchored_matches_pattern_raises(self):
+        # MB `matches` is an unanchored search; urlPathPattern anchors. Translating an unanchored
+        # pattern as anchored would change which requests match.
+        self._expect_fail({"predicates": [{"matches": {"path": "pattern[0-9]+"}}],
+                           "responses": [{"is": {"statusCode": 200}}]}, "not anchored")
+
+    def test_deepequals_headers_and_query_raise(self):
+        # WireMock's headers/queryParameters are SUBSET matchers with no "and nothing else", so a
+        # deepEquals over them has no faithful translation. Translating it as a subset anyway would
+        # be worse than failing: it is also strictly cheaper than the exact-set check Rift/MB run,
+        # so it would quietly flatter WireMock in the published table.
+        for field, value in (("headers", {"A": "b"}), ("query", {"page": "1"})):
+            with self.subTest(field=field):
+                self._expect_fail(
+                    {"predicates": [{"deepEquals": {"path": "/x", field: value}}],
+                     "responses": [{"is": {"statusCode": 200}}]},
+                    f"deepEquals.{field}")
+
+    def test_equals_headers_and_query_still_translate(self):
+        # The guard must be scoped to deepEquals — plain `equals` IS a subset match in MB, so
+        # queryParameters/headers are the faithful translation there.
+        m = _translated([{"predicates": [{"equals": {"path": "/x", "headers": {"A": "b"},
+                                                     "query": {"page": "1"}}}],
+                          "responses": [{"is": {"statusCode": 200}}]}])
+        self.assertEqual(m[0]["request"]["headers"], {"A": {"equalTo": "b"}})
+        self.assertEqual(m[0]["request"]["queryParameters"], {"page": {"equalTo": "1"}})
+
+    def test_two_url_matchers_raise(self):
+        self._expect_fail({"predicates": [{"and": [{"equals": {"path": "/a"}},
+                                                   {"startsWith": {"path": "/a"}}]}],
+                           "responses": [{"is": {"statusCode": 200}}]}, "two URL matchers")
+
+
+class FixtureNotMutated(unittest.TestCase):
+    """`bench_direct.py` is untouched by this change, and importing it must stay side-effect free —
+    otherwise a wiremock run could perturb the rift/mb stability contract."""
+
+    def test_translation_does_not_mutate_the_fixture(self):
+        before = copy.deepcopy(bd.IMPOSTERS)
+        scenarios_before = copy.deepcopy(bd.SCENARIOS)
+        for _port, _name, stubs in bd.IMPOSTERS:
+            bw.wiremock_mappings(stubs)
+        self.assertEqual(bd.IMPOSTERS, before)
+        self.assertEqual(bd.SCENARIOS, scenarios_before)
+
+    def test_default_comparison_set_is_still_the_published_thirteen(self):
+        self.assertEqual(len(bd.SCENARIOS), 13)
+
+
+class JavaPreflight(unittest.TestCase):
+    def test_parses_modern_and_legacy_version_strings(self):
+        self.assertEqual(bw.parse_java_major('openjdk version "17.0.13" 2024-10-15'), 17)
+        self.assertEqual(bw.parse_java_major('java version "21.0.4" 2024-07-16 LTS'), 21)
+        self.assertEqual(bw.parse_java_major('java version "1.8.0_402"'), 8)
+
+    def test_unparseable_is_none(self):
+        self.assertIsNone(bw.parse_java_major("no version here"))
+
+    def test_minimum_is_wiremock_3s_requirement(self):
+        self.assertEqual(bw.MIN_JAVA_MAJOR, 11)
+
+
+class Ports(unittest.TestCase):
+    def test_offset_is_disjoint_from_rift_and_mb(self):
+        self.assertEqual(bw.WIREMOCK_OFFSET, 200)
+        wm = set(bw.instance_ports())
+        rift = {p for p, _, _ in bd.IMPOSTERS}
+        mb = {p + 100 for p, _, _ in bd.IMPOSTERS}
+        self.assertFalse(wm & rift)
+        self.assertFalse(wm & mb)
+
+    def test_one_instance_per_imposter(self):
+        self.assertEqual(len(bw.instance_ports()), len(bd.IMPOSTERS))
+
+    def test_command_pins_the_port_and_disables_the_request_journal(self):
+        # `--no-request-journal` is a fairness requirement: WireMock records every request by
+        # default, unbounded, while rift and mb are both measured with recording off. Without it
+        # the table compares WireMock-with-journaling against Rift-without.
+        self.assertEqual(bw.wiremock_cmd("/x/wm.jar", 4745),
+                         ["java", "-jar", "/x/wm.jar", "--port", "4745", "--disable-banner",
+                          "--no-request-journal"])
+
+
+class ReportCombiner(unittest.TestCase):
+    HEADER = bd.CSV_HEADER
+
+    def _write(self, tmp, engine, rows, suffix=""):
+        path = os.path.join(tmp, f"direct_{engine}{suffix}.csv")
+        with open(path, "w") as f:
+            f.write(self.HEADER + "\n")
+            for r in rows:
+                f.write(r + "\n")
+        return path
+
+    def _row(self, scenario, conns=50, mode="closed", rps=1000.0):
+        return f"{scenario},{conns},{mode},{rps},1.0,2.0,3.0,4.0,1.5,,"
+
+    def _all_scenarios(self, conns=50, mode="closed", rps=1000.0):
+        return [self._row(s[0], conns, mode, rps) for s in bd.SCENARIOS]
+
+    def test_renders_na_when_mountebank_csv_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=50000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=10000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("n/a", text)
+        self.assertIn("not measured on this box", text)
+        self.assertIn("5.0x", text)  # Rift/WM speedup still rendered
+
+    def test_three_way_table_when_all_three_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))
+                self._write(tmp, "mb", self._all_scenarios(rps=6000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("| Scenario | Mountebank | WireMock | Rift | Rift/MB | Rift/WM |", text)
+        self.assertIn("10.0x", text)  # 60000/6000
+        self.assertIn("3.0x", text)   # 60000/20000
+
+    def test_refuses_a_csv_whose_connections_do_not_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(conns=50))
+                self._write(tmp, "wiremock", self._all_scenarios(conns=200))
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50)
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("wiremock", str(ctx.exception))
+
+    def test_refuses_open_loop_rows_for_the_closed_loop_table(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios())
+                self._write(tmp, "wiremock", self._all_scenarios(mode="open"))
+                with self.assertRaises(SystemExit):
+                    bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50)
+            finally:
+                bw.RESULTS_DIR = orig
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `tests/benchmark/scripts/bench_wiremock.py`: a WireMock suite that reuses the canonical `bench_direct` fixture, translates imposter stubs into WireMock mappings, benches the same 13 scenarios at port offset +200, and combines the CSVs into a 3-way report.

`bench_direct.py` is **untouched** — the rift-vs-mb stability contract (`DefaultRunUnchanged`) is unaffected by construction, and its own 132 tests still pass.

## Verified against a real WireMock, not just unit tests

Golden tests can only prove a translator is self-consistent. This suite was run end-to-end against **WireMock 3.9.1**: 14 instances launched, mappings loaded and count-verified, and **all 13 scenarios passed the body-marker assertion** — including `complex_predicate` (and/or/contains), `jsonpath`, `xpath`, `template` (literal `${request.path}`) and `no_match` hitting the empty-200 catch-all. Mapping counts confirm the splits: Complex 50 → 101, Literal 100 → 201, MethodMix 50 → 201.

## Fairness, which is the whole point of a published comparison

- **Request journal off** (`--no-request-journal`). It is on and unbounded by default; rift and mb are both measured with recording off. Re-measured on the same box, this was worth ~30% throughput and ~5× p99.9 to WireMock — leaving it on would have published a materially unfair number.
- **`deepEquals` over headers/query is refused, not approximated.** WireMock's `headers`/`queryParameters` are subset matchers with no "and no other keys"; translating anyway would be semantically wrong *and* cheaper than the exact-set check Rift/Mountebank run.
- **`complex_predicate` scans twice as far** under WireMock (no cross-field OR in one stub). Unavoidable and representative, but disclosed in the report so the ratio is not read as pure predicate cost.
- **The all-2xx gate is weaker here** — the catch-all that reproduces Rift/MB's empty-200 default means every response is 200, so `verify_body`'s marker is the real gate. Also stated.
- Templating stays off so `${request.path}` is served literally, exactly as Mountebank does.

## Tests

42 new tests (175 total in the benchmark suite): golden mappings per stub generator, priority ordering (strictly increasing — a tie would *invert* first-match-wins, since WireMock breaks ties by most-recently-added), the `or`-split, the catch-all, java preflight, port disjointness, and the report combiner's stale-artefact guard.

Two of them exist because the suite was **mutation-tested**: six plausible translator defects were planted, and one initially slipped through — `startsWith` losing its `re.escape`, invisible because every path in the fixture is metacharacter-free. A synthetic case now covers it, and all six are caught.

## Docs

`tests/benchmark/README.md` gains the Java/jar prerequisite and a WireMock section carrying the two caveats above.

Closes #861