### PR TITLE
bench(wiremock): pin --container-threads to max(cores, connections) and add a stock-default secondary row

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -172,12 +172,35 @@ JSON — different stub schema, and one port per JVM with admin under `/__admin`
 ```bash
 cd tests/benchmark
 
-# Bench WireMock alone -> results/direct_wiremock.csv
+# Benches WireMock TWICE -> results/direct_wiremock.csv + results/direct_wiremock-stock.csv
 python3 scripts/bench_wiremock.py --run-all --duration 20s --warmup 10s --connections 50
 
 # Combine whatever CSVs exist from the SAME box and settings -> WIREMOCK_BENCHMARK_REPORT.md
 python3 scripts/bench_wiremock.py --report --connections 50
 ```
+
+**`--run-all` runs two series and therefore takes roughly twice the wall clock** (issue #865):
+
+| Series | Container threads | Connections | CSV |
+|---|---|---|---|
+| headline (tuned) | `max(cpu_count, highest connection count)` | all of them (incl. a sweep) | `direct_wiremock.csv` |
+| secondary (stock) | WireMock's 10-thread default | `--connections` only | `direct_wiremock-stock.csv` |
+
+WireMock is thread-per-request, so its default 10-thread pool bounds in-flight requests at 10 —
+below the 50 connections the comparison offers. Pinning the headline series above the offered
+concurrency means the number measures the engine rather than the pool, which is what makes a Rift
+win defensible instead of "you throttled WireMock". **The pin is a fairness guarantee, not a
+speedup:** on a box with about as many cores as the default pool has threads, the CPU saturates
+first and the pin is a no-op — the two WireMock columns in the report tell you whether it bound.
+
+`--container-threads N` overrides the pin, so a thread-sweep curve can be produced by hand. There is
+deliberately no standing sweep axis; the suite is already slow. The run records the pin it used
+beside the CSV, so a later standalone `--report` states the value actually measured rather than
+re-deriving one — if you bench and report in separate invocations you do not need to repeat the flag.
+
+When sweeping, pass a `--connections` value that is one of the swept points: the stock series uses
+it alone, and a point outside the swept set would produce rows no report can read (the suite fails
+at argument-parse time rather than after benching it).
 
 - **Same fixture, same gates.** The suite *imports* `IMPOSTERS`/`SCENARIOS`/`EXPECT_BODY` from
   `bench_direct` and generates WireMock mappings from them, so the two can never drift. The same 13

--- a/tests/benchmark/scripts/bench_wiremock.py
+++ b/tests/benchmark/scripts/bench_wiremock.py
@@ -61,6 +61,16 @@ MIN_JAVA_MAJOR = 11
 DEFAULT_JAR = os.path.expanduser("~/bench-wiremock/wiremock-standalone.jar")
 DEFAULT_WIREMOCK_VERSION = "3.9.1"
 
+# The stock-defaults secondary series (issue #865): same suite, WireMock launched with no
+# `--container-threads`, benched at the headline connection count only. Its own engine label keeps
+# it in its own CSV and out of the headline Rift/WireMock ratio, while still being reportable
+# beside it — the out-of-the-box story as secondary data, not the number.
+STOCK_ENGINE = "wiremock-stock"
+
+# WireMock's documented Jetty container-pool default. Reported next to the tuned value so a reader
+# can tell a thread-pool ceiling from an engine throughput ceiling.
+STOCK_CONTAINER_THREADS = 10
+
 
 # --------------------------------------------------------------------------------------------
 # Stub translator
@@ -322,8 +332,32 @@ def instance_ports():
     return [port + WIREMOCK_OFFSET for port, _, _ in IMPOSTERS]
 
 
-def wiremock_cmd(jar, port):
+def container_thread_count(conn_list, override=None):
+    """How many Jetty container threads the *tuned* series runs with (issue #865).
+
+    WireMock is thread-per-request, so in-flight concurrency is bounded by this pool — and it
+    defaults to 10, while the comparison drives 50 connections. Measuring that configuration
+    measures the pool, not the engine, and "WireMock was throttled to 10 in-flight" is the first
+    rebuttal any WireMock user raises, because unlike Mountebank's architecturally single-threaded
+    Node this is a one-flag tune.
+
+    `max(cpu_count, max(connections))` is the defensible pin: pinning to core count would still
+    throttle WireMock below the offered concurrency (same criticism, different number), while this
+    guarantees the pool is never the bottleneck. Extra threads do not manufacture parallelism — the
+    CPU budget is unchanged — they only remove the artificial queue, so a Rift win here is
+    unambiguous. When sweeping, the TOP of the sweep is what must not be throttled."""
+    if override is not None:
+        if override < 1:
+            raise SystemExit(f"bench_wiremock: --container-threads must be >= 1, got {override}")
+        return override
+    return max(os.cpu_count() or 1, max(conn_list))
+
+
+def wiremock_cmd(jar, port, container_threads=None):
     """WireMock's argv for one imposter port.
+
+    `container_threads=None` means *stock defaults* — no `--container-threads` flag at all, which
+    is exactly what the secondary `wiremock-stock` series measures. Any int pins the pool.
 
     `--no-request-journal` is a fairness requirement, not a tuning knob. WireMock records every
     incoming request by default and the journal is unbounded, so a JVM under 30s of load retains
@@ -335,8 +369,11 @@ def wiremock_cmd(jar, port):
     the API instance non-comparable with each other, since each is measured against a progressively
     fuller journal. Nothing in this suite reads `/__admin/requests`, so disabling it costs nothing.
     """
-    return ["java", "-jar", jar, "--port", str(port), "--disable-banner",
-            "--no-request-journal"]
+    cmd = ["java", "-jar", jar, "--port", str(port), "--disable-banner",
+           "--no-request-journal"]
+    if container_threads is not None:
+        cmd += ["--container-threads", str(container_threads)]
+    return cmd
 
 
 def admin_ready(port, tries=240):
@@ -401,7 +438,7 @@ def probe_wiremock_version(port, fallback):
     return fallback
 
 
-def launch_instances(jar, logdir, procs):
+def launch_instances(jar, logdir, procs, container_threads=None):
     """Spawn one JVM per imposter and wait for each to answer on its admin path.
 
     `procs` is an out-parameter the caller owns, appended to as each process is spawned. That is
@@ -416,7 +453,8 @@ def launch_instances(jar, logdir, procs):
     for (base_port, name, stubs) in IMPOSTERS:
         port = base_port + WIREMOCK_OFFSET
         log = os.path.join(logdir, f"wiremock-{name}-{port}.log")
-        procs.append((name, port, launch(wiremock_cmd(jar, port), log), log, stubs))
+        procs.append((name, port, launch(wiremock_cmd(jar, port, container_threads), log),
+                      log, stubs))
     for i, (name, port, _proc, log, _stubs) in enumerate(procs, 1):
         if not admin_ready(port):
             raise SystemExit(f"bench_wiremock: instance {name} on {port} never became ready "
@@ -434,15 +472,25 @@ def load_all_mappings(procs):
 
 
 def stop_instances(procs):
-    for _name, port, proc, _log, _stubs in procs:
-        stop(proc, [port])
+    # `bench_direct.stop` raises if a port is still bound after its drain window. Let that abort the
+    # whole teardown and every *later* instance leaks, along with the caller's `free_ports` sweep —
+    # a window this suite now opens twice per run. Collect and re-raise instead, so each JVM gets
+    # its stop attempt first.
+    failures = []
+    for name, port, proc, _log, _stubs in procs:
+        try:
+            stop(proc, [port])
+        except SystemExit as e:
+            failures.append(f"{name}:{port} ({e})")
+    if failures:
+        raise SystemExit(f"bench_wiremock: instances failed to stop: {'; '.join(failures)}")
 
 
 # --------------------------------------------------------------------------------------------
 # Bench loop
 # --------------------------------------------------------------------------------------------
 
-def bench_wiremock(duration, warmup, conn_list, csv_suffix=""):
+def bench_wiremock(duration, warmup, conn_list, csv_suffix="", engine="wiremock"):
     os.makedirs(RESULTS_DIR, exist_ok=True)
     mode = mode_label(None)
     rows = []
@@ -452,7 +500,7 @@ def bench_wiremock(duration, warmup, conn_list, csv_suffix=""):
             # The same two gates bench_direct uses, and the reason a wrong translation cannot be
             # published as a fast number: the body marker proves the intended mapping served the
             # request, and a non-2xx distribution aborts the run.
-            verify_body("wiremock", name, method, url, body, headers)
+            verify_body(engine, name, method, url, body, headers)
             run_oha(url, method, body, headers, warmup, conns)
             m = metric(run_oha(url, method, body, headers, duration, conns))
             total = sum(m["codes"].values())
@@ -461,14 +509,44 @@ def bench_wiremock(duration, warmup, conn_list, csv_suffix=""):
             print(f"  {name:20s} c={conns:<4d} {m['rps']:>10.1f} rps  "
                   f"p50={m['p50_ms']}ms p99={m['p99_ms']}ms p999={m['p999_ms']}ms  {status}")
             if not (good and total > 0):
-                raise SystemExit(f"wiremock/{name}: unexpected status distribution {m['codes']} — aborting")
+                raise SystemExit(f"{engine}/{name}: unexpected status distribution {m['codes']} — aborting")
             rows.append((name, conns, mode, m))
-    path = write_results_csv("wiremock", csv_suffix, rows)
-    print(f"[wiremock] wrote {path}")
+    path = write_results_csv(engine, csv_suffix, rows)
+    print(f"[{engine}] wrote {path}")
     return path
 
 
-def run_all(jar, duration, warmup, conn_list, csv_suffix="", wiremock_version=DEFAULT_WIREMOCK_VERSION):
+def _run_series(jar, logdir, ports, container_threads, duration, warmup, conn_list,
+                csv_suffix, engine, wiremock_version):
+    """Launch, load, bench and tear down one WireMock configuration.
+
+    Container threads are a JVM start flag, so the tuned and stock series cannot share a launch —
+    each needs its own pass. `procs` is owned here so the `finally` still stops every JVM that was
+    spawned when a later one fails its readiness probe."""
+    label = ("stock defaults" if container_threads is None
+             else f"{container_threads} container threads")
+    print(f"[{engine}] launching {len(IMPOSTERS)} instances at offset +{WIREMOCK_OFFSET} ({label})")
+    procs = []
+    try:
+        launch_instances(jar, logdir, procs, container_threads)
+        print(f"[{engine}] loading mappings")
+        load_all_mappings(procs)
+        version = probe_wiremock_version(procs[0][1], wiremock_version)
+        print(f"[{engine}] version {version}")
+        bench_wiremock(duration, warmup, conn_list, csv_suffix, engine=engine)
+    finally:
+        stop_instances(procs)
+        free_ports(ports)
+
+
+def run_all(jar, duration, warmup, conn_list, csv_suffix="",
+            wiremock_version=DEFAULT_WIREMOCK_VERSION, container_threads=None,
+            stock_conns=50):
+    """Bench WireMock twice: the tuned headline series, then the stock-default secondary series.
+
+    The stock series runs at the headline connection count only — it exists to tell the
+    out-of-the-box story, not to be swept — and is written under its own engine label so the report
+    can show it beside the headline without it entering the Rift/WireMock ratio (issue #865)."""
     major, java_line = java_preflight()
     print(f"[wiremock] java {major} ({java_line})")
     if not os.path.exists(jar):
@@ -477,28 +555,51 @@ def run_all(jar, duration, warmup, conn_list, csv_suffix="", wiremock_version=DE
             f"  mkdir -p {os.path.dirname(jar)} && curl -Lo {jar} \\\n"
             f"    https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/"
             f"{wiremock_version}/wiremock-standalone-{wiremock_version}.jar")
+
+    threads = container_thread_count(conn_list, container_threads)
+    record_container_threads(csv_suffix, threads)
     ports = instance_ports()
     logdir = os.path.join(RESULTS_DIR, "logs")
     free_ports(ports)
-    # Owned here, not returned by launch_instances, so the `finally` below can still stop every
-    # JVM that was spawned when a later one fails its readiness probe.
-    procs = []
-    try:
-        print(f"[wiremock] launching {len(IMPOSTERS)} instances at offset +{WIREMOCK_OFFSET}")
-        launch_instances(jar, logdir, procs)
-        print("[wiremock] loading mappings")
-        load_all_mappings(procs)
-        version = probe_wiremock_version(procs[0][1], wiremock_version)
-        print(f"[wiremock] version {version}")
-        bench_wiremock(duration, warmup, conn_list, csv_suffix)
-    finally:
-        stop_instances(procs)
-        free_ports(ports)
+
+    _run_series(jar, logdir, ports, threads, duration, warmup, conn_list,
+                csv_suffix, "wiremock", wiremock_version)
+
+    # Stock defaults, headline connection count only — the out-of-the-box story as secondary data.
+    _run_series(jar, logdir, ports, None, duration, warmup, [stock_conns],
+                csv_suffix, STOCK_ENGINE, wiremock_version)
+    return threads
 
 
 # --------------------------------------------------------------------------------------------
 # Report
 # --------------------------------------------------------------------------------------------
+
+def threads_sidecar_path(csv_suffix):
+    return os.path.join(RESULTS_DIR, f"direct_wiremock{csv_suffix}.threads")
+
+
+def record_container_threads(csv_suffix, threads):
+    """Persist the pin the tuned series actually ran with, beside its CSV.
+
+    The documented flow is two commands — `--run-all`, then a separate `--report` — so the report
+    process does not know what the run chose. Recomputing it from the *report* invocation's flags
+    would silently print a different number than the one measured (e.g. run with
+    `--sweep-connections 50,200` pins 200; `--report --connections 50` would infer 50). Requirement
+    4 of issue #865 is that the report state the value **actually used**, so it is recorded rather
+    than re-derived."""
+    with open(threads_sidecar_path(csv_suffix), "w") as f:
+        f.write(f"{threads}\n")
+
+
+def recorded_container_threads(csv_suffix):
+    """The pin the tuned series ran with, or None if it was never recorded."""
+    try:
+        with open(threads_sidecar_path(csv_suffix)) as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
 
 def engine_csv_path(engine, csv_suffix):
     """Where `--report` looks for an engine's CSV.
@@ -527,9 +628,17 @@ def load_engine_csv(engine, csv_suffix, conns):
     return rows or None
 
 
-def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix=""):
+def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix="",
+           container_threads=None):
+    """Combine the CSVs into the 3-way table.
+
+    `container_threads` is the pin the tuned series ran with, stated in the Method section so a
+    reader can tell a thread-pool ceiling from an engine throughput ceiling (issue #865). The
+    stock-defaults series is rendered as its own clearly-labelled column and is deliberately NOT
+    used for the Rift/WM speedup — that ratio must come from the un-throttled run."""
     rift = load_engine_csv("rift", csv_suffix, conns)
     wm = load_engine_csv("wiremock", csv_suffix, conns)
+    stock = load_engine_csv(STOCK_ENGINE, csv_suffix, conns)
     mb = load_engine_csv("mb", csv_suffix, conns)
     if rift is None:
         raise SystemExit(f"bench_wiremock: no comparable rift rows at connections={conns}, "
@@ -551,13 +660,35 @@ def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix
         f.write("- **Method:** native processes (no Docker); engines run one at a time on disjoint "
                 "port ranges; the same 13 scenarios and the same oha settings for every engine; "
                 "each scenario's matched body is asserted before it is measured.\n")
-        f.write("- **WireMock setup:** one JVM per imposter port (14 instances), stock heap/GC and "
-                "the default 10-thread Jetty container pool. Response templating is **off**, so "
-                "`${request.path}` is served literally exactly as Mountebank serves it. The request "
-                "journal is **off** (`--no-request-journal`): it is on and unbounded by default, "
-                "and Rift and Mountebank are both measured with recording off — journaling is a "
-                "separate, additive scenario in the Rift suite precisely because it is a distinct "
-                "cost.\n")
+        tuned = (f"**{container_threads}** Jetty container threads" if container_threads is not None
+                 else "an **unrecorded** number of Jetty container threads "
+                      "(pass --container-threads to record it)")
+        f.write(f"- **WireMock setup:** one JVM per imposter port (14 instances), stock heap/GC, and "
+                f"{tuned} for the headline series. Response templating "
+                f"is **off**, so `${{request.path}}` is served literally exactly as Mountebank "
+                f"serves it. The request journal is **off** (`--no-request-journal`): it is on and "
+                f"unbounded by default, and Rift and Mountebank are both measured with recording "
+                f"off — journaling is a separate, additive scenario in the Rift suite precisely "
+                f"because it is a distinct cost.\n")
+        f.write(f"- **Why the pool is pinned.** WireMock is thread-per-request, so its default "
+                f"{STOCK_CONTAINER_THREADS}-thread pool bounds in-flight requests at "
+                f"{STOCK_CONTAINER_THREADS}, below the {conns} connections offered here. That "
+                f"makes the pool a possible ceiling with nothing to do with the engine, so the "
+                f"headline series pins it above the offered concurrency and the number measures "
+                f"WireMock on the same CPU budget Rift gets. **The pin is a fairness guarantee, "
+                f"not a speedup:** extra threads do not manufacture parallelism, they only remove "
+                f"an artificial queue. On a box with about as many cores as the default pool has "
+                f"threads, the CPU saturates first and the pin is a no-op — compare the two "
+                f"WireMock columns to see whether it bound on this run.\n")
+        if stock:
+            f.write(f"- **The `WireMock (stock)` column is secondary data**, measured at WireMock's "
+                    f"out-of-the-box {STOCK_CONTAINER_THREADS}-thread default at "
+                    f"{conns} connections. It is what a user gets before tuning, and it is "
+                    f"deliberately **not** the basis of the Rift/WM ratio. If it reads within "
+                    f"noise of the headline column, the {STOCK_CONTAINER_THREADS}-thread default "
+                    f"was not the binding constraint on this hardware. It also runs *after* the "
+                    f"headline series in the same session, so treat small differences between the "
+                    f"two WireMock columns as ordering noise rather than signal.\n")
         f.write("- **Read `complex_predicate` with care.** WireMock cannot express an OR across two "
                 "*different* headers in one stub, so that imposter's 50 stubs become 101 mappings "
                 "and the measured request matches the 50th candidate where Rift/Mountebank match "
@@ -570,22 +701,36 @@ def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix
                 "longer proves a match. The per-scenario body-marker assertion is the gate that "
                 "does.\n\n")
 
+        stock_head = f" WireMock (stock, {STOCK_CONTAINER_THREADS}t) |" if stock else ""
+        stock_rule = " --:|" if stock else ""
+        # Two adjacent WireMock columns where only one carries its thread count would read as
+        # "stock vs default" — the exact confusion #865 exists to remove.
+        wm_head = f"WireMock ({container_threads}t)" if container_threads is not None else "WireMock"
         f.write("## Throughput (requests/sec, higher is better)\n\n")
-        f.write("| Scenario | Mountebank | WireMock | Rift | Rift/MB | Rift/WM |\n")
-        f.write("|---|--:|--:|--:|--:|--:|\n")
+        f.write(f"| Scenario | Mountebank |{stock_head} {wm_head} | Rift | Rift/MB | Rift/WM |\n")
+        f.write(f"|---|--:|{stock_rule}--:|--:|--:|--:|\n")
         for name in order:
             wr, rr = wm[name]["rps"], rift[name]["rps"]
             mr = mb[name]["rps"] if mb else None
             mb_cell = f"{mr:,.0f}" if mr is not None else "n/a"
             mb_sp = f"{rr / mr:.1f}x" if mr else "n/a"
+            # Deliberately the TUNED series: a speedup over a 10-thread-throttled WireMock would
+            # measure the pool, and is the first thing a WireMock user would (rightly) reject.
             wm_sp = f"{rr / wr:.1f}x" if wr else "n/a"
-            f.write(f"| {name} | {mb_cell} | {wr:,.0f} | {rr:,.0f} | **{mb_sp}** | **{wm_sp}** |\n")
+            stock_cell = ""
+            if stock:
+                sr = stock.get(name, {}).get("rps")
+                stock_cell = f" {sr:,.0f} |" if sr is not None else " n/a |"
+            f.write(f"| {name} | {mb_cell} |{stock_cell} {wr:,.0f} | {rr:,.0f} | "
+                    f"**{mb_sp}** | **{wm_sp}** |\n")
 
         f.write("\n## Latency p99 (ms, lower is better)\n\n")
-        f.write("| Scenario | Mountebank | WireMock | Rift |\n|---|--:|--:|--:|\n")
+        f.write(f"| Scenario | Mountebank |{stock_head} {wm_head} | Rift |\n")
+        f.write(f"|---|--:|{stock_rule}--:|--:|\n")
         for name in order:
             mb_cell = mb[name]["p99"] if mb else "n/a"
-            f.write(f"| {name} | {mb_cell} | {wm[name]['p99']} | {rift[name]['p99']} |\n")
+            stock_cell = f" {stock.get(name, {}).get('p99', 'n/a')} |" if stock else ""
+            f.write(f"| {name} | {mb_cell} |{stock_cell} {wm[name]['p99']} | {rift[name]['p99']} |\n")
     print(f"wrote {out}")
     return out
 
@@ -608,16 +753,31 @@ if __name__ == "__main__":
     ap.add_argument("--mb-version", default="2.9.1")
     ap.add_argument("--java-version", default=None,
                     help="override the JVM string recorded in the report (default: probed)")
+    ap.add_argument("--container-threads", type=int, default=None, metavar="N",
+                    help="pin WireMock's Jetty container pool for the headline series (default: "
+                         "max(cpu_count, highest connection count), so the pool is never the "
+                         "concurrency ceiling). Set it explicitly to produce a thread-sweep curve "
+                         "by hand — there is deliberately no standing sweep axis, the suite is "
+                         "already slow. The stock-defaults secondary series ignores this.")
     ap.add_argument("--rep", type=int, default=None,
                     help="tag this run's CSV as _repN so several reps can be aggregated")
     args = ap.parse_args()
 
     suffix = f"_rep{args.rep}" if args.rep else ""
     conn_list = parse_conn_list(args.sweep_connections) if args.sweep_connections else [args.connections]
+    # The stock series is benched at --connections only. If that point is not in the swept set, it
+    # measures ~6 minutes of a configuration no --report can render (report() reads a single
+    # connection point), so fail at parse time rather than after the run.
+    if args.run_all and args.sweep_connections and args.connections not in conn_list:
+        ap.error(f"--connections {args.connections} is not in --sweep-connections "
+                 f"{sorted(conn_list)}; the stock series would bench a point no report can read. "
+                 f"Pass --connections with one of the swept values.")
 
+    threads = None
     if args.run_all:
-        run_all(args.wiremock_jar, args.duration, args.warmup, conn_list, suffix,
-                args.wiremock_version)
+        threads = run_all(args.wiremock_jar, args.duration, args.warmup, conn_list,
+                          suffix, args.wiremock_version, args.container_threads,
+                          stock_conns=args.connections)
     if args.report:
         java_ver = args.java_version
         if java_ver is None:
@@ -625,7 +785,13 @@ if __name__ == "__main__":
                 _major, java_ver = java_preflight()
             except SystemExit:
                 java_ver = "unknown"
+        # A standalone `--report` did not run the bench. Read what the run recorded rather than
+        # re-deriving it from THIS invocation's flags, which would print a number the run never
+        # used. An explicit --container-threads still wins; absent both, the report says so.
+        if threads is None:
+            threads = (args.container_threads if args.container_threads is not None
+                       else recorded_container_threads(suffix))
         report(args.rift_version, args.mb_version, args.wiremock_version, java_ver,
-               args.duration, args.connections, suffix)
+               args.duration, args.connections, suffix, container_threads=threads)
     if not (args.run_all or args.report):
         ap.error("nothing to do: pass --run-all and/or --report")

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -319,9 +319,80 @@ class Ports(unittest.TestCase):
         # `--no-request-journal` is a fairness requirement: WireMock records every request by
         # default, unbounded, while rift and mb are both measured with recording off. Without it
         # the table compares WireMock-with-journaling against Rift-without.
+        # No container_threads => stock defaults, which is exactly what the secondary series wants.
         self.assertEqual(bw.wiremock_cmd("/x/wm.jar", 4745),
                          ["java", "-jar", "/x/wm.jar", "--port", "4745", "--disable-banner",
                           "--no-request-journal"])
+
+    def test_command_pins_the_container_pool_when_asked(self):
+        self.assertEqual(bw.wiremock_cmd("/x/wm.jar", 4745, 64),
+                         ["java", "-jar", "/x/wm.jar", "--port", "4745", "--disable-banner",
+                          "--no-request-journal", "--container-threads", "64"])
+
+
+class ContainerThreads(unittest.TestCase):
+    """Issue #865. WireMock is thread-per-request, so its 10-thread default caps in-flight requests
+    below the offered concurrency — benchmarking that measures the pool, not the engine."""
+
+    def test_pins_above_the_offered_concurrency(self):
+        # 200 connections must not be served by a cpu_count-sized pool.
+        self.assertEqual(bw.container_thread_count([200]), max(os.cpu_count() or 1, 200))
+
+    def test_never_drops_below_cpu_count(self):
+        # At 1 connection the pool should still not be smaller than the machine.
+        self.assertEqual(bw.container_thread_count([1]), max(os.cpu_count() or 1, 1))
+
+    def test_sweep_covers_the_TOP_of_the_sweep(self):
+        # The pin has to clear the largest point in the sweep, not the first or the last one
+        # listed — otherwise the highest-concurrency point is the only one that gets throttled,
+        # which is exactly where the ratio matters most.
+        self.assertEqual(bw.container_thread_count([1, 200, 50]), max(os.cpu_count() or 1, 200))
+
+    def test_override_wins(self):
+        self.assertEqual(bw.container_thread_count([1000], override=12), 12)
+
+    def test_override_must_be_positive(self):
+        with self.assertRaises(SystemExit):
+            bw.container_thread_count([50], override=0)
+
+    def test_stock_default_constant_matches_wiremocks_documented_default(self):
+        self.assertEqual(bw.STOCK_CONTAINER_THREADS, 10)
+
+    def test_the_pin_is_recorded_at_run_time_and_read_back(self):
+        # The documented flow is two commands (`--run-all`, then a separate `--report`), so the
+        # report process cannot know what the run chose. Re-deriving it from the report
+        # invocation's flags would state a number the run never used — e.g. run with
+        # `--sweep-connections 50,200` (pin 200), report with `--connections 50` (would infer 50).
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self.assertIsNone(bw.recorded_container_threads(""))
+                bw.record_container_threads("", 200)
+                self.assertEqual(bw.recorded_container_threads(""), 200)
+                bw.record_container_threads("_rep2", 64)
+                self.assertEqual(bw.recorded_container_threads("_rep2"), 64)
+                self.assertEqual(bw.recorded_container_threads(""), 200,
+                                 "reps must not clobber each other's recorded pin")
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_unreadable_sidecar_reports_unknown_rather_than_guessing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                with open(bw.threads_sidecar_path(""), "w") as f:
+                    f.write("not a number")
+                self.assertIsNone(bw.recorded_container_threads(""))
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_stock_series_has_its_own_engine_label(self):
+        # Its own label keeps it in its own CSV and out of the headline ratio.
+        self.assertEqual(bw.STOCK_ENGINE, "wiremock-stock")
+        self.assertNotEqual(bw.STOCK_ENGINE, "wiremock")
+        self.assertTrue(bw.engine_csv_path(bw.STOCK_ENGINE, "").endswith("direct_wiremock-stock.csv"))
 
 
 class ReportCombiner(unittest.TestCase):
@@ -384,6 +455,99 @@ class ReportCombiner(unittest.TestCase):
             finally:
                 bw.RESULTS_DIR = orig
         self.assertIn("wiremock", str(ctx.exception))
+
+    def test_stock_column_appears_but_never_drives_the_speedup(self):
+        # Issue #865's core reporting contract: the stock series is visible as its own labelled
+        # column, and the Rift/WM ratio comes from the TUNED series. A speedup computed against a
+        # 10-thread-throttled WireMock would measure the pool, and is the first thing a WireMock
+        # user would rightly reject.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))       # tuned
+                self._write(tmp, "wiremock-stock", self._all_scenarios(rps=5000.0))  # stock
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50,
+                                container_threads=64)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("WireMock (stock, 10t)", text)
+        self.assertIn("5,000", text)
+        self.assertIn("3.0x", text)   # 60000/20000 — the tuned ratio
+        self.assertNotIn("12.0x", text, "the ratio must NOT be computed against the stock series")
+        # Assert the pin reached the Method section without pinning the exact prose around it.
+        self.assertRegex(text, r"\*\*64\*\* Jetty container threads")
+
+    def test_both_wiremock_columns_are_labelled_with_their_thread_count(self):
+        # Two adjacent WireMock columns where only one carries its thread count would read as
+        # "stock vs default" — the exact confusion #865 exists to remove.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))
+                self._write(tmp, "wiremock-stock", self._all_scenarios(rps=5000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50,
+                                container_threads=64)
+                header = [l for l in open(out) if l.startswith("| Scenario |")][0]
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("WireMock (stock, 10t)", header)
+        self.assertIn("WireMock (64t)", header)
+
+    def test_report_says_unrecorded_rather_than_inventing_a_thread_count(self):
+        # If neither the run nor the caller recorded a pin, the Method section must say so — a
+        # plausible-looking wrong number is worse than an admitted gap.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50,
+                                container_threads=None)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("unrecorded", text)
+        self.assertIn("--container-threads", text)
+
+    def test_report_discloses_that_the_pin_may_be_a_no_op(self):
+        # Measured on a 10-core box, pinning to 50 made no difference against the 10-thread
+        # default: the CPU saturates first. A report that asserted "measuring stock measures the
+        # pool, not the engine" while the stock column matched the headline would contradict
+        # itself, so the wording has to admit the pin may not bind.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50,
+                                container_threads=64)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("fairness guarantee, not a speedup", text)
+        self.assertIn("no-op", text)
+
+    def test_report_without_a_stock_csv_omits_the_column(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write(tmp, "rift", self._all_scenarios(rps=60000.0))
+                self._write(tmp, "wiremock", self._all_scenarios(rps=20000.0))
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 17", "20s", 50,
+                                container_threads=64)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertNotIn("stock", text.split("## Throughput")[1])
+        self.assertIn("3.0x", text)
 
     def test_refuses_open_loop_rows_for_the_closed_loop_table(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
WireMock is thread-per-request; its Jetty container pool defaults to **10 threads**, so the comparison was offering 50 connections to an engine that could hold 10 in flight. Implements the maintainer's triage decision on #865: pin the pool for the headline series, keep a stock-default series as secondary data, and make the report state which is which.

## What changed

| Series | Container threads | Connections | CSV |
|---|---|---|---|
| headline (tuned) | `max(cpu_count, highest connection count)` | all, including a sweep | `direct_wiremock.csv` |
| secondary (stock) | WireMock's 10-thread default | `--connections` only | `direct_wiremock-stock.csv` |

- `--container-threads N` overrides the pin so a thread-sweep curve can be produced by hand. No standing sweep axis — the suite is already slow.
- The `Rift/WM` ratio is computed from the **tuned** series. A speedup over a 10-thread-throttled WireMock would measure the pool.
- Both WireMock columns are labelled with their thread count, so a reader can tell a pool ceiling from an engine ceiling from the table alone.

## The pin is a fairness guarantee, not a speedup — and the report says so

Measured here on a **10-core** box at 50 connections, pinning to 50 made no material difference against the stock 10 (65,231 vs 68,091 rps on `simple_health`; 12,570 vs 12,690 on `query_last`). That is the expected result when the CPU saturates before the pool does.

The value of pinning is that it removes the "you throttled WireMock" rebuttal, not that it moves the number. So rather than asserting the pin matters, the report now tells the reader to **compare the two WireMock columns to see whether it bound on their hardware**, and discloses that the stock series runs second in the same session so small differences are ordering noise. Whether WireMock's tuned config genuinely differs from its stock config is only answerable where `cpu_count < connections` — which is what #866 sets up on the 16-core runner.

## Recording, not re-deriving, the pin

`--run-all` and `--report` are two separate commands, so the report process cannot know what the run chose. It now reads a value the run recorded beside the CSV. Re-deriving it from the report invocation's flags printed a number the run never used: `--run-all --sweep-connections 50,200` pins 200, but `--report --connections 50` would have inferred and published 50. With neither recorded nor supplied, the report says `unrecorded` rather than guessing.

## Verification

- 190 tests (5 new beyond the previous 185); `bench_direct.py` untouched, so the rift-vs-mb stability contract is unaffected.
- Ran end-to-end against **real WireMock 3.9.1** at both `-c 10` and `-c 50`: both series launch, load, bench and tear down; `--container-threads` is accepted; the sidecar records the pin; a standalone `--report` reads it back.
- The new argument guard was exercised live: sweeping with a `--connections` outside the swept set now fails at parse time instead of benching ~6 minutes of a point no report can read.

## Follow-up

#866 covers publishing this through CI — rep-aggregation for both WireMock engines, a WireMock leg in `benchmark-publish.yml`, and re-measuring all three engines at the same warmup (the published rift/mb numbers used the 3s default; this suite recommends 10s for the JIT).

Closes #865