### PR TITLE
bench(ci): publish the 3-way WireMock comparison — rep-aggregation for bench_wiremock + a WireMock leg in benchmark-publish.yml

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -8,8 +8,11 @@
 #   1. Every published cell is a MEDIAN with its spread stated. A benchmark host is not a constant
 #      — issue #746 published a number from a single rep that landed on a degraded runner and had
 #      to be retracted. `--rep` plus the aggregation step below makes that structurally impossible.
-#   2. Mountebank is pinned and installed here, not taken from whoever ran it. The comparison is
-#      only meaningful if both engines are the same versions every time.
+#   2. Mountebank and WireMock are pinned and installed here, not taken from whoever ran them. The
+#      comparison is only meaningful if every engine is the same version every time.
+#   3. All three engines are measured in ONE dispatch at ONE warmup. A published ratio between a
+#      3s-warmed Rift and a 10s-warmed JVM is not a comparison, and nothing in the table would say
+#      so — hence a single `warmup` input rather than a per-leg constant.
 name: Benchmark (publish)
 
 on:
@@ -27,9 +30,18 @@ on:
       connections:
         description: "Keep-alive connections for the comparison table"
         default: "50"
+      warmup:
+        description: >-
+          Warmup per scenario point, applied to ALL THREE engines. 3s is thin for a JVM's JIT, so a
+          3s rift/mb table cannot have a WireMock column bolted onto it — the whole table is
+          re-measured at one warmup per dispatch.
+        default: "10s"
       mb_version:
         description: "Mountebank version (pinned so the comparison is reproducible)"
         default: "2.9.1"
+      wiremock_version:
+        description: "WireMock version (pinned, same reason as Mountebank)"
+        default: "3.9.1"
 
 permissions:
   contents: read
@@ -38,6 +50,16 @@ jobs:
   publish:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 360
+    # Dispatch inputs reach the shell as environment variables, never interpolated into the script
+    # body — `${{ }}` is substituted before bash parses the line, so a crafted input would run as
+    # code. `BENCH_`-prefixed because Mountebank and Rift both read `MB_*` from the environment.
+    env:
+      BENCH_REPS: ${{ inputs.reps }}
+      BENCH_DURATION: ${{ inputs.duration }}
+      BENCH_CONNECTIONS: ${{ inputs.connections }}
+      BENCH_WARMUP: ${{ inputs.warmup }}
+      BENCH_MB_VERSION: ${{ inputs.mb_version }}
+      BENCH_WIREMOCK_VERSION: ${{ inputs.wiremock_version }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -45,16 +67,27 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
 
-      - name: Install oha and Mountebank ${{ inputs.mb_version }}
+      - name: Install oha, Mountebank ${{ inputs.mb_version }}, WireMock ${{ inputs.wiremock_version }}
         run: |
           set -euo pipefail
           curl -sfL -o /usr/local/bin/oha \
             https://github.com/hatoo/oha/releases/download/v1.12.0/oha-linux-amd64 \
             && chmod +x /usr/local/bin/oha && oha --version \
             || cargo install oha --locked
-          npm install --prefix "$HOME/bench-mb" "mountebank@${{ inputs.mb_version }}"
+          npm install --prefix "$HOME/bench-mb" "mountebank@$BENCH_MB_VERSION"
           "$HOME/bench-mb/node_modules/mountebank/bin/mb" --version
+          mkdir -p "$HOME/bench-wiremock"
+          curl -sfL -o "$HOME/bench-wiremock/wiremock-standalone.jar" \
+            "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/$BENCH_WIREMOCK_VERSION/wiremock-standalone-$BENCH_WIREMOCK_VERSION.jar"
+          # Integrity, not a version flag: a truncated jar still downloads cleanly and only fails
+          # 40 minutes later inside the first rep.
+          unzip -qt "$HOME/bench-wiremock/wiremock-standalone.jar"
+          java -version
 
       - name: Record environment
         run: |
@@ -72,17 +105,18 @@ jobs:
         working-directory: tests/benchmark
         run: |
           set -euo pipefail
-          for rep in $(seq 1 ${{ inputs.reps }}); do
+          for rep in $(seq 1 "$BENCH_REPS"); do
             echo "===== comparison rep=$rep ====="
             python3 -u scripts/bench_direct.py --run-all --engines rift,mb --rep "$rep" \
-              --connections "${{ inputs.connections }}" --duration "${{ inputs.duration }}" \
-              --warmup 3s --rift-bin ../../target/release/rift-http-proxy \
+              --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION" \
+              --warmup "$BENCH_WARMUP" \
+              --rift-bin ../../target/release/rift-http-proxy \
               --mb-bin "$HOME/bench-mb/node_modules/mountebank/bin/mb"
           done
           python3 -u scripts/bench_direct.py --aggregate-comparison "" \
-            --connections "${{ inputs.connections }}" \
+            --connections "$BENCH_CONNECTIONS" \
             --rift-version "$(../../target/release/rift-http-proxy --version)" \
-            --mb-version "${{ inputs.mb_version }}"
+            --mb-version "$BENCH_MB_VERSION"
           # Both phases write direct_rift_repN.csv — same engine, same empty variant suffix — so
           # the sweep below would silently overwrite the comparison's inputs and the published
           # table would be built from whatever survived. Park the comparison artefacts first.
@@ -92,16 +126,66 @@ jobs:
           mv results/direct_rift.csv results/direct_mb.csv results/comparison/ 2>/dev/null || true
           ls results/comparison
 
+      # The third engine. It runs here — after the comparison, before the sweep — because the 3-way
+      # median table needs rift and mb at the SAME point, and the sweep below re-writes
+      # direct_rift_rep*.csv at other connection counts.
+      #
+      # WireMock is benched by its own suite (bench_wiremock.py): it cannot consume the imposter
+      # JSON, so its mappings are generated from the same fixture instead. Two series come out of
+      # each rep — `wiremock` with the Jetty pool pinned (issue #865) and `wiremock-stock` at
+      # out-of-the-box defaults — so the report can distinguish a thread-pool ceiling from an
+      # engine ceiling.
+      - name: WireMock ${{ inputs.wiremock_version }} + 3-way comparison (repeated)
+        working-directory: tests/benchmark
+        run: |
+          set -euo pipefail
+          for rep in $(seq 1 "$BENCH_REPS"); do
+            echo "===== wiremock rep=$rep ====="
+            python3 -u scripts/bench_wiremock.py --run-all --rep "$rep" \
+              --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION" \
+              --warmup "$BENCH_WARMUP" \
+              --wiremock-jar "$HOME/bench-wiremock/wiremock-standalone.jar" \
+              --wiremock-version "$BENCH_WIREMOCK_VERSION"
+          done
+          # Bring the parked comparison reps back so all four series aggregate together and the
+          # table is one dispatch's data end to end. Unequal rep counts are refused by the
+          # aggregation, so a partial copy cannot quietly become a thinner column.
+          cp results/comparison/direct_rift_rep*.csv results/comparison/direct_mb_rep*.csv results/
+          # No --warmup here on purpose: the report states what the reps recorded, so a mismatch
+          # between what CI asked for and what ran shows up instead of being papered over.
+          python3 -u scripts/bench_wiremock.py --aggregate-reps --report \
+            --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION" \
+            --rift-version "$(../../target/release/rift-http-proxy --version)" \
+            --mb-version "$BENCH_MB_VERSION" \
+            --wiremock-version "$BENCH_WIREMOCK_VERSION"
+          # Park before the sweep: it writes direct_rift_rep*.csv and its own direct_rift_median.csv,
+          # which would otherwise overwrite the inputs and the output of the table just built.
+          # Named individually rather than by one broad glob: `direct_wiremock*.csv` and
+          # `*_median.csv` overlap on direct_wiremock_median.csv, and `mv` given the same source
+          # twice fails on the second — an hour of benching thrown away at the last command.
+          mkdir -p results/wiremock
+          mv results/direct_wiremock*.csv results/wiremock/
+          mv results/direct_wiremock*.threads results/direct_wiremock*.warmup results/wiremock/
+          mv results/WIREMOCK_BENCHMARK_REPORT*.md results/wiremock/
+          # Renamed, not just moved: the sweep writes its own direct_rift_median.csv at other
+          # connection counts, and two files with the same basename in one artefact is how the
+          # wrong one gets published.
+          mv results/direct_rift_median.csv results/wiremock/direct_rift_comparison_median.csv
+          mv results/direct_mb_median.csv results/wiremock/direct_mb_comparison_median.csv
+          rm -f results/direct_rift_rep*.csv results/direct_mb_rep*.csv
+          ls results/wiremock
+
       # Rift-only sweep: connection scaling plus the matching-dimension scenarios that the
       # comparison set deliberately excludes (it is a stability contract).
       - name: Rift concurrency sweep + matching dimensions (repeated)
         working-directory: tests/benchmark
         run: |
           set -euo pipefail
-          for rep in $(seq 1 ${{ inputs.reps }}); do
+          for rep in $(seq 1 "$BENCH_REPS"); do
             echo "===== sweep rep=$rep ====="
             python3 -u scripts/bench_direct.py --run-all --rep "$rep" \
-              --sweep-connections 1,50,256,512 --duration "${{ inputs.duration }}" --warmup 3s \
+              --sweep-connections 1,50,256,512 --duration "$BENCH_DURATION" \
+              --warmup "$BENCH_WARMUP" \
               --rift-bin ../../target/release/rift-http-proxy
           done
           python3 -u scripts/bench_direct.py --aggregate-reps ""
@@ -110,7 +194,10 @@ jobs:
         if: failure()
         run: |
           free -m; df -h / | tail -1
-          tail -40 tests/benchmark/results/*.log 2>/dev/null || echo "(no logs)"
+          # results/logs/ as well as results/: the WireMock leg spawns 14 JVMs and writes each one's
+          # log there, and it is the leg most likely to die on a readiness probe or an OOM.
+          tail -40 tests/benchmark/results/*.log tests/benchmark/results/logs/*.log 2>/dev/null \
+            || echo "(no logs)"
 
       - uses: actions/upload-artifact@v7
         if: always()
@@ -120,6 +207,8 @@ jobs:
             tests/benchmark/results/*.csv
             tests/benchmark/results/*.md
             tests/benchmark/results/comparison/*
+            tests/benchmark/results/wiremock/*
             tests/benchmark/results/environment.txt
             tests/benchmark/results/*.log
+            tests/benchmark/results/logs/*.log
           retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,20 @@ jobs:
           ./scripts/verify-feature-propagation.sh --self-test
           ./scripts/verify-feature-propagation.sh
 
+  benchmark-scripts:
+    name: Benchmark Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Issue #866. The benchmark suites had unit tests but no CI ran them, so the gate protecting
+      # every published number — stub translation, rep aggregation, the report combiner — could go
+      # red for months without anyone noticing. The live path (14 JVMs + oha) is not CI-runnable;
+      # this is the pure logic underneath it, and it takes seconds.
+      - name: Run benchmark suite unit tests
+        working-directory: tests/benchmark/scripts
+        run: python3 -m unittest discover -p 'test_*.py'
+
   image-hardening:
     name: Image Hardening
     runs-on: ubuntu-latest

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -237,7 +237,61 @@ table:
 Translator logic is gate-tested in `scripts/test_bench_wiremock.py` (golden mappings per stub
 generator, priority ordering, the `or`-split, the catch-all, and a completeness test that runs
 *every* stub in the live fixture through the translator so a new generator in `bench_direct.py`
-cannot ship silently untranslated).
+cannot ship silently untranslated). CI runs it — the `Benchmark Scripts` job in `ci.yml` executes
+both suites' unit tests on every PR.
+
+#### Publishing the 3-way table (issue #866)
+
+Do not publish a number from one rep, and **do not bolt a WireMock column onto an existing
+rift-vs-mb table**. Both are handled by the `Benchmark (publish)` workflow
+(`.github/workflows/benchmark-publish.yml`, `workflow_dispatch` only):
+
+```
+gh workflow run benchmark-publish.yml \
+  -f runner=ubuntu-16core -f reps=3 -f duration=20s -f connections=50 -f warmup=10s
+```
+
+It measures **all three engines in one dispatch at one `warmup`**, three reps each, then publishes
+medians. That single-warmup rule is the point of the input existing: a 3s-warmed Rift against a
+10s-warmed JVM is not a comparison, and the rendered table would say nothing about it. The legs run
+in a fixed order — comparison, then WireMock, then the Rift-only sweep — because the sweep re-writes
+`direct_rift_rep*.csv` at other connection counts; the WireMock leg parks its artefacts under
+`results/wiremock/` before that happens. `wiremock_version` and `mb_version` are pinned inputs so a
+re-run is reproducible.
+
+The same aggregation runs locally:
+
+```bash
+for rep in 1 2 3; do
+  python3 scripts/bench_wiremock.py --run-all --rep $rep --connections 50 --warmup 10s
+done
+# -> direct_<engine>_median.csv for every engine with rep files, then the median table
+python3 scripts/bench_wiremock.py --aggregate-reps --report --connections 50
+```
+
+`--aggregate-reps` collapses `_repN` CSVs for `wiremock`, `wiremock-stock`, and `rift`/`mb` when
+those are present, carrying `reps` and peak-to-peak `rps_spread_pct` into the median CSV. The report
+then renders a **Repetition spread** table with each column's `n` in its own header — a single rep
+shows `n/a`, never `0.0%`, because peak-to-peak over one sample is zero and the thinnest column
+would otherwise read as the steadiest engine.
+
+Four things are hard errors rather than a quieter number:
+
+| Refused | Why |
+|---|---|
+| a scenario point missing from any rep | the median would rest on fewer samples than the table claims (#773) |
+| engines with **different** rep counts | unequal replication favours whichever engine got more samples — the rule `bench_direct` already applies to rift-vs-mb |
+| reps with different `--container-threads` | their median describes a configuration nothing measured |
+| reps with different `--warmup` | same, and this is the setting the 3-way claim rests on |
+| no tuned `wiremock` reps | the headline ratio comes from that series; stock alone cannot stand in |
+
+Both the pin and the warmup are carried onto the `_median` suffix, so the median report states the
+values actually used. `--report` prints the **recorded** warmup, not the flag default — passing
+`--warmup` to a standalone `--report` overrides it, so omit it unless you mean to.
+
+> The Rift-only sweep now runs at the same `warmup` input as everything else (previously a hardcoded
+> `3s`). Sweep figures published from this workflow before that change are not comparable with ones
+> produced after it.
 
 ### Matching-dimension scenarios (Rift-only, additive)
 

--- a/tests/benchmark/scripts/bench_wiremock.py
+++ b/tests/benchmark/scripts/bench_wiremock.py
@@ -33,6 +33,7 @@ Prerequisites: a JRE (WireMock 3 needs 11+; use an LTS, 17 or 21) and the WireMo
       https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
 """
 import argparse
+import glob
 import json
 import os
 import re
@@ -44,8 +45,8 @@ import urllib.request
 
 sys.path.insert(0, os.path.dirname(__file__))
 from bench_direct import (  # noqa: E402
-    IMPOSTERS, RESULTS_DIR, SCENARIOS,
-    free_ports, launch, load_rift_csv, metric, mode_label,
+    CSV_HEADER, IMPOSTERS, REP_FILE_RX, RESULTS_DIR, SCENARIOS,
+    aggregate_reps, csv_row, free_ports, launch, load_rift_csv, metric, mode_label,
     parse_conn_list, run_oha, stop, verify_body, write_results_csv,
 )
 
@@ -60,6 +61,11 @@ CATCH_ALL_PRIORITY = 999_999
 MIN_JAVA_MAJOR = 11
 DEFAULT_JAR = os.path.expanduser("~/bench-wiremock/wiremock-standalone.jar")
 DEFAULT_WIREMOCK_VERSION = "3.9.1"
+
+# 3s is thin for a JIT. The value matters beyond this suite: the published 3-way table is only
+# like-for-like if rift and mb were measured at the same warmup, which is why it is a single input
+# in benchmark-publish.yml rather than a per-leg constant (issue #866).
+DEFAULT_WARMUP = "10s"
 
 # The stock-defaults secondary series (issue #865): same suite, WireMock launched with no
 # `--container-threads`, benched at the headline connection count only. Its own engine label keeps
@@ -558,6 +564,7 @@ def run_all(jar, duration, warmup, conn_list, csv_suffix="",
 
     threads = container_thread_count(conn_list, container_threads)
     record_container_threads(csv_suffix, threads)
+    record_warmup(csv_suffix, warmup)
     ports = instance_ports()
     logdir = os.path.join(RESULTS_DIR, "logs")
     free_ports(ports)
@@ -575,8 +582,38 @@ def run_all(jar, duration, warmup, conn_list, csv_suffix="",
 # Report
 # --------------------------------------------------------------------------------------------
 
+def sidecar_path(name, csv_suffix):
+    """Where a run records one setting it was invoked with, beside its CSV."""
+    return os.path.join(RESULTS_DIR, f"direct_wiremock{csv_suffix}.{name}")
+
+
+def recorded_setting(name, csv_suffix):
+    """A setting the run recorded, or None if it never did."""
+    try:
+        with open(sidecar_path(name, csv_suffix)) as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
 def threads_sidecar_path(csv_suffix):
-    return os.path.join(RESULTS_DIR, f"direct_wiremock{csv_suffix}.threads")
+    return sidecar_path("threads", csv_suffix)
+
+
+def record_warmup(csv_suffix, warmup):
+    """Persist the warmup the series ran with, for the same reason the pin is persisted.
+
+    The warmup is the one setting the 3-way comparison exists to hold equal across engines
+    (issue #866), and `--report` is a separate invocation that would otherwise have to be told
+    again — or, worse, leave it out of the published Method section entirely, so a reader cannot
+    check the like-for-like claim and two dispatches at different warmups produce indistinguishable
+    documents."""
+    with open(sidecar_path("warmup", csv_suffix), "w") as f:
+        f.write(f"{warmup}\n")
+
+
+def recorded_warmup(csv_suffix):
+    return recorded_setting("warmup", csv_suffix)
 
 
 def record_container_threads(csv_suffix, threads):
@@ -601,6 +638,151 @@ def recorded_container_threads(csv_suffix):
         return None
 
 
+# What a reader needs to see in the Method section to check the like-for-like claim, and what
+# `--report --csv-suffix _median` would otherwise lose because the reps recorded it under `_repN`.
+# Mapped to the flag that sets each one, so a disagreement error names something runnable.
+PROPAGATED_SETTINGS = {"threads": "--container-threads", "warmup": "--warmup"}
+
+
+def propagate_run_settings(base_suffix=""):
+    """Carry the reps' recorded settings onto the `_median` suffix, so `--report --csv-suffix
+    _median` states the values actually measured instead of "unrecorded".
+
+    Disagreement between reps is a hard error, not a majority vote: reps that ran with different
+    Jetty pools — or different warmups — are different configurations, and a median across them
+    describes no configuration that was ever measured."""
+    # Both series share one sidecar per rep (it is keyed by csv-suffix, not by engine), so either
+    # engine's rep numbers enumerate them. Reading both means a partial re-run that left only the
+    # stock series still recovers the settings instead of publishing "unrecorded".
+    reps = sorted({n for engine in ("wiremock", STOCK_ENGINE)
+                   for n, _p in find_engine_reps(engine, base_suffix)})
+    resolved = {}
+    for name, flag in PROPAGATED_SETTINGS.items():
+        seen = {f"{base_suffix}_rep{n}": recorded_setting(name, f"{base_suffix}_rep{n}")
+                for n in reps}
+        known = {v for v in seen.values() if v is not None}
+        if not known:
+            continue
+        if len(known) > 1:
+            detail = ", ".join(f"{s}={v}" for s, v in sorted(seen.items()) if v is not None)
+            raise SystemExit(
+                f"bench_wiremock: reps disagree on {flag} ({detail}). A median across reps that "
+                f"ran with different {flag} values describes no configuration that was measured. "
+                f"Re-run them with one {flag}, or aggregate them separately.")
+        value = known.pop()
+        with open(sidecar_path(name, f"{base_suffix}_median"), "w") as f:
+            f.write(f"{value}\n")
+        resolved[name] = value
+    return resolved
+
+
+# Every engine whose `_repN.csv` files this suite knows how to collapse. `wiremock` and
+# `wiremock-stock` are the ones issue #866 requires; `rift` and `mb` are included because the 3-way
+# median table needs their medians too, and `bench_direct`'s own aggregation emits a median CSV for
+# `rift` alone (its comparison path writes a report, not per-engine CSVs). Aggregating them here
+# keeps `bench_direct.py` untouched.
+AGGREGATABLE_ENGINES = ("rift", "mb", "wiremock", STOCK_ENGINE)
+
+
+def find_engine_reps(engine, base_suffix=""):
+    """Every `direct_<engine><base_suffix>_repN.csv` as `(rep_number, path)`, in rep order.
+
+    `bench_direct.find_rep_files` does this but hardcodes a `direct_rift` prefix, so it cannot see
+    the WireMock series at all. Matching on the `_rep<digits>.csv` tail (the shared `REP_FILE_RX`)
+    keeps a stale unsuffixed file, or a different variant sharing a prefix, out of the aggregate.
+
+    The rep number is returned alongside the path so callers never have to re-run the regex and
+    dereference a match that could be `None`."""
+    pattern = os.path.join(RESULTS_DIR, f"direct_{engine}{base_suffix}_rep*.csv")
+    matched = []
+    for p in glob.glob(pattern):
+        m = REP_FILE_RX.search(p)
+        if m:
+            matched.append((int(m.group(1)), p))
+    return sorted(matched)
+
+
+def find_engine_rep_files(engine, base_suffix=""):
+    """Just the paths from `find_engine_reps`, in rep order."""
+    return [p for _n, p in find_engine_reps(engine, base_suffix)]
+
+
+def aggregate_engine(engine, base_suffix=""):
+    """Collapse one engine's reps into `direct_<engine><base_suffix>_median.csv`.
+
+    Returns `(path, n_reps)`, or `None` when the engine has no rep files (a run may legitimately
+    not include Mountebank, or not produce a stock series).
+
+    The median maths is `bench_direct.aggregate_reps`, imported rather than reimplemented — two
+    suites with independently written definitions of "median" is a drift waiting to happen."""
+    paths = find_engine_rep_files(engine, base_suffix)
+    if not paths:
+        return None
+    reps = []
+    for p in paths:
+        with open(p) as f:
+            reps.append(load_rift_csv(f))
+    agg = aggregate_reps(reps)
+
+    # Same hard error as bench_direct (#773): a point missing from one rep produces a
+    # complete-looking report whose cells rest on fewer samples than it claims, with exit 0 and
+    # nothing said. Refuse rather than publish that.
+    incomplete = {k: c["reps"] for k, c in agg.items() if c["reps"] != len(paths)}
+    if incomplete:
+        detail = ", ".join(f"{s}@c={c}/{m}: {n} of {len(paths)}"
+                           for (s, c, m), n in sorted(incomplete.items())[:8])
+        raise SystemExit(
+            f"bench_wiremock: incomplete repetitions for '{engine}{base_suffix}' across "
+            f"{len(paths)} rep files: {detail}{' …' if len(incomplete) > 8 else ''}\n"
+            f"Every point must appear in every rep, or the median silently rests on fewer samples "
+            f"than the report claims. Re-run the missing reps, or aggregate a consistent subset.")
+
+    out = os.path.join(RESULTS_DIR, f"direct_{engine}{base_suffix}_median.csv")
+    with open(out, "w") as f:
+        f.write(CSV_HEADER + ",reps,rps_spread_pct\n")
+        for (scen, conns, mode), c in sorted(agg.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+            spread = f"{c['rps_spread_pct']:.1f}" if c["rps_spread_pct"] != "" else ""
+            f.write(f"{csv_row(scen, conns, mode, c)},{c['reps']},{spread}\n")
+    print(f"  {engine}: {len(paths)} reps -> {os.path.basename(out)}")
+    return out, len(paths)
+
+
+def aggregate_all_reps(base_suffix=""):
+    """Collapse every engine that has rep files into `_median` CSVs.
+
+    Two hard errors guard the published table. The tuned `wiremock` series must be present — it is
+    the one the headline ratio is computed from, and aggregating only `wiremock-stock` would print
+    a success line for a run that cannot produce the number. And every engine must have the *same*
+    rep count, mirroring `bench_direct.aggregate_comparison_reps`."""
+    done = {}
+    for engine in AGGREGATABLE_ENGINES:
+        result = aggregate_engine(engine, base_suffix)
+        if result is not None:
+            done[engine] = result[1]
+    if "wiremock" not in done:
+        raise SystemExit(
+            f"bench_wiremock: no tuned WireMock rep files matched "
+            f"direct_wiremock{base_suffix}_rep*.csv in {RESULTS_DIR} — the headline ratio is "
+            f"computed from that series, so there is nothing to publish "
+            f"(run `--run-all --rep N` first).")
+
+    # Unequal replication favours whichever engine got more samples, and the spread table makes it
+    # worse rather than better: peak-to-peak over a single rep is 0.0%, so the *least*-replicated
+    # engine renders as the most stable one. bench_direct refuses the same case for rift-vs-mb.
+    if len(set(done.values())) > 1:
+        detail = ", ".join(f"{e}={n}" for e, n in sorted(done.items()))
+        raise SystemExit(
+            f"bench_wiremock: rep-count mismatch across engines ({detail}). A table built from "
+            f"unequal replication favours whichever engine got more samples, and a one-rep column "
+            f"reports 0.0% spread — the least-replicated engine would read as the most stable. "
+            f"Re-run the short engines, or move the stale reps out of {RESULTS_DIR}.")
+
+    propagate_run_settings(base_suffix)
+    counts = ", ".join(f"{e}={n}" for e, n in sorted(done.items()))
+    print(f"[aggregate] {counts}; render with --report --csv-suffix {base_suffix}_median")
+    return done
+
+
 def engine_csv_path(engine, csv_suffix):
     """Where `--report` looks for an engine's CSV.
 
@@ -622,20 +804,28 @@ def load_engine_csv(engine, csv_suffix, conns):
     if not os.path.exists(path):
         return None
     with open(path) as f:
-        rows = {r["scenario"]: {"rps": float(r["rps"]), "p50": r["p50_ms"], "p99": r["p99_ms"]}
+        rows = {r["scenario"]: {"rps": float(r["rps"]), "p50": r["p50_ms"], "p99": r["p99_ms"],
+                                # Present only in a `_median.csv` produced by --aggregate-reps.
+                                # A median with no visible spread cannot distinguish a clean run
+                                # from one where a rep disagreed, so carry it through.
+                                "reps": r.get("reps", ""), "spread": r.get("rps_spread_pct", "")}
                 for r in load_rift_csv(f)
                 if r["mode"] == "closed" and int(r["connections"]) == conns}
     return rows or None
 
 
 def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix="",
-           container_threads=None):
+           container_threads=None, warmup=None):
     """Combine the CSVs into the 3-way table.
 
     `container_threads` is the pin the tuned series ran with, stated in the Method section so a
     reader can tell a thread-pool ceiling from an engine throughput ceiling (issue #865). The
     stock-defaults series is rendered as its own clearly-labelled column and is deliberately NOT
-    used for the Rift/WM speedup — that ratio must come from the un-throttled run."""
+    used for the Rift/WM speedup — that ratio must come from the un-throttled run.
+
+    `warmup` is stated for the same reason: it is the setting the 3-way comparison holds equal
+    across engines, so a table that omits it cannot be checked against its own like-for-like
+    claim (issue #866)."""
     rift = load_engine_csv("rift", csv_suffix, conns)
     wm = load_engine_csv("wiremock", csv_suffix, conns)
     stock = load_engine_csv(STOCK_ENGINE, csv_suffix, conns)
@@ -655,8 +845,9 @@ def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix
         f.write(f"- **Rift:** {rift_ver}\n")
         f.write(f"- **WireMock:** {wiremock_ver} (JVM: {java_ver})\n")
         f.write(f"- **Mountebank:** {mb_ver if mb else 'not measured on this box'}\n")
+        warm = f"{warmup} warmup" if warmup else "an **unrecorded** warmup"
         f.write(f"- **Load generator:** oha, {conns} keep-alive connections, {duration} per scenario "
-                f"(after warmup)\n")
+                f"after {warm} — the same for every engine in this table\n")
         f.write("- **Method:** native processes (no Docker); engines run one at a time on disjoint "
                 "port ranges; the same 13 scenarios and the same oha settings for every engine; "
                 "each scenario's matched body is asserted before it is measured.\n")
@@ -724,6 +915,44 @@ def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix
             f.write(f"| {name} | {mb_cell} |{stock_cell} {wr:,.0f} | {rr:,.0f} | "
                     f"**{mb_sp}** | **{wm_sp}** |\n")
 
+        # Medians only: a median with no visible spread cannot distinguish a clean run from one
+        # where a rep disagreed, which is how a degraded sample becomes a published number. Emitted
+        # only when --aggregate-reps produced the inputs, so a single-rep report stays unchanged.
+        spread_series = [(label, rows) for label, rows in
+                         (("Mountebank", mb), (f"WireMock (stock, {STOCK_CONTAINER_THREADS}t)", stock),
+                          ("WireMock", wm), ("Rift", rift))
+                         if rows and any(r.get("spread") not in (None, "") for r in rows.values())]
+        if spread_series:
+            # The rep count goes in each column header, not in one prose sentence listing every
+            # distinct value: "a median of 1, 3 repetitions" does not say WHICH engine got one, and
+            # a one-rep column reports 0.0% spread — peak-to-peak over a single sample — so the
+            # least-replicated engine would otherwise read as the most stable one in the table.
+            headers = []
+            for label, rows in spread_series:
+                ns = {r["reps"] for r in rows.values() if r.get("reps") not in (None, "")}
+                if not ns:
+                    headers.append(label)
+                    continue
+                n = f"n={'/'.join(sorted(ns))}"
+                # Fold into the label's existing parenthesis rather than adding a second one:
+                # "WireMock (stock, 10t) (n=3)" reads as two separate annotations.
+                headers.append(f"{label[:-1]}, {n})" if label.endswith(")") else f"{label} ({n})")
+            f.write("\n## Repetition spread (peak-to-peak RPS as % of the mean)\n\n")
+            f.write("Every throughput cell above is a **median** over that column's `n` "
+                    "repetitions. A large spread means the reps disagree — treat that row as "
+                    "provisional and look at the individual reps before quoting it. A single rep "
+                    "has no spread to report and shows `n/a`, not 0%.\n\n")
+            f.write("| Scenario | " + " | ".join(headers) + " |\n")
+            f.write("|---|" + "--:|" * len(spread_series) + "\n")
+            for name in order:
+                cells = []
+                for _label, rows in spread_series:
+                    row = rows.get(name, {})
+                    s, n = row.get("spread", ""), row.get("reps", "")
+                    single = str(n) == "1"
+                    cells.append("n/a" if s in (None, "") or single else f"{float(s):.1f}%")
+                f.write(f"| {name} | " + " | ".join(cells) + " |\n")
+
         f.write("\n## Latency p99 (ms, lower is better)\n\n")
         f.write(f"| Scenario | Mountebank |{stock_head} {wm_head} | Rift |\n")
         f.write(f"|---|--:|{stock_rule}--:|--:|\n")
@@ -735,6 +964,21 @@ def report(rift_ver, mb_ver, wiremock_ver, java_ver, duration, conns, csv_suffix
     return out
 
 
+def resolve_suffix(csv_suffix, rep):
+    """The CSV suffix a run reads and writes under: an explicit `--csv-suffix`, else the `--rep`
+    tag, else none."""
+    if csv_suffix is not None:
+        return csv_suffix
+    return f"_rep{rep}" if rep else ""
+
+
+def median_suffix(base_suffix):
+    """Where `--aggregate-reps` writes, and therefore what a `--report` in the same invocation must
+    read. Kept as a function so the `--aggregate-reps --report` chaining the CI workflow relies on
+    is unit-testable without driving argparse."""
+    return f"{base_suffix}_median"
+
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(description="WireMock benchmark suite (issue #861)")
     ap.add_argument("--run-all", action="store_true", help="bench WireMock alone")
@@ -742,9 +986,12 @@ if __name__ == "__main__":
                     help="combine direct_rift.csv / direct_mb.csv / direct_wiremock.csv from the "
                          "SAME box and settings into WIREMOCK_BENCHMARK_REPORT.md")
     ap.add_argument("--duration", default="20s")
-    ap.add_argument("--warmup", default="10s",
-                    help="3s is thin for a JIT; 10s is the recommended default for WireMock runs. "
-                         "Quote rift/mb numbers measured with the same warmup for comparability.")
+    ap.add_argument("--warmup", default=None,
+                    help=f"default {DEFAULT_WARMUP}. 3s is thin for a JIT; {DEFAULT_WARMUP} is the "
+                         f"recommended default for WireMock runs. Quote rift/mb numbers measured "
+                         f"with the same warmup for comparability. On a standalone --report, this "
+                         f"overrides the warmup the run recorded — omit it to state what was "
+                         f"actually measured.")
     ap.add_argument("--connections", type=int, default=50)
     ap.add_argument("--sweep-connections", help="comma-separated connection counts")
     ap.add_argument("--wiremock-jar", default=DEFAULT_JAR)
@@ -761,9 +1008,23 @@ if __name__ == "__main__":
                          "already slow. The stock-defaults secondary series ignores this.")
     ap.add_argument("--rep", type=int, default=None,
                     help="tag this run's CSV as _repN so several reps can be aggregated")
+    ap.add_argument("--aggregate-reps", action="store_true",
+                    help="collapse direct_<engine>_repN.csv files into direct_<engine>_median.csv "
+                         "for every engine that has them (wiremock, wiremock-stock, and rift/mb "
+                         "when present). A point missing from any rep is a hard error, never a "
+                         "quietly thinner median. Render with --report --csv-suffix _median.")
+    ap.add_argument("--csv-suffix", default=None,
+                    help="the BASE suffix to read/write CSVs under, instead of the --rep tag. "
+                         "--aggregate-reps appends _median itself, so pass the suffix the reps were "
+                         "written with (usually none) — not _median.")
     args = ap.parse_args()
 
-    suffix = f"_rep{args.rep}" if args.rep else ""
+    # Both set the same thing, so honouring one and dropping the other silently would run under a
+    # suffix the caller did not think they asked for.
+    if args.csv_suffix is not None and args.rep:
+        ap.error("--csv-suffix and --rep both set the CSV suffix; pass one or the other")
+
+    suffix = resolve_suffix(args.csv_suffix, args.rep)
     conn_list = parse_conn_list(args.sweep_connections) if args.sweep_connections else [args.connections]
     # The stock series is benched at --connections only. If that point is not in the swept set, it
     # measures ~6 minutes of a configuration no --report can render (report() reads a single
@@ -773,11 +1034,18 @@ if __name__ == "__main__":
                  f"{sorted(conn_list)}; the stock series would bench a point no report can read. "
                  f"Pass --connections with one of the swept values.")
 
-    threads = None
+    threads, warmup = None, None
     if args.run_all:
-        threads = run_all(args.wiremock_jar, args.duration, args.warmup, conn_list,
+        warmup = args.warmup or DEFAULT_WARMUP
+        threads = run_all(args.wiremock_jar, args.duration, warmup, conn_list,
                           suffix, args.wiremock_version, args.container_threads,
                           stock_conns=args.connections)
+    if args.aggregate_reps:
+        # Aggregation reads `_repN` files, so it must not inherit a `_repN` suffix
+        # of its own; it writes the `_median` suffix the report then reads.
+        aggregate_all_reps(args.csv_suffix or "")
+        suffix = median_suffix(args.csv_suffix or "")
+
     if args.report:
         java_ver = args.java_version
         if java_ver is None:
@@ -791,7 +1059,13 @@ if __name__ == "__main__":
         if threads is None:
             threads = (args.container_threads if args.container_threads is not None
                        else recorded_container_threads(suffix))
+        # Same rule for the warmup, and it matters more: it is the setting the 3-way table claims
+        # to hold equal. `--warmup` defaults to None rather than DEFAULT_WARMUP precisely so a
+        # standalone --report can tell "the caller asked for this" from "nobody said", and print
+        # what the run recorded instead of the default it may never have used.
+        if warmup is None:
+            warmup = args.warmup if args.warmup is not None else recorded_warmup(suffix)
         report(args.rift_version, args.mb_version, args.wiremock_version, java_ver,
-               args.duration, args.connections, suffix, container_threads=threads)
-    if not (args.run_all or args.report):
-        ap.error("nothing to do: pass --run-all and/or --report")
+               args.duration, args.connections, suffix, container_threads=threads, warmup=warmup)
+    if not (args.run_all or args.report or args.aggregate_reps):
+        ap.error("nothing to do: pass --run-all, --aggregate-reps and/or --report")

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -10,6 +10,8 @@ imported fixture through it.
 Run: python3 -m unittest test_bench_wiremock   (from tests/benchmark/scripts)
 """
 import copy
+import csv
+import glob
 import json
 import os
 import re
@@ -393,6 +395,461 @@ class ContainerThreads(unittest.TestCase):
         self.assertEqual(bw.STOCK_ENGINE, "wiremock-stock")
         self.assertNotEqual(bw.STOCK_ENGINE, "wiremock")
         self.assertTrue(bw.engine_csv_path(bw.STOCK_ENGINE, "").endswith("direct_wiremock-stock.csv"))
+
+
+class AggregateReps(unittest.TestCase):
+    """Issue #866. A published number must not rest on one sample of each engine, and a median must
+    not silently rest on fewer reps than it claims."""
+
+    HEADER = bd.CSV_HEADER
+
+    def _write_rep(self, tmp, engine, rep, rps, scenarios=None, conns=50):
+        path = os.path.join(tmp, f"direct_{engine}_rep{rep}.csv")
+        with open(path, "w") as f:
+            f.write(self.HEADER + "\n")
+            for s in (scenarios if scenarios is not None else [x[0] for x in bd.SCENARIOS]):
+                f.write(f"{s},{conns},closed,{rps},1.0,2.0,3.0,4.0,1.5,,\n")
+        return path
+
+    def test_finds_rep_files_for_any_engine_not_just_rift(self):
+        # bench_direct.find_rep_files hardcodes a `direct_rift` prefix, so it cannot see these.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write_rep(tmp, "wiremock", 1, 100.0)
+                self._write_rep(tmp, "wiremock", 2, 200.0)
+                self._write_rep(tmp, "wiremock-stock", 1, 50.0)
+                self.assertEqual(len(bw.find_engine_rep_files("wiremock")), 2)
+                self.assertEqual(len(bw.find_engine_rep_files("wiremock-stock")), 1)
+                self.assertEqual(bw.find_engine_rep_files("mb"), [])
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_rep_files_are_ordered_numerically_not_lexically(self):
+        # rep10 must sort after rep2. The median itself is order-independent, but the rep numbers
+        # this ordering yields are what `propagate_run_settings` reads the per-rep sidecars by.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2, 10):
+                    self._write_rep(tmp, "wiremock", rep, 100.0)
+                got = [os.path.basename(p) for p in bw.find_engine_rep_files("wiremock")]
+                self.assertEqual(got, ["direct_wiremock_rep1.csv", "direct_wiremock_rep2.csv",
+                                       "direct_wiremock_rep10.csv"])
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_median_and_spread_are_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep, rps in ((1, 100.0), (2, 200.0), (3, 300.0)):
+                    self._write_rep(tmp, "wiremock", rep, rps)
+                path, n = bw.aggregate_engine("wiremock")
+                self.assertEqual(n, 3)
+                with open(path) as f:
+                    rows = list(csv.DictReader(f))
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(float(rows[0]["rps"]), 200.0, "median of 100/200/300")
+        self.assertEqual(rows[0]["reps"], "3")
+        # peak-to-peak (300-100) over mean (200) = 100%
+        self.assertAlmostEqual(float(rows[0]["rps_spread_pct"]), 100.0, places=1)
+
+    def test_a_point_missing_from_one_rep_is_a_hard_error(self):
+        # The #773 rule: a complete-looking report whose cells rest on 2 of 3 reps, exit 0, nothing
+        # said, is exactly the silence this must not reproduce.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write_rep(tmp, "wiremock", 1, 100.0)
+                self._write_rep(tmp, "wiremock", 2, 200.0,
+                                scenarios=[s[0] for s in bd.SCENARIOS][:-1])  # one point short
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_engine("wiremock")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("incomplete repetitions", str(ctx.exception))
+
+    def test_absent_engine_yields_none_not_an_error(self):
+        # A run may legitimately not include Mountebank.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self.assertIsNone(bw.aggregate_engine("mb"))
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_aggregate_all_covers_both_wiremock_engines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for eng in ("wiremock", "wiremock-stock", "rift"):
+                    for rep in (1, 2):
+                        self._write_rep(tmp, eng, rep, 100.0 * rep)
+                done = bw.aggregate_all_reps()
+                produced = sorted(os.path.basename(p) for p in
+                                  glob.glob(os.path.join(tmp, "*_median.csv")))
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(done, {"wiremock": 2, "wiremock-stock": 2, "rift": 2})
+        self.assertEqual(produced, ["direct_rift_median.csv", "direct_wiremock-stock_median.csv",
+                                    "direct_wiremock_median.csv"])
+
+    def test_aggregate_all_with_no_wiremock_reps_is_an_error(self):
+        # Producing nothing and exiting 0 would read as success.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write_rep(tmp, "rift", 1, 100.0)
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_all_reps()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("no tuned WireMock rep files", str(ctx.exception))
+
+    def test_median_csv_is_readable_by_the_report_loader(self):
+        # The whole point: --aggregate-reps then --report --csv-suffix _median.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep, rps in ((1, 100.0), (2, 300.0)):
+                    self._write_rep(tmp, "wiremock", rep, rps)
+                bw.aggregate_engine("wiremock")
+                rows = bw.load_engine_csv("wiremock", "_median", 50)
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIsNotNone(rows)
+        self.assertEqual(rows["simple_health"]["rps"], 200.0)
+        self.assertEqual(rows["simple_health"]["reps"], "2")
+
+    def test_the_reps_thread_pin_reaches_the_median_suffix(self):
+        # Without this the median report says "unrecorded" for a pin every rep actually ran with,
+        # and #865's requirement (state the value used) is lost the moment reps are aggregated.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    self._write_rep(tmp, "wiremock", rep, 100.0 * rep)
+                    bw.record_container_threads(f"_rep{rep}", 16)
+                bw.aggregate_all_reps()
+                got = bw.recorded_container_threads("_median")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(got, 16)
+
+    def test_reps_that_disagree_on_the_pin_are_a_hard_error(self):
+        # Different Jetty pool sizes are different configurations; their median describes none.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep, threads in ((1, 16), (2, 10)):
+                    self._write_rep(tmp, "wiremock", rep, 100.0)
+                    bw.record_container_threads(f"_rep{rep}", threads)
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_all_reps()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("disagree on --container-threads", str(ctx.exception))
+
+    def test_engines_with_unequal_rep_counts_are_a_hard_error(self):
+        # bench_direct refuses this for rift-vs-mb; the 3-way table is the more-quoted artefact and
+        # had no equivalent guard. Worse than unfair weighting: the one-rep column reports 0.0%
+        # spread, so the thinnest data renders as the steadiest engine.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                self._write_rep(tmp, "rift", 1, 9000.0)
+                for rep in (1, 2, 3):
+                    self._write_rep(tmp, "wiremock", rep, 3000.0)
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_all_reps()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("rep-count mismatch", str(ctx.exception))
+        self.assertIn("rift=1", str(ctx.exception))
+
+    def test_stock_reps_alone_cannot_stand_in_for_the_tuned_series(self):
+        # The headline ratio comes from the tuned series; aggregating only the stock one and
+        # printing a success line would misrepresent what the run can publish.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    self._write_rep(tmp, "wiremock-stock", rep, 900.0)
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_all_reps()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("no tuned WireMock rep files", str(ctx.exception))
+
+    def test_the_reps_warmup_reaches_the_median_suffix(self):
+        # The warmup is the setting the 3-way table claims to hold equal, so losing it at
+        # aggregation is what makes the published claim uncheckable.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    self._write_rep(tmp, "wiremock", rep, 100.0 * rep)
+                    bw.record_warmup(f"_rep{rep}", "10s")
+                bw.aggregate_all_reps()
+                got = bw.recorded_warmup("_median")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(got, "10s")
+
+    def test_reps_that_disagree_on_the_warmup_are_a_hard_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep, warm in ((1, "10s"), (2, "3s")):
+                    self._write_rep(tmp, "wiremock", rep, 100.0)
+                    bw.record_warmup(f"_rep{rep}", warm)
+                with self.assertRaises(SystemExit) as ctx:
+                    bw.aggregate_all_reps()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIn("disagree on --warmup", str(ctx.exception))
+
+    def test_the_pin_is_recovered_when_only_the_stock_series_survived(self):
+        # Both series share one sidecar per rep. Enumerating rep numbers from the tuned series
+        # alone loses the pin whenever a partial re-run left only the stock CSVs behind.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    self._write_rep(tmp, "wiremock", rep, 100.0)
+                    self._write_rep(tmp, "wiremock-stock", rep, 50.0)
+                    bw.record_container_threads(f"_rep{rep}", 16)
+                os.remove(os.path.join(tmp, "direct_wiremock_rep1.csv"))
+                os.remove(os.path.join(tmp, "direct_wiremock_rep2.csv"))
+                self.assertEqual(bw.propagate_run_settings(""), {"threads": "16"})
+                got = bw.recorded_container_threads("_median")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(got, 16)
+
+    def test_unrecorded_pin_stays_unrecorded_rather_than_invented(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    self._write_rep(tmp, "wiremock", rep, 100.0)
+                bw.aggregate_all_reps()
+                got = bw.recorded_container_threads("_median")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertIsNone(got)
+
+
+class ReportSpread(unittest.TestCase):
+    """AC3. The spread table is the part of #866 a reader actually sees: it is what stops a median
+    over a degraded rep from reading like a clean number."""
+
+    def _median_csv(self, tmp, engine, rps, reps, spread):
+        path = os.path.join(tmp, f"direct_{engine}_median.csv")
+        with open(path, "w") as f:
+            f.write(bd.CSV_HEADER + ",reps,rps_spread_pct\n")
+            for s, *_ in bd.SCENARIOS:
+                f.write(f"{s},50,closed,{rps},1.0,2.0,3.0,4.0,1.5,,,{reps},{spread}\n")
+
+    def _render(self, tmp, series, **kw):
+        for engine, rps, reps, spread in series:
+            self._median_csv(tmp, engine, rps, reps, spread)
+        out = bw.report("local", "2.9.1", "3.9.1", "openjdk 21", "20s", 50,
+                        csv_suffix="_median", **kw)
+        return open(out).read()
+
+    def _in_tmp(self, series, **kw):
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                return self._render(tmp, series, **kw)
+            finally:
+                bw.RESULTS_DIR = orig
+
+    def test_the_spread_table_is_rendered_for_medians(self):
+        text = self._in_tmp([("rift", 60000.0, 3, "4.2"), ("wiremock", 20000.0, 3, "11.5")])
+        self.assertIn("## Repetition spread", text)
+        self.assertIn("4.2%", text)
+        self.assertIn("11.5%", text)
+
+    def test_a_single_rep_reports_n_a_not_zero_percent(self):
+        # Peak-to-peak over one sample is 0.0%, so a one-rep column would render as the STEADIEST
+        # engine in a table whose entire purpose is to expose thin replication.
+        text = self._in_tmp([("rift", 60000.0, 1, "0.0"), ("wiremock", 20000.0, 3, "11.5")])
+        spread = text.split("## Repetition spread")[1]
+        row = [l for l in spread.splitlines() if l.startswith("| simple_health |")][0]
+        self.assertIn("n/a", row)
+        self.assertNotIn("0.0%", row)
+
+    def test_each_column_states_its_own_rep_count(self):
+        # "a median of 1, 3 repetitions" does not say WHICH engine got one.
+        text = self._in_tmp([("rift", 60000.0, 1, "0.0"), ("wiremock", 20000.0, 3, "11.5")])
+        header = [l for l in text.split("## Repetition spread")[1].splitlines()
+                  if l.startswith("| Scenario |")][0]
+        self.assertIn("Rift (n=1)", header)
+        self.assertIn("WireMock (n=3)", header)
+
+    def test_a_single_rep_report_has_no_spread_table_at_all(self):
+        # A plain (non-aggregated) run must render exactly as it did before #866.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for engine, rps in (("rift", 60000.0), ("wiremock", 20000.0)):
+                    path = os.path.join(tmp, f"direct_{engine}.csv")
+                    with open(path, "w") as f:
+                        f.write(bd.CSV_HEADER + "\n")
+                        for s, *_ in bd.SCENARIOS:
+                            f.write(f"{s},50,closed,{rps},1.0,2.0,3.0,4.0,1.5,,\n")
+                out = bw.report("local", "2.9.1", "3.9.1", "openjdk 21", "20s", 50)
+                text = open(out).read()
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertNotIn("## Repetition spread", text)
+
+    def test_the_warmup_reaches_the_method_section(self):
+        # #866's premise: a 3s-warmed Rift against a 10s-warmed JVM is not a comparison. A reader
+        # who cannot see the warmup cannot check that claim.
+        text = self._in_tmp([("rift", 60000.0, 3, "4.2"), ("wiremock", 20000.0, 3, "11.5")],
+                            warmup="10s")
+        self.assertIn("10s warmup", text)
+
+    def test_an_unrecorded_warmup_is_admitted_rather_than_defaulted(self):
+        text = self._in_tmp([("rift", 60000.0, 3, "4.2"), ("wiremock", 20000.0, 3, "11.5")])
+        self.assertIn("**unrecorded** warmup", text)
+        self.assertNotIn("10s warmup", text)
+
+
+class ReportSuffixChaining(unittest.TestCase):
+    """`--aggregate-reps --report` in one invocation is exactly what benchmark-publish.yml runs.
+    The suffix hand-off between the two lives in `__main__`, so it is extracted to be testable —
+    without this the report would silently render the un-aggregated single-rep CSVs."""
+
+    def test_rep_tag_is_the_default_suffix(self):
+        self.assertEqual(bw.resolve_suffix(None, 3), "_rep3")
+
+    def test_explicit_suffix_wins_over_no_rep(self):
+        self.assertEqual(bw.resolve_suffix("_variant", None), "_variant")
+
+    def test_no_rep_and_no_suffix_is_unsuffixed(self):
+        self.assertEqual(bw.resolve_suffix(None, None), "")
+
+    def test_aggregation_writes_where_the_report_then_reads(self):
+        # The contract that makes `--aggregate-reps --report` work as one command.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = bw.RESULTS_DIR
+            bw.RESULTS_DIR = tmp
+            try:
+                for rep in (1, 2):
+                    for engine in ("rift", "wiremock"):
+                        path = os.path.join(tmp, f"direct_{engine}_rep{rep}.csv")
+                        with open(path, "w") as f:
+                            f.write(bd.CSV_HEADER + "\n")
+                            for s, *_ in bd.SCENARIOS:
+                                f.write(f"{s},50,closed,{100.0 * rep},1.0,2.0,3.0,4.0,1.5,,\n")
+                bw.aggregate_all_reps("")
+                suffix = bw.median_suffix("")
+                self.assertIsNotNone(bw.load_engine_csv("wiremock", suffix, 50),
+                                     "the report must find what the aggregation just wrote")
+            finally:
+                bw.RESULTS_DIR = orig
+        self.assertEqual(suffix, "_median")
+
+
+class PublishWorkflow(unittest.TestCase):
+    """Issue #866. The publication workflow is where a like-for-like comparison is won or lost, and
+    the failure mode is silent: a table whose engines were warmed differently still renders."""
+
+    WORKFLOW = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                            ".github", "workflows", "benchmark-publish.yml")
+
+    @classmethod
+    def setUpClass(cls):
+        with open(cls.WORKFLOW) as f:
+            cls.text = f.read()
+
+    def test_all_three_engines_are_warmed_by_one_and_the_same_expression(self):
+        # The whole point of issue #866. Capturing to end-of-line, not to the first space: a regex
+        # that stops at whitespace matches the shared `"${{` prefix of ANY expression, so one leg
+        # silently warmed from a different variable would still look identical.
+        runs = []
+        for line in self.text.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            m = re.search(r"--warmup\s+(.+)$", line)
+            if m:
+                runs.append(m.group(1).strip().rstrip("\\").strip())
+        self.assertEqual(len(runs), 3, f"expected 3 benched legs, saw {runs}")
+        self.assertEqual(len(set(runs)), 1,
+                         f"the legs are warmed differently, so the ratio is not like-for-like: {runs}")
+
+    def test_no_leg_hardcodes_a_warmup_duration(self):
+        self.assertNotRegex(self.text, r"--warmup\s+\d+[smh]\b")
+
+    def test_the_warmup_the_legs_use_is_bound_to_the_dispatch_input(self):
+        # Guards the other half: three legs could agree on a variable that is wired to `duration`,
+        # or to nothing at all (unset + `set -u` would at least fail loudly, but a typo'd binding
+        # to another input would not).
+        warmup_var = re.search(r"--warmup\s+\"\$(\w+)\"", self.text)
+        self.assertIsNotNone(warmup_var, "the legs should take the warmup from an env var")
+        self.assertRegex(
+            self.text,
+            rf"{warmup_var.group(1)}:\s*\$\{{\{{\s*inputs\.warmup\s*\}}\}}",
+            "the legs' warmup variable must be bound to the `warmup` dispatch input")
+
+    def test_dispatch_inputs_are_not_interpolated_into_shell_bodies(self):
+        # `${{ }}` is substituted before bash parses the line, so an input reaching a run: body is
+        # script injection. Step `name:` fields are not shell and are excluded.
+        offenders = [l.strip() for l in self.text.splitlines()
+                     if "${{ inputs." in l and not l.lstrip().startswith(("- name:", "#"))
+                     and ":" not in l.split("${{")[0].rstrip()[-1:]]
+        self.assertEqual(offenders, [], f"inputs reach the shell directly: {offenders}")
+
+    def test_wiremock_version_is_pinned_by_input_not_by_the_jar_that_happened_to_be_there(self):
+        self.assertIn("wiremock_version:", self.text)
+        self.assertIn("--wiremock-version", self.text)
+        self.assertNotIn("/wiremock-standalone/3.9.1/", self.text,
+                         "the download URL must interpolate the input, not a frozen version")
+
+    def test_wiremock_jvm_logs_are_collected(self):
+        # 14 JVMs write to results/logs/; the flat results/*.log globs do not reach them, and this
+        # is the leg most likely to die on a readiness probe or an OOM.
+        self.assertIn("tests/benchmark/results/logs/*.log", self.text)
+        self.assertIn("results/logs/*.log", self.text.split("Diagnostics on failure")[1])
+
+    def test_the_parked_comparison_medians_do_not_collide_with_the_sweeps(self):
+        # results/direct_rift_median.csv means two different things (c=50 comparison vs the sweep's
+        # 1/50/256/512) and only one is the basis of the published ratio.
+        self.assertIn("direct_rift_comparison_median.csv", self.text)
+        self.assertIn("direct_mb_comparison_median.csv", self.text)
+
+    def test_the_wiremock_leg_parks_its_medians_before_the_sweep_overwrites_them(self):
+        # The sweep re-runs bench_direct --aggregate-reps, which writes direct_rift_median.csv.
+        # Without the park, the published 3-way table is silently rebuilt from sweep data.
+        wm = self.text.index("bench_wiremock.py --run-all")
+        sweep = self.text.index("--sweep-connections")
+        self.assertLess(wm, sweep, "the WireMock leg must run before the Rift-only sweep")
+        park = self.text.index("results/wiremock/")
+        self.assertLess(park, sweep, "medians must be parked before the sweep runs")
 
 
 class ReportCombiner(unittest.TestCase):


### PR DESCRIPTION
Makes the 3-way Rift/Mountebank/WireMock table something CI can publish and a reader can check.

- **`--aggregate-reps`** collapses `_repN` CSVs into per-engine medians (reusing `bench_direct`'s median maths, not a second copy) and carries `reps` + peak-to-peak spread into a **Repetition spread** table. A single rep shows `n/a`, never `0.0%` — peak-to-peak over one sample is zero, so the thinnest column would otherwise read as the *steadiest* engine. Each column states its own `n`.
- **`benchmark-publish.yml`** gains `warmup` and `wiremock_version` inputs plus a WireMock leg, so all three engines are measured **in one dispatch at one warmup**. The warmup is now recorded beside the CSVs (like the #865 Jetty pin) and stated in the Method section, so the like-for-like claim is verifiable from the artefact itself.
- **Refused rather than published quietly:** a scenario point missing from any rep (#773's rule), engines with unequal rep counts (the rule `bench_direct` already applies to rift-vs-mb), reps disagreeing on `--container-threads` or `--warmup`, and an aggregation with no tuned WireMock series.
- **`ci.yml` now runs the benchmark suites' unit tests.** They existed since #861 but no workflow executed them, so the gate protecting every published number could have gone red for months unnoticed.
- Dispatch inputs reach the shell via `env:` rather than being interpolated into `run:` bodies.

`bench_direct.py` is byte-identical to master, so the rift-vs-mb stability contract is unaffected by construction.

### Verification

224 unit tests pass. Beyond that, the gates were mutation-tested — seven mutants, all killed, including three regressions that review proved the *first* draft of these tests did **not** catch (a leg warmed from a different variable, deleting the spread table entirely, and breaking the aggregate→report suffix hand-off). The workflow's file choreography is simulated by extracting the real `cp`/`mv`/`rm` lines from the YAML, and the exact CI command was smoke-run end to end on synthetic reps.

### Follow-ups, not in this PR

- `benchmark-scripts` only gates once it is added to the required-checks list — that is a repo setting.
- `recorded_container_threads` folds a *corrupt* sidecar into the same "unrecorded" bucket as "never ran" (pre-existing, from #865).

Closes #866
