### PR TITLE
test(flake): upstream_failure_releases_claim_end_to_end races on a reusable ephemeral port

### DIFF
--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -550,6 +550,14 @@ mod tests {
     use crate::intercept_rules::{ForwardTarget, InterceptRule};
     use rift_mock_core::proxy::intercept_ca::CertificateAuthority;
 
+    /// A port with nothing listening, for the tests that need a forward target that always fails.
+    /// Port 1 is below the privileged threshold, so no test can bind it, and outside the ephemeral
+    /// range `bind(:0)` allocates from, so the allocator can never hand it out — `connect` here is
+    /// always refused. These tests used to bind an ephemeral port and drop the listener, which
+    /// returns the number to the allocator immediately; under full-suite parallelism another test
+    /// takes it and the "dead" upstream answers (issue #859).
+    const CLOSED_PORT: u16 = 1;
+
     // Issue #522: a panicked accept loop must not be swallowed by `shutdown`/`stop` — its
     // `JoinError` is logged rather than discarded.
     #[tokio::test]
@@ -1023,10 +1031,10 @@ mod tests {
             }
         });
 
-        // Bind then drop, to get a port that is very likely closed for the test's lifetime.
-        let closed = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let dead_port = closed.local_addr().unwrap().port();
-        drop(closed);
+        // A port nothing can be listening on — see the note on CLOSED_PORT below (issue #859).
+        // Bind-then-drop returns the number to the ephemeral allocator, so another test in this
+        // binary can take it and turn "dead upstream" into a live one.
+        let dead_port = CLOSED_PORT;
 
         let rules = InterceptRules::new();
         rules
@@ -1086,18 +1094,12 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_forward_port_returns_502() {
-        // Bind then immediately drop a listener to get a port that is very likely closed for
-        // the lifetime of the test.
-        let closed = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let closed_port = closed.local_addr().unwrap().port();
-        drop(closed);
-
         let rules = InterceptRules::new();
         rules
             .add(InterceptRule {
                 host: None,
                 predicates: vec![],
-                action: InterceptAction::Forward(ForwardTarget { port: closed_port }),
+                action: InterceptAction::Forward(ForwardTarget { port: CLOSED_PORT }),
             })
             .unwrap();
         let (listener, ca_pem) = start_listener(rules).await;

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -3966,15 +3966,14 @@ mod tests {
             manager.create_imposter(cfg).await.expect("create upstream")
         }
 
-        /// A port with nothing listening: bind an ephemeral port to learn a free number, then drop
-        /// the listener so a connection there is refused — deterministic, unlike a guessed literal.
-        fn closed_port() -> u16 {
-            std::net::TcpListener::bind("127.0.0.1:0")
-                .expect("bind ephemeral")
-                .local_addr()
-                .expect("local_addr")
-                .port()
-        }
+        /// A port with nothing listening, chosen so the suite cannot race it (issue #859). Port 1
+        /// is below the privileged threshold, so no test can bind it, and outside the ephemeral
+        /// range `bind(:0)` allocates from, so the allocator can never hand it out — `connect`
+        /// here is always refused. Binding an ephemeral port and dropping the listener, as this
+        /// did before, returns the number to the allocator immediately; under full-suite
+        /// parallelism another test took it before the proxy dialled, the upstream *succeeded*,
+        /// and no claim was released.
+        const CLOSED_PORT: u16 = 1;
 
         // AC7: a shared proxy store is injected into imposters, keyed by port, exercised on the
         // proxy hot path, and cleared on imposter deletion.
@@ -4039,7 +4038,7 @@ mod tests {
             let manager = ImposterManager::new()
                 .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
             // Forward to a closed port so the upstream leg always fails.
-            let dead = closed_port();
+            let dead = CLOSED_PORT;
             let proxy_port = proxy_imposter(&manager, &format!("http://127.0.0.1:{dead}")).await;
 
             for _ in 0..2 {


### PR DESCRIPTION
Three tests got a "closed" port by binding `127.0.0.1:0`, reading the number, and dropping the listener — which hands the port straight back to the kernel's ephemeral allocator. Under full-suite parallelism (~1300 tests in one binary, many binding ephemeral ports) another test could take it before the proxy dialled; the "dead" upstream then answered, no claim was released, and the assertion failed with `left: 0 / right: 2`.

Port 1 cannot be raced: below the privileged threshold so no test can bind it, and outside the ephemeral range `bind(:0)` allocates from so the allocator can never hand it out. `connect()` there is refused immediately.

Holding the listener open instead would *not* have worked — the kernel completes the handshake into the accept backlog even with nothing calling `accept()`, so the proxy would connect and then block until its read timeout. That trades a flaky failure for a reliably slow one.

**Fixed at all three sites, not just the one that failed.** The issue named two; sweeping for the pattern found a third in the same file:

- `crates/rift-mock-core/src/imposter/manager.rs` — the `closed_port()` helper (the one that flaked)
- `crates/rift-http-proxy/src/intercept.rs` — `unknown_forward_port_returns_502`, which documented the hazard in its own comment ("very likely closed")
- `crates/rift-http-proxy/src/intercept.rs` — the dead/live forward test, same bind-then-drop

No bind-then-drop pattern remains in the workspace.

### Verification

`cargo clippy --all-targets -- -D warnings` clean; `cargo test -p rift-mock-core -p rift-http-proxy` fully green (1307 in the main lib binary, 0 failed).

The test was also checked against the failure mode that matters most for a flake fix — a change that stops the test detecting anything. Pointing the "dead" upstream at a **live** imposter makes it fail with exactly the original signature:

```
assertion `left == right` failed: each failed upstream call releases its claim
  left: 0
 right: 2
```

So the test still guards what it was written to guard, and this independently confirms the diagnosis that a live upstream is what produced the flake.

Test-only; no production path changes, no CHANGELOG entry.

Closes #859
