### PR TITLE
bench(ci): let a dispatch skip the Rift-only sweep

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -42,6 +42,12 @@ on:
       wiremock_version:
         description: "WireMock version (pinned, same reason as Mountebank)"
         default: "3.9.1"
+      run_sweep:
+        description: >-
+          Run the Rift-only connection sweep. It is ~75% of the wall clock and contributes nothing
+          to the 3-way comparison table, so turn it off when you only want the engine comparison.
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -178,6 +184,7 @@ jobs:
       # Rift-only sweep: connection scaling plus the matching-dimension scenarios that the
       # comparison set deliberately excludes (it is a stability contract).
       - name: Rift concurrency sweep + matching dimensions (repeated)
+        if: inputs.run_sweep
         working-directory: tests/benchmark
         run: |
           set -euo pipefail

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -252,7 +252,12 @@ gh workflow run benchmark-publish.yml \
 ```
 
 It measures **all three engines in one dispatch at one `warmup`**, three reps each, then publishes
-medians. That single-warmup rule is the point of the input existing: a 3s-warmed Rift against a
+medians.
+
+Pass `-f run_sweep=false` when you only want the engine-comparison table. The Rift-only sweep is
+roughly three quarters of the wall clock and feeds none of the 3-way numbers, so skipping it turns
+a ~3–4 hour dispatch into well under an hour. Leave it on when you are refreshing the published
+connection-scaling curve. That single-warmup rule is the point of the input existing: a 3s-warmed Rift against a
 10s-warmed JVM is not a comparison, and the rendered table would say nothing about it. The legs run
 in a fixed order — comparison, then WireMock, then the Rift-only sweep — because the sweep re-writes
 `direct_rift_rep*.csv` at other connection counts; the WireMock leg parks its artefacts under

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -836,6 +836,19 @@ class PublishWorkflow(unittest.TestCase):
         self.assertIn("tests/benchmark/results/logs/*.log", self.text)
         self.assertIn("results/logs/*.log", self.text.split("Diagnostics on failure")[1])
 
+    def test_the_sweep_can_be_skipped_without_touching_the_comparison_legs(self):
+        # The sweep is ~75% of the wall clock and contributes nothing to the 3-way table, so a
+        # WireMock-only dispatch must be able to turn it off — and ONLY it. Gating a comparison
+        # leg by mistake would publish a table missing an engine.
+        self.assertIn("run_sweep:", self.text)
+        gated = [l for l in self.text.splitlines() if "if: inputs.run_sweep" in l]
+        self.assertEqual(len(gated), 1, "exactly one leg may be gated by run_sweep")
+        sweep_at = self.text.index("Rift concurrency sweep")
+        gate_at = self.text.index("if: inputs.run_sweep")
+        self.assertLess(
+            abs(self.text[:gate_at].count("\n") - self.text[:sweep_at].count("\n")), 3,
+            "the run_sweep gate must sit on the sweep step, not on a comparison leg")
+
     def test_the_parked_comparison_medians_do_not_collide_with_the_sweeps(self):
         # results/direct_rift_median.csv means two different things (c=50 comparison vs the sweep's
         # 1/50/256/512) and only one is the basis of the published ratio.


### PR DESCRIPTION
The Rift-only connection sweep is roughly three quarters of `benchmark-publish.yml`'s wall clock and feeds none of the 3-way comparison table. A dispatch that only wants the engine comparison currently spends hours measuring something it will not publish.

`-f run_sweep=false` gates that one leg, turning a ~3–4 hour run into well under an hour.

The comparison legs are deliberately **not** gateable. Skipping the sweep costs you a curve you can regenerate; skipping a comparison leg would publish a table silently missing an engine — a wrong number rather than a slower run. A test pins that exactly one leg carries the gate and that it is the sweep, and it was mutation-checked by moving the gate onto the Rift-vs-Mountebank leg (caught).

Measured on the smoke dispatch that validated the new WireMock leg (2 reps, 5s duration): comparison 7 min, WireMock 7 min, sweep 18+ min — and the sweep scales worst, since it is the only leg with four connection points.

225 benchmark unit tests pass; both workflow YAMLs parse.