### PR TITLE
feat(admin-api): AdminAuthorizer — pluggable request authorization hook with parsed route context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **`AdminAuthorizer` — pluggable per-request admin-API authorization** (issue #854). The
+  `--api-key` gate grants *access*, not an identity, so an embedder with its own identity system
+  had to reverse-proxy the admin API and re-parse routes to decide anything.
+  `ServerBuilder::admin_authorizer` installs a hook that is consulted **after** authentication and
+  **after** the route is parsed, receiving a stable action string, the port, the space and the
+  already-extracted path params. Install nothing and nothing changes.
+
+  Authentication still runs first and unconditionally, so an unauthenticated request answers `401`
+  whatever the path — unknown paths never become a route-existence oracle. A `Deny` on an
+  authenticated request is a `403`. Requests may carry an `x-rift-scope` header, passed through
+  verbatim as the authorizer's `scope`; it is caller-asserted and must be cross-checked against the
+  credential rather than trusted as identity. See `docs/embedding/spi.md`.
+
 ### Security
 
 - **An empty `--api-key` enabled the admin auth gate and then authenticated everyone** (issue #844).

--- a/crates/rift-http-proxy/src/admin_api/authz.rs
+++ b/crates/rift-http-proxy/src/admin_api/authz.rs
@@ -1,0 +1,419 @@
+//! Route classification for the [`AdminAuthorizer`] hook (issue #854).
+//!
+//! The hook's whole value is that an embedder does not have to re-parse admin routes to decide
+//! anything. That means upstream must hand it the route class, the port and the path params it
+//! already extracted — which is what [`classify`] produces.
+//!
+//! Kept as a pure `(method, path) -> Option<AuthzTarget>` function, deliberately separate from
+//! dispatch: the mapping from route to permission is the security-relevant part, and it should be
+//! testable without standing up a server or a manager.
+//!
+//! [`AdminAuthorizer`]: rift_mock_core::extensions::authz::AdminAuthorizer
+
+use crate::admin_api::router::ImposterRoute;
+use hyper::Method;
+use rift_mock_core::extensions::authz::actions;
+
+/// A route as the authorizer needs to see it: what is being attempted, and against what.
+///
+/// Owns its param strings because they are borrowed slices of a path that the caller may not keep
+/// alive; [`AuthzRequest`](rift_mock_core::extensions::authz::AuthzRequest) borrows from this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthzTarget {
+    pub action: &'static str,
+    pub port: Option<u16>,
+    pub space: Option<String>,
+    pub params: Vec<(&'static str, String)>,
+}
+
+impl AuthzTarget {
+    fn new(action: &'static str) -> Self {
+        Self {
+            action,
+            port: None,
+            space: None,
+            params: Vec::new(),
+        }
+    }
+
+    fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self.params.push(("port", port.to_string()));
+        self
+    }
+
+    fn with_space(mut self, space: &str) -> Self {
+        self.space = Some(space.to_string());
+        self.params.push(("space", space.to_string()));
+        self
+    }
+
+    fn with_param(mut self, name: &'static str, value: &str) -> Self {
+        self.params.push((name, value.to_string()));
+        self
+    }
+}
+
+/// The verb class of a method, for the routes whose permission is purely read-vs-mutate.
+///
+/// Mechanical rather than hand-assigned per route, so the mapping stays predictable as routes are
+/// added and a new route cannot accidentally land on a weaker permission than its siblings.
+fn imposter_action(method: &Method) -> &'static str {
+    match *method {
+        Method::GET | Method::HEAD => actions::IMPOSTER_READ,
+        Method::DELETE => actions::IMPOSTER_DELETE,
+        _ => actions::IMPOSTER_WRITE,
+    }
+}
+
+/// Classify an admin request for authorization.
+///
+/// `None` means "not an authorizable admin route" — the gateway (`/__rift/...`, which is
+/// data-plane traffic and deliberately not admin-gated) and paths that match no route at all. An
+/// unmatched path falls through to the ordinary 404 without consulting the hook: it reaches no
+/// handler and changes nothing, so there is no action to authorize. Note the consequence — an
+/// authenticated caller can still distinguish a 404 from a 403, so the hook bounds what a
+/// principal can *do*, not what it can learn about which routes exist.
+#[must_use]
+pub fn classify(method: &Method, path: &str) -> Option<AuthzTarget> {
+    // Belt-and-braces, and deliberately kept as such: `/__rift/...` matches none of the branches
+    // below, so today it would fall through to `None` without this. It is here so that a future
+    // catch-all or broadened branch cannot silently start authorizing gateway traffic — that is
+    // data-plane imposter traffic, and requiring an admin identity for it would force the app
+    // under test to carry the admin credential.
+    if path.starts_with("/__rift/") {
+        return None;
+    }
+
+    match path {
+        "/" | "/health" | "/config" | "/logs" | "/metrics" => {
+            return Some(AuthzTarget::new(actions::SYSTEM_READ));
+        }
+        "/admin/reload" => return Some(AuthzTarget::new(actions::SYSTEM_WRITE)),
+        _ => {}
+    }
+
+    // The SSE streams (issue #461) are dispatched in `service_fn` *before* the router, so they
+    // reach no branch below and would otherwise be the one admin surface the hook cannot gate.
+    // That is the worst possible gap to leave: `/events` streams recorded method, path, headers
+    // and bodies across every imposter, so it is the highest-value read on the whole plane.
+    //
+    // `/events` gets its own action because it is cross-imposter — there is no port to scope it
+    // to, and an authorizer granting `imposter.read` on one port must not thereby leak all of
+    // them. The per-imposter alias is an ordinary scoped read.
+    if let Some(forced_port) = crate::admin_api::handlers::events::stream_target(path) {
+        return Some(match forced_port {
+            None => AuthzTarget::new(actions::EVENTS_READ),
+            Some(port) => AuthzTarget::new(actions::IMPOSTER_READ).with_port(port),
+        });
+    }
+
+    if path == "/intercept" || path.starts_with("/intercept/") {
+        let action = match *method {
+            Method::GET | Method::HEAD => actions::INTERCEPT_READ,
+            _ => actions::INTERCEPT_WRITE,
+        };
+        return Some(AuthzTarget::new(action));
+    }
+
+    if path == "/imposters" {
+        // `PUT /imposters` reconciles the whole set toward the payload, so `{"imposters":[]}`
+        // destroys every imposter. Classifying it by method alone would call that `imposter.write`
+        // and hand a "may write, may not delete" principal a trivial way round the restriction.
+        let action = if method == Method::PUT {
+            actions::IMPOSTER_DELETE
+        } else {
+            // No port yet on a create — this is exactly the case the `scope` field exists for.
+            imposter_action(method)
+        };
+        return Some(AuthzTarget::new(action));
+    }
+
+    if let Some(rest) = path.strip_prefix("/admin/imposters/") {
+        return classify_admin_flow_state(method, rest);
+    }
+
+    if let Some(rest) = path.strip_prefix("/imposters/") {
+        return classify_imposter(method, rest);
+    }
+
+    None
+}
+
+/// `/admin/imposters/:port/flow-state/:flow_id[/:key]`
+fn classify_admin_flow_state(method: &Method, rest: &str) -> Option<AuthzTarget> {
+    let segments: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
+    let (port_str, flow_id, key) = match segments.as_slice() {
+        [port, "flow-state", flow_id] => (port, *flow_id, None),
+        [port, "flow-state", flow_id, key] => (port, *flow_id, Some(*key)),
+        _ => return None,
+    };
+    let port: u16 = port_str.parse().ok()?;
+    let mut target = AuthzTarget::new(imposter_action(method))
+        .with_port(port)
+        .with_space(flow_id);
+    if let Some(key) = key {
+        target = target.with_param("key", key);
+    }
+    Some(target)
+}
+
+/// `/imposters/:port/...`
+///
+/// Delegates to the router's own [`ImposterRoute::parse`] rather than re-deriving the route.
+/// A second parser is a security bug waiting to happen: this one used to filter empty segments
+/// while the router does not, so `PUT /imposters/:port/scenarios//state` dispatched into a real
+/// mutation that the classifier had never seen, and `POST /imposters/:port/spaces//stubs` was
+/// authorized against the space `"stubs"` while writing into `""`. Sharing the parser makes that
+/// class of divergence impossible, and the exhaustive match below turns a new route variant into
+/// a compile error instead of a silently unauthorized handler.
+fn classify_imposter(method: &Method, rest: &str) -> Option<AuthzTarget> {
+    // Split exactly as `route_imposter` does — no `filter`. Hyper does not normalise `//` or a
+    // trailing `/`, so an empty segment reaches here and must reach the router's parser too.
+    let segments: Vec<&str> = rest.split('/').collect();
+    let port: u16 = segments.first()?.parse().ok()?;
+    let route = ImposterRoute::parse(&segments[1..])?;
+
+    let base = |action: &'static str| AuthzTarget::new(action).with_port(port);
+
+    let target = match route {
+        ImposterRoute::Root
+        | ImposterRoute::Stubs
+        | ImposterRoute::SavedRequests
+        | ImposterRoute::SavedProxyResponses
+        | ImposterRoute::Scenarios => base(imposter_action(method)),
+
+        // A POST that mutates nothing: it asserts against already-recorded requests. Mapping it
+        // to `imposter.write` on method alone would stop a read-only principal verifying.
+        ImposterRoute::Verify => base(actions::IMPOSTER_VERIFY),
+
+        ImposterRoute::Enable | ImposterRoute::Disable | ImposterRoute::ScenariosReset => {
+            base(actions::IMPOSTER_WRITE)
+        }
+
+        ImposterRoute::StubByIndex(index) => {
+            base(imposter_action(method)).with_param("stubIndex", &index.to_string())
+        }
+        ImposterRoute::StubById(id) => base(imposter_action(method)).with_param("stubId", &id),
+
+        ImposterRoute::ScenarioState(name) => {
+            base(actions::IMPOSTER_WRITE).with_param("scenario", &name)
+        }
+
+        ImposterRoute::Space(flow_id) | ImposterRoute::SpaceStubs(flow_id) => {
+            base(imposter_action(method)).with_space(&flow_id)
+        }
+    };
+    Some(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn action_of(method: Method, path: &str) -> Option<&'static str> {
+        classify(&method, path).map(|t| t.action)
+    }
+
+    #[test]
+    fn system_routes_are_reads_and_reload_is_a_write() {
+        for p in ["/", "/health", "/config", "/logs", "/metrics"] {
+            assert_eq!(action_of(Method::GET, p), Some(actions::SYSTEM_READ), "{p}");
+        }
+        assert_eq!(
+            action_of(Method::POST, "/admin/reload"),
+            Some(actions::SYSTEM_WRITE)
+        );
+    }
+
+    #[test]
+    fn the_gateway_is_not_an_admin_route() {
+        // `/__rift/...` is data-plane imposter traffic and is deliberately not admin-gated;
+        // authorizing it would force app-under-test traffic to carry an admin identity.
+        //
+        // Note this test does not currently distinguish the explicit guard in `classify` from the
+        // fall-through — deleting the guard keeps it green, because no other branch matches
+        // `/__rift/` either. It pins the *contract*, and it starts biting the moment anyone adds a
+        // catch-all that would otherwise swallow gateway paths.
+        assert_eq!(classify(&Method::GET, "/__rift/4545/orders"), None);
+        assert_eq!(classify(&Method::POST, "/__rift/4545/orders"), None);
+    }
+
+    #[test]
+    fn unknown_paths_are_not_authorizable() {
+        assert_eq!(classify(&Method::GET, "/nope"), None);
+        assert_eq!(classify(&Method::GET, "/imposters/abc"), None);
+        assert_eq!(classify(&Method::GET, "/imposters/4545/nope"), None);
+        // A non-numeric stub index is not a route.
+        assert_eq!(classify(&Method::GET, "/imposters/4545/stubs/xyz"), None);
+    }
+
+    #[test]
+    fn method_decides_read_write_delete_on_imposter_routes() {
+        assert_eq!(
+            action_of(Method::GET, "/imposters/4545"),
+            Some(actions::IMPOSTER_READ)
+        );
+        assert_eq!(
+            action_of(Method::DELETE, "/imposters/4545"),
+            Some(actions::IMPOSTER_DELETE)
+        );
+        assert_eq!(
+            action_of(Method::PUT, "/imposters/4545/stubs"),
+            Some(actions::IMPOSTER_WRITE)
+        );
+        assert_eq!(
+            action_of(Method::POST, "/imposters"),
+            Some(actions::IMPOSTER_WRITE)
+        );
+        assert_eq!(
+            action_of(Method::DELETE, "/imposters"),
+            Some(actions::IMPOSTER_DELETE)
+        );
+    }
+
+    #[test]
+    fn verify_is_not_a_write_despite_being_a_post() {
+        assert_eq!(
+            action_of(Method::POST, "/imposters/4545/verify"),
+            Some(actions::IMPOSTER_VERIFY)
+        );
+    }
+
+    #[test]
+    fn enable_and_disable_are_writes_despite_carrying_no_body() {
+        assert_eq!(
+            action_of(Method::POST, "/imposters/4545/enable"),
+            Some(actions::IMPOSTER_WRITE)
+        );
+        assert_eq!(
+            action_of(Method::POST, "/imposters/4545/disable"),
+            Some(actions::IMPOSTER_WRITE)
+        );
+    }
+
+    #[test]
+    fn create_has_no_port_so_scope_is_the_only_target_selector() {
+        // The issue's stated reason for `scope` existing: POST /imposters names no port.
+        let t = classify(&Method::POST, "/imposters").unwrap();
+        assert_eq!(t.port, None);
+        assert!(t.params.is_empty());
+    }
+
+    #[test]
+    fn port_is_extracted_and_also_exposed_as_a_param() {
+        let t = classify(&Method::GET, "/imposters/4545/stubs").unwrap();
+        assert_eq!(t.port, Some(4545));
+        assert!(t.params.contains(&("port", "4545".to_string())));
+    }
+
+    #[test]
+    fn path_params_reach_the_authorizer() {
+        let by_id = classify(&Method::PUT, "/imposters/4545/stubs/by-id/abc123").unwrap();
+        assert!(by_id.params.contains(&("stubId", "abc123".to_string())));
+
+        let by_index = classify(&Method::DELETE, "/imposters/4545/stubs/7").unwrap();
+        assert!(by_index.params.contains(&("stubIndex", "7".to_string())));
+
+        let scenario = classify(&Method::PUT, "/imposters/4545/scenarios/checkout/state").unwrap();
+        assert!(
+            scenario
+                .params
+                .contains(&("scenario", "checkout".to_string()))
+        );
+    }
+
+    #[test]
+    fn space_routes_expose_the_flow_id() {
+        let t = classify(&Method::POST, "/imposters/4545/spaces/flow-9/stubs").unwrap();
+        assert_eq!(t.space.as_deref(), Some("flow-9"));
+        assert_eq!(t.port, Some(4545));
+
+        let s = classify(&Method::DELETE, "/imposters/4545/spaces/flow-9").unwrap();
+        assert_eq!(s.space.as_deref(), Some("flow-9"));
+        assert_eq!(s.action, actions::IMPOSTER_DELETE);
+    }
+
+    #[test]
+    fn flow_state_inspection_carries_port_space_and_key() {
+        let t = classify(&Method::GET, "/admin/imposters/4545/flow-state/flow-9/cart").unwrap();
+        assert_eq!(t.port, Some(4545));
+        assert_eq!(t.space.as_deref(), Some("flow-9"));
+        assert!(t.params.contains(&("key", "cart".to_string())));
+        assert_eq!(t.action, actions::IMPOSTER_READ);
+
+        let whole = classify(&Method::DELETE, "/admin/imposters/4545/flow-state/flow-9").unwrap();
+        assert_eq!(whole.action, actions::IMPOSTER_DELETE);
+        assert!(!whole.params.iter().any(|(n, _)| *n == "key"));
+    }
+
+    #[test]
+    fn intercept_routes_split_read_from_write() {
+        assert_eq!(
+            action_of(Method::GET, "/intercept"),
+            Some(actions::INTERCEPT_READ)
+        );
+        assert_eq!(
+            action_of(Method::POST, "/intercept"),
+            Some(actions::INTERCEPT_WRITE)
+        );
+        assert_eq!(
+            action_of(Method::DELETE, "/intercept/rules"),
+            Some(actions::INTERCEPT_WRITE)
+        );
+    }
+
+    #[test]
+    fn the_requests_alias_classifies_like_saved_requests() {
+        // `/requests` is an alias for `/savedRequests`; a permission difference between them
+        // would be a bypass of whichever is stricter.
+        assert_eq!(
+            action_of(Method::DELETE, "/imposters/4545/requests"),
+            action_of(Method::DELETE, "/imposters/4545/savedRequests")
+        );
+        assert_eq!(
+            action_of(Method::GET, "/imposters/4545/requests"),
+            action_of(Method::GET, "/imposters/4545/savedRequests")
+        );
+    }
+
+    #[test]
+    fn every_dispatchable_imposter_route_classifies() {
+        // A route the router dispatches but `classify` returns None for would reach its handler
+        // without ever consulting the authorizer — a silent hole. Mirrors ImposterRoute::parse.
+        let routes = [
+            (Method::GET, ""),
+            (Method::DELETE, ""),
+            (Method::GET, "/stubs"),
+            (Method::POST, "/stubs"),
+            (Method::PUT, "/stubs"),
+            (Method::GET, "/stubs/0"),
+            (Method::PUT, "/stubs/0"),
+            (Method::DELETE, "/stubs/0"),
+            (Method::GET, "/stubs/by-id/x"),
+            (Method::PUT, "/stubs/by-id/x"),
+            (Method::DELETE, "/stubs/by-id/x"),
+            (Method::GET, "/savedRequests"),
+            (Method::DELETE, "/savedRequests"),
+            (Method::GET, "/requests"),
+            (Method::POST, "/verify"),
+            (Method::DELETE, "/savedProxyResponses"),
+            (Method::POST, "/enable"),
+            (Method::POST, "/disable"),
+            (Method::GET, "/scenarios"),
+            (Method::PUT, "/scenarios/s/state"),
+            (Method::POST, "/scenarios/reset"),
+            (Method::GET, "/spaces/f"),
+            (Method::DELETE, "/spaces/f"),
+            (Method::POST, "/spaces/f/stubs"),
+            (Method::GET, "/spaces/f/stubs"),
+        ];
+        for (method, tail) in routes {
+            let path = format!("/imposters/4545{tail}");
+            assert!(
+                classify(&method, &path).is_some(),
+                "{method} {path} dispatches but does not classify"
+            );
+        }
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! The API listens on a configurable port (default: 2525).
 
+pub(crate) mod authz;
 mod handlers;
 mod request_filter;
 mod router;

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tracing::debug;
 
 /// Parsed route for imposter-specific endpoints
-enum ImposterRoute {
+pub(crate) enum ImposterRoute {
     /// GET/DELETE /imposters/:port
     Root,
     /// POST/PUT/GET /imposters/:port/stubs
@@ -49,7 +49,7 @@ enum ImposterRoute {
 
 impl ImposterRoute {
     /// Parse route from path segments after `/imposters/:port`
-    fn parse(segments: &[&str]) -> Option<Self> {
+    pub(crate) fn parse(segments: &[&str]) -> Option<Self> {
         match segments {
             [] => Some(ImposterRoute::Root),
             ["stubs"] => Some(ImposterRoute::Stubs),

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -1,5 +1,6 @@
 //! Admin API server.
 
+use crate::admin_api::authz;
 use crate::admin_api::handlers::events::{self, AdminBody};
 use crate::admin_api::router::route_request;
 use crate::config_loader::ConfigSource;
@@ -12,6 +13,7 @@ use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use rift_mock_core::extensions::authz::{AdminAuthorizer, AuthzDecision, AuthzRequest};
 use rift_mock_core::proxy::{
     AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, classify_accept_error,
     is_fatal_listener_error,
@@ -30,6 +32,11 @@ use tracing::{debug, error, info};
 /// Bounded grace given to in-flight connections on `shutdown()` before the wait is abandoned.
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
+/// Header carrying the embedder-defined scope selector handed to an [`AdminAuthorizer`]
+/// (issue #854). Upstream never parses or interprets the value — it exists because an authorizer
+/// often cannot derive the target from the port alone (`POST /imposters` has no port yet).
+const SCOPE_HEADER: &str = "x-rift-scope";
+
 /// Admin API server for Rift
 pub struct AdminApiServer {
     addr: SocketAddr,
@@ -39,6 +46,7 @@ pub struct AdminApiServer {
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
+    authorizer: Option<Arc<dyn AdminAuthorizer>>,
 }
 
 impl AdminApiServer {
@@ -52,7 +60,19 @@ impl AdminApiServer {
             allow_injection: false,
             intercept: None,
             scripts_dir: None,
+            authorizer: None,
         }
+    }
+
+    /// Install a per-request authorization hook (issue #854).
+    ///
+    /// Consulted after authentication and after the route is parsed, so it receives the action,
+    /// port and path params rather than a raw path. Without one the api-key comparison decides
+    /// alone, exactly as before.
+    #[must_use]
+    pub fn with_admin_authorizer(mut self, authorizer: Arc<dyn AdminAuthorizer>) -> Self {
+        self.authorizer = Some(authorizer);
+        self
     }
 
     /// Set the config source (`--configfile`/`--datadir`) so `POST /admin/reload` can re-read it
@@ -148,6 +168,7 @@ impl AdminApiServer {
                 self.allow_injection,
                 self.intercept,
                 self.scripts_dir,
+                self.authorizer,
                 loop_cancel,
                 loop_tracker,
             )
@@ -357,6 +378,7 @@ async fn accept_loop(
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
+    authorizer: Option<Arc<dyn AdminAuthorizer>>,
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
@@ -467,6 +489,7 @@ async fn accept_loop(
         let api_key = api_key.clone();
         let config_source = config_source.clone();
         let intercept = intercept.clone();
+        let authorizer = authorizer.clone();
         let scripts_dir = scripts_dir.clone();
         let conn_cancel = cancel.clone();
 
@@ -479,6 +502,7 @@ async fn accept_loop(
                 let api_key = api_key.clone();
                 let config_source = config_source.clone();
                 let intercept = intercept.clone();
+                let authorizer = authorizer.clone();
                 let scripts_dir = scripts_dir.clone();
                 let stream_cancel = stream_cancel.clone();
                 async move {
@@ -503,6 +527,45 @@ async fn accept_loop(
                                 .unwrap_or("");
                             if !api_key_matches(auth, key.as_str()) {
                                 return Ok::<_, hyper::Error>(box_full(unauthorized_response()));
+                            }
+                        }
+                        // Authorization (issue #854), strictly after authentication. Ordering is
+                        // load-bearing: moving the api-key gate below this would let an
+                        // unauthenticated request to an unknown path answer 404 instead of 401,
+                        // turning unknown-path responses into a route-existence oracle.
+                        //
+                        // Gateway traffic is exempt for the same reason it skips the api key —
+                        // `classify` returns None for `/__rift/`, so app-under-test requests are
+                        // never asked to carry an admin identity.
+                        if let Some(ref authorizer) = authorizer
+                            && let Some(target) = authz::classify(req.method(), req.uri().path())
+                        {
+                            let params: Vec<(&str, &str)> = target
+                                .params
+                                .iter()
+                                .map(|(name, value)| (*name, value.as_str()))
+                                .collect();
+                            let decision = authorizer.authorize(AuthzRequest {
+                                credential: req
+                                    .headers()
+                                    .get("authorization")
+                                    .and_then(|v| v.to_str().ok()),
+                                action: target.action,
+                                port: target.port,
+                                space: target.space.as_deref(),
+                                scope: req
+                                    .headers()
+                                    .get(SCOPE_HEADER)
+                                    .and_then(|v| v.to_str().ok()),
+                                params: &params,
+                            });
+                            match decision {
+                                AuthzDecision::Allow { principal: _ } => {}
+                                AuthzDecision::Deny { reason } => {
+                                    return Ok::<_, hyper::Error>(box_full(forbidden_response(
+                                        reason,
+                                    )));
+                                }
                             }
                         }
                         // Admin SSE stream (issue #461): `/events` + the
@@ -647,6 +710,23 @@ fn unauthorized_response() -> Response<Full<Bytes>> {
         .header("Content-Type", "application/json")
         .body(Full::new(Bytes::from(body)))
         .expect("infallible")
+}
+
+/// An installed [`AdminAuthorizer`] denied an *authenticated* request (issue #854).
+///
+/// 403, not 401: the credential was accepted, so telling the caller to re-authenticate would send
+/// them round a loop that cannot succeed. 401 stays reserved for a missing or malformed
+/// credential.
+///
+/// `reason` comes from the authorizer and is echoed to the caller, which is why it is a
+/// `&'static str` — an embedder has to write it as a literal rather than formatting a principal,
+/// a policy id or an internal error into it by accident.
+fn forbidden_response(reason: &'static str) -> Response<Full<Bytes>> {
+    // The shared builder, not a hand-rolled envelope: it emits `code = "403"` and
+    // `type = "insufficient access"` per the #797 format that all four SDKs and rift-conformance
+    // parse. `unauthorized_response` above predates that format and is grandfathered; copying its
+    // shape onto a brand-new surface would spread the wart rather than contain it.
+    crate::admin_api::types::error_response(StatusCode::FORBIDDEN, reason)
 }
 
 #[cfg(test)]

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -18,6 +18,7 @@ use crate::sources::{
 };
 use arc_swap::ArcSwap;
 use clap::{Parser, Subcommand};
+use rift_mock_core::extensions::authz::AdminAuthorizer;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -328,6 +329,7 @@ pub struct ServerBuilder {
     manager: Option<Arc<ImposterManager>>,
     accept_runtimes: Vec<tokio::runtime::Handle>,
     imposter_sources: Vec<Arc<dyn ImposterSource>>,
+    admin_authorizer: Option<Arc<dyn AdminAuthorizer>>,
 }
 
 impl ServerBuilder {
@@ -339,6 +341,7 @@ impl ServerBuilder {
             manager: None,
             accept_runtimes: Vec::new(),
             imposter_sources: Vec::new(),
+            admin_authorizer: None,
         }
     }
 
@@ -364,6 +367,21 @@ impl ServerBuilder {
         self
     }
 
+    /// Install a per-request admin-API authorization hook (issue #854).
+    ///
+    /// Consulted after authentication and after the route is parsed, so the hook receives the
+    /// action, port and path params instead of having to re-parse the path itself. Install
+    /// nothing and nothing changes: without one, the `--api-key` comparison decides alone.
+    ///
+    /// Authentication still runs first and unconditionally — an unauthenticated request answers
+    /// `401` whatever the path, so unknown paths never become a route-existence oracle. A `Deny`
+    /// on an authenticated request is a `403`.
+    #[must_use]
+    pub fn admin_authorizer(mut self, authorizer: Arc<dyn AdminAuthorizer>) -> Self {
+        self.admin_authorizer = Some(authorizer);
+        self
+    }
+
     /// Inject a pre-built manager (skipping internal construction, including `--datadir`
     /// write-through and TLS defaults) — the embedding seam.
     #[must_use]
@@ -384,6 +402,7 @@ impl ServerBuilder {
     pub async fn start(self) -> anyhow::Result<RunningServer> {
         let cli = self.cli;
         let extra_sources = self.imposter_sources;
+        let admin_authorizer = self.admin_authorizer;
         // Refuse a blank `--api-key` before anything binds (issue #844). Same reasoning as the
         // front-door check below, with a security edge: a blank key enables the auth gate and then
         // authenticates every request, so the admin plane must never reach the accept loop in that
@@ -516,6 +535,9 @@ impl ServerBuilder {
         // Injection gating is threaded explicitly (issue #342) rather than read from env.
         let mut server = AdminApiServer::new(addr, manager, cli.api_key)
             .with_allow_injection(cli.allow_injection);
+        if let Some(authorizer) = admin_authorizer {
+            server = server.with_admin_authorizer(authorizer);
+        }
         if let Some(scripts_dir) = cli.scripts_dir {
             server = server.with_scripts_dir(scripts_dir);
         }

--- a/crates/rift-http-proxy/tests/admin_authorizer.rs
+++ b/crates/rift-http-proxy/tests/admin_authorizer.rs
@@ -1,0 +1,448 @@
+//! Issue #854: the `AdminAuthorizer` hook — inert by default, `403` on deny, and an ordering
+//! guarantee that authentication always precedes route parsing.
+//!
+//! The ordering is the security-relevant part and is what most of this file is about. If the
+//! api-key gate ever moved below route parsing, an unauthenticated request to an unknown path
+//! would answer `404` instead of `401`, and unknown-path responses would become an
+//! unauthenticated route-existence oracle.
+
+use parking_lot::Mutex;
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use rift_mock_core::extensions::authz::{AdminAuthorizer, AuthzDecision, AuthzRequest, actions};
+use std::sync::Arc;
+
+fn imposter_cfg(v: serde_json::Value) -> ImposterConfig {
+    serde_json::from_value(v).expect("test imposter config")
+}
+
+/// What the hook was asked, flattened so assertions do not depend on borrowed lifetimes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SeenCall {
+    action: String,
+    port: Option<u16>,
+    space: Option<String>,
+    scope: Option<String>,
+    credential: Option<String>,
+    params: Vec<(String, String)>,
+}
+
+struct SpyAuthorizer {
+    calls: Mutex<Vec<SeenCall>>,
+    decision: AuthzDecision,
+}
+
+impl SpyAuthorizer {
+    fn new(decision: AuthzDecision) -> Arc<Self> {
+        Arc::new(Self {
+            calls: Mutex::new(Vec::new()),
+            decision,
+        })
+    }
+    fn calls(&self) -> Vec<SeenCall> {
+        self.calls.lock().clone()
+    }
+}
+
+impl AdminAuthorizer for SpyAuthorizer {
+    fn authorize(&self, req: AuthzRequest<'_>) -> AuthzDecision {
+        self.calls.lock().push(SeenCall {
+            action: req.action.to_string(),
+            port: req.port,
+            space: req.space.map(str::to_string),
+            scope: req.scope.map(str::to_string),
+            credential: req.credential.map(str::to_string),
+            params: req
+                .params
+                .iter()
+                .map(|(n, v)| ((*n).to_string(), (*v).to_string()))
+                .collect(),
+        });
+        self.decision.clone()
+    }
+}
+
+async fn start_admin(
+    admin_port: u16,
+    api_key: Option<&str>,
+    authorizer: Option<Arc<dyn AdminAuthorizer>>,
+) {
+    let manager = Arc::new(ImposterManager::new());
+    let mut server = AdminApiServer::new(
+        format!("127.0.0.1:{admin_port}").parse().expect("addr"),
+        manager,
+        api_key.map(str::to_string),
+    );
+    if let Some(a) = authorizer {
+        server = server.with_admin_authorizer(a);
+    }
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+}
+
+fn base(port: u16) -> String {
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn no_authorizer_installed_changes_nothing() {
+    // The seam's premise: install nothing, behave exactly as before.
+    let port = 14801;
+    start_admin(port, None, None).await;
+
+    let resp = reqwest::get(format!("{}/imposters", base(port)))
+        .await
+        .expect("list imposters");
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn deny_on_an_authenticated_request_is_403_not_401() {
+    // 401 would tell an authenticated caller to re-authenticate, sending them round a loop that
+    // cannot succeed. The credential was fine; the permission was not.
+    let port = 14802;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny {
+        reason: "not your tenant",
+    });
+    start_admin(port, Some("s3cret"), Some(spy.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/imposters", base(port)))
+        .header("authorization", "s3cret")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 403);
+
+    // The house envelope (#797): `code` is the status, `type` is the slug. They must not be
+    // identical strings — a client has to be able to tell them apart.
+    let body: serde_json::Value = resp.json().await.expect("json envelope");
+    assert_eq!(body["errors"][0]["code"], "403");
+    assert_eq!(body["errors"][0]["type"], "insufficient access");
+    assert_eq!(body["errors"][0]["message"], "not your tenant");
+}
+
+#[tokio::test]
+async fn allow_lets_the_request_through() {
+    let port = 14803;
+    let spy = SpyAuthorizer::new(AuthzDecision::Allow {
+        principal: Some("alice".into()),
+    });
+    start_admin(port, Some("s3cret"), Some(spy.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/imposters", base(port)))
+        .header("authorization", "s3cret")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(spy.calls().len(), 1);
+}
+
+#[tokio::test]
+async fn an_unauthenticated_request_is_401_and_never_reaches_the_authorizer() {
+    // Both halves matter. The 401 is the ordering guarantee; the empty call log proves the hook
+    // cannot be used as an oracle by an anonymous caller, and that an authorizer cannot
+    // accidentally *grant* access to a request that failed authentication.
+    let port = 14804;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, Some("s3cret"), Some(spy.clone())).await;
+
+    let resp = reqwest::get(format!("{}/imposters", base(port)))
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 401);
+    assert!(
+        spy.calls().is_empty(),
+        "the hook must not see unauthenticated requests, saw: {:?}",
+        spy.calls()
+    );
+}
+
+#[tokio::test]
+async fn an_unauthenticated_request_to_an_unknown_path_is_401_not_404() {
+    // The route-existence oracle. If authentication ever moved after route parsing this would
+    // answer 404 and leak which admin routes exist to an anonymous caller.
+    let port = 14805;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, Some("s3cret"), Some(spy.clone())).await;
+
+    for path in [
+        "/definitely-not-a-route",
+        "/imposters/4545/nope",
+        "/admin/reload",
+    ] {
+        let resp = reqwest::get(format!("{}{path}", base(port)))
+            .await
+            .expect("request");
+        assert_eq!(resp.status(), 401, "{path} leaked its existence");
+    }
+    assert!(spy.calls().is_empty());
+}
+
+#[tokio::test]
+async fn an_unknown_path_still_404s_for_an_authorized_caller() {
+    // `classify` returns None for unmatched paths, so the hook is skipped and the ordinary 404
+    // stands. A denying authorizer must not turn 404s into 403s — that would be a behaviour
+    // change for a route that reaches no handler.
+    let port = 14806;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny { reason: "nope" });
+    start_admin(port, Some("s3cret"), Some(spy.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/definitely-not-a-route", base(port)))
+        .header("authorization", "s3cret")
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 404);
+    assert!(spy.calls().is_empty());
+}
+
+#[tokio::test]
+async fn the_hook_receives_the_parsed_route_not_a_raw_path() {
+    // The reason the seam exists: an embedder should not have to re-parse admin routes.
+    let port = 14807;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, None, Some(spy.clone())).await;
+
+    reqwest::Client::new()
+        .post(format!("{}/imposters", base(port)))
+        .header("x-rift-scope", "tenant-7")
+        .json(&serde_json::json!({"protocol": "http", "port": 14899}))
+        .send()
+        .await
+        .expect("create imposter");
+
+    let create = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(create.action, actions::IMPOSTER_WRITE);
+    assert_eq!(create.port, None, "a create names no port yet");
+    assert_eq!(
+        create.scope.as_deref(),
+        Some("tenant-7"),
+        "scope is how an authorizer targets a create"
+    );
+
+    reqwest::Client::new()
+        .put(format!(
+            "{}/imposters/14899/scenarios/checkout/state",
+            base(port)
+        ))
+        .json(&serde_json::json!({"state": "Started"}))
+        .send()
+        .await
+        .expect("set scenario state");
+
+    let scenario = spy.calls().pop().expect("second call");
+    assert_eq!(scenario.action, actions::IMPOSTER_WRITE);
+    assert_eq!(scenario.port, Some(14899));
+    assert!(
+        scenario
+            .params
+            .contains(&("scenario".to_string(), "checkout".to_string())),
+        "path params must reach the hook, saw: {:?}",
+        scenario.params
+    );
+}
+
+#[tokio::test]
+async fn the_credential_is_passed_through_verbatim() {
+    // Upstream must not parse or normalise it: an embedder's credential format is not upstream's
+    // vocabulary.
+    let port = 14808;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, None, Some(spy.clone())).await;
+
+    reqwest::Client::new()
+        .get(format!("{}/imposters", base(port)))
+        .header("authorization", "Bearer  weird.token  ")
+        .send()
+        .await
+        .expect("request");
+
+    let seen = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(seen.credential.as_deref(), Some("Bearer  weird.token"));
+}
+
+#[tokio::test]
+async fn gateway_traffic_is_not_authorized() {
+    // `/__rift/` is data-plane imposter traffic. It skips the admin api key for the same reason,
+    // and authorizing it would force the app under test to carry an admin identity.
+    let port = 14809;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny {
+        reason: "would break the data plane",
+    });
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let manager_resp = reqwest::Client::new()
+        .post(format!("{}/imposters", base(port)))
+        .json(&serde_json::json!({
+            "protocol": "http", "port": 14898,
+            "stubs": [{"responses": [{"is": {"statusCode": 200, "body": "gw"}}]}]
+        }))
+        .send()
+        .await;
+    // The create itself is denied (it is an admin route), which is fine — what matters is that a
+    // gateway request is never handed to the hook at all.
+    drop(manager_resp);
+    spy.calls.lock().clear();
+
+    let _ = reqwest::get(format!("{}/__rift/14898/anything", base(port))).await;
+    assert!(
+        spy.calls().is_empty(),
+        "gateway traffic must not consult the admin authorizer, saw: {:?}",
+        spy.calls()
+    );
+}
+
+#[tokio::test]
+async fn verify_is_not_classified_as_a_write() {
+    // A POST that mutates nothing. A read-only principal must still be able to verify.
+    let port = 14810;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let manager = reqwest::Client::new();
+    manager
+        .post(format!("{}/imposters", base(port)))
+        .json(&imposter_cfg(serde_json::json!({
+            "protocol": "http", "port": 14897,
+            "stubs": [{"responses": [{"is": {"statusCode": 200}}]}]
+        })))
+        .send()
+        .await
+        .expect("create");
+    spy.calls.lock().clear();
+
+    let _ = manager
+        .post(format!("{}/imposters/14897/verify", base(port)))
+        .json(&serde_json::json!({"predicates": [], "atLeast": 0}))
+        .send()
+        .await;
+
+    let seen = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(seen.action, actions::IMPOSTER_VERIFY);
+    assert_ne!(seen.action, actions::IMPOSTER_WRITE);
+}
+
+#[tokio::test]
+async fn the_cross_imposter_event_stream_is_gated() {
+    // `GET /events` is dispatched before the router, so it was invisible to the hook: a Deny-all
+    // authorizer could not stop a caller streaming every imposter's recorded requests, headers
+    // and bodies. The highest-value read on the admin plane must not be the one it cannot gate.
+    let port = 14811;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny {
+        reason: "no event access",
+    });
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/events", base(port)))
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(
+        resp.status(),
+        403,
+        "the event stream bypassed the authorizer"
+    );
+
+    let seen = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(seen.action, actions::EVENTS_READ);
+    assert_eq!(
+        seen.port, None,
+        "the stream is cross-imposter, not port-scoped"
+    );
+}
+
+#[tokio::test]
+async fn the_per_imposter_stream_alias_is_gated_and_scoped() {
+    let port = 14812;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny { reason: "nope" });
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/imposters/4545/savedRequests/stream",
+            base(port)
+        ))
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(resp.status(), 403);
+
+    let seen = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(seen.action, actions::IMPOSTER_READ);
+    assert_eq!(seen.port, Some(4545), "the alias is scoped to its port");
+}
+
+#[tokio::test]
+async fn an_empty_path_segment_cannot_route_past_the_classifier() {
+    // Hyper does not normalise `//`, and the router does not filter empty segments. When the
+    // classifier did, these dispatched into real handlers the hook had never seen.
+    let port = 14813;
+    let spy = SpyAuthorizer::new(AuthzDecision::Deny { reason: "denied" });
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let client = reqwest::Client::new();
+    for (method, path) in [
+        ("PUT", "/imposters/4545/scenarios//state"),
+        ("GET", "/imposters/4545/spaces/"),
+        ("DELETE", "/imposters/4545/spaces/"),
+        ("GET", "/imposters/4545/stubs/by-id/"),
+    ] {
+        let req = client.request(
+            method.parse().expect("method"),
+            format!("{}{path}", base(port)),
+        );
+        let status = req.send().await.expect("request").status();
+        assert_ne!(
+            status, 200,
+            "{method} {path} reached a handler despite a Deny-all authorizer"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_empty_space_segment_is_not_authorized_against_the_wrong_space() {
+    // The subtler half: `POST /imposters/:port/spaces//stubs` writes into space "" but the old
+    // classifier reported space "stubs", so an authorizer scoping by space granted on the wrong
+    // subject rather than simply missing the route.
+    let port = 14814;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let _ = reqwest::Client::new()
+        .post(format!("{}/imposters/4545/spaces//stubs", base(port)))
+        .json(&serde_json::json!({"responses": [{"is": {"statusCode": 200}}]}))
+        .send()
+        .await;
+
+    if let Some(seen) = spy.calls().into_iter().next() {
+        assert_ne!(
+            seen.space.as_deref(),
+            Some("stubs"),
+            "authorized against the literal path segment instead of the real space"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_destructive_put_requires_delete_not_write() {
+    // `PUT /imposters {"imposters":[]}` reconciles the set toward the payload and removes
+    // everything. Classifying it as `imposter.write` would let a write-but-not-delete principal
+    // wipe the server.
+    let port = 14815;
+    let spy = SpyAuthorizer::new(AuthzDecision::allow());
+    start_admin(port, None, Some(spy.clone())).await;
+
+    let _ = reqwest::Client::new()
+        .put(format!("{}/imposters", base(port)))
+        .json(&serde_json::json!({"imposters": []}))
+        .send()
+        .await;
+
+    let seen = spy.calls().into_iter().next().expect("hook was consulted");
+    assert_eq!(seen.action, actions::IMPOSTER_DELETE);
+}

--- a/crates/rift-mock-core/src/extensions/authz.rs
+++ b/crates/rift-mock-core/src/extensions/authz.rs
@@ -1,0 +1,260 @@
+//! Pluggable admin-API authorization (issue #854).
+//!
+//! The built-in admin gate is a single global api key: success yields *access*, not an identity.
+//! Every caller is equivalent, so an embedder with its own identity system has to reverse-proxy
+//! the admin API and re-parse routes just to recover enough context to make a decision — exactly
+//! the drift-prone part.
+//!
+//! [`AdminAuthorizer`] is consulted **after** the route has been parsed, with the route class,
+//! port and path params already extracted. Install nothing and nothing changes: with no authorizer
+//! registered the api-key comparison decides on its own, exactly as before.
+//!
+//! # Ordering is part of the contract
+//!
+//! Authentication runs first and unconditionally; only then is the route parsed and this hook
+//! consulted. That ordering is load-bearing: if authentication moved after route parsing, an
+//! unauthenticated request to an unknown path would answer `404` instead of `401`, turning
+//! unknown-path responses into an unauthenticated route-existence oracle.
+//!
+//! `Deny` on an authenticated request is a `403`. `401` stays reserved for a missing or malformed
+//! credential.
+
+use std::sync::Arc;
+
+/// What the caller is trying to do, as the admin router understood it.
+///
+/// Borrows from the request, so an authorizer sees the credential and path params without this
+/// type having to allocate on a hot path.
+///
+/// `Debug` is hand-written to redact [`credential`](Self::credential): it is the verbatim admin
+/// token, and a derived `Debug` would put it in any embedder's log the first time someone writes
+/// `tracing::debug!("{req:?}")`. Same rule the CA key material follows in `intercept_control`.
+#[derive(Clone, Copy)]
+pub struct AuthzRequest<'a> {
+    /// The `Authorization` header value, verbatim — `None` when the header is absent.
+    ///
+    /// Passed through untouched: upstream neither parses nor validates the scheme, because an
+    /// embedder's credential format (bearer JWT, mTLS-derived, opaque session) is not upstream's
+    /// vocabulary.
+    pub credential: Option<&'a str>,
+    /// A stable action string such as `"imposter.write"`.
+    ///
+    /// Deliberately a string and not an enum: an enum would force every embedder's action
+    /// vocabulary to be upstream's, and adding an action would be a breaking change. See
+    /// [`actions`] for the ones upstream emits.
+    pub action: &'static str,
+    /// The imposter port the route targets, when the route has one. `None` for collection routes
+    /// (`POST /imposters` has no port yet) and for system routes.
+    pub port: Option<u16>,
+    /// The flow/space identifier, for the correlated-isolation routes.
+    pub space: Option<&'a str>,
+    /// Embedder-defined scope selector, verbatim from the request.
+    ///
+    /// Upstream neither parses nor interprets it. An authorizer often cannot derive the target
+    /// from [`port`](Self::port) alone — `POST /imposters` creates a port rather than naming one —
+    /// so this is the escape hatch for saying *which* tenant/scope a create belongs to.
+    ///
+    /// **It is caller-asserted and must never be trusted as identity.** It arrives in a request
+    /// header, so any authenticated caller can set it to any value. Cross-check it against what
+    /// [`credential`](Self::credential) actually entitles the caller to; using it directly as the
+    /// authorization subject authorizes the caller's own claim about themselves.
+    pub scope: Option<&'a str>,
+    /// Route path parameters already parsed by the router, as `(name, value)`.
+    ///
+    /// Opaque to upstream beyond having been extracted. Without these an authorizer cannot make a
+    /// decision about routes keyed by a path param rather than by port (a stub id, a scenario
+    /// name, a flow-state key).
+    pub params: &'a [(&'a str, &'a str)],
+}
+
+impl std::fmt::Debug for AuthzRequest<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthzRequest")
+            .field("credential", &self.credential.map(|_| "<redacted>"))
+            .field("action", &self.action)
+            .field("port", &self.port)
+            .field("space", &self.space)
+            .field("scope", &self.scope)
+            .field("params", &self.params)
+            .finish()
+    }
+}
+
+/// The authorizer's verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthzDecision {
+    /// Let the request through, optionally attributing it to a principal.
+    ///
+    /// `principal` is the attribution handoff: it is what reaches change events so an audit trail
+    /// can say *who* changed something and not only *what* changed.
+    Allow { principal: Option<String> },
+    /// Refuse the request. Answers `403` with the standard error envelope; `reason` is surfaced
+    /// as the message, so it must not carry anything the caller should not see.
+    Deny { reason: &'static str },
+}
+
+impl AuthzDecision {
+    /// Allow with no attribution — what the built-in api-key gate returns.
+    #[must_use]
+    pub fn allow() -> Self {
+        Self::Allow { principal: None }
+    }
+
+    #[must_use]
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allow { .. })
+    }
+}
+
+/// The action strings upstream emits, as constants so an embedder can match without retyping
+/// them and a rename here becomes a compile error there rather than a silently-never-matching
+/// arm.
+///
+/// The mapping is mechanical — resource plus verb class — so it stays predictable as routes are
+/// added, with one deliberate exception noted on [`IMPOSTER_VERIFY`].
+pub mod actions {
+    /// `GET /`, `/health`, `/config`, `/logs`, `/metrics`.
+    pub const SYSTEM_READ: &str = "system.read";
+    /// `POST /admin/reload`.
+    pub const SYSTEM_WRITE: &str = "system.write";
+    /// Any `GET` under `/imposters`, including stubs, saved requests and scenarios.
+    pub const IMPOSTER_READ: &str = "imposter.read";
+    /// Any `POST`/`PUT` that mutates an imposter or its stubs, scenarios or flow state.
+    pub const IMPOSTER_WRITE: &str = "imposter.write";
+    /// Any `DELETE` under `/imposters`, including `DELETE /imposters` (delete-all).
+    ///
+    /// Also covers `PUT /imposters`, which is destructive despite its method: it reconciles the
+    /// imposter set toward the payload, so an empty list removes everything. A principal granted
+    /// [`IMPOSTER_WRITE`] but not this cannot reach it.
+    pub const IMPOSTER_DELETE: &str = "imposter.delete";
+    /// `POST /imposters/:port/verify`.
+    ///
+    /// A `POST` that mutates nothing — it asserts against already-recorded requests. Mapping it
+    /// to [`IMPOSTER_WRITE`] purely because of its method would stop a read-only principal
+    /// verifying, so it gets its own string rather than a wrong one.
+    pub const IMPOSTER_VERIFY: &str = "imposter.verify";
+    /// `GET /events` — the cross-imposter SSE stream.
+    ///
+    /// Distinct from [`IMPOSTER_READ`] because it is not scoped to a port: it carries recorded
+    /// requests from *every* imposter, so granting a principal read on one port must not
+    /// implicitly grant this.
+    pub const EVENTS_READ: &str = "events.read";
+    /// `GET` under `/intercept`.
+    pub const INTERCEPT_READ: &str = "intercept.read";
+    /// `POST`/`PUT`/`DELETE` under `/intercept` — lifecycle, rules and CA.
+    pub const INTERCEPT_WRITE: &str = "intercept.write";
+}
+
+/// Decides whether an authenticated admin request may proceed.
+///
+/// Registered with `ServerBuilder::admin_authorizer`. Implementations must be cheap and must not
+/// block: this runs inline on every admin request, before the handler.
+pub trait AdminAuthorizer: Send + Sync {
+    fn authorize(&self, req: AuthzRequest<'_>) -> AuthzDecision;
+}
+
+/// An authorizer that allows everything, attributing nothing.
+///
+/// Not installed by default — the default is *no* authorizer at all, which skips the hook
+/// entirely. This exists so an embedder can wrap or test against a known-inert baseline.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AllowAll;
+
+impl AdminAuthorizer for AllowAll {
+    fn authorize(&self, _req: AuthzRequest<'_>) -> AuthzDecision {
+        AuthzDecision::allow()
+    }
+}
+
+/// Convenience alias for the registration type.
+pub type SharedAdminAuthorizer = Arc<dyn AdminAuthorizer>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_helper_carries_no_principal() {
+        assert_eq!(
+            AuthzDecision::allow(),
+            AuthzDecision::Allow { principal: None }
+        );
+    }
+
+    #[test]
+    fn deny_is_not_allowed() {
+        assert!(!AuthzDecision::Deny { reason: "nope" }.is_allowed());
+        assert!(AuthzDecision::allow().is_allowed());
+        assert!(
+            AuthzDecision::Allow {
+                principal: Some("alice".into())
+            }
+            .is_allowed()
+        );
+    }
+
+    #[test]
+    fn allow_all_admits_every_action() {
+        let a = AllowAll;
+        for action in [
+            actions::IMPOSTER_WRITE,
+            actions::SYSTEM_READ,
+            actions::IMPOSTER_DELETE,
+        ] {
+            let decision = a.authorize(AuthzRequest {
+                credential: None,
+                action,
+                port: None,
+                space: None,
+                scope: None,
+                params: &[],
+            });
+            assert_eq!(decision, AuthzDecision::allow());
+        }
+    }
+
+    #[test]
+    fn debug_redacts_the_admin_credential() {
+        // A derived Debug would put the verbatim admin token in any embedder's log the first time
+        // someone formats the request. Same rule `intercept_control` applies to CA key material.
+        let req = AuthzRequest {
+            credential: Some("super-secret-token"),
+            action: actions::IMPOSTER_WRITE,
+            port: Some(4545),
+            space: None,
+            scope: None,
+            params: &[],
+        };
+        let rendered = format!("{req:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "the credential leaked into Debug: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "got: {rendered}");
+        // Absence must stay distinguishable from redaction, or a missing credential reads as one
+        // that was merely hidden.
+        let anon = AuthzRequest {
+            credential: None,
+            ..req
+        };
+        assert!(format!("{anon:?}").contains("credential: None"));
+    }
+
+    #[test]
+    fn action_strings_are_distinct() {
+        // A duplicated constant would silently collapse two route classes into one permission.
+        let all = [
+            actions::SYSTEM_READ,
+            actions::SYSTEM_WRITE,
+            actions::IMPOSTER_READ,
+            actions::IMPOSTER_WRITE,
+            actions::IMPOSTER_DELETE,
+            actions::IMPOSTER_VERIFY,
+            actions::EVENTS_READ,
+            actions::INTERCEPT_READ,
+            actions::INTERCEPT_WRITE,
+        ];
+        let unique: std::collections::BTreeSet<_> = all.iter().collect();
+        assert_eq!(unique.len(), all.len(), "action constants must be distinct");
+    }
+}

--- a/crates/rift-mock-core/src/extensions/mod.rs
+++ b/crates/rift-mock-core/src/extensions/mod.rs
@@ -15,7 +15,10 @@
 //! - **Routing** (`routing`): Multi-upstream routing for reverse proxy mode
 //! - **No-Match Interceptor** (`no_match`): Last-chance hook for a genuine no-match, before the
 //!   defaultForward/defaultResponse/empty-200 fallthrough (issue #819)
+//! - **Admin Authorization** (`authz`): Pluggable per-request admin-API authorization with parsed
+//!   route context, consulted after authentication (issue #854)
 
+pub mod authz;
 pub mod decorate;
 pub mod fault;
 pub mod flow_state;

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -256,6 +256,88 @@ Contract:
 
 Registering no interceptor leaves behaviour byte-identical, on both the serve loop and the gateway.
 
+## `AdminAuthorizer` — per-request admin authorization
+
+The built-in `--api-key` gate yields *access*, not an identity: every caller that presents the key
+is equivalent. `AdminAuthorizer` lets an embedder decide per request, with the route already parsed.
+
+```rust
+use rift_mock_core::extensions::authz::{
+    AdminAuthorizer, AuthzDecision, AuthzRequest, actions,
+};
+
+struct TenantAuthorizer;
+
+impl AdminAuthorizer for TenantAuthorizer {
+    fn authorize(&self, req: AuthzRequest<'_>) -> AuthzDecision {
+        let principal = match req.credential.and_then(lookup_principal) {
+            Some(p) => p,
+            None => return AuthzDecision::Deny { reason: "unknown principal" },
+        };
+        match req.action {
+            actions::IMPOSTER_DELETE if !principal.may_delete => {
+                AuthzDecision::Deny { reason: "delete not permitted" }
+            }
+            _ => AuthzDecision::Allow { principal: Some(principal.name) },
+        }
+    }
+}
+
+let server = ServerBuilder::from_cli(cli)
+    .admin_authorizer(Arc::new(TenantAuthorizer))
+    .start()
+    .await?;
+```
+
+**Install nothing, change nothing.** With no authorizer registered the api-key comparison decides
+alone, exactly as before.
+
+### Ordering is part of the contract
+
+Authentication runs **first and unconditionally**; only then is the route parsed and the hook
+consulted. That order is load-bearing — if authentication ran after route parsing, an
+unauthenticated request to an unknown path would answer `404` instead of `401` and unknown-path
+responses would become a route-existence oracle for anonymous callers.
+
+- Missing or invalid credential → `401`, and the hook is **not** consulted.
+- `Deny` on an authenticated request → `403` with the standard error envelope.
+- A path matching no route → the ordinary `404`; the hook is not consulted, because nothing runs.
+
+### Actions
+
+`action` is a stable string rather than an enum, so an embedder can extend its own vocabulary
+without waiting for an upstream release. The values upstream emits are constants in
+`extensions::authz::actions`:
+
+| Action | Routes |
+|:--|:--|
+| `system.read` | `GET /`, `/health`, `/config`, `/logs`, `/metrics` |
+| `system.write` | `POST /admin/reload` |
+| `imposter.read` | any `GET` under `/imposters`, and the per-imposter SSE alias |
+| `imposter.write` | mutating `POST`/`PUT` on an imposter, its stubs, scenarios or flow state |
+| `imposter.delete` | any `DELETE` under `/imposters` — **and `PUT /imposters`**, which reconciles the whole set and so removes everything not in the payload |
+| `imposter.verify` | `POST /imposters/:port/verify`, which mutates nothing |
+| `events.read` | `GET /events`, the cross-imposter stream |
+| `intercept.read` / `intercept.write` | `/intercept` and below |
+
+`events.read` is separate from `imposter.read` on purpose: `/events` carries recorded requests from
+*every* imposter, so granting read on one port must not implicitly grant all of them.
+
+### Targeting: `port`, `space`, `params`, `scope`
+
+`port`, `space` and `params` come from the router's own parser, so they cannot drift from what the
+handler will actually act on.
+
+`scope` is different. It is read verbatim from the **`x-rift-scope` request header** and exists
+because some routes have no target to key on — `POST /imposters` creates a port rather than naming
+one. Because it is a request header, **it is caller-asserted**: any authenticated caller can set it
+to any value. Cross-check it against what the credential entitles the caller to; never use it
+directly as the authorization subject.
+
+The data plane is never authorized. Gateway traffic (`/__rift/...`) skips this hook for the same
+reason it skips the api key — it is app-under-test traffic, and requiring an admin identity for it
+would force the application to carry the admin credential.
+
 ## Backend errors and annotations
 
 A custom backend signals unavailability by attaching `BackendUnavailable` to a failed operation's


### PR DESCRIPTION
The `--api-key` gate grants *access*, not an identity — every caller presenting the key is equivalent. `ServerBuilder::admin_authorizer` installs a hook consulted **after** authentication and **after** the route is parsed, so an embedder gets the action, port, space and already-extracted path params instead of having to re-parse the admin API behind a reverse proxy.

Install nothing and nothing changes: with no authorizer registered, the api-key comparison decides alone.

### The ordering contract

Authentication runs first and unconditionally. An unauthenticated request answers `401` whatever the path — if auth ran after route parsing, unknown paths would answer `404` and become a route-existence oracle for anonymous callers. `Deny` on an authenticated request is `403`; `401` stays reserved for a missing or malformed credential. An unmatched path still `404`s and never reaches the hook.

### Two authorization holes found in review, both closed

**`GET /events` bypassed the hook entirely.** The SSE streams dispatch before the router, so the classifier never saw them — a `Deny`-everything authorizer could not stop a caller streaming recorded methods, paths, headers and bodies across *every* imposter. It now classifies as a distinct `events.read`, deliberately not `imposter.read`, so granting read on one port cannot leak all of them.

**A second route parser diverged from the router's.** The classifier filtered empty path segments; the router does not, and hyper does not normalise `//`. So `PUT /imposters/:port/scenarios//state` dispatched into a real mutation the hook never saw, and `POST /imposters/:port/spaces//stubs` was authorized against space `"stubs"` while writing into `""` — the hook answering about the wrong subject. Fixed structurally: `classify` now delegates to the router's own `ImposterRoute::parse`, so divergence is impossible and a new route variant is a compile error rather than a silently ungated handler.

### Also from review

- **`PUT /imposters` is destructive** — it reconciles toward the payload, so `{"imposters":[]}` wipes everything. Classified `imposter.delete`, not `imposter.write`.
- **The 403 used a hand-rolled envelope.** Now uses the shared builder (`code:"403"`, `type:"insufficient access"` per #797) — this matters because all four SDKs and rift-conformance parse it.
- **`AuthzRequest` derived `Debug`**, which would print the raw admin token into an embedder's log. Hand-written with redaction now, matching `intercept_control`'s CA key handling, with a test pinning it.

### Design notes

`action` is a stable string, not an enum, so an embedder can extend its vocabulary without an upstream release. The mapping is mechanical (resource + verb class) with one exception: `POST /imposters/:port/verify` mutates nothing, so it gets `imposter.verify` rather than being called a write on the strength of its method.

`scope` arrives via an `x-rift-scope` header, because `POST /imposters` has no port to key on. It is **caller-asserted** — the docs say so explicitly, since an embedder trusting it as identity would be authorizing the caller's own claim about themselves.

### Verification

1986 tests pass. Clippy clean at `-D warnings`; `cargo fmt --all --check` clean. Beyond the suite, the security-relevant behaviour was mutation-tested — re-introducing each of the four regressions above (plus the ordering guarantee, the gateway exemption and the verify carve-out) fails a test in every case.

### Not in this PR

- `AuthzDecision::Allow { principal }` is bound but unused — it is the attribution handoff consumed by #855. Bound explicitly rather than via `_`, so the compiler points at the line when #855 lands.
- **FFI embedders cannot install an authorizer.** `rift-ffi` builds `AdminApiServer` directly with no seam, so rift-java/go/node get nothing from this. Expected for a Rust-trait hook, but it means the C-ABI SDKs still need the reverse-proxy workaround this issue set out to remove — worth a follow-up.

Closes #854
