### PR TITLE
fix(flow-state): server-level flowState.ttlSeconds < 1 is not rejected, unlike the per-imposter path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Server-level `flowState.ttlSeconds` below 1 is now rejected** (issue #860). The per-imposter
+  path has refused a non-positive TTL at construction since #530, but the server-level
+  `flowState` block had no such check: `ttlSeconds: 0` was accepted and then misbehaved late and
+  backend-dependently — the in-memory store expired every write instantly, Redis failed on the
+  first `SETEX`. A static config error surfaced as a runtime mystery, which is the exact failure
+  #530 set out to remove.
+
+  Both paths now share one guard, so they cannot drift on the rule or the message. The error
+  surface stays deliberately different: the per-imposter path answers `400`, while the
+  server-level path fails startup, which is correct for an embedder configuring the server rather
+  than a client creating an imposter. **If you were setting `ttlSeconds: 0` at server level**, it
+  was never doing what it looked like — set a real TTL, or omit the key for the default.
+
 ### Added
 
 - **`AdminAuthorizer` — pluggable per-request admin-API authorization** (issue #854). The

--- a/crates/rift-mock-core/src/extensions/flow_state.rs
+++ b/crates/rift-mock-core/src/extensions/flow_state.rs
@@ -293,10 +293,31 @@ impl FlowStore for NoOpFlowStore {
 /// backend living outside this crate — `"redis"`, from `rift-store-redis` — is selectable without
 /// `rift-mock-core` depending on it. An unregistered name is an error listing what is available,
 /// never a silent downgrade to [`NoOpFlowStore`] (issues #325/#377).
+/// Reject a non-positive flow-state TTL at construction (issue #530, extended to the server-level
+/// path by #860).
+///
+/// A non-positive TTL fails late and differently per backend — in-memory expires every write
+/// immediately, Redis errors on the first `SETEX` — so a static config error would otherwise
+/// surface as a runtime mystery. Shared by both the per-imposter and server-level factories so the
+/// two paths cannot drift on the rule or the wording.
+pub(crate) fn validate_ttl_seconds(ttl_seconds: i64) -> Result<()> {
+    if ttl_seconds < 1 {
+        anyhow::bail!(
+            "flowState.ttlSeconds must be >= 1 (got {ttl_seconds}); a non-positive TTL would \
+             expire every write immediately"
+        );
+    }
+    Ok(())
+}
+
 pub fn create_flow_store(
     config: &crate::config::FlowStateConfig,
     backends: &FlowStoreBackends,
 ) -> Result<Arc<dyn FlowStore>> {
+    // Before the backend match, not after: the per-imposter path validates the TTL ahead of its
+    // own dispatch, so `{backend: "nope", ttlSeconds: 0}` must report the TTL error on both paths
+    // rather than whichever error the dispatch happens to reach first.
+    validate_ttl_seconds(config.ttl_seconds)?;
     match config.backend.as_str() {
         "inmemory" => {
             use crate::backends::InMemoryFlowStore;
@@ -467,6 +488,73 @@ mod tests {
         };
         let store = create_flow_store(&config, &FlowStoreBackends::new());
         assert!(store.is_ok());
+    }
+
+    /// Issue #860: the server-level path had no TTL guard, so `ttlSeconds: 0` was accepted and
+    /// then misbehaved late and backend-dependently — the exact failure #530 removed from the
+    /// per-imposter path.
+    #[test]
+    fn server_level_rejects_a_non_positive_ttl() {
+        use crate::config::FlowStateConfig;
+        for ttl in [0, -1, -3600] {
+            let config = FlowStateConfig {
+                backend: "inmemory".to_string(),
+                ttl_seconds: ttl,
+                redis: None,
+            };
+            let err = build_error(
+                create_flow_store(&config, &FlowStoreBackends::new()),
+                &format!("ttlSeconds {ttl} must be rejected, not accepted and expired instantly"),
+            );
+            assert!(
+                err.contains("flowState.ttlSeconds must be >= 1"),
+                "ttl={ttl} gave: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn ttl_one_is_the_boundary_and_is_accepted() {
+        use crate::config::FlowStateConfig;
+        let config = FlowStateConfig {
+            backend: "inmemory".to_string(),
+            ttl_seconds: 1,
+            redis: None,
+        };
+        assert!(create_flow_store(&config, &FlowStoreBackends::new()).is_ok());
+    }
+
+    /// The guard runs *before* the backend match, matching the per-imposter path's ordering. If it
+    /// ran after, `{backend: "nope", ttlSeconds: 0}` would report an unknown-backend error on one
+    /// path and a TTL error on the other for the same config.
+    #[test]
+    fn a_bad_ttl_is_reported_before_an_unknown_backend() {
+        use crate::config::FlowStateConfig;
+        let config = FlowStateConfig {
+            backend: "definitely-not-a-backend".to_string(),
+            ttl_seconds: 0,
+            redis: None,
+        };
+        let err = build_error(
+            create_flow_store(&config, &FlowStoreBackends::new()),
+            "a config wrong in two ways must still fail",
+        );
+        assert!(
+            err.contains("flowState.ttlSeconds must be >= 1"),
+            "TTL must be reported first, got: {err}"
+        );
+    }
+
+    /// Both entry points share one guard, so they cannot drift on the rule or the wording.
+    #[test]
+    fn both_paths_report_the_same_ttl_error() {
+        assert!(
+            validate_ttl_seconds(0)
+                .unwrap_err()
+                .to_string()
+                .contains("flowState.ttlSeconds must be >= 1")
+        );
+        assert!(validate_ttl_seconds(1).is_ok());
     }
 
     /// `Arc<dyn FlowStore>` is not `Debug`, so `expect_err` is unavailable — unwrap the error

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -373,12 +373,7 @@ impl Imposter {
             // and inconsistently (in-memory → instant expiry of every write; Redis → SETEX error on
             // the first write), so reject it at construction. This surfaces as a 400 via
             // ImposterError::FlowStoreConfig, matching the unrecognized-backend rule (#377).
-            if flow_state_config.ttl_seconds < 1 {
-                anyhow::bail!(
-                    "flowState.ttlSeconds must be >= 1 (got {}); a non-positive TTL would expire every write immediately",
-                    flow_state_config.ttl_seconds
-                );
-            }
+            crate::extensions::flow_state::validate_ttl_seconds(flow_state_config.ttl_seconds)?;
             return match flow_state_config.backend.as_str() {
                 "inmemory" => {
                     info!(

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -585,4 +585,7 @@ only) and raw throughput (Rhai, compiled and cached).
 3. **Keep scripts simple** - Complex logic is harder to debug and maintain
 4. **Choose `flowIdSource` wisely** - it determines what `ctx.state` isolates by (request header,
    imposter port); pick a source that keys state per request/user/session to avoid collisions
-5. **Set appropriate TTLs** - Prevent unbounded state growth with `ttlSeconds` config
+5. **Set appropriate TTLs** - Prevent unbounded state growth with `ttlSeconds` config. It must be
+   **>= 1**; a non-positive value is rejected at construction rather than accepted, because it would
+   expire every write immediately (in-memory) or fail on the first write (Redis). This applies to
+   both the per-imposter `_rift.flowState` block and the server-level `flowState` config


### PR DESCRIPTION
The per-imposter path has rejected a non-positive flow-state TTL at construction since #530. The server-level path had no such check — `create_flow_store` went straight to the backend match — so `ttlSeconds: 0` was accepted and then misbehaved **late and backend-dependently**: in-memory expired every write instantly, Redis failed on the first `SETEX`. A static config error surfaced as a runtime mystery, which is exactly what #530 removed from the other entry point.

Both paths now call one shared `validate_ttl_seconds`, so the rule and the wording cannot drift.

### Ordering is asserted, not incidental

The guard runs **before** the backend match, matching the per-imposter path. A config wrong in two ways — `{backend: "nope", ttlSeconds: 0}` — must report the same error on both paths rather than whichever the dispatch happens to reach first. A test pins this.

### What is deliberately left alone

The two error surfaces stay different: the per-imposter path answers `400` via `ImposterError::FlowStoreConfig`; the server-level path fails startup out of `ProxyServer::new`. That is correct — one is a client creating an imposter, the other an embedder configuring a server. No new error variant, no mapping change.

### Reachability

Low severity but a live defect, not a theoretical one: no shipped CLI path reaches the server-level factory, but `ProxyServer` is re-exported and so is `create_flow_store`, so an embedder hits it.

### Verification

Full `rift-mock-core` suite green; `clippy --workspace --all-targets -D warnings` and `fmt --all --check` clean. Mutation-checked: removing the guard fails both the rejection test and the ordering test.

**Docs:** `docs/features/scripting.md` now states the `>= 1` rule and that it applies to both config surfaces. CHANGELOG entry under *Fixed* notes that `ttlSeconds: 0` at server level was never doing what it looked like.

<sub>Note: the issue's triage said `FlowStoreBackendFactory` did not exist yet and to write against master's older shape — that is now stale, #853 merged in the meantime. The guard sits above the backend dispatch either way.</sub>

Closes #860