### PR TITLE
feat(admin-api): warn on a keyless off-host admin plane, with opt-in --require-admin-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ record.
 
 ### Added
 
+- **`--require-admin-auth` — opt in to refusing a keyless off-host admin plane** (issue #863).
+  `--host` defaults to `0.0.0.0`, so a bare keyless `rift` already serves the full admin API — which
+  can create imposters and drive the TLS intercept proxy — on every interface with no
+  authentication. Rift now says so at startup (see *Changed*), and `--require-admin-auth`
+  (`RIFT_REQUIRE_ADMIN_AUTH`, rcfile `requireAdminAuth`) turns that warning into a startup failure
+  for fleets that want fail-closed.
+
+  The flag gates on *authentication*, not on the address: a real `--api-key` satisfies it on any
+  bind, and loopback (`127.0.0.0/8`, `::1`) satisfies it with no key. `0.0.0.0` and `::` are
+  unspecified addresses — not loopback — so they are flagged, as is any specific off-host interface.
+  The check runs before anything binds, so a refusal never orphans a listener.
+
+  The same rule applies at all three doors onto the admin plane, so an embedded host inherits it
+  rather than reimplementing it: the C-ABI takes `"requireAdminAuth": true` in `rift_serve_admin`'s
+  options (an optional field — omitting it is the previous behaviour exactly, so existing SDKs are
+  unaffected), and `AdminApiServer::with_require_admin_auth(true)` is the in-process spelling.
+
 - **`AdminAuthorizer` — pluggable per-request admin-API authorization** (issue #854). The
   `--api-key` gate grants *access*, not an identity, so an embedder with its own identity system
   had to reverse-proxy the admin API and re-parse routes to decide anything.
@@ -63,6 +80,26 @@ record.
   compared byte for byte, untrimmed.
 
 ### Changed
+
+- **`--local-only` now restricts the metrics listener too** (issue #880). The metrics server
+  hardcoded `0.0.0.0`, so a flag documented as "only accept connections from localhost" narrowed the
+  admin plane while leaving `/metrics` reachable on every interface. It now binds `127.0.0.1` under
+  `--local-only`. **If you scrape `/metrics` from another host while passing `--local-only`**, that
+  scrape now fails — drop the flag, or bind the admin plane with `--host 127.0.0.1` instead, which
+  leaves metrics where it was. `--host` on its own still does not move the metrics listener.
+
+- **Startup now states the admin API's authentication posture either way** (issue #863). The
+  `Admin API authentication enabled (--apikey)` line only ever fired when a key *was* set, so the
+  riskier configuration was the silent one. An unauthenticated admin plane now logs that it is
+  unauthenticated, and one bound to a non-loopback address with no key additionally logs a warning
+  naming the address and every remedy (`--api-key`, `--local-only`, `--host 127.0.0.1`, and
+  `--require-admin-auth` to make it fatal).
+
+  This is a **warning, not a refusal**: `--host 0.0.0.0` is the documented default and containers
+  require it — binding loopback inside Docker makes the published port unreachable — so refusing
+  would break the no-argument invocation, every keyless quickstart and every CI sandbox. Nothing
+  that started before starts differently now; opt in with `--require-admin-auth` if you want the
+  hard failure. Log-scraping CI that asserts on exact startup output may need updating.
 
 - **The Redis flow store moved to its own opt-in crate, `rift-store-redis`** (issue #853).
   `rift-mock-core` now carries **no `redis`/`r2d2` dependency under any feature combination**, so

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -245,6 +245,10 @@ struct ServeOptions {
     /// `rift_create_imposter` — is ungated by design: that host can already execute code in this
     /// process, so gating its own JSON would restrict nobody.
     allow_injection: Option<bool>,
+    /// Refuse to bind when the admin plane would be reachable off-host with no `apiKey`
+    /// (issue #863), instead of warning. Optional and defaulting to `false`, so every existing SDK
+    /// that omits it keeps the previous behaviour unchanged.
+    require_admin_auth: Option<bool>,
 }
 
 /// Parse `{"imposters":[...]}` or a bare `[...]` into imposter configs (the reload input shape).
@@ -1870,6 +1874,16 @@ async fn build_admin_plane_inner(
         None => None,
     };
 
+    // Issue #863: judge the resolved admin address before any side effect, for the same reason the
+    // blank-key check above is here — this is the one boundary every SDK reaches the admin plane
+    // through, so the policy belongs here rather than copied into each of them. `host` defaults to
+    // loopback for this door, so an embedder has to ask for an off-host bind to reach the warning.
+    rift_http_proxy::admin_api::check_admin_exposure(
+        addr,
+        opts.api_key.as_deref(),
+        opts.require_admin_auth.unwrap_or(false).into(),
+    )?;
+
     // configFile: apply the loaded set via apply_config, mirroring the inline `config` path and
     // POST /admin/reload. apply_config validates the whole set up front (Err => nothing mutated)
     // and reports per-port failures in its report rather than a half-applied create loop that
@@ -1933,9 +1947,12 @@ async fn build_admin_plane_inner(
     // serves the full `/intercept*` surface against the same listener the C-ABI drives: a
     // `rift_start_intercept` is then visible to `GET /intercept`, and `POST /intercept` feeds
     // `rift_intercept_add_rules` — a double-start across surfaces 409s/-1s consistently.
+    // `with_exposure_checked`: the issue #863 check already ran above, before any side effect.
+    // Without this the same call would log the warning twice.
     let mut server = AdminApiServer::new(addr, Arc::clone(&handle.manager), api_key)
         .with_allow_injection(allow_injection)
-        .with_intercept(handle.intercept.clone());
+        .with_intercept(handle.intercept.clone())
+        .with_exposure_checked();
     if let Some(source) = config_source {
         server = server.with_config_source(source);
     }
@@ -2144,6 +2161,7 @@ mod build_admin_plane_chain_tests {
             config_file: Some("/nonexistent/rift-688/does-not-exist.json".to_string()),
             config: None,
             allow_injection: None,
+            require_admin_auth: None,
         };
         let Err(err) = handle.runtime.block_on(build_admin_plane(&handle, &opts)) else {
             panic!("a missing configFile must fail the admin build");

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -2507,3 +2507,65 @@ fn ffi_start_registers_the_shipped_flow_store_backends() {
         rift_stop(h);
     }
 }
+
+// ── issue #863: the keyless off-host admin plane, at the C-ABI door ──────────────────────────
+//
+// This is the boundary every SDK reaches the admin plane through, so the policy has to live here
+// rather than in each SDK. Unlike the CLI, `host` defaults to `127.0.0.1` here — an embedder has
+// to ask for an off-host bind, and only then does the check have anything to say.
+
+// AC11: `requireAdminAuth: true` + a non-loopback host + no key fails, with the reason in
+// last_error rather than a bare NULL the SDK would have to guess at.
+#[test]
+fn ffi_require_admin_auth_refuses_a_keyless_off_host_bind() {
+    unsafe {
+        let h = rift_start();
+        let opts = cstr(r#"{"host": "0.0.0.0", "port": 0, "requireAdminAuth": true}"#);
+        assert!(
+            rift_serve_admin(h, opts.as_ptr()).is_null(),
+            "requireAdminAuth must refuse a keyless off-host admin bind"
+        );
+
+        let err = rift_last_error();
+        assert!(!err.is_null(), "the refusal must record last_error");
+        let msg = take_json(err);
+        assert!(
+            msg.contains("--api-key"),
+            "the refusal must name the remedy, got: {msg}"
+        );
+
+        rift_stop(h);
+    }
+}
+
+// AC11: a real key satisfies the gate on any address — it gates on authentication, not on the
+// address. Without this an SDK setting requireAdminAuth could never bind off-host at all.
+#[test]
+fn ffi_require_admin_auth_accepts_an_off_host_bind_with_a_key() {
+    unsafe {
+        let h = rift_start();
+        let info = serve_admin(
+            h,
+            r#"{"host": "0.0.0.0", "port": 0, "apiKey": "s3cr3t", "requireAdminAuth": true}"#,
+        );
+        assert!(info["adminPort"].as_u64().expect("adminPort") > 0);
+        rift_stop(h);
+    }
+}
+
+// AC11: the version-gate regression guard. `requireAdminAuth` is an *optional* addition to
+// ServeOptions — every existing SDK omits it and must keep working unchanged. A regression here
+// (a required field, or a default of `true`) breaks all four SDKs at once, silently for the ones
+// that never bind off-host and loudly for the ones that do.
+#[test]
+fn ffi_omitting_require_admin_auth_is_accepted_and_defaults_off() {
+    unsafe {
+        let h = rift_start();
+        let info = serve_admin(h, r#"{"host": "0.0.0.0", "port": 0}"#);
+        assert!(
+            info["adminPort"].as_u64().expect("adminPort") > 0,
+            "omitting requireAdminAuth must keep the previous keyless behaviour"
+        );
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -16,7 +16,10 @@ mod server;
 pub mod types;
 
 pub use handlers::imposters::{filter_proxy_responses, filter_proxy_stubs};
-pub use server::{AdminApiServer, RunningAdminApi, validate_admin_api_key};
+pub use server::{
+    AdminApiServer, AdminExposurePolicy, RunningAdminApi, check_admin_exposure,
+    validate_admin_api_key,
+};
 
 /// Default port for the Mountebank-compatible admin API.
 pub const DEFAULT_ADMIN_PORT: u16 = 2525;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -27,7 +27,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Bounded grace given to in-flight connections on `shutdown()` before the wait is abandoned.
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
@@ -47,6 +47,9 @@ pub struct AdminApiServer {
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
     authorizer: Option<Arc<dyn AdminAuthorizer>>,
+    /// Exposure policy for [`bind`](Self::bind) (issue #863), or `None` when an outer door already
+    /// ran the check — see [`with_exposure_checked`](Self::with_exposure_checked).
+    exposure: Option<AdminExposurePolicy>,
 }
 
 impl AdminApiServer {
@@ -61,7 +64,34 @@ impl AdminApiServer {
             intercept: None,
             scripts_dir: None,
             authorizer: None,
+            exposure: Some(AdminExposurePolicy::default()),
         }
+    }
+
+    /// Refuse to bind when this server would be reachable off-host with no API key, instead of
+    /// warning (issue #863). The embedder-facing spelling of `--require-admin-auth`; `false` (the
+    /// default) keeps the warning.
+    #[must_use]
+    pub fn with_require_admin_auth(mut self, require: bool) -> Self {
+        self.exposure = Some(require.into());
+        self
+    }
+
+    /// Suppress this server's own exposure check because an outer door already ran it (issue #863).
+    ///
+    /// The CLI and the C-ABI both have to run [`check_admin_exposure`] *before* they bind anything
+    /// else — under `Refuse` the error must not have to unwind an already-bound metrics listener —
+    /// so without this the same startup would emit the warning twice. Not for embedders building an
+    /// `AdminApiServer` directly: for them `bind()` is the only door, and it must do the checking.
+    ///
+    /// Hidden from the rendered docs deliberately — it is a "skip the check" switch, public only
+    /// because `rift-ffi` is a separate crate and needs to reach it. Order-sensitive: calling it
+    /// after [`with_require_admin_auth`](Self::with_require_admin_auth) discards that strictness.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_exposure_checked(mut self) -> Self {
+        self.exposure = None;
+        self
     }
 
     /// Install a per-request authorization hook (issue #854).
@@ -129,6 +159,17 @@ impl AdminApiServer {
         // authentication is enabled. Checking at the one point all three doors converge on makes
         // the diagnosis loud wherever the key came from (issue #844).
         validate_admin_api_key(self.api_key.as_deref().map(String::as_str))?;
+        // Issue #863: same convergence point, one step further — an off-host bind with no key at
+        // all. Runs before `TcpListener::bind` so a `Refuse` policy never has to unwind a live
+        // listener. Skipped when an outer door (CLI, C-ABI) already checked, so a single startup
+        // warns once.
+        if let Some(policy) = self.exposure {
+            check_admin_exposure(
+                self.addr,
+                self.api_key.as_deref().map(String::as_str),
+                policy,
+            )?;
+        }
         let listener = TcpListener::bind(self.addr).await?;
         let local_addr = listener.local_addr()?;
         info!(
@@ -136,8 +177,12 @@ impl AdminApiServer {
             local_addr
         );
 
+        // Stated either way (issue #863): logging only the authenticated case made the riskier
+        // posture the silent one, so the startup output never said the admin plane was open.
         if self.api_key.is_some() {
             info!("Admin API authentication enabled (--apikey)");
+        } else {
+            info!("Admin API authentication disabled — no --api-key is set");
         }
 
         let cancel = CancellationToken::new();
@@ -696,6 +741,79 @@ pub fn validate_admin_api_key(api_key: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// What to do when the admin plane would be reachable off-host with no API key (issue #863).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdminExposurePolicy {
+    /// Log a warning and continue. The default, and deliberately so: `--host` defaults to
+    /// `0.0.0.0` and containers need it (binding loopback inside Docker makes the published port
+    /// unreachable), so refusing here would break the no-argument invocation, every quickstart and
+    /// every CI sandbox. A refusal everyone opts out of immediately is worse than a warning read
+    /// once — the opt-out ends up permanent in the base image.
+    #[default]
+    Warn,
+    /// Refuse to start (`--require-admin-auth` / `RIFT_REQUIRE_ADMIN_AUTH`). Opting *in* to
+    /// strictness rather than out of a refusal keeps the default compatible and needs no escape
+    /// hatch of its own.
+    Refuse,
+}
+
+impl From<bool> for AdminExposurePolicy {
+    /// `true` is the `--require-admin-auth` / `requireAdminAuth` spelling of [`Refuse`]. One
+    /// mapping, so the CLI, the C-ABI and the embedder builder cannot drift on what the flag means.
+    ///
+    /// [`Refuse`]: AdminExposurePolicy::Refuse
+    fn from(require_admin_auth: bool) -> Self {
+        if require_admin_auth {
+            Self::Refuse
+        } else {
+            Self::Warn
+        }
+    }
+}
+
+/// Warn or refuse when the admin plane would bind a non-loopback address with no API key
+/// (issue #863).
+///
+/// `addr` is the *resolved* bind address, so `0.0.0.0`, `::` and any specific interface are all
+/// covered by one `is_loopback()` test — an unspecified address is not loopback, which is exactly
+/// the case this catches. Rift parses `--host` as a literal `SocketAddr` and never resolves DNS, so
+/// there is no name left to resolve by the time the address gets here.
+///
+/// Callers must invoke this before binding anything: under [`AdminExposurePolicy::Refuse`] the
+/// error must not have to unwind a listener that is already up.
+///
+/// `api_key` being `Some(_)` is taken to mean a usable key, which holds because
+/// [`validate_admin_api_key`] rejects a blank one upstream (issue #844) — reversing that order
+/// would let `Some("")` satisfy the very gate it defeats.
+pub fn check_admin_exposure(
+    addr: SocketAddr,
+    api_key: Option<&str>,
+    policy: AdminExposurePolicy,
+) -> anyhow::Result<()> {
+    // `to_canonical` first: `Ipv6Addr::is_loopback` matches only the literal `::1`, so an
+    // IPv4-mapped `::ffff:127.0.0.1` — which some address-normalising front ends hand over — would
+    // otherwise be judged off-host and refused under `Refuse` despite being loopback-only. The
+    // mapping is safe in the other direction too: `::ffff:10.0.0.5` canonicalises to `10.0.0.5`,
+    // which is still not loopback, so nothing genuinely reachable becomes exempt.
+    if api_key.is_some() || addr.ip().to_canonical().is_loopback() {
+        return Ok(());
+    }
+    let message = format!(
+        "the admin API is bound to {addr}, which is reachable from outside this host, with no API \
+         key — anyone who can reach that address can create imposters and drive the TLS intercept \
+         proxy. Set `--api-key <token>` (`MB_APIKEY`), or restrict the bind with `--local-only` or \
+         `--host 127.0.0.1`. Set `--require-admin-auth` (`RIFT_REQUIRE_ADMIN_AUTH`) to make this a \
+         startup failure instead of a warning."
+    );
+    match policy {
+        AdminExposurePolicy::Warn => {
+            warn!("{message}");
+            Ok(())
+        }
+        AdminExposurePolicy::Refuse => anyhow::bail!(message),
+    }
+}
+
 /// Box a `Full<Bytes>` response into the streaming-unified `AdminBody` (issue #461), so the normal
 /// router path and the SSE stream path share one response type. `Full`'s error is `Infallible`, so
 /// the `map_err` closure is unreachable.
@@ -868,6 +986,163 @@ mod tests {
             !api_key_matches("padded", " padded "),
             "the comparison must not trim; a trimmed guess is a different key"
         );
+    }
+
+    // ── issue #863: the keyless off-host admin plane ─────────────────────────────────────────
+    //
+    // The classifier is one `is_loopback()` test because the bind address reaching it is already
+    // resolved and parsed as a literal `SocketAddr` — Rift never resolves DNS for `--host`, so
+    // there is no name to look up here and no case where the "address" is still a hostname.
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().expect("test address parses")
+    }
+
+    /// Every address the check must treat as off-host. `0.0.0.0` and `::` are *unspecified*, not
+    /// loopback: binding them reaches every interface, which is exactly the case being caught.
+    const OFF_HOST: [&str; 4] = [
+        "0.0.0.0:2525",
+        "[::]:2525",
+        "10.0.0.5:2525",
+        // Canonicalising must not exempt a genuinely reachable address: this maps to `10.0.0.5`,
+        // which is still not loopback.
+        "[::ffff:10.0.0.5]:2525",
+    ];
+    /// Loopback in both families. `::1` is the one an IPv4-only `is_loopback` would misclassify;
+    /// `::ffff:127.0.0.1` is the one `Ipv6Addr::is_loopback` alone misclassifies, since it matches
+    /// only the literal `::1` — hence the `to_canonical()` in the classifier.
+    const LOOPBACK: [&str; 3] = ["127.0.0.1:2525", "[::1]:2525", "[::ffff:127.0.0.1]:2525"];
+
+    // AC1: `Refuse` errors on exactly the off-host × no-key cells and nowhere else.
+    #[test]
+    fn refuse_rejects_exactly_the_keyless_off_host_binds() {
+        for a in OFF_HOST {
+            assert!(
+                check_admin_exposure(addr(a), None, AdminExposurePolicy::Refuse).is_err(),
+                "{a} with no key must be refused under --require-admin-auth"
+            );
+        }
+        for a in LOOPBACK {
+            assert!(
+                check_admin_exposure(addr(a), None, AdminExposurePolicy::Refuse).is_ok(),
+                "{a} is loopback: unreachable off-host, so no key is needed"
+            );
+        }
+    }
+
+    // AC2: IPv6 loopback is loopback. Called out separately from the loop above because getting
+    // this wrong is silent — `::1` would be refused as if it were world-reachable.
+    #[test]
+    fn ipv6_loopback_is_not_treated_as_exposed() {
+        assert!(
+            check_admin_exposure(addr("[::1]:2525"), None, AdminExposurePolicy::Refuse).is_ok()
+        );
+    }
+
+    // AC3: the flag gates on authentication, not on the address. A real key makes any bind
+    // acceptable — otherwise `--require-admin-auth` would just be a second `--local-only`.
+    #[test]
+    fn a_real_key_satisfies_the_check_on_any_address() {
+        for a in OFF_HOST.iter().chain(LOOPBACK.iter()) {
+            assert!(
+                check_admin_exposure(addr(a), Some("s3cr3t"), AdminExposurePolicy::Refuse).is_ok(),
+                "{a} with a real key is authenticated, so it must be accepted"
+            );
+        }
+    }
+
+    // The default posture is advisory: the same cell that errors under `Refuse` must return `Ok`
+    // under `Warn`. This is the compatibility guarantee for every existing keyless deployment.
+    #[test]
+    fn warn_never_refuses() {
+        for a in OFF_HOST {
+            assert!(
+                check_admin_exposure(addr(a), None, AdminExposurePolicy::Warn).is_ok(),
+                "{a} must only warn by default; refusing is opt-in"
+            );
+        }
+        assert_eq!(
+            AdminExposurePolicy::default(),
+            AdminExposurePolicy::Warn,
+            "the default policy must be Warn, so an embedder that sets nothing is unaffected"
+        );
+    }
+
+    // AC4: an operator must be able to act on the message without reading source, so it names the
+    // address and every remedy — including `--require-admin-auth` itself, for anyone who arrives
+    // via the warning and wants it to be fatal next time.
+    #[test]
+    fn the_refusal_names_the_address_and_every_remedy() {
+        let err = check_admin_exposure(addr("0.0.0.0:2525"), None, AdminExposurePolicy::Refuse)
+            .expect_err("a keyless 0.0.0.0 bind must be refused under Refuse")
+            .to_string();
+        for expected in [
+            "0.0.0.0:2525",
+            "--api-key",
+            "--local-only",
+            "--host 127.0.0.1",
+            "--require-admin-auth",
+        ] {
+            assert!(
+                err.contains(expected),
+                "the refusal must mention `{expected}`, got: {err}"
+            );
+        }
+    }
+
+    // Interaction with #844: a blank key is rejected by `validate_admin_api_key` upstream, so it
+    // can never reach this check. Were the order ever reversed, `Some("")` would read as "a key is
+    // set" here and silently satisfy the very gate it defeats — pin the ordering assumption.
+    #[test]
+    fn a_blank_key_is_already_rejected_before_this_check_runs() {
+        assert!(
+            validate_admin_api_key(Some("")).is_err(),
+            "the blank-key validator must run first; this check trusts that Some(_) is a real key"
+        );
+    }
+
+    // AC12 — the third door. The CLI and the C-ABI both run the check themselves and then call
+    // `with_exposure_checked()`, so `bind()`'s own check is reached ONLY by an embedder building an
+    // `AdminApiServer` directly. Without these two tests `with_require_admin_auth` and the check
+    // inside `bind()` are public API that no test exercises: both could be deleted and everything
+    // would still pass.
+
+    #[tokio::test]
+    async fn with_require_admin_auth_refuses_at_the_embedder_door_before_binding() {
+        // `expect_err` is unavailable here — `RunningAdminApi` is not `Debug` — and matching also
+        // lets the success arm shut the listener down rather than leaking it into the test run.
+        let err =
+            match AdminApiServer::new(addr("0.0.0.0:0"), Arc::new(ImposterManager::new()), None)
+                .with_require_admin_auth(true)
+                .bind()
+                .await
+            {
+                Ok(running) => {
+                    running.shutdown().await;
+                    panic!(
+                        "an embedder opting into strict mode must not get a keyless off-host bind"
+                    );
+                }
+                Err(err) => err,
+            };
+        // Port 0 would bind successfully if the check never ran, so an exposure message here — as
+        // opposed to an I/O error — is what proves `bind()` refused rather than failed to listen.
+        assert!(
+            err.to_string().contains("--api-key"),
+            "the embedder must get the exposure refusal, not an I/O error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_embedder_door_defaults_to_warning_and_still_binds() {
+        let running =
+            AdminApiServer::new(addr("0.0.0.0:0"), Arc::new(ImposterManager::new()), None)
+                .bind()
+                .await
+                .expect(
+                    "the default policy warns; it must never refuse an embedder's keyless bind",
+                );
+        running.shutdown().await;
     }
 }
 

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -56,6 +56,24 @@ pub fn apply_rcfile_defaults(cli: &mut Cli, rcfile: &Path) -> Result<(), anyhow:
                     cli.local_only = val.as_bool().unwrap_or(false);
                 }
             }
+            "requireAdminAuth" | "require_admin_auth" => {
+                if !cli.require_admin_auth {
+                    // Deliberately stricter than the sibling booleans above: this one is a security
+                    // gate, and `false` is its *permissive* state. `"requireAdminAuth": "true"` (a
+                    // plausible hand-edit) would coerce to `false` under `unwrap_or`, so a fleet
+                    // that believed it had opted every host into fail-closed startup would keep
+                    // booting keyless and off-host with nothing said — the exact posture this key
+                    // exists to make impossible. `allowInjection` can default to `false` safely
+                    // because there `false` is the deny state; here it is not.
+                    let Some(b) = val.as_bool() else {
+                        anyhow::bail!(
+                            "--rcfile: '{key}' must be a JSON boolean, got {val}. Refusing rather \
+                             than silently leaving --require-admin-auth off."
+                        );
+                    };
+                    cli.require_admin_auth = b;
+                }
+            }
             "datadir" => {
                 if cli.datadir.is_none()
                     && let Some(d) = val.as_str()

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -89,6 +89,12 @@ pub struct Cli {
     #[arg(long, env = "MB_LOCAL_ONLY")]
     pub local_only: bool,
 
+    /// Refuse to start when the admin API would bind a non-loopback address with no `--api-key`
+    /// (issue #863). Off by default: `--host` defaults to `0.0.0.0` and containers need it, so the
+    /// default is a startup warning instead.
+    #[arg(long, env = "RIFT_REQUIRE_ADMIN_AUTH")]
+    pub require_admin_auth: bool,
+
     /// Log level (debug, info, warn, error)
     #[arg(long, default_value = "info", env = "MB_LOGLEVEL")]
     pub loglevel: String,
@@ -408,6 +414,22 @@ impl ServerBuilder {
         // authenticates every request, so the admin plane must never reach the accept loop in that
         // state.
         crate::admin_api::validate_admin_api_key(cli.api_key.as_deref())?;
+        // Resolve the admin bind address here rather than at the `AdminApiServer::new` call below,
+        // because both things that read it must happen before anything binds (issue #863):
+        //   * the exposure check — under `--require-admin-auth` its error must not have to unwind
+        //     the metrics listener, which binds further down;
+        //   * the `SocketAddr` parse itself — a malformed `--host` used to fail *after* the metrics
+        //     server was already up.
+        // Owned rather than borrowed: `admin_bind_host` takes the whole `Cli`, and holding that
+        // borrow across the rest of `start()` would block moving `cli.scripts_dir` / `cli.datadir`
+        // out below.
+        let host = admin_bind_host(&cli).to_string();
+        let admin_addr: SocketAddr = format!("{}:{}", host, cli.port).parse::<SocketAddr>()?;
+        crate::admin_api::check_admin_exposure(
+            admin_addr,
+            cli.api_key.as_deref(),
+            cli.require_admin_auth.into(),
+        )?;
         // Validate `--front-door` before anything else binds (issue #19 / U-11): a malformed
         // address is then a clean, fast failure that never has to unwind an already-bound
         // listener behind it.
@@ -469,7 +491,18 @@ impl ServerBuilder {
         // Bind the metrics server now so a `:0` request can report its port. A bind failure
         // stays non-fatal and only logs — matching the binary, which spawned the metrics
         // server and kept the admin plane up regardless.
-        let metrics_addr = SocketAddr::from(([0, 0, 0, 0], cli.metrics_port));
+        //
+        // `--local-only` reaches this listener too (issue #880). It used to hardcode `0.0.0.0`, so
+        // a flag documented as "only accept connections from localhost" restricted the admin plane
+        // while leaving `/metrics` on every interface — the same class of surprise as #863, one
+        // listener over. `--host` deliberately still does NOT move metrics: that would relocate it
+        // for anyone who binds the admin plane to a specific interface, which is a separate call.
+        let metrics_ip = if cli.local_only {
+            [127, 0, 0, 1]
+        } else {
+            [0, 0, 0, 0]
+        };
+        let metrics_addr = SocketAddr::from((metrics_ip, cli.metrics_port));
         let metrics = match bind_metrics_server(metrics_addr).await {
             Ok(running) => Some(running),
             Err(e) => {
@@ -504,16 +537,9 @@ impl ServerBuilder {
             None => None,
         };
 
-        let host = if cli.local_only {
-            "127.0.0.1"
-        } else {
-            &cli.host
-        };
-        let addr: SocketAddr = format!("{}:{}", host, cli.port).parse()?;
-
         info!(
             "Rift Admin API (Mountebank-compatible) starting on http://{}",
-            addr
+            admin_addr
         );
         info!(
             "Metrics available at http://{}:{}/metrics",
@@ -533,8 +559,11 @@ impl ServerBuilder {
 
         // Retain the config source so POST /admin/reload can re-read it (issue #197).
         // Injection gating is threaded explicitly (issue #342) rather than read from env.
-        let mut server = AdminApiServer::new(addr, manager, cli.api_key)
-            .with_allow_injection(cli.allow_injection);
+        // `with_exposure_checked`: the issue #863 check already ran above, before the metrics
+        // bind. Without this the same startup would log the warning twice.
+        let mut server = AdminApiServer::new(admin_addr, manager, cli.api_key)
+            .with_allow_injection(cli.allow_injection)
+            .with_exposure_checked();
         if let Some(authorizer) = admin_authorizer {
             server = server.with_admin_authorizer(authorizer);
         }
@@ -563,7 +592,7 @@ impl ServerBuilder {
         let start_options = intercept_block.or_else(|| {
             cli.intercept_port
                 .map(|intercept_port| InterceptStartOptions {
-                    host: Some(host.to_string()),
+                    host: Some(host.clone()),
                     port: Some(intercept_port),
                     ca_cert_path: cli
                         .intercept_ca_cert
@@ -737,6 +766,17 @@ impl RunningServer {
 /// [`bind_metrics_server`] + [`RunningMetrics::join`] so the binary path is unchanged.
 pub async fn run_metrics_server(addr: SocketAddr) -> anyhow::Result<()> {
     bind_metrics_server(addr).await?.join().await
+}
+
+/// The host the admin API binds: `--local-only` pins loopback, otherwise `--host` (default
+/// `0.0.0.0`). One definition so the issue #863 exposure check and the actual bind can never
+/// disagree about which address is being judged.
+fn admin_bind_host(cli: &Cli) -> &str {
+    if cli.local_only {
+        "127.0.0.1"
+    } else {
+        &cli.host
+    }
 }
 
 /// Bind the metrics listener (`:0` is fine) and start serving, returning a handle that reports

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -30,7 +30,7 @@ fn rcfile_fills_fields_left_at_defaults() {
     let rcfile = write_rcfile(
         &dir,
         r#"{"port": 4321, "host": "127.0.0.1", "logLevel": "debug",
-            "allowInjection": true, "localOnly": true,
+            "allowInjection": true, "localOnly": true, "requireAdminAuth": true,
             "datadir": "/tmp/rc-datadir", "configfile": "/tmp/rc-config.json"}"#,
     );
 
@@ -42,6 +42,10 @@ fn rcfile_fills_fields_left_at_defaults() {
     assert_eq!(parsed.loglevel, "debug");
     assert!(parsed.allow_injection);
     assert!(parsed.local_only);
+    // Issue #863: the strict admin-auth gate is settable from a config file too. A fleet sets it
+    // once in a shipped rcfile rather than editing every invocation — the same reach `localOnly`
+    // above already has.
+    assert!(parsed.require_admin_auth);
     assert_eq!(
         parsed.datadir.as_deref(),
         Some(std::path::Path::new("/tmp/rc-datadir"))
@@ -82,6 +86,45 @@ fn rcfile_unknown_key_is_ignored_without_dropping_the_rest() {
     let mut parsed = cli(&[]);
     bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile).expect("unknown keys are not fatal");
     assert_eq!(parsed.port, 4321);
+}
+
+// Issue #863: `requireAdminAuth` is deliberately stricter than its sibling booleans. `false` is its
+// *permissive* state, so coercing a mistyped value to `false` would silently leave a fleet that
+// believed it had opted into fail-closed startup running keyless and off-host with nothing said.
+// A wrong-typed value is therefore a hard rcfile error, not a default.
+#[test]
+fn rcfile_non_boolean_require_admin_auth_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for bad in ["\"true\"", "1", "null", "[]"] {
+        let rcfile = write_rcfile(&dir, &format!(r#"{{"requireAdminAuth": {bad}}}"#));
+        let mut parsed = cli(&[]);
+        let err = bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile)
+            .expect_err("a non-boolean requireAdminAuth must be rejected, never coerced to false");
+        assert!(
+            err.to_string().contains("requireAdminAuth"),
+            "the error must name the offending key, got: {err}"
+        );
+        assert!(
+            !parsed.require_admin_auth,
+            "a rejected rcfile must not leave the flag half-applied"
+        );
+    }
+}
+
+// The sibling booleans keep their tolerant behaviour — the stricter rule above is scoped to the one
+// key where the coerced default is the permissive state, not applied across the board.
+#[test]
+fn rcfile_non_boolean_local_only_is_still_tolerated() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rcfile = write_rcfile(&dir, r#"{"localOnly": "yes", "port": 4321}"#);
+    let mut parsed = cli(&[]);
+    bootstrap::apply_rcfile_defaults(&mut parsed, &rcfile)
+        .expect("a mistyped localOnly stays non-fatal");
+    assert!(!parsed.local_only);
+    assert_eq!(
+        parsed.port, 4321,
+        "the recognised keys beside it still apply"
+    );
 }
 
 // AC4: a structurally wrong rcfile is an error, not a silent no-op.

--- a/crates/rift-http-proxy/tests/issue_863_admin_exposure.rs
+++ b/crates/rift-http-proxy/tests/issue_863_admin_exposure.rs
@@ -1,0 +1,207 @@
+//! Issue #863: the admin plane binds `0.0.0.0` by default (`--host`, env `MB_HOST`), so a bare
+//! keyless `rift` already exposes the full control plane — which can create imposters and drive the
+//! TLS intercept proxy — on every interface with no authentication.
+//!
+//! Maintainer decision (option A): **warn by default, refuse only on opt-in**. `--host 0.0.0.0` is
+//! the documented default and containers require it, so a hard refusal would break the no-argument
+//! invocation, every quickstart and every CI sandbox. `--require-admin-auth` /
+//! `RIFT_REQUIRE_ADMIN_AUTH` is the opt-in gate for fleets that want fail-closed.
+//!
+//! These tests pin the CLI door. The unit matrix over the classifier lives beside
+//! `check_admin_exposure` in `admin_api/server.rs`; the C-ABI door is covered in
+//! `rift-ffi/tests/round_trip.rs`.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use std::net::{SocketAddr, TcpListener};
+
+/// Reserve a port, then release it, so the caller can assert whether something later bound it.
+/// Binding `0.0.0.0` deliberately mirrors the metrics listener's own hardcoded bind address.
+///
+/// The gap between releasing the probe and re-binding below is a TOCTOU window: another process
+/// could claim the port meanwhile. Nothing in-process races here (each `tests/*.rs` is its own
+/// binary and this port is not shared), so this is only worth revisiting if it is ever seen to
+/// flake in CI.
+fn free_port() -> u16 {
+    let probe = TcpListener::bind("0.0.0.0:0").expect("probe bind");
+    let port = probe.local_addr().expect("probe addr").port();
+    drop(probe);
+    port
+}
+
+// AC7: under `--require-admin-auth`, a non-loopback bind with no key must fail without leaving
+// anything bound. The metrics listener is the discriminator: it binds early in `start()` and its
+// handle moves the listener into a spawned task with no `Drop` that stops it, so an error raised
+// after it would leave the port held with no way to reclaim it.
+//
+// Precisely: this pins the observable guarantee ("nothing is left bound on refusal"), not source
+// ordering. Moving the check below the metrics bind fails this test — but moving it below *and*
+// adding the explicit `metrics.shutdown().await` unwind that the front-door error path already
+// uses would pass it. That is the intended contract either way; do not cite this test as proof of
+// where the check sits.
+#[tokio::test]
+async fn require_admin_auth_refuses_a_keyless_non_loopback_bind_before_anything_binds() {
+    let metrics_port = free_port();
+    let cli = Cli::parse_from([
+        "rift",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "0",
+        "--metrics-port",
+        &metrics_port.to_string(),
+        "--require-admin-auth",
+    ]);
+
+    let err = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .err()
+        .expect("--require-admin-auth must refuse a keyless non-loopback admin bind");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--api-key"),
+        "the refusal must name the flag an operator would fix, got: {msg}"
+    );
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+    TcpListener::bind(addr).unwrap_or_else(|e| {
+        panic!(
+            "the refusal must happen before the metrics listener binds, but port {metrics_port} \
+             is still held: {e}"
+        )
+    });
+}
+
+// AC8: `--local-only` resolves the admin host to loopback, so strict mode is satisfied without a
+// key — the escape hatch the warning points operators at must actually work under the strict flag.
+#[tokio::test]
+async fn require_admin_auth_accepts_local_only_without_a_key() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--require-admin-auth",
+    ]);
+    let server = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("--local-only satisfies --require-admin-auth with no key");
+    assert!(
+        server.admin_addr().ip().is_loopback(),
+        "--local-only must resolve the admin bind to loopback"
+    );
+    server.shutdown().await;
+}
+
+// Issue #880 (found while reviewing this change): `--local-only` must reach the metrics listener
+// too. It used to hardcode `0.0.0.0`, so a flag documented as "only accept connections from
+// localhost" left `/metrics` reachable on every interface.
+#[tokio::test]
+async fn local_only_restricts_the_metrics_listener_too() {
+    let cli = Cli::parse_from(["rift", "--local-only", "--port", "0", "--metrics-port", "0"]);
+    let server = ServerBuilder::from_cli(cli).start().await.expect("start");
+
+    let metrics = server
+        .metrics_addr()
+        .expect("metrics listener bound on an ephemeral port");
+    assert!(
+        metrics.ip().is_loopback(),
+        "--local-only must bind /metrics to loopback, got {metrics}"
+    );
+
+    server.shutdown().await;
+}
+
+// The converse: without `--local-only`, metrics keeps binding every interface. `--host` alone must
+// NOT relocate it — that would move the listener for anyone who binds the admin plane to a specific
+// interface, which is a separate decision from the one above.
+#[tokio::test]
+async fn without_local_only_metrics_still_binds_every_interface() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ]);
+    let server = ServerBuilder::from_cli(cli).start().await.expect("start");
+
+    let metrics = server.metrics_addr().expect("metrics listener bound");
+    assert!(
+        metrics.ip().is_unspecified(),
+        "--host must not relocate the metrics listener, got {metrics}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC3 at the CLI door: strict mode gates on *authentication*, not on the address. A real key makes
+// `0.0.0.0` acceptable — otherwise the flag would be an unavoidable `--local-only`, which is not
+// what it means.
+#[tokio::test]
+async fn require_admin_auth_accepts_a_non_loopback_bind_with_a_key() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--require-admin-auth",
+        "--api-key",
+        "s3cr3t",
+    ]);
+    let server = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("a real key satisfies --require-admin-auth on any address");
+    server.shutdown().await;
+}
+
+// AC9: the compatibility guarantee. The default is a *warning*, never a refusal — a regression here
+// breaks the no-argument invocation, every keyless quickstart and every existing container image.
+#[tokio::test]
+async fn the_default_keyless_non_loopback_bind_still_starts() {
+    let cli = Cli::parse_from(["rift", "--port", "0", "--metrics-port", "0"]);
+    assert_eq!(cli.host, "0.0.0.0", "the default --host must stay 0.0.0.0");
+    assert!(
+        !cli.require_admin_auth,
+        "strict mode must be opt-in, never the default"
+    );
+
+    let server = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("a keyless bare start must keep working; the default posture is a warning");
+    server.shutdown().await;
+}
+
+// AC6: the flag is reachable by its env var too, so a fleet can set it once in a base image
+// instead of editing every invocation.
+//
+// Asserted against clap's declared metadata rather than by setting the variable and re-parsing:
+// the process environment is shared by every test in this binary, and mutating it mid-run flipped
+// `the_default_keyless_non_loopback_bind_still_starts` above into the strict mode it exists to
+// prove is NOT the default.
+#[test]
+fn require_admin_auth_is_reachable_by_env() {
+    use clap::CommandFactory;
+
+    let command = Cli::command();
+    let arg = command
+        .get_arguments()
+        .find(|a| a.get_id() == "require_admin_auth")
+        .expect("--require-admin-auth is declared");
+    assert_eq!(
+        arg.get_env().and_then(|e| e.to_str()),
+        Some("RIFT_REQUIRE_ADMIN_AUTH"),
+        "the flag must be settable from the environment"
+    );
+}

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -131,7 +131,8 @@ Options:
       --datadir <DIR>              Directory for persistent imposter storage
       --scripts-dir <DIR>          Root directory for admin-API `file:`/`ref:` script resolution; references that escape it are rejected (unset ⇒ file-backed scripts via the admin API are refused)
       --allow-injection            Enable JavaScript injection in responses (alias: --allowInjection)
-      --local-only                 Only accept connections from localhost
+      --local-only                 Only accept connections from localhost (binds both the admin API and /metrics to loopback)
+      --require-admin-auth         Refuse to start when the admin API would bind a non-loopback address with no --api-key (default: warn)
       --loglevel <LEVEL>           Log level: debug, info, warn, error [default: info]
       --runtime <MODE>             Runtime topology: work-stealing (default) or per-core[=N] (RFC-712; experimental, Linux-first — macOS falls back with a warning, Windows rejects it)
       --runtime-affinity           Pin per-core worker threads to CPU cores (with --runtime per-core; effective on Linux)
@@ -145,7 +146,7 @@ Options:
       --pidfile <FILE>             PID file path
       --origin <ORIGIN>            CORS allowed origin
       --api-key <TOKEN>            Require this token in the Authorization header for all admin API requests
-      --rcfile <FILE>              RC file of default flag values (a subset: port/host/loglevel/allowInjection/localOnly/datadir/configfile)
+      --rcfile <FILE>              RC file of default flag values (a subset: port/host/loglevel/allowInjection/localOnly/requireAdminAuth/datadir/configfile)
       --default-tls-cert <FILE>    Default TLS certificate (PEM) for HTTPS imposters without their own
       --default-tls-key <FILE>     Default TLS private key (PEM), paired with --default-tls-cert
       --no-self-signed-tls         Disable the self-signed fallback; an HTTPS imposter with no cert is an error
@@ -199,6 +200,40 @@ rift-http-proxy --api-key s3cr3t
 curl -H "Authorization: s3cr3t" http://localhost:2525/imposters
 ```
 
+### Unauthenticated admin plane on a public interface
+
+`--host` defaults to `0.0.0.0`, so a bare `rift-http-proxy` with no `--api-key` already serves the
+full admin API — which can create imposters and drive the TLS intercept proxy — on every interface
+with no authentication. Since 0.18.0 that posture is stated at startup instead of being silent:
+
+```
+WARN the admin API is bound to 0.0.0.0:2525, which is reachable from outside this host, with no
+     API key — anyone who can reach that address can create imposters and drive the TLS intercept
+     proxy. Set `--api-key <token>` (`MB_APIKEY`), or restrict the bind with `--local-only` or
+     `--host 127.0.0.1`. Set `--require-admin-auth` (`RIFT_REQUIRE_ADMIN_AUTH`) to make this a
+     startup failure instead of a warning.
+```
+
+The default is a **warning, not a refusal**: containers require `0.0.0.0` (binding loopback inside
+Docker makes the published port unreachable), so refusing would break the no-argument invocation
+and every keyless quickstart. Fleets that want fail-closed opt in:
+
+```bash
+# Refuse to start unless the admin plane is authenticated or loopback-only
+rift-http-proxy --require-admin-auth              # errors: 0.0.0.0 with no key
+rift-http-proxy --require-admin-auth --api-key s3cr3t   # ok — authenticated
+rift-http-proxy --require-admin-auth --local-only       # ok — not reachable off-host
+```
+
+`--require-admin-auth` gates on *authentication*, not on the address: a real `--api-key` satisfies
+it on any bind. Loopback (`127.0.0.0/8`, `::1`) satisfies it with no key. `0.0.0.0` and `::` are
+unspecified addresses, not loopback, so they are flagged — as is any specific off-host interface
+such as `10.0.0.5`.
+
+The same rule applies at every door onto the admin plane, so an embedded host gets it too: the
+C-ABI `rift_serve_admin` accepts `"requireAdminAuth": true` in its options, and an embedder building
+an `AdminApiServer` directly gets it from `.with_require_admin_auth(true)`.
+
 ### Default TLS for HTTPS imposters
 
 An imposter declared with `protocol: https` terminates TLS. If it carries no `cert`/`key`, Rift
@@ -247,6 +282,7 @@ Environment variables override CLI defaults:
 | `MB_DATADIR` | Persistent storage directory | |
 | `MB_ALLOW_INJECTION` | Enable injection (`true`/`false`) | `false` |
 | `MB_LOCAL_ONLY` | Localhost only | `false` |
+| `RIFT_REQUIRE_ADMIN_AUTH` | Refuse to start on a keyless non-loopback admin bind (env alias of `--require-admin-auth`) | `false` |
 | `MB_LOGLEVEL` | Log level | `info` |
 | `MB_APIKEY` | Admin API authorization token (see `--api-key`) | |
 | `RIFT_SCRIPTS_DIR` | Root directory for admin-API `file:`/`ref:` script resolution (env alias of `--scripts-dir`); references escaping it are rejected | |

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -107,7 +107,7 @@ rift_free(result);
 ```
 
 - **Options JSON** (pass `NULL` or `{}` for all defaults; every field optional):
-  `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false}`.
+  `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false,"requireAdminAuth":false}`.
   `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
   `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
 - **`apiKey`**: a blank string is rejected — `rift_serve_admin` returns `NULL` and records the
@@ -115,6 +115,24 @@ rift_free(result);
   every request, and the realistic way to send one is plumbing rather than intent
   (`apiKey(getProperty("rift.apikey", ""))`, a config value that renders empty). Pass a real token,
   or omit the field to leave the admin plane unauthenticated.
+- **`requireAdminAuth`** (default `false`, issue #863): refuse to serve when the admin plane would
+  bind a non-loopback address with no `apiKey`, instead of logging a warning. `host` defaults to
+  `127.0.0.1` for this door, so the check is silent unless you ask for an off-host bind. It gates on
+  *authentication*, not on the address — a real `apiKey` satisfies it on any bind. Under a refusal
+  `rift_serve_admin` returns `NULL` with the reason in `rift_last_error`, and nothing has been bound.
+
+  **This field is not self-gating — check the engine version before relying on it.** `ServeOptions`
+  does not use `deny_unknown_fields`, so an engine older than 0.18.0 **silently ignores**
+  `requireAdminAuth` and serves the keyless off-host admin plane anyway, returning a normal
+  `{"adminPort":…}`. There is no error to detect. An SDK that offers this option must gate it on the
+  engine version from `rift_build_info` rather than assuming a rejection it will never receive.
+  (Note this is not something a newer engine can fix retroactively: the old engine is the one doing
+  the ignoring.) Omitting the field is the previous behaviour exactly, so an SDK built against an
+  older engine is otherwise unaffected.
+
+  The default `Warn` posture writes through the `tracing` facade. `rift-ffi` installs **no**
+  subscriber — correct for a library, but it means an embedding host that has not installed one of
+  its own sees nothing at all. Install a `tracing` subscriber if you want the warning to be visible.
 - **`allowInjection`** (default `false`): whether Rift admits script/`inject` imposters
   (`inject`/`decorate`/`shellTransform`/JS-function `wait`/`_rift.script`), mirroring the
   `--allowInjection` CLI flag. Leave it `false` unless you intend to permit them.

--- a/docs/embedding/server.md
+++ b/docs/embedding/server.md
@@ -127,7 +127,15 @@ println!("admin bound to {}", running.local_addr());
 | `AdminApiServer::new` | `fn new(addr: SocketAddr, manager: Arc<ImposterManager>, api_key: Option<String>) -> Self` | Construct the admin server; `api_key` (when `Some`) gates the admin API via the `Authorization` header. |
 | `with_config_source` | `fn with_config_source(self, source: ConfigSource) -> Self` | Retain the load source so `POST /admin/reload` can re-read it. |
 | `with_allow_injection` | `fn with_allow_injection(self, allow: bool) -> Self` | Enable JavaScript `inject` responses. |
+| `with_require_admin_auth` | `fn with_require_admin_auth(self, require: bool) -> Self` | Make `bind` **fail** when this server would be reachable off-host with no `api_key`, instead of warning (issue #863). The embedder spelling of `--require-admin-auth`. |
 | `bind` | `async fn bind(self) -> anyhow::Result<RunningAdminApi>` | Bind and start serving; returns once bound. |
+
+`bind` reports the authentication posture either way. When `addr` is **not** loopback and `api_key`
+is `None`, it logs a warning naming the address and the remedies — the admin API can create
+imposters and drive the TLS intercept proxy, so an unauthenticated off-host bind is worth stating
+out loud. `with_require_admin_auth(true)` turns that warning into a startup error; the check runs
+before the listener binds, so a refusal never leaves a socket behind. It gates on *authentication*,
+not on the address: a real `api_key` satisfies it on any bind, and loopback satisfies it with none.
 
 `RunningAdminApi`: `local_addr(&self) -> SocketAddr`, `shutdown(&self)`, `join(self) -> anyhow::Result<()>`,
 `wait(&self) -> anyhow::Result<()>` (the non-consuming form of `join`, as above).
@@ -198,7 +206,7 @@ imposters. These live in `rift_http_proxy::bootstrap` so an alternative binary k
 | `save_imposters` | `fn save_imposters(host: &str, port: u16, savefile: &Path, remove_proxies: bool) -> anyhow::Result<()>` | Blocking wrapper over `save_imposters_async` for the sync `save` subcommand path. |
 
 Supported rcfile keys: `port`, `host`, `logLevel`/`loglevel`, `allowInjection`/`allow_injection`,
-`localOnly`/`local_only`, `datadir`, `configfile`.
+`localOnly`/`local_only`, `requireAdminAuth`/`require_admin_auth`, `datadir`, `configfile`.
 
 ```rust
 use rift_http_proxy::bootstrap;


### PR DESCRIPTION
Keyless rift defaults to 0.0.0.0, exposing the full admin API (imposters, TLS intercept) unauthenticated on every interface. Maintainer decision: warn by default, opt in to refusal via --require-admin-auth CLI flag, RIFT_REQUIRE_ADMIN_AUTH env var, or rcfile requireAdminAuth. Single rule at CLI, C-ABI (rift_serve_admin), and embedded (AdminApiServer), evaluated before bind to prevent orphaned listeners. Startup now logs auth posture either way.

Fixes #880 in same PR: --local-only now restricts metrics listener too (was hardcoded 0.0.0.0). Behaviour change for anyone scraping /metrics off-host with --local-only.

C-ABI requireAdminAuth field is not self-gating against older engines (tracked in #877).

Closes #863
Closes #880