### PR TITLE
feat(reconcile): EventContext on ImposterEventListener — attribute change events to a principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,29 @@ record.
   verbatim as the authorizer's `scope`; it is caller-asserted and must be cross-checked against the
   credential rather than trusted as identity. See `docs/embedding/spi.md`.
 
+- **`EventContext` on `ImposterEventListener` — change events now say *who*, not just *what***
+  (issue #855). Audit logging was a listed motivation for the change-event seam (#316), but an
+  event named the change and not the actor, so anyone building an audit trail had to correlate
+  events against request logs out of band — guesswork under concurrency. `on_event` now receives an
+  `EventContext` carrying `principal`, populated from `AuthzDecision::Allow { principal }` when an
+  `AdminAuthorizer` (#854) is installed.
+
+  **Breaking for embedders who implement `ImposterEventListener`:** the trait method gains a second
+  parameter, so existing implementations need `fn on_event(&self, event: &ImposterEvent, ctx:
+  &EventContext)`. Add `_ctx` and ignore it to restore the previous behaviour exactly. The
+  `ImposterEvent` **enum is deliberately untouched** — attribution rides on the listener signature
+  precisely so that every downstream `match` over the enum keeps compiling. `EventContext` itself is
+  `#[non_exhaustive]` so that adding a second attribution field later is not a third break; build
+  one in your own tests with `EventContext::default()` and assign the fields you need.
+
+  `principal` is `None` whenever nobody can honestly be named — no authorizer installed, an
+  authorizer that allowed without identifying anyone, or a change with no request behind it (the
+  startup config read, or an embedder driving `ImposterManager` directly). It is never guessed.
+  Two stated bounds: `AllDeleted` carries no port, so a fleet-wide delete records the actor but no
+  per-resource target; and the principal is scoped to the admin request task, so a mutation driven
+  from your own `tokio::spawn`ed task reports `None`. The admin SSE bus (`/events`) is **not**
+  attributed — only the in-process listener is. See `docs/embedding/spi.md`.
+
 ### Security
 
 - **An empty `--api-key` enabled the admin auth gate and then authenticated everyone** (issue #844).

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -13,7 +13,9 @@ use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use rift_mock_core::extensions::authz::{AdminAuthorizer, AuthzDecision, AuthzRequest};
+use rift_mock_core::extensions::authz::{
+    AdminAuthorizer, AuthzDecision, AuthzRequest, with_principal_scope,
+};
 use rift_mock_core::proxy::{
     AcceptBackoff, AcceptErrorClass, AcceptErrorEvent, AcceptErrorLog, classify_accept_error,
     is_fatal_listener_error,
@@ -537,6 +539,10 @@ async fn accept_loop(
                         // Gateway traffic is exempt for the same reason it skips the api key —
                         // `classify` returns None for `/__rift/`, so app-under-test requests are
                         // never asked to carry an admin identity.
+                        // Attribution for change events (issue #855). Stays `None` unless an
+                        // authorizer both runs and names someone, so an embedder who installs no
+                        // authorizer sees exactly the previous behaviour and data.
+                        let mut principal: Option<String> = None;
                         if let Some(ref authorizer) = authorizer
                             && let Some(target) = authz::classify(req.method(), req.uri().path())
                         {
@@ -560,7 +566,9 @@ async fn accept_loop(
                                 params: &params,
                             });
                             match decision {
-                                AuthzDecision::Allow { principal: _ } => {}
+                                AuthzDecision::Allow { principal: allowed } => {
+                                    principal = allowed;
+                                }
                                 AuthzDecision::Deny { reason } => {
                                     return Ok::<_, hyper::Error>(box_full(forbidden_response(
                                         reason,
@@ -580,13 +588,18 @@ async fn accept_loop(
                                 stream_cancel,
                             ));
                         }
-                        route_request(
-                            req,
-                            manager,
-                            config_source,
-                            allow_injection,
-                            intercept,
-                            scripts_dir,
+                        // Only the router mutates, so the attribution scope wraps just this call —
+                        // the SSE stream above is read-only and returns before it (issue #855).
+                        with_principal_scope(
+                            principal,
+                            route_request(
+                                req,
+                                manager,
+                                config_source,
+                                allow_injection,
+                                intercept,
+                                scripts_dir,
+                            ),
                         )
                         .await
                         .map(box_full)

--- a/crates/rift-http-proxy/tests/issue_855_event_attribution.rs
+++ b/crates/rift-http-proxy/tests/issue_855_event_attribution.rs
@@ -1,0 +1,404 @@
+//! Issue #855: change events say *what* changed but not *who* changed it, which makes them
+//! unusable for the audit logging they were partly built for (issue #316). `EventContext` carries
+//! the attribution on the **listener signature** rather than on `ImposterEvent`, so the enum — and
+//! every downstream `match` on it — is untouched.
+//!
+//! The principal originates in `AuthzDecision::Allow { principal }` (issue #854) at the admin
+//! listener and has to reach `ImposterManager::emit` deep in `rift-mock-core`, through manager
+//! methods that take no principal. It travels as a `tokio` task-local, mirroring the existing
+//! `with_annotation_scope` seam. That mechanism has one real boundary and these tests pin both
+//! sides of it: inside a request task the principal is present; outside any request — a config-file
+//! load, an embedder calling the manager directly — it is `None` rather than wrong.
+
+use parking_lot::Mutex;
+use rift_http_proxy::admin_api::AdminApiServer;
+use rift_http_proxy::imposter::{ImposterConfig, ImposterManager};
+use rift_mock_core::extensions::authz::{AdminAuthorizer, AuthzDecision, AuthzRequest};
+use rift_mock_core::imposter::{EventContext, ImposterEvent, ImposterEventListener};
+use std::sync::Arc;
+
+fn imposter_cfg(port: u16) -> ImposterConfig {
+    serde_json::from_value(serde_json::json!({
+        "port": port, "protocol": "http", "stubs": []
+    }))
+    .expect("test imposter config")
+}
+
+/// Records each event together with the attribution it arrived with, so assertions read as
+/// "this change was attributed to this principal".
+struct RecordingListener {
+    seen: Mutex<Vec<(ImposterEvent, Option<String>)>>,
+}
+
+impl RecordingListener {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            seen: Mutex::new(Vec::new()),
+        })
+    }
+    fn seen(&self) -> Vec<(ImposterEvent, Option<String>)> {
+        self.seen.lock().clone()
+    }
+    /// The attribution recorded for the first event matching `pred`.
+    fn principal_for(&self, pred: impl Fn(&ImposterEvent) -> bool) -> Option<String> {
+        self.seen
+            .lock()
+            .iter()
+            .find(|(e, _)| pred(e))
+            .expect("no matching event was emitted")
+            .1
+            .clone()
+    }
+}
+
+impl ImposterEventListener for RecordingListener {
+    fn on_event(&self, event: &ImposterEvent, ctx: &EventContext) {
+        self.seen
+            .lock()
+            .push((event.clone(), ctx.principal.clone()));
+    }
+}
+
+struct FixedAuthorizer(AuthzDecision);
+
+impl AdminAuthorizer for FixedAuthorizer {
+    fn authorize(&self, _req: AuthzRequest<'_>) -> AuthzDecision {
+        self.0.clone()
+    }
+}
+
+/// Start an admin API on an ephemeral port over a manager carrying `listener`.
+async fn start(
+    authorizer: Option<AuthzDecision>,
+) -> (
+    String,
+    Arc<RecordingListener>,
+    rift_http_proxy::admin_api::RunningAdminApi,
+) {
+    let listener = RecordingListener::new();
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_event_listener(Arc::clone(&listener) as Arc<dyn ImposterEventListener>),
+    );
+    let mut server = AdminApiServer::new("127.0.0.1:0".parse().expect("addr"), manager, None);
+    if let Some(decision) = authorizer {
+        server = server.with_admin_authorizer(Arc::new(FixedAuthorizer(decision)));
+    }
+    let running = server.bind().await.expect("admin API binds");
+    let base = format!("http://{}", running.local_addr());
+    (base, listener, running)
+}
+
+// AC3: the whole point — an authorizer that names a principal makes that name reach the change
+// event, so an audit trail can record who created the imposter without correlating request logs
+// out of band.
+#[tokio::test]
+async fn a_named_principal_reaches_the_change_event() {
+    let (base, listener, running) = start(Some(AuthzDecision::Allow {
+        principal: Some("alice".to_string()),
+    }))
+    .await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18551, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    assert_eq!(resp.status(), 201);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18551))),
+        Some("alice".to_string()),
+        "the creating principal must be attributed to the Created event"
+    );
+
+    running.shutdown().await;
+}
+
+// AC4: the seam's stated premise — install no authorizer and nothing changes. This is what makes
+// the feature safe to ship: an embedder who wants none of it sees identical behaviour and data.
+#[tokio::test]
+async fn no_authorizer_installed_leaves_the_principal_unset() {
+    let (base, listener, running) = start(None).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18552, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    assert_eq!(resp.status(), 201);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18552))),
+        None,
+        "with no authorizer installed there is no principal to attribute"
+    );
+
+    running.shutdown().await;
+}
+
+// AC5: an authorizer may allow without identifying anyone — that is exactly what the built-in
+// api-key gate does (`AuthzDecision::allow()`). Allowing must not invent an attribution.
+#[tokio::test]
+async fn an_allow_without_a_principal_leaves_it_unset() {
+    let (base, listener, running) = start(Some(AuthzDecision::allow())).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18553, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    assert_eq!(resp.status(), 201);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18553))),
+        None,
+        "an Allow that names nobody must not manufacture a principal"
+    );
+
+    running.shutdown().await;
+}
+
+// AC7: the bound the issue states up front — `AllDeleted` carries no port, so a fleet-wide delete
+// records the actor but not a per-resource target. Pinned deliberately: this is the documented
+// shape, and a future change to it should have to edit this assertion consciously.
+#[tokio::test]
+async fn a_fleet_wide_delete_attributes_the_actor_but_names_no_port() {
+    let (base, listener, running) = start(Some(AuthzDecision::Allow {
+        principal: Some("carol".to_string()),
+    }))
+    .await;
+
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18554, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    let resp = client
+        .delete(format!("{base}/imposters"))
+        .send()
+        .await
+        .expect("delete all");
+    assert_eq!(resp.status(), 200);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::AllDeleted)),
+        Some("carol".to_string()),
+        "a fleet-wide delete must still record who did it"
+    );
+
+    running.shutdown().await;
+}
+
+// The four remaining event variants. `Created`/`AllDeleted` above went through one route each, so
+// without these the majority of the enum — and the stub and enable/disable code paths — had no
+// attribution coverage at all. They matter because the mechanism's stated failure mode is silent:
+// an emit that ever moves into a spawned task attributes `None` with nothing to catch it, and
+// `apply_config`'s per-port loop is exactly the kind of code someone parallelises later.
+
+// `Deleted`, via a single-imposter delete.
+#[tokio::test]
+async fn a_single_imposter_delete_is_attributed() {
+    let (base, listener, running) = start(Some(AuthzDecision::Allow {
+        principal: Some("dave".to_string()),
+    }))
+    .await;
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18556, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    let resp = client
+        .delete(format!("{base}/imposters/18556"))
+        .send()
+        .await
+        .expect("delete imposter");
+    assert_eq!(resp.status(), 200);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Deleted(18556))),
+        Some("dave".to_string()),
+        "deleting one imposter must record who deleted it"
+    );
+    running.shutdown().await;
+}
+
+// `StubsChanged`, via the stub-append route — a different handler and manager method from the
+// imposter-level CRUD above.
+#[tokio::test]
+async fn a_stub_mutation_is_attributed() {
+    let (base, listener, running) = start(Some(AuthzDecision::Allow {
+        principal: Some("erin".to_string()),
+    }))
+    .await;
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18557, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    let resp = client
+        .post(format!("{base}/imposters/18557/stubs"))
+        .json(&serde_json::json!({
+            "stub": {
+                "predicates": [{"equals": {"path": "/ping"}}],
+                "responses": [{"is": {"statusCode": 200, "body": "hi"}}]
+            }
+        }))
+        .send()
+        .await
+        .expect("add stub");
+    assert!(resp.status().is_success(), "add stub: {}", resp.status());
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::StubsChanged(18557))),
+        Some("erin".to_string()),
+        "a stub edit must record who made it"
+    );
+    running.shutdown().await;
+}
+
+// `EnabledChanged`, via the serve/pause toggle — its own manager method again.
+#[tokio::test]
+async fn an_enabled_toggle_is_attributed() {
+    let (base, listener, running) = start(Some(AuthzDecision::Allow {
+        principal: Some("frank".to_string()),
+    }))
+    .await;
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{base}/imposters"))
+        .json(&serde_json::json!({"port": 18558, "protocol": "http", "stubs": []}))
+        .send()
+        .await
+        .expect("create imposter");
+    let resp = client
+        .post(format!("{base}/imposters/18558/disable"))
+        .send()
+        .await
+        .expect("disable imposter");
+    assert!(resp.status().is_success(), "disable: {}", resp.status());
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(
+            e,
+            ImposterEvent::EnabledChanged {
+                port: 18558,
+                enabled: false
+            }
+        )),
+        Some("frank".to_string()),
+        "pausing an imposter must record who paused it"
+    );
+    running.shutdown().await;
+}
+
+// Cross-request isolation. This is the one property here guaranteed only by an implementation
+// detail — `tokio`'s task-local is scoped to the *future*, so concurrent requests cannot see each
+// other's principal. Nothing in application logic enforces it, so a refactor that hoisted the
+// principal onto the connection (a shared `Mutex<Option<String>>`, say) would leak one caller's
+// identity into another's audit record and every single-request test above would still pass.
+#[tokio::test]
+async fn concurrent_requests_do_not_cross_attribute() {
+    // Attribution echoes a per-request header, so the two in-flight requests carry different
+    // principals through one server.
+    struct HeaderAuthorizer;
+    impl AdminAuthorizer for HeaderAuthorizer {
+        fn authorize(&self, req: AuthzRequest<'_>) -> AuthzDecision {
+            AuthzDecision::Allow {
+                principal: req.credential.map(str::to_string),
+            }
+        }
+    }
+
+    let listener = RecordingListener::new();
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_event_listener(Arc::clone(&listener) as Arc<dyn ImposterEventListener>),
+    );
+    let running = AdminApiServer::new("127.0.0.1:0".parse().expect("addr"), manager, None)
+        .with_admin_authorizer(Arc::new(HeaderAuthorizer))
+        .bind()
+        .await
+        .expect("admin API binds");
+    let base = format!("http://{}", running.local_addr());
+
+    let client = reqwest::Client::new();
+    let one = client
+        .post(format!("{base}/imposters"))
+        .header("authorization", "grace")
+        .json(&serde_json::json!({"port": 18559, "protocol": "http", "stubs": []}))
+        .send();
+    let two = client
+        .post(format!("{base}/imposters"))
+        .header("authorization", "heidi")
+        .json(&serde_json::json!({"port": 18560, "protocol": "http", "stubs": []}))
+        .send();
+    let (r1, r2) = tokio::join!(one, two);
+    assert_eq!(r1.expect("create 18559").status(), 201);
+    assert_eq!(r2.expect("create 18560").status(), 201);
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18559))),
+        Some("grace".to_string()),
+        "each imposter must be attributed to the caller that created it"
+    );
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18560))),
+        Some("heidi".to_string()),
+        "a concurrent request must not inherit the other caller's principal"
+    );
+
+    running.shutdown().await;
+}
+
+// AC6: the task-local's boundary, asserted rather than assumed. An embedder driving the manager
+// directly — or a config-file load at startup — runs outside any request scope. Reading the
+// principal there must yield `None`, not panic and not leak an unrelated request's principal.
+#[tokio::test]
+async fn a_direct_manager_mutation_outside_any_request_has_no_principal() {
+    let listener = RecordingListener::new();
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_event_listener(Arc::clone(&listener) as Arc<dyn ImposterEventListener>),
+    );
+
+    manager
+        .create_imposter(imposter_cfg(18555))
+        .await
+        .expect("create imposter directly");
+
+    assert_eq!(
+        listener.principal_for(|e| matches!(e, ImposterEvent::Created(18555))),
+        None,
+        "outside a request scope there is no principal; reading one must be None, not a panic"
+    );
+    assert_eq!(listener.seen().len(), 1);
+}
+
+// AC8: `ImposterEvent` is untouched. This match is exhaustive with NO wildcard arm, so adding,
+// removing or reshaping a variant fails to compile here — which is the guarantee the issue makes
+// ("existing matches keep compiling") expressed as a test rather than as prose.
+#[test]
+fn the_event_enum_is_unchanged() {
+    fn describe(e: &ImposterEvent) -> &'static str {
+        match e {
+            ImposterEvent::Created(_) => "created",
+            ImposterEvent::Replaced(_) => "replaced",
+            ImposterEvent::StubsChanged(_) => "stubs-changed",
+            ImposterEvent::EnabledChanged { .. } => "enabled-changed",
+            ImposterEvent::Deleted(_) => "deleted",
+            ImposterEvent::AllDeleted => "all-deleted",
+        }
+    }
+    assert_eq!(describe(&ImposterEvent::Created(1)), "created");
+    assert_eq!(describe(&ImposterEvent::AllDeleted), "all-deleted");
+}

--- a/crates/rift-mock-core/src/extensions/authz.rs
+++ b/crates/rift-mock-core/src/extensions/authz.rs
@@ -19,6 +19,7 @@
 //! `Deny` on an authenticated request is a `403`. `401` stays reserved for a missing or malformed
 //! credential.
 
+use std::future::Future;
 use std::sync::Arc;
 
 /// What the caller is trying to do, as the admin router understood it.
@@ -168,6 +169,37 @@ impl AdminAuthorizer for AllowAll {
 
 /// Convenience alias for the registration type.
 pub type SharedAdminAuthorizer = Arc<dyn AdminAuthorizer>;
+
+tokio::task_local! {
+    /// Attribution for the admin request the current task is serving (issue #855).
+    static PRINCIPAL: Option<String>;
+}
+
+/// Run `fut` with `principal` as the ambient attribution for change events (issue #855).
+///
+/// The principal is decided at the admin listener, but it has to reach `ImposterManager::emit`,
+/// which sits several layers down in `rift-mock-core` behind manager methods that take no
+/// principal. Threading a parameter through every one of those — `create_imposter`,
+/// `delete_imposter`, `apply_config`, `add_stub`, … — would be a large breaking API change for one
+/// optional feature, so this follows the seam the codebase already uses for exactly this shape:
+/// `with_annotation_scope` in [`crate::extensions::decorate`]. Task-locals follow the task across
+/// `.await`s, so a synchronous `emit` anywhere inside the request lands in this scope.
+///
+/// **Boundary:** `tokio::spawn` starts a task that does *not* inherit this scope. Every current
+/// emit site is a direct call inside the mutating manager method, so all of them are covered; an
+/// emit moved into a spawned task would silently attribute `None`.
+pub async fn with_principal_scope<F: Future>(principal: Option<String>, fut: F) -> F::Output {
+    PRINCIPAL.scope(principal, fut).await
+}
+
+/// The principal attributed to the current request, or `None` outside any request scope.
+#[must_use]
+pub fn current_principal() -> Option<String> {
+    // Domain-optional read, not a swallowed error: `try_with` fails precisely when no scope is
+    // open, which is the legitimate "no request behind this change" case (config-file load, an
+    // embedder calling the manager directly). There is nothing to report and nothing to fail.
+    PRINCIPAL.try_with(Clone::clone).ok().flatten()
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -6,7 +6,9 @@
 use super::core::Imposter;
 use super::fault_io::{FaultCell, FaultIo, TcpFaultKind};
 use super::handler::handle_imposter_request_decorated;
-use super::reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, StubReconcile};
+use super::reconcile::{
+    ApplyReport, EventContext, ImposterEvent, ImposterEventListener, StubReconcile,
+};
 use super::types::{ImposterConfig, ImposterError, Stub};
 use crate::behaviors::ResponseSequencer;
 use crate::extensions::decorate::ResponseDecorator;
@@ -439,7 +441,12 @@ impl ImposterManager {
 
     fn emit(&self, event: ImposterEvent) {
         if let Some(listener) = &self.event_listener {
-            listener.on_event(&event);
+            // Built only when someone is listening — outside a request scope this is a cheap miss,
+            // but there is no reason to pay even that when no listener is installed (issue #855).
+            let ctx = EventContext {
+                principal: crate::extensions::authz::current_principal(),
+            };
+            listener.on_event(&event, &ctx);
         }
         // Additionally fan the event out to the admin SSE bus (issue #461) — separate from the
         // single-slot embedder listener above, which callers may already hold.
@@ -2077,7 +2084,7 @@ mod tests {
     // =========================================================================
 
     use super::super::core::StubState;
-    use super::super::reconcile::{ImposterEvent, ImposterEventListener};
+    use super::super::reconcile::{EventContext, ImposterEvent, ImposterEventListener};
     use super::super::types::RecordedRequest;
     use serde_json::json;
 
@@ -2456,7 +2463,7 @@ mod tests {
     struct RecordingListener(Mutex<Vec<ImposterEvent>>);
 
     impl ImposterEventListener for RecordingListener {
-        fn on_event(&self, event: &ImposterEvent) {
+        fn on_event(&self, event: &ImposterEvent, _ctx: &EventContext) {
             self.0.lock().push(event.clone());
         }
     }

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -69,7 +69,7 @@ pub use manager::{ImposterManager, TlsDefaults};
 
 // Re-export incremental reconciliation types (issue #316)
 pub use events::{AdminEvent, AdminEventBus, AdminEventKind, ImposterAction};
-pub use reconcile::{ApplyReport, ImposterEvent, ImposterEventListener, stub_key};
+pub use reconcile::{ApplyReport, EventContext, ImposterEvent, ImposterEventListener, stub_key};
 
 // Re-export predicate utilities (used in tests and for external consumers)
 #[allow(unused_imports)]

--- a/crates/rift-mock-core/src/imposter/reconcile.rs
+++ b/crates/rift-mock-core/src/imposter/reconcile.rs
@@ -44,11 +44,36 @@ pub enum ImposterEvent {
     AllDeleted,
 }
 
+/// Who caused a change event (issue #855).
+///
+/// Attribution rides here, on the listener signature, rather than on [`ImposterEvent`]: the enum
+/// is not `#[non_exhaustive]`, so adding a field to every variant would break every downstream
+/// `match` — the wrong trade for a seam whose premise is that installing nothing changes nothing.
+/// `#[non_exhaustive]` for the same reason attribution is not on [`ImposterEvent`]: the next
+/// attribution field (scope, request id, remote addr) must not be a second breaking change to the
+/// same seam. Embedders read this type; to build one in a test, start from
+/// [`Default`] and assign — a struct literal, including `..Default::default()`, is not available
+/// outside this crate.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EventContext {
+    /// The principal an [`AdminAuthorizer`](crate::extensions::authz::AdminAuthorizer) attributed
+    /// the causing request to, via `AuthzDecision::Allow { principal }`.
+    ///
+    /// `None` whenever there is nobody to name — no authorizer installed, an authorizer that
+    /// allowed without identifying anyone, or a mutation with no request behind it at all (a
+    /// config-file load, or an embedder driving [`ImposterManager`](super::ImposterManager)
+    /// directly). Absent attribution is reported as absent; it is never guessed.
+    pub principal: Option<String>,
+}
+
 /// Observer for [`ImposterEvent`]s; register via
 /// [`ImposterManager::with_event_listener`](super::ImposterManager::with_event_listener).
 /// Called synchronously on the mutating path — keep implementations fast and non-blocking.
+///
+/// `ctx` carries attribution (issue #855). A listener that only cares *what* changed ignores it.
 pub trait ImposterEventListener: Send + Sync {
-    fn on_event(&self, event: &ImposterEvent);
+    fn on_event(&self, event: &ImposterEvent, ctx: &EventContext);
 }
 
 /// Stable stub identity: the explicit `id` (issue #202) if set, else

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -172,13 +172,53 @@ pub enum ImposterEvent {
     AllDeleted,        // every imposter removed
 }
 
+pub struct EventContext {
+    pub principal: Option<String>,   // who caused the change
+}
+
 pub trait ImposterEventListener: Send + Sync {
-    fn on_event(&self, event: &ImposterEvent);
+    fn on_event(&self, event: &ImposterEvent, ctx: &EventContext);
 }
 ```
 
 `on_event` is called **synchronously on the mutating path** — keep implementations fast and
 non-blocking. Inject with `.with_event_listener(Arc<dyn ImposterEventListener>)`.
+
+### Attribution — who changed it
+
+An event says *what* changed; `ctx.principal` says *who* (issue #855). It is populated from
+`AuthzDecision::Allow { principal }` when an [`AdminAuthorizer`](#adminauthorizer--authorize-admin-requests)
+is installed, which is what makes these events usable as an audit trail instead of something you
+have to correlate against request logs out of band.
+
+`principal` is `None` whenever there is genuinely nobody to name, and it is never guessed:
+
+| Situation | `ctx.principal` |
+|:---|:---|
+| No authorizer installed | `None` — the seam stays inert by default |
+| Authorizer returned `AuthzDecision::allow()` | `None` — allowed, but nobody identified |
+| Authorizer returned `Allow { principal: Some(p) }` | `Some(p)` |
+| `POST /admin/reload` (re-reads `--configfile`) | `Some(p)` — it is an admin request like any other |
+| The **startup** config read, or your own direct `ImposterManager` call | `None` — no request behind the change |
+
+Note the third and fourth rows together: what decides attribution is whether a request caused the
+change, not where the config came from. The same `--configfile` yields `None` when read at boot and
+`Some(p)` when re-read through `POST /admin/reload`.
+
+Attribution rides on the **listener signature**, not on `ImposterEvent`. The enum is unchanged, so
+an existing `match` over it keeps compiling untouched. `EventContext` is `#[non_exhaustive]` so a
+later attribution field is not another break — construct one in your own tests from
+`EventContext::default()` and assign fields.
+
+Three bounds worth knowing:
+
+- `AllDeleted` carries no port, so a fleet-wide delete records the actor but no per-resource
+  target. That is the shape, not a defect.
+- The principal travels as a `tokio` task-local scoped to the admin request. A mutation you drive
+  from a `tokio::spawn`ed task of your own does not inherit that scope and will report `None`.
+- **Only this listener is attributed.** The admin SSE bus (`GET /events`) publishes the same
+  lifecycle changes with no principal, so an audit collector pointed at `/events` gets *what* but
+  not *who*. If you need attribution, consume it here.
 
 ## `ResponseDecorator` — cross-cutting response headers
 


### PR DESCRIPTION
Change events previously said what changed but not who, making them unsuitable for the audit logging that was a listed motivation of the event seam (#316) — embedders had to correlate events against request logs out of band, which is guesswork under concurrency.

on_event now takes an EventContext { principal }, populated from AuthzDecision::Allow { principal } (#854). Attribution rides on the listener signature, not on ImposterEvent — the enum is untouched so every downstream match keeps compiling.

**BREAKING for embedders implementing ImposterEventListener**: the trait method gains a second parameter. Add _ctx to restore previous behaviour.

Closes #855