### PR TITLE
docs: correct the release version gating --require-admin-auth to 0.17.0

### DIFF
--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -204,7 +204,7 @@ curl -H "Authorization: s3cr3t" http://localhost:2525/imposters
 
 `--host` defaults to `0.0.0.0`, so a bare `rift-http-proxy` with no `--api-key` already serves the
 full admin API — which can create imposters and drive the TLS intercept proxy — on every interface
-with no authentication. Since 0.18.0 that posture is stated at startup instead of being silent:
+with no authentication. Since 0.17.0 that posture is stated at startup instead of being silent:
 
 ```
 WARN the admin API is bound to 0.0.0.0:2525, which is reachable from outside this host, with no

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -122,7 +122,7 @@ rift_free(result);
   `rift_serve_admin` returns `NULL` with the reason in `rift_last_error`, and nothing has been bound.
 
   **This field is not self-gating — check the engine version before relying on it.** `ServeOptions`
-  does not use `deny_unknown_fields`, so an engine older than 0.18.0 **silently ignores**
+  does not use `deny_unknown_fields`, so an engine older than 0.17.0 **silently ignores**
   `requireAdminAuth` and serves the keyless off-host admin plane anyway, returning a normal
   `{"adminPort":…}`. There is no error to detect. An SDK that offers this option must gate it on the
   engine version from `rift_build_info` rather than assuming a rejection it will never receive.


### PR DESCRIPTION
PR #881 documented the new startup warning as landing in `0.18.0`, and told SDK authors that engines "older than `0.18.0`" silently ignore `requireAdminAuth`. Both are wrong — the latest tag is `v0.16.0` and 0.17.0 has not been cut (#801 is still open, titled for 0.17.0), so the #863 work ships in **0.17.0**.

The `ffi.md` line is the one that matters. It is the instruction SDKs use to gate the option, and because `ServeOptions` has no `deny_unknown_fields` there is no error to fall back on — an SDK gating on a version that never exists would either refuse to send the option forever, or send it to an engine that drops it silently and fails open.

Two lines, docs only. `scripts/verify-docs-coverage.sh` passes.

Follow-up to #881 (issue #863). The underlying feature-detection gap is tracked in #877.