### PR TITLE
C-ABI: SDKs cannot feature-detect new ServeOptions — expose a capability list on rift_build_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ record.
 
 ### Added
 
+- **Serve options are now feature-detectable — `serveOptions` on `rift_build_info` and `GET /config`**
+  (issue #877). `ServeOptions` fields have no symbol for an SDK to probe, so the "additive symbols are
+  discovered by presence" convention `rift_abi_version` documents could not reach them: an SDK sending
+  a new option to an older engine got a normal success and an option that silently did nothing. For
+  `requireAdminAuth` (#863) that silence was *fail-open*.
+
+  Both surfaces now publish the accepted keys, from one shared constant. **Absence of the key is the
+  signal**: an engine older than 0.17.0 reports no `serveOptions` at all, so an SDK reading it knows to
+  treat every option as unsupported. That is what makes this work against already-released engines —
+  detection by provoking an error cannot, because the engine doing the ignoring is the old one.
+  `serveOptions` is deliberately separate from `features`, which lists compiled cargo features.
+
 - **`--require-admin-auth` — opt in to refusing a keyless off-host admin plane** (issue #863).
   `--host` defaults to `0.0.0.0`, so a bare keyless `rift` already serves the full admin API — which
   can create imposters and drive the TLS intercept proxy — on every interface with no
@@ -103,6 +115,16 @@ record.
   compared byte for byte, untrimmed.
 
 ### Changed
+
+- **An unknown key in the C-ABI serve-options JSON is now a hard error** (issue #877). `ServeOptions`
+  gained `deny_unknown_fields`, so `rift_serve_admin` answers `NULL` with the offending key named in
+  `rift_last_error` instead of silently dropping it and returning success. **If you pass extra keys
+  today** — a forward-compatibility habit, or a serializer emitting nulls for unknown members — that
+  call now fails; send only the keys `rift_build_info().serveOptions` advertises.
+
+  This catches typos going forward; it is **not** the feature-detection mechanism, and cannot be. An
+  engine released before this change still silently ignores unknown keys, so an SDK must read the
+  capability list rather than infer support from the absence of an error.
 
 - **`--local-only` now restricts the metrics listener too** (issue #880). The metrics server
   hardcoded `0.0.0.0`, so a flag documented as "only accept connections from localhost" narrowed the

--- a/crates/rift-ffi/include/rift_ffi.h
+++ b/crates/rift-ffi/include/rift_ffi.h
@@ -434,8 +434,14 @@ uint32_t rift_abi_version(void);
 
 /**
  * Build identity as a STATIC JSON string — never freed; probe this symbol to detect a v2 library
- * (issue #343). `{"version":"..","commit":"<sha>|null","builtAt":"<iso8601>|null","features":[..]}`.
+ * (issue #343).
+ * `{"version":"..","commit":"<sha>|null","builtAt":"<iso8601>|null","features":[..],"serveOptions":[..]}`.
  * `commit`/`builtAt` are `null` unless stamped at build time (issue #344).
+ *
+ * `serveOptions` lists the keys `rift_serve_admin`'s options document accepts (issue #877) — read
+ * it to feature-detect an option before sending it. It is **absent** on engines older than 0.17.0,
+ * and that absence is the signal: treat every serve option as unsupported. `features` is a
+ * different question (compiled cargo features), so do not conflate the two arrays.
  */
 const char *rift_build_info(void);
 

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -35,7 +35,7 @@
 use anyhow::Context;
 use parking_lot::Mutex;
 use rift_http_proxy::admin_api::{
-    AdminApiServer, RunningAdminApi, filter_proxy_responses, filter_proxy_stubs,
+    AdminApiServer, RunningAdminApi, SERVE_OPTION_KEYS, filter_proxy_responses, filter_proxy_stubs,
 };
 use rift_http_proxy::config_loader::{self, ConfigSource};
 use rift_http_proxy::injection_gate;
@@ -228,8 +228,17 @@ unsafe fn resolve_flow_arg(
 /// `rift_serve_admin` options (all fields optional). Typed so a wrong-JSON-type field is a serde
 /// error surfaced via `last_error` — not silently coerced to a default (a non-string `apiKey`
 /// silently disabling auth, or an out-of-range `port` truncating, would be a real footgun).
+/// `deny_unknown_fields` (issue #877): an unknown key is a hard error naming the key, rather than a
+/// silent drop that returns success while the option does nothing. This catches typos going
+/// forward; it is NOT the feature-detection mechanism — see [`SERVE_OPTION_KEYS`], since an engine
+/// released before this attribute existed cannot report anything about a key it never knew.
+///
+/// **Do not add `#[serde(alias = "…")]` to a field here.** serde-derive omits aliases from the
+/// `expected one of …` list that `serve_option_keys_match_the_struct_exactly` derives the field set
+/// from, so an alias would be silently accepted but never advertised — undiscoverable by exactly the
+/// SDKs `SERVE_OPTION_KEYS` exists to serve, and invisible to the drift guard.
 #[derive(serde::Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ServeOptions {
     host: Option<String>,
     port: Option<u16>,
@@ -2053,8 +2062,14 @@ pub extern "C" fn rift_abi_version() -> u32 {
 }
 
 /// Build identity as a STATIC JSON string — never freed; probe this symbol to detect a v2 library
-/// (issue #343). `{"version":"..","commit":"<sha>|null","builtAt":"<iso8601>|null","features":[..]}`.
+/// (issue #343).
+/// `{"version":"..","commit":"<sha>|null","builtAt":"<iso8601>|null","features":[..],"serveOptions":[..]}`.
 /// `commit`/`builtAt` are `null` unless stamped at build time (issue #344).
+///
+/// `serveOptions` lists the keys `rift_serve_admin`'s options document accepts (issue #877) — read
+/// it to feature-detect an option before sending it. It is **absent** on engines older than 0.17.0,
+/// and that absence is the signal: treat every serve option as unsupported. `features` is a
+/// different question (compiled cargo features), so do not conflate the two arrays.
 #[unsafe(no_mangle)]
 pub extern "C" fn rift_build_info() -> *const c_char {
     static INFO: OnceLock<CString> = OnceLock::new();
@@ -2071,6 +2086,10 @@ pub extern "C" fn rift_build_info() -> *const c_char {
             "commit": option_env!("RIFT_COMMIT"),
             "builtAt": option_env!("RIFT_BUILT_AT"),
             "features": features,
+            // Serve-option capability list (issue #877), deliberately a sibling of `features`:
+            // that array means compiled cfg features, and an SDK checking for `redis-backend`
+            // asks a different question from one checking whether `requireAdminAuth` is accepted.
+            "serveOptions": SERVE_OPTION_KEYS,
         });
         // Terminal last-resort: `json!` output cannot contain an interior NUL, so this fallback is
         // unreachable; and build info carries no status for the `{}` fallback to misreport
@@ -2341,5 +2360,122 @@ mod serve_options_tests {
             serde_json::from_str::<ServeOptions>(r#"{"allowInjection": "yes"}"#).is_err(),
             "a non-bool allowInjection must be a parse error, not silently coerced"
         );
+    }
+}
+
+#[cfg(test)]
+mod serve_option_capability_tests {
+    use super::*;
+
+    /// The field names serde itself will accept, taken from the `deny_unknown_fields` error rather
+    /// than from a hand-written list — so this is the authoritative set, not a second copy of it.
+    fn fields_serde_actually_accepts() -> Vec<String> {
+        // `.err().expect(..)` rather than `.expect_err(..)`: the latter needs `ServeOptions: Debug`,
+        // and this struct holds `api_key` — deriving Debug on it would put a credential one `{:?}`
+        // away from a log line.
+        let err = serde_json::from_str::<ServeOptions>(r#"{"__definitely_not_a_field__": 1}"#)
+            .err()
+            .expect("deny_unknown_fields must reject an unknown key");
+        let msg = err.to_string();
+        let Some((_, list)) = msg.split_once("expected one of ") else {
+            panic!(
+                "serde's unknown-field message no longer contains `expected one of` — this drift \
+                 guard derives the field set from it and must be updated. Got: {msg}"
+            );
+        };
+        let fields: Vec<String> = list
+            .split(',')
+            .filter_map(|part| part.trim().trim_end_matches('.').split('`').nth(1))
+            .map(str::to_owned)
+            .collect();
+        // Without this the guard degrades silently: a format change that keeps `expected one of`
+        // but drops the backticks yields an empty list, and the caller's assertion then fails as a
+        // confusing "declared vs nothing" diff instead of naming the real cause.
+        assert!(
+            !fields.is_empty(),
+            "parsed no field names out of serde's message — the format changed and this drift \
+             guard must be updated. Got: {msg}"
+        );
+        fields
+    }
+
+    // AC4: the capability list and the struct cannot drift apart. Both directions matter — a name
+    // in the list that is not a field would advertise an option that silently does nothing, and a
+    // field missing from the list would be undiscoverable by the SDKs this exists to serve.
+    // Deriving the truth from serde means adding a field without listing it fails here, which a
+    // hand-maintained length assertion would not reliably catch.
+    #[test]
+    fn serve_option_keys_match_the_struct_exactly() {
+        let mut actual = fields_serde_actually_accepts();
+        let mut declared: Vec<String> = SERVE_OPTION_KEYS.iter().map(|k| (*k).to_owned()).collect();
+        actual.sort();
+        declared.sort();
+        assert_eq!(
+            declared, actual,
+            "SERVE_OPTION_KEYS must name exactly the fields ServeOptions accepts"
+        );
+    }
+
+    // AC2: the list is published where an SDK can read it, and is kept out of `features`.
+    // `features` means compiled cfg features; conflating the two namespaces would make an SDK
+    // checking for `redis-backend` and one checking for `requireAdminAuth` read the same array.
+    #[test]
+    fn build_info_publishes_the_capability_list_separately_from_features() {
+        let raw = unsafe { CStr::from_ptr(rift_build_info()) }
+            .to_str()
+            .expect("build info is utf8");
+        let info: serde_json::Value = serde_json::from_str(raw).expect("build info is JSON");
+
+        let published: Vec<&str> = info["serveOptions"]
+            .as_array()
+            .expect("build info exposes a serveOptions array")
+            .iter()
+            .map(|v| v.as_str().expect("serveOptions entries are strings"))
+            .collect();
+        assert_eq!(published, SERVE_OPTION_KEYS);
+
+        let features = info["features"].as_array().expect("features array");
+        for key in SERVE_OPTION_KEYS {
+            assert!(
+                !features.iter().any(|f| f.as_str() == Some(key)),
+                "`{key}` leaked into `features`; option names and cfg features are separate namespaces"
+            );
+        }
+    }
+
+    // AC3: an unknown key is now a hard error that names the offending key. Naming it is the point —
+    // a bare "invalid options" would leave an operator guessing which of eight keys they mistyped.
+    #[test]
+    fn an_unknown_option_is_rejected_and_names_the_key() {
+        let err = serde_json::from_str::<ServeOptions>(r#"{"requireAdminAuthh": true}"#)
+            .err()
+            .expect("an unknown key must be rejected");
+        assert!(
+            err.to_string().contains("requireAdminAuthh"),
+            "the error must name the offending key, got: {err}"
+        );
+    }
+
+    // AC5: the compatibility direction. Every documented key, type-valid, must still parse — a
+    // false positive here would break every SDK at once, which is the risk `deny_unknown_fields`
+    // carries and the reason this guard sits next to it.
+    #[test]
+    fn a_document_using_every_option_still_parses() {
+        let full = serde_json::json!({
+            "host": "127.0.0.1",
+            "port": 0,
+            "apiKey": "s3cr3t",
+            "metricsPort": 0,
+            "configFile": "/tmp/nope.json",
+            "config": {"imposters": []},
+            "allowInjection": true,
+            "requireAdminAuth": false,
+        });
+        assert_eq!(
+            full.as_object().expect("object").len(),
+            SERVE_OPTION_KEYS.len(),
+            "this fixture must exercise every advertised key"
+        );
+        serde_json::from_value::<ServeOptions>(full).expect("a full valid options document parses");
     }
 }

--- a/crates/rift-ffi/tests/round_trip.rs
+++ b/crates/rift-ffi/tests/round_trip.rs
@@ -2569,3 +2569,100 @@ fn ffi_omitting_require_admin_auth_is_accepted_and_defaults_off() {
         rift_stop(h);
     }
 }
+
+// ── issue #877: serve-option capability list + unknown-key rejection, across the C-ABI ────────
+
+// AC3 at the real boundary: an SDK that misspells an option now gets NULL and a last_error naming
+// the key, instead of a success response and an option that silently did nothing.
+#[test]
+fn ffi_unknown_serve_option_is_rejected_naming_the_key() {
+    unsafe {
+        let h = rift_start();
+        let opts = cstr(r#"{"host": "127.0.0.1", "port": 0, "requireAdminAuthh": true}"#);
+        assert!(
+            rift_serve_admin(h, opts.as_ptr()).is_null(),
+            "an unknown serve option must be rejected, not silently dropped"
+        );
+
+        let err = rift_last_error();
+        assert!(!err.is_null(), "the rejection must record last_error");
+        let msg = take_json(err);
+        assert!(
+            msg.contains("requireAdminAuthh"),
+            "last_error must name the offending key, got: {msg}"
+        );
+
+        rift_stop(h);
+    }
+}
+
+// AC2/AC6: the capability list an SDK reads before sending an option. `rift_build_info` is a static
+// string needing no handle, so an SDK can probe it before deciding anything — which is the whole
+// point: absence of `serveOptions` means an engine too old to report capabilities.
+#[test]
+fn ffi_build_info_advertises_serve_options() {
+    unsafe {
+        let raw = CStr::from_ptr(rift_build_info())
+            .to_str()
+            .expect("build info utf8");
+        let info: serde_json::Value = serde_json::from_str(raw).expect("build info is JSON");
+        let opts = info["serveOptions"]
+            .as_array()
+            .expect("build info advertises serveOptions");
+        let names: Vec<&str> = opts.iter().filter_map(|v| v.as_str()).collect();
+        for expected in [
+            "host",
+            "port",
+            "apiKey",
+            "allowInjection",
+            "requireAdminAuth",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "serveOptions must advertise `{expected}`, got: {names:?}"
+            );
+        }
+    }
+}
+
+// AC5 across the ABI: the compatibility direction — a document using every advertised option still
+// serves. This is the regression `deny_unknown_fields` could break for all four SDKs at once.
+#[test]
+fn ffi_a_document_using_every_advertised_option_still_serves() {
+    unsafe {
+        let h = rift_start();
+        let info: serde_json::Value = {
+            let raw = CStr::from_ptr(rift_build_info()).to_str().expect("utf8");
+            serde_json::from_str(raw).expect("json")
+        };
+        let advertised: Vec<String> = info["serveOptions"]
+            .as_array()
+            .expect("serveOptions")
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect();
+
+        // Built from the advertised list, so this fails if the engine advertises a key it will not
+        // actually accept — the failure mode the capability list exists to prevent.
+        let mut doc = serde_json::Map::new();
+        for key in &advertised {
+            let value = match key.as_str() {
+                "host" => serde_json::json!("127.0.0.1"),
+                "port" | "metricsPort" => serde_json::json!(0),
+                "apiKey" => serde_json::json!("s3cr3t"),
+                "configFile" => continue, // mutually exclusive with `config`; covered elsewhere
+                "config" => serde_json::json!({"imposters": []}),
+                "allowInjection" => serde_json::json!(true),
+                "requireAdminAuth" => serde_json::json!(false),
+                other => {
+                    panic!("unhandled advertised serve option `{other}` — extend this fixture")
+                }
+            };
+            doc.insert(key.clone(), value);
+        }
+
+        let info = serve_admin(h, &serde_json::Value::Object(doc).to_string());
+        assert!(info["adminPort"].as_u64().expect("adminPort") > 0);
+        rift_stop(h);
+    }
+}

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -70,6 +70,11 @@ pub fn handle_config(allow_injection: bool) -> Response<Full<Bytes>> {
             "localOnly": false,
             "ipWhitelist": ["*"]
         },
+        // Serve-option capability list (issue #877), a sibling of the Mountebank-shaped `options`
+        // above rather than a member of it — existing clients parse that object, and this is ours.
+        // An HTTP-only consumer feature-detects on this exactly as an FFI consumer does on
+        // `rift_build_info().serveOptions`; absence means an engine too old to report capabilities.
+        "serveOptions": crate::admin_api::SERVE_OPTION_KEYS,
         "process": {
             "nodeVersion": "N/A (Rust)",
             "architecture": std::env::consts::ARCH,

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -23,3 +23,26 @@ pub use server::{
 
 /// Default port for the Mountebank-compatible admin API.
 pub const DEFAULT_ADMIN_PORT: u16 = 2525;
+
+/// Every key the embedded serve-options document accepts (`rift_serve_admin`'s JSON, issue #877),
+/// published verbatim by `rift_build_info().serveOptions` and `GET /config`.
+///
+/// This exists because `rift_abi_version`'s "additive symbols are discovered by presence"
+/// convention cannot reach a JSON *field* — there is no symbol for an SDK to probe. Publishing the
+/// accepted keys is the only mechanism that works against **already-released** engines: an older
+/// engine simply has no `serveOptions` key, so its absence is the signal. A `deny_unknown_fields`
+/// rejection cannot do that, because the engine doing the ignoring is the old one.
+///
+/// It lives here rather than beside `ServeOptions` in `rift-ffi` so the C-ABI and the admin API can
+/// publish one list instead of two that drift; `rift-ffi` already depends on this crate.
+/// `rift-ffi`'s `serve_option_keys_match_the_struct_exactly` pins it to the struct.
+pub const SERVE_OPTION_KEYS: &[&str] = &[
+    "host",
+    "port",
+    "apiKey",
+    "metricsPort",
+    "configFile",
+    "config",
+    "allowInjection",
+    "requireAdminAuth",
+];

--- a/crates/rift-http-proxy/tests/issue_877_serve_option_capabilities.rs
+++ b/crates/rift-http-proxy/tests/issue_877_serve_option_capabilities.rs
@@ -1,0 +1,57 @@
+//! Issue #877: `GET /config` publishes the same serve-option capability list the C-ABI does, so an
+//! HTTP-only consumer can feature-detect without going through `rift_build_info`.
+//!
+//! The list exists because `ServeOptions` fields have no symbol to probe — `rift_abi_version`'s
+//! "additive symbols are discovered by presence" convention cannot reach them. Absence of the key
+//! is the signal an engine is too old to report capabilities, which is why this works against
+//! already-released engines where a `deny_unknown_fields` rejection would not.
+
+use rift_http_proxy::admin_api::{AdminApiServer, SERVE_OPTION_KEYS};
+use rift_http_proxy::imposter::ImposterManager;
+use std::sync::Arc;
+
+// AC6: the HTTP surface advertises exactly the shared constant — not a hand-copied second literal,
+// which is the drift this asserts against.
+#[tokio::test]
+async fn get_config_publishes_the_serve_option_capability_list() {
+    let running = AdminApiServer::new(
+        "127.0.0.1:0".parse().expect("addr"),
+        Arc::new(ImposterManager::new()),
+        None,
+    )
+    .bind()
+    .await
+    .expect("admin API binds");
+    let base = format!("http://{}", running.local_addr());
+
+    let config: serde_json::Value = reqwest::get(format!("{base}/config"))
+        .await
+        .expect("GET /config")
+        .json()
+        .await
+        .expect("config is JSON");
+
+    let published: Vec<&str> = config["serveOptions"]
+        .as_array()
+        .expect("GET /config exposes a serveOptions array")
+        .iter()
+        .map(|v| v.as_str().expect("entries are strings"))
+        .collect();
+    assert_eq!(
+        published, SERVE_OPTION_KEYS,
+        "the HTTP surface must publish the shared list verbatim"
+    );
+
+    // The Mountebank-compatible `options` object is deliberately untouched: the capability list is
+    // a sibling key, not a new member of a shape existing clients already parse.
+    assert!(
+        config["options"]["port"].is_number(),
+        "the Mountebank-shaped options object must be unchanged"
+    );
+    assert!(
+        config["options"]["serveOptions"].is_null(),
+        "the capability list must NOT be nested inside the Mountebank options object"
+    );
+
+    running.shutdown().await;
+}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -669,13 +669,31 @@ Get current configuration.
 **Response:**
 ```json
 {
+  "version": "0.17.0",
   "options": {
     "port": 2525,
     "allowInjection": true,
     "localOnly": false
-  }
+  },
+  "serveOptions": [
+    "host", "port", "apiKey", "metricsPort",
+    "configFile", "config", "allowInjection", "requireAdminAuth"
+  ]
 }
 ```
+
+`serveOptions` (since 0.17.0, issue #877) lists the keys the embedded serve-options document
+accepts, so a consumer can feature-detect an option before sending it. **Absence of the key means an
+engine too old to report capabilities** — treat every option as unsupported rather than assuming a
+rejection you will never receive. It is the same list `rift_build_info().serveOptions` publishes over
+the C-ABI, and is a sibling of `options` rather than a member of it: `options` is the
+Mountebank-compatible shape and is unchanged.
+
+**Reading this from the standalone binary:** there is no serve-options document in process mode —
+that door only exists for an embedded host going through `rift_serve_admin`. The list is still a
+faithful capability signal for the running release, but a process-mode consumer sets the equivalent
+lever on the command line instead: `requireAdminAuth` → `--require-admin-auth`, `allowInjection` →
+`--allow-injection`, `configFile` → `--configfile`, `apiKey` → `--api-key`, and so on.
 
 ---
 

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -110,6 +110,8 @@ rift_free(result);
   `{"host":"127.0.0.1","port":0,"apiKey":null,"metricsPort":null,"configFile":null,"config":null,"allowInjection":false,"requireAdminAuth":false}`.
   `port: 0` binds an ephemeral port; `configFile` is loaded as the reload source (like `--configfile`);
   `config` is an inline `{"imposters":[...]}`. `configFile` and `config` do not compose — pass one.
+  Since 0.17.0 an **unknown key is a hard error** naming the key (`NULL` + `rift_last_error`), not a
+  silent drop — so a typo fails loudly instead of leaving the option quietly inert.
 - **`apiKey`**: a blank string is rejected — `rift_serve_admin` returns `NULL` and records the
   reason in `rift_last_error`. A blank key would enable the admin auth gate and then authenticate
   every request, and the realistic way to send one is plumbing rather than intent
@@ -121,14 +123,9 @@ rift_free(result);
   *authentication*, not on the address — a real `apiKey` satisfies it on any bind. Under a refusal
   `rift_serve_admin` returns `NULL` with the reason in `rift_last_error`, and nothing has been bound.
 
-  **This field is not self-gating — check the engine version before relying on it.** `ServeOptions`
-  does not use `deny_unknown_fields`, so an engine older than 0.17.0 **silently ignores**
-  `requireAdminAuth` and serves the keyless off-host admin plane anyway, returning a normal
-  `{"adminPort":…}`. There is no error to detect. An SDK that offers this option must gate it on the
-  engine version from `rift_build_info` rather than assuming a rejection it will never receive.
-  (Note this is not something a newer engine can fix retroactively: the old engine is the one doing
-  the ignoring.) Omitting the field is the previous behaviour exactly, so an SDK built against an
-  older engine is otherwise unaffected.
+  **Feature-detect it** — see *Detecting which options an engine accepts* below. Against an engine
+  released before 0.17.0 this field is silently ignored and the keyless off-host admin plane is
+  served anyway, with a normal `{"adminPort":…}` and nothing to catch.
 
   The default `Warn` posture writes through the `tracing` facade. `rift-ffi` installs **no**
   subscriber — correct for a library, but it means an embedding host that has not installed one of
@@ -156,6 +153,31 @@ rift_free(result);
   fails the serve outright (`NULL` + `rift_last_error`) rather than loading, so nothing is applied.
 - **Returns** (caller frees): `{"adminPort":...,"adminUrl":"...","metricsPort":...}`, or `NULL` on
   error (bad JSON, bind failure, or already serving — one admin plane per handle).
+
+### Detecting which options an engine accepts
+
+`rift_build_info()` publishes the accepted option keys as `serveOptions` (issue #877), so an SDK can
+check before sending one:
+
+```jsonc
+{"version":"0.17.0","commit":"…","builtAt":"…","features":["javascript"],
+ "serveOptions":["host","port","apiKey","metricsPort","configFile","config",
+                 "allowInjection","requireAdminAuth"]}
+```
+
+**Absence of the key is the signal.** An engine older than 0.17.0 reports no `serveOptions` at all —
+treat that as "no serve option can be relied upon" and fall back to the behaviour you would have had
+without the option. This is the only check that works against already-released engines, and it is why
+you must not feature-detect by sending the option and watching for an error:
+
+- an engine **older** than 0.17.0 accepts the JSON, ignores the key, and returns success — there is
+  no error to catch, and for `requireAdminAuth` specifically the silent outcome is *fail-open*;
+- an engine **0.17.0 or newer** does reject an unknown key, but relying on that means probing by
+  deliberately provoking a failure, and it still tells you nothing about the older engines.
+
+`serveOptions` is deliberately separate from `features`, which lists compiled cargo features
+(`redis-backend`, `javascript`) — different question, different array. The same list is published
+over HTTP at `GET /config` for consumers that do not link the C-ABI.
 
 ## Intercept proxy over FFI
 


### PR DESCRIPTION
SDKs could not feature-detect new ServeOptions keys — sending a new option to an older engine returned success and silently did nothing. For requireAdminAuth (#863), that silence was fail-OPEN.

rift_build_info() and GET /config now publish the accepted keys as serveOptions, from one shared constant. Absence of the key is the signal for an older engine.

ServeOptions gains deny_unknown_fields for hard errors on typos. Passing an unknown key to rift_serve_admin now fails.

Closes #877