### PR TITLE
--intercept-port exposes an unauthenticated TLS-MITM proxy — add Proxy-Authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ record.
 
 ### Added
 
+- **`--intercept-auth` — require `Proxy-Authorization` on the TLS intercept proxy** (issue #878).
+  The intercept listener took its bind host from the admin host (default `0.0.0.0`) and had no
+  authentication of any kind, so `--require-admin-auth --api-key … --intercept-port 8888` gave an
+  authenticated admin plane beside an open MITM proxy. `--intercept-auth user:pass`
+  (`RIFT_INTERCEPT_AUTH`, the config block's `auth`, `POST /intercept`'s `auth`, and
+  `rift_start_intercept`'s `auth`) requires `Proxy-Authorization: Basic …` on every `CONNECT`;
+  anything else is `407` **before** the TLS handshake, so an unauthenticated caller never causes a
+  leaf certificate to be minted.
+
+  It is a separate credential from `--api-key` deliberately: `Proxy-Authorization` is hop-by-hop and
+  consumed by the proxy, while `Authorization` is end-to-end and would be forwarded to every
+  intercepted origin.
+
+  `--require-admin-auth` now also covers this listener, at every door on the standalone binary — the
+  flag, the config block, and a listener started at runtime over `POST /intercept`, which answers
+  `403` rather than binding an exposed keyless one. (Checking only at boot would have left the
+  runtime door open, which is the same hole one layer along.) Embedders using the C-ABI get the
+  warning but not the refusal, since the policy travels on the process's `InterceptControl`.
+  `--intercept-auth` without `--intercept-port` is now a startup error too — a credential guarding
+  nothing reads as protection while providing none.
+
 - **`--require-admin-auth` — opt in to refusing a keyless off-host admin plane** (issue #863).
   `--host` defaults to `0.0.0.0`, so a bare keyless `rift` already serves the full admin API — which
   can create imposters and drive the TLS intercept proxy — on every interface with no
@@ -82,6 +103,19 @@ record.
   attributed — only the in-process listener is. See `docs/embedding/spi.md`.
 
 ### Security
+
+- **The TLS intercept proxy was reachable off-host with no authentication** (issue #878). Every
+  release that shipped `--intercept-port` bound the listener to the admin host — `0.0.0.0` by
+  default — with no credential and no way to add one. Anyone who could reach the port could route
+  traffic through it and receive certificates forged by Rift's CA, which are trusted wherever that
+  CA has been installed; installing it in the system or JVM truststore is the documented way to use
+  the feature, so the trusted case is the normal one.
+
+  **If you run `--intercept-port` on anything but loopback**, set `--intercept-auth user:pass` (see
+  *Added*), or restrict the bind with `--local-only` / `--host 127.0.0.1`. The default is unchanged
+  and still open — turning auth on by default would break every existing intercept user — so this
+  needs an explicit action from you. Setting `--require-admin-auth` makes the exposed case a startup
+  failure instead.
 
 - **An empty `--api-key` enabled the admin auth gate and then authenticated everyone** (issue #844).
   `Some("")` is `Some`, so the gate switched on; a request with no `Authorization` header degrades

--- a/crates/rift-ffi/src/lib.rs
+++ b/crates/rift-ffi/src/lib.rs
@@ -1473,6 +1473,12 @@ pub unsafe extern "C" fn rift_start_intercept(
                     InterceptStartError::InvalidAddr(s) => {
                         format!("rift_start_intercept: invalid host/port: {s}")
                     }
+                    InterceptStartError::InvalidAuth(s) => {
+                        format!("rift_start_intercept: invalid auth: {s}")
+                    }
+                    InterceptStartError::Exposed(s) => {
+                        format!("rift_start_intercept: refused: {s}")
+                    }
                     // `{err:#}` so the chained cause (missing file, bad PEM, mismatched pair)
                     // reaches the caller — `rift_last_error` is their only diagnostic channel.
                     // (`InterceptControl::start` already `warn!`s the CA/bind failure server-side.)

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -127,6 +127,10 @@ async fn start_from_bytes(
                 // Same code the runtime rule route returns for a full store, so one condition has
                 // one status whichever door reports it (issue #655).
                 InterceptStartError::Rules(_) => StatusCode::TOO_MANY_REQUESTS,
+                // Policy refusal, not a malformed body (issue #878): the options are valid, the
+                // server is configured to refuse an off-host listener with no credential. `403`
+                // rather than `400` so a caller can tell "fix your JSON" from "not allowed here".
+                InterceptStartError::Exposed(_) => StatusCode::FORBIDDEN,
                 _ => StatusCode::BAD_REQUEST,
             };
             error_response(status, &e.to_string())
@@ -505,6 +509,7 @@ mod tests {
             "127.0.0.1:0".parse().unwrap(),
             resolver,
             state.rules.clone(),
+            None,
         )
         .await
         .expect("bind");

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -18,7 +18,7 @@ pub mod types;
 pub use handlers::imposters::{filter_proxy_responses, filter_proxy_stubs};
 pub use server::{
     AdminApiServer, AdminExposurePolicy, RunningAdminApi, check_admin_exposure,
-    validate_admin_api_key,
+    check_intercept_exposure, validate_admin_api_key,
 };
 
 /// Default port for the Mountebank-compatible admin API.

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -803,14 +803,6 @@ pub fn check_admin_exposure(
     api_key: Option<&str>,
     policy: AdminExposurePolicy,
 ) -> anyhow::Result<()> {
-    // `to_canonical` first: `Ipv6Addr::is_loopback` matches only the literal `::1`, so an
-    // IPv4-mapped `::ffff:127.0.0.1` — which some address-normalising front ends hand over — would
-    // otherwise be judged off-host and refused under `Refuse` despite being loopback-only. The
-    // mapping is safe in the other direction too: `::ffff:10.0.0.5` canonicalises to `10.0.0.5`,
-    // which is still not loopback, so nothing genuinely reachable becomes exempt.
-    if api_key.is_some() || addr.ip().to_canonical().is_loopback() {
-        return Ok(());
-    }
     let message = format!(
         "the admin API is bound to {addr}, which is reachable from outside this host, with no API \
          key — anyone who can reach that address can create imposters and drive the TLS intercept \
@@ -818,12 +810,61 @@ pub fn check_admin_exposure(
          `--host 127.0.0.1`. Set `--require-admin-auth` (`RIFT_REQUIRE_ADMIN_AUTH`) to make this a \
          startup failure instead of a warning."
     );
+    judge_exposure(addr, api_key.is_some(), policy, &message)
+}
+
+/// Warn or refuse when the **intercept** listener would bind a non-loopback address with no proxy
+/// credential (issue #878).
+///
+/// Same rule and same policy as [`check_admin_exposure`], one listener over. It is a sibling rather
+/// than a widened signature because `check_admin_exposure` is public API that `rift-ffi` already
+/// calls, and because the two need different remedies in their messages.
+///
+/// This listener deserves the check at least as much as the admin plane: it is a TLS-MITM proxy, so
+/// an unauthenticated caller who can reach it is served forged certificates from Rift's CA — which
+/// is trusted wherever that CA was installed, and installing it is the entire point of the feature.
+///
+/// Callers must invoke this before binding anything, for the reason given on [`check_admin_exposure`].
+pub fn check_intercept_exposure(
+    addr: SocketAddr,
+    has_credential: bool,
+    policy: AdminExposurePolicy,
+) -> anyhow::Result<()> {
+    let message = format!(
+        "the TLS intercept proxy is bound to {addr}, which is reachable from outside this host, \
+         with no proxy credential — anyone who can reach that address can route traffic through it \
+         and be served certificates forged by Rift's CA. Set `--intercept-auth <user:pass>` \
+         (`RIFT_INTERCEPT_AUTH`), or restrict the bind with `--local-only` or `--host 127.0.0.1`. \
+         Set `--require-admin-auth` (`RIFT_REQUIRE_ADMIN_AUTH`) to make this a startup failure \
+         instead of a warning."
+    );
+    judge_exposure(addr, has_credential, policy, &message)
+}
+
+/// The one exposure rule both public checks apply: a bind reachable off-host with no credential is
+/// warned about, or refused under [`AdminExposurePolicy::Refuse`]. Shared so the two listeners can
+/// never drift on what "exposed" means.
+///
+/// `to_canonical` first: `Ipv6Addr::is_loopback` matches only the literal `::1`, so an IPv4-mapped
+/// `::ffff:127.0.0.1` — which some address-normalising front ends hand over — would otherwise be
+/// judged off-host and refused despite being loopback-only. The mapping is safe in the other
+/// direction too: `::ffff:10.0.0.5` canonicalises to `10.0.0.5`, still not loopback, so nothing
+/// genuinely reachable becomes exempt.
+fn judge_exposure(
+    addr: SocketAddr,
+    has_credential: bool,
+    policy: AdminExposurePolicy,
+    message: &str,
+) -> anyhow::Result<()> {
+    if has_credential || addr.ip().to_canonical().is_loopback() {
+        return Ok(());
+    }
     match policy {
         AdminExposurePolicy::Warn => {
             warn!("{message}");
             Ok(())
         }
-        AdminExposurePolicy::Refuse => anyhow::bail!(message),
+        AdminExposurePolicy::Refuse => anyhow::bail!(message.to_string()),
     }
 }
 

--- a/crates/rift-http-proxy/src/config_loader.rs
+++ b/crates/rift-http-proxy/src/config_loader.rs
@@ -470,6 +470,7 @@ mod tests {
         "intercept": {
             "host": "0.0.0.0",
             "port": 8080,
+            "auth": {"username":"ci","password":"s3cr3t"},
             "rules": [{"host":"cdn.example.com","action":{"forward":{"port":4545}}}]
         }
     }"#;
@@ -561,6 +562,11 @@ mod tests {
         assert_eq!(intercept.port, Some(8080));
         assert_eq!(intercept.rules.len(), 1);
         assert_eq!(intercept.rules[0].host.as_deref(), Some("cdn.example.com"));
+        // Issue #878: the config-file door had no coverage of `auth` at all — it had never been
+        // proven to parse, let alone reach the listener.
+        let auth = intercept.auth.expect("the block's auth is read");
+        assert_eq!(auth.username, "ci");
+        assert_eq!(auth.password, "s3cr3t");
     }
 
     /// AC2: absent block → exactly today's behaviour, imposters untouched.

--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -16,10 +16,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::intercept_control::InterceptAuth;
 use crate::intercept_rules::{InterceptAction, InterceptRules, ServeStub};
 use base64::Engine;
 use rift_mock_core::proxy::intercept_ca::SniCertResolver;
 use rustls::ServerConfig;
+use subtle::ConstantTimeEq;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
@@ -64,10 +66,14 @@ impl InterceptListener {
     ///
     /// `rules` is matched against every intercepted request (issue #398); an empty store falls
     /// back to the fixed slice-3 200 response.
+    ///
+    /// `auth`, when set, requires `Proxy-Authorization: Basic …` on every `CONNECT` (issue #878);
+    /// `None` leaves the proxy open, which is the behaviour it has always had.
     pub async fn bind(
         addr: SocketAddr,
         resolver: Arc<SniCertResolver>,
         rules: InterceptRules,
+        auth: Option<InterceptAuth>,
     ) -> anyhow::Result<Self> {
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
@@ -80,6 +86,7 @@ impl InterceptListener {
         // multi-instance use keeps pools independent; building here also surfaces a failure as a
         // start error instead of a lazy-init panic.
         let forward_client = build_forward_client()?;
+        let auth = auth.map(Arc::new);
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
         let handle = tokio::spawn(async move {
@@ -91,8 +98,9 @@ impl InterceptListener {
                             let tls = tls.clone();
                             let rules = rules.clone();
                             let forward_client = forward_client.clone();
+                            let auth = auth.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, tls, rules, forward_client).await {
+                                if let Err(e) = handle_connection(stream, tls, rules, forward_client, auth).await {
                                     tracing::debug!(%peer, error = %e, "intercept connection ended");
                                 }
                             });
@@ -166,6 +174,7 @@ async fn handle_connection(
     tls: TlsAcceptor,
     rules: InterceptRules,
     forward_client: reqwest::Client,
+    auth: Option<Arc<InterceptAuth>>,
 ) -> anyhow::Result<()> {
     let head = timeout(IO_TIMEOUT, read_connect_head(&mut stream))
         .await
@@ -176,6 +185,24 @@ async fn handle_connection(
             .await?;
         return Ok(());
     };
+
+    // Issue #878, and the ordering is load-bearing: this sits BEFORE the `200` below, because TLS
+    // only starts after it. Checking here means an unauthenticated caller never reaches the
+    // handshake, so Rift never mints a leaf certificate for an SNI of their choosing. Moving this
+    // after the `200` would still refuse the request while doing exactly the work worth refusing.
+    if let Some(ref auth) = auth
+        && !proxy_credential_matches(&head, auth)
+    {
+        stream
+            .write_all(
+                b"HTTP/1.1 407 Proxy Authentication Required\r\n\
+                  Proxy-Authenticate: Basic realm=\"rift-intercept\"\r\n\
+                  connection: close\r\n\r\n",
+            )
+            .await?;
+        tracing::debug!(%target, "intercept CONNECT refused: missing or invalid Proxy-Authorization");
+        return Ok(());
+    }
 
     stream
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
@@ -481,6 +508,38 @@ where
     Ok(body)
 }
 
+/// Does the `CONNECT` head carry a `Proxy-Authorization: Basic …` matching `expected` (issue #878)?
+///
+/// Reuses [`parse_request_head`] rather than parsing the header block a second time — it already
+/// lowercases names, so the lookup is case-insensitive as HTTP requires.
+///
+/// Fails **closed** at every step it cannot complete: a missing header, a non-Basic scheme,
+/// undecodable base64, non-UTF-8 bytes or a value with no `:` all return `false`. A classifier that
+/// cannot read the credential must treat it as absent, never as valid.
+fn proxy_credential_matches(head: &[u8], expected: &InterceptAuth) -> bool {
+    let (_, _, _, headers) = parse_request_head(head);
+    let Some(value) = headers.get("proxy-authorization") else {
+        return false;
+    };
+    let Some(encoded) = value
+        .split_once(char::is_whitespace)
+        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("basic"))
+        .map(|(_, rest)| rest.trim())
+    else {
+        return false;
+    };
+    let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(encoded) else {
+        return false;
+    };
+
+    // Compare the whole `user:pass` in one pass, so timing cannot reveal whether the username alone
+    // was right — which comparing the halves separately would leak. `ct_eq` short-circuits on a
+    // length mismatch, so the credential's *length* is still observable; that is inherent to
+    // comparing variable-length secrets and is the same bound `api_key_matches` accepts.
+    let expected_pair = format!("{}:{}", expected.username, expected.password);
+    expected_pair.as_bytes().ct_eq(&decoded).into()
+}
+
 fn parse_connect(head: &[u8]) -> Option<ConnectTarget> {
     let text = std::str::from_utf8(head).ok()?;
     let line = text.lines().next().unwrap_or("");
@@ -674,6 +733,140 @@ mod tests {
         }
     }
 
+    // Issue #878: `proxy_credential_matches` is a security classifier, so its fail-closed branches
+    // are the point of it. The integration tests cover missing / wrong / non-Basic over a real
+    // socket; these cover the decode paths that are awkward to provoke there and would otherwise
+    // rest entirely on the doc comment's word.
+    mod proxy_auth {
+        use super::*;
+
+        fn auth() -> InterceptAuth {
+            InterceptAuth {
+                username: "ci".to_string(),
+                password: "s3cr3t".to_string(),
+            }
+        }
+
+        fn head(extra: &str) -> Vec<u8> {
+            format!("CONNECT cdn.example.com:443 HTTP/1.1\r\nHost: cdn.example.com\r\n{extra}\r\n")
+                .into_bytes()
+        }
+
+        fn encoded(raw: &str) -> String {
+            base64::engine::general_purpose::STANDARD.encode(raw)
+        }
+
+        #[test]
+        fn accepts_only_the_exact_credential() {
+            let ok = head(&format!(
+                "Proxy-Authorization: Basic {}\r\n",
+                encoded("ci:s3cr3t")
+            ));
+            assert!(proxy_credential_matches(&ok, &auth()));
+        }
+
+        #[test]
+        fn fails_closed_on_every_unreadable_credential() {
+            let cases = vec![
+                ("no header at all", head("")),
+                (
+                    "wrong password",
+                    head(&format!(
+                        "Proxy-Authorization: Basic {}\r\n",
+                        encoded("ci:wrong")
+                    )),
+                ),
+                (
+                    "right password, wrong user",
+                    head(&format!(
+                        "Proxy-Authorization: Basic {}\r\n",
+                        encoded("nope:s3cr3t")
+                    )),
+                ),
+                (
+                    "non-Basic scheme",
+                    head("Proxy-Authorization: Bearer abc\r\n"),
+                ),
+                (
+                    "scheme with no value",
+                    head("Proxy-Authorization: Basic\r\n"),
+                ),
+                (
+                    "undecodable base64",
+                    head("Proxy-Authorization: Basic !!!not-base64!!!\r\n"),
+                ),
+                (
+                    "decodes, but carries no colon",
+                    head(&format!(
+                        "Proxy-Authorization: Basic {}\r\n",
+                        encoded("cis3cr3t")
+                    )),
+                ),
+                (
+                    "empty credential",
+                    head(&format!("Proxy-Authorization: Basic {}\r\n", encoded(""))),
+                ),
+                (
+                    // The `Authorization` header is NOT a substitute: it is end-to-end and meant for
+                    // the origin, so accepting it here would be the credential-leak this design
+                    // deliberately avoids.
+                    "admin-style Authorization header instead",
+                    head(&format!(
+                        "Authorization: Basic {}\r\n",
+                        encoded("ci:s3cr3t")
+                    )),
+                ),
+            ];
+            for (why, h) in cases {
+                assert!(
+                    !proxy_credential_matches(&h, &auth()),
+                    "must fail closed: {why}"
+                );
+            }
+        }
+
+        // Headers land in a `HashMap`, so a duplicate overwrites: last wins. Pinned as intentional
+        // — Rift is the terminal parser here, so this cannot be smuggled past a downstream hop, but
+        // the behaviour should change deliberately rather than by accident.
+        #[test]
+        fn a_duplicate_header_takes_the_last_value() {
+            let good = encoded("ci:s3cr3t");
+            let bad = encoded("ci:wrong");
+            let last_is_good = head(&format!(
+                "Proxy-Authorization: Basic {bad}\r\nProxy-Authorization: Basic {good}\r\n"
+            ));
+            let last_is_bad = head(&format!(
+                "Proxy-Authorization: Basic {good}\r\nProxy-Authorization: Basic {bad}\r\n"
+            ));
+            assert!(proxy_credential_matches(&last_is_good, &auth()));
+            assert!(!proxy_credential_matches(&last_is_bad, &auth()));
+        }
+
+        #[test]
+        fn header_name_is_case_insensitive() {
+            let h = head(&format!(
+                "PROXY-AUTHORIZATION: Basic {}\r\n",
+                encoded("ci:s3cr3t")
+            ));
+            assert!(proxy_credential_matches(&h, &auth()));
+        }
+
+        #[test]
+        fn a_blank_half_is_rejected_by_validate() {
+            for (u, p) in [("", "p"), ("u", ""), ("  ", "p"), ("u", "  ")] {
+                let a = InterceptAuth {
+                    username: u.to_string(),
+                    password: p.to_string(),
+                };
+                assert!(
+                    a.validate().is_err(),
+                    "a blank half enables the gate and then admits everyone: {u:?}/{p:?}"
+                );
+            }
+            assert!(auth().validate().is_ok());
+        }
+    }
+
     #[test]
     fn parse_connect_accepts_authority() {
         let t = parse_connect(b"CONNECT cdn.example.com:443 HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
@@ -709,9 +902,10 @@ mod tests {
         let ca = CertificateAuthority::generate().expect("ca");
         let ca_pem = ca.ca_cert_pem().to_string();
         let resolver = Arc::new(SniCertResolver::new(Arc::new(ca)));
-        let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules)
-            .await
-            .expect("bind");
+        let listener =
+            InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules, None)
+                .await
+                .expect("bind");
         (listener, ca_pem)
     }
 

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use crate::admin_api::{AdminExposurePolicy, check_intercept_exposure};
 use crate::intercept::InterceptListener;
 use crate::intercept_rules::{InterceptRule, InterceptRules, InterceptState, RulesAtCapacity};
 use rift_mock_core::proxy::intercept_ca::{CaSource, CertificateAuthority, SniCertResolver};
@@ -39,7 +40,15 @@ pub struct InterceptPlane {
 /// (an `Arc` inside). The `std` mutex is never held across an `.await` (see [`InterceptControl::start`]);
 /// poisoning is recovered rather than propagated, like [`InterceptRules`].
 #[derive(Clone, Default)]
-pub struct InterceptControl(Arc<Mutex<Option<InterceptPlane>>>);
+pub struct InterceptControl {
+    plane: Arc<Mutex<Option<InterceptPlane>>>,
+    /// What to do when a start would expose this listener off-host with no credential (issue #878).
+    ///
+    /// Deployment policy, so it lives on the control rather than on [`InterceptStartOptions`] — it
+    /// is the operator's call, not the caller's, and putting it in the request body would let the
+    /// very caller being judged turn the judgement off.
+    exposure: AdminExposurePolicy,
+}
 
 /// Start options — the exact shape (and serde attributes) of the FFI's former `InterceptOptions`,
 /// so the admin `POST /intercept` body and `rift_start_intercept` parse identically.
@@ -66,12 +75,55 @@ pub struct InterceptStartOptions {
     /// Generate a fresh CA and return its cert **and** key in the start response (issue #593).
     /// Only valid when no CA source is supplied — combining it with a path/PEM pair is a `400`.
     pub return_ca_key: Option<bool>,
+    /// Require `Proxy-Authorization: Basic <base64(user:pass)>` on `CONNECT` (issue #878).
+    /// `None` leaves the listener open, which is what it has always been — auth is opt-in because
+    /// the listener is off unless asked for and most uses are loopback test rigs.
+    pub auth: Option<InterceptAuth>,
     /// Rules to install before the listener accepts anything (issue #655). Lets one declarative
     /// document — a `--configfile` `intercept` block, a `POST /intercept` body, or an FFI start —
     /// bring up a listener that is already correct, instead of requiring a follow-up
     /// `POST /intercept/rules` that traffic can race.
     #[serde(default)]
     pub rules: Vec<InterceptRule>,
+}
+
+/// The credential the intercept proxy demands (issue #878).
+///
+/// Basic only. It is what every HTTP client and every `HTTPS_PROXY=http://user:pass@host` URL
+/// already speaks, and the tunnel it guards is plaintext to the client anyway — a stronger scheme
+/// here would imply a confidentiality this hop cannot provide.
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InterceptAuth {
+    pub username: String,
+    pub password: String,
+}
+
+impl InterceptAuth {
+    /// Reject a blank username or password, mirroring `validate_admin_api_key` (issue #844): a
+    /// blank secret switches the gate on and then admits everyone, which is strictly worse than
+    /// no gate because the operator believes one is in force. Whitespace-only counts as blank.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.username.trim().is_empty() || self.password.trim().is_empty() {
+            return Err(
+                "intercept proxy auth needs a non-blank username and password; a blank value \
+                 would enable the gate and then accept every request. Omit it entirely to run the \
+                 intercept listener explicitly unauthenticated."
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for InterceptAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Secret material — the username is shown because it is an identity, the password never is.
+        f.debug_struct("InterceptAuth")
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for InterceptStartOptions {
@@ -88,6 +140,7 @@ impl std::fmt::Debug for InterceptStartOptions {
                 &self.ca_key_pem.as_ref().map(|_| "<redacted>"),
             )
             .field("return_ca_key", &self.return_ca_key)
+            .field("auth", &self.auth)
             // Count only: a rule's serve body can be an arbitrarily large payload.
             .field("rules", &self.rules.len())
             .finish()
@@ -161,6 +214,14 @@ pub enum InterceptStartError {
     AlreadyRunning,
     #[error("invalid host/port: {0}")]
     InvalidAddr(String),
+    /// A supplied proxy credential is unusable (issue #878). Its own variant rather than folded
+    /// into `InvalidAddr` so the admin API's 400 names the real problem.
+    #[error("invalid intercept auth: {0}")]
+    InvalidAuth(String),
+    /// The start would expose the listener off-host with no credential, under a `Refuse` policy
+    /// (issue #878). Distinct from `InvalidAuth`: the options are well-formed, the *posture* is not.
+    #[error("{0}")]
+    Exposed(String),
     // `{0:#}` keeps the anyhow chain (missing file, bad PEM, mismatched pair). Never file contents.
     #[error("CA setup failed: {0:#}")]
     Ca(#[source] anyhow::Error),
@@ -173,8 +234,20 @@ pub enum InterceptStartError {
 }
 
 impl InterceptControl {
+    /// Set the exposure policy every [`start`](Self::start) through this control is judged against
+    /// (issue #878). The standalone binary threads `--require-admin-auth` in here, so a listener
+    /// brought up at runtime over `POST /intercept` gets the same answer as one asked for at boot.
+    ///
+    /// Clone-before-configure would lose it: set this on the control **before** handing clones to
+    /// the admin server.
+    #[must_use]
+    pub fn with_exposure_policy(mut self, policy: AdminExposurePolicy) -> Self {
+        self.exposure = policy;
+        self
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, Option<InterceptPlane>> {
-        self.0.lock().unwrap_or_else(|e| e.into_inner())
+        self.plane.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// True if a listener currently occupies the slot. A sync helper so the (`!Send`) `std`
@@ -212,6 +285,22 @@ impl InterceptControl {
         let addr: SocketAddr = format!("{host}:{}", opts.port.unwrap_or(0))
             .parse()
             .map_err(|e| InterceptStartError::InvalidAddr(format!("{e}")))?;
+
+        // Validate the credential before any side effect: a blank secret must never reach the
+        // listener, where it would switch the gate on and then admit everyone (issue #878/#844).
+        let auth = opts.auth;
+        if let Some(ref auth) = auth {
+            auth.validate().map_err(InterceptStartError::InvalidAuth)?;
+        }
+
+        // Judge the exposure here, at the one point all four doors converge, rather than only at
+        // the CLI ones (issue #878). `POST /intercept` and `rift_start_intercept` can bring up a
+        // listener long after boot: checking only at startup would let an operator who set
+        // `--require-admin-auth` still end up with an open MITM proxy on `0.0.0.0`, which is
+        // precisely the assurance that flag is supposed to give. Before any side effect, so a
+        // refusal never has to unwind a bound listener.
+        check_intercept_exposure(addr, auth.is_some(), self.exposure)
+            .map_err(|e| InterceptStartError::Exposed(format!("{e:#}")))?;
 
         // Resolve the single CA source (validating both-or-neither + pair exclusion) before binding.
         // Log CA/option failures here so every surface (FFI, admin `POST /intercept`, CLI flag) gets
@@ -256,7 +345,7 @@ impl InterceptControl {
         })?;
 
         let resolver = Arc::new(SniCertResolver::new(ca.clone()));
-        let listener = InterceptListener::bind(addr, resolver, rules.clone())
+        let listener = InterceptListener::bind(addr, resolver, rules.clone(), auth)
             .await
             .map_err(|e| {
                 warn_intercept_start_failure(&e, "bind failed");

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -12,7 +12,7 @@ use crate::imposter::{
     ImposterConfig, ImposterManager, ScriptBaseDir, TlsDefaults, resolve_scripts,
 };
 use crate::injection_gate::GATED_SCRIPT_SURFACES;
-use crate::intercept_control::{InterceptControl, InterceptStartOptions};
+use crate::intercept_control::{InterceptAuth, InterceptControl, InterceptStartOptions};
 use crate::sources::{
     self, FileSource, HttpSource, ImposterSource, SourceRef, SourceRegistry, SourceSet,
 };
@@ -190,6 +190,12 @@ pub struct Cli {
     /// unset. Configure rules and export the CA via the admin API's `/intercept/*` routes.
     #[arg(long, value_name = "PORT", env = "RIFT_INTERCEPT_PORT")]
     pub intercept_port: Option<u16>,
+
+    /// Require `Proxy-Authorization: Basic <user:pass>` on every `CONNECT` to the intercept
+    /// listener (issue #878). Off when unset — the proxy is then open, which is what it has always
+    /// been. The value is `user:pass`; a value with no `:` is a startup error.
+    #[arg(long, value_name = "USER:PASS", env = "RIFT_INTERCEPT_AUTH")]
+    pub intercept_auth: Option<String>,
 
     /// PEM CA certificate for interception. Used with `--intercept-ca-key`; a CA is generated
     /// in-memory when both are omitted.
@@ -430,6 +436,40 @@ impl ServerBuilder {
             cli.api_key.as_deref(),
             cli.require_admin_auth.into(),
         )?;
+        // The intercept listener gets the same judgement (issue #878) — it is a TLS-MITM proxy, so
+        // an exposed keyless one is worse than an exposed keyless admin plane, not better.
+        //
+        // Only the `--intercept-port` spelling is checked here. The config file's `intercept` block
+        // is not loaded yet, and it is checked at its own start site below; the two can never both
+        // be present, because supplying both is already refused when the file is loaded.
+        let cli_intercept_auth = parse_intercept_auth(cli.intercept_auth.as_deref())?;
+        if cli_intercept_auth.is_some() && cli.intercept_port.is_none() {
+            // A credential with no listener to guard is a misconfiguration that reads as a
+            // protection: the operator sets it, no listener starts at boot, and a later
+            // `POST /intercept` brings up an *open* proxy. Refusing is the same fail-loud rule as a
+            // blank secret — a gate the operator believes is in force must actually be in force.
+            anyhow::bail!(
+                "--intercept-auth was given without --intercept-port, so no listener uses it. \
+                 Add --intercept-port to start an authenticated listener now, or drop the flag and \
+                 supply `auth` in the `POST /intercept` body when you start one at runtime."
+            );
+        }
+        // The exposure judgement itself lives in `InterceptControl::start`, the one point all four
+        // doors converge on, so a listener started at runtime over `POST /intercept` is judged too.
+        // This early call exists only for the *refusal ordering*: under `Refuse` the error must not
+        // have to unwind the metrics listener that binds further down. Skipped under `Warn`, where
+        // `start` does the warning — running both would log it twice.
+        if cli.require_admin_auth
+            && let Some(intercept_port) = cli.intercept_port
+        {
+            let intercept_addr: SocketAddr =
+                format!("{host}:{intercept_port}").parse::<SocketAddr>()?;
+            crate::admin_api::check_intercept_exposure(
+                intercept_addr,
+                cli_intercept_auth.is_some(),
+                crate::admin_api::AdminExposurePolicy::Refuse,
+            )?;
+        }
         // Validate `--front-door` before anything else binds (issue #19 / U-11): a malformed
         // address is then a clean, fast failure that never has to unwind an already-bound
         // listener behind it.
@@ -588,7 +628,11 @@ impl ServerBuilder {
         // of the same listener; supplying both was already refused when the file was loaded, so at
         // most one of these arms can run. The block declares its own bind host, so unlike the flag
         // it does not inherit the admin `host`.
-        let intercept = InterceptControl::default();
+        // The policy is set on the control, not passed per start, so every door through it — the
+        // flag, the config block, and a runtime `POST /intercept` — is judged the same. Set before
+        // the clone handed to the admin server, or the runtime door would inherit the default.
+        let intercept =
+            InterceptControl::default().with_exposure_policy(cli.require_admin_auth.into());
         let start_options = intercept_block.or_else(|| {
             cli.intercept_port
                 .map(|intercept_port| InterceptStartOptions {
@@ -604,6 +648,7 @@ impl ServerBuilder {
                         .map(|p| p.to_string_lossy().into_owned()),
                     ca_cert_pem: cli.intercept_ca_cert_pem.clone(),
                     ca_key_pem: cli.intercept_ca_key_pem.clone(),
+                    auth: cli_intercept_auth,
                     // Cloned (not moved) because `cli` is borrowed for the rest of startup.
                     ..Default::default()
                 })
@@ -1108,9 +1153,36 @@ fn parse_front_door_addr(value: &str) -> anyhow::Result<SocketAddr> {
 }
 
 /// The `--intercept-*` flags the operator supplied, by long name; empty when none were.
+/// Parse `--intercept-auth <user:pass>` into a credential (issue #878).
+///
+/// A value with no `:` is a startup error rather than a silently-disabled gate: an operator who
+/// mistyped it must not end up running an open MITM proxy while believing it is closed. The blank
+/// halves are rejected by [`InterceptAuth::validate`] at start, so the two checks together cover
+/// `""`, `"user:"` and `":pass"`.
+fn parse_intercept_auth(raw: Option<&str>) -> anyhow::Result<Option<InterceptAuth>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let Some((username, password)) = raw.split_once(':') else {
+        anyhow::bail!(
+            "--intercept-auth must be `user:pass` (got a value with no `:`). It is the credential \
+             the intercept proxy requires in `Proxy-Authorization`; omit the flag entirely to run \
+             the listener explicitly unauthenticated."
+        );
+    };
+    let auth = InterceptAuth {
+        username: username.to_string(),
+        password: password.to_string(),
+    };
+    auth.validate()
+        .map_err(|e| anyhow::anyhow!("--intercept-auth: {e}"))?;
+    Ok(Some(auth))
+}
+
 fn cli_intercept_flags(cli: &Cli) -> Vec<&'static str> {
     [
         ("--intercept-port", cli.intercept_port.is_some()),
+        ("--intercept-auth", cli.intercept_auth.is_some()),
         ("--intercept-ca-cert", cli.intercept_ca_cert.is_some()),
         ("--intercept-ca-key", cli.intercept_ca_key.is_some()),
         (
@@ -2016,6 +2088,9 @@ mod tests {
     fn intercept_conflict_names_every_supplied_flag() {
         for (args, expected) in [
             (vec!["rift", "--intercept-port", "8080"], "--intercept-port"),
+            // Issue #878: without its entry in `cli_intercept_flags` the credential would be
+            // silently ignored beside a config block rather than reported as the conflict it is.
+            (vec!["rift", "--intercept-auth", "u:p"], "--intercept-auth"),
             (
                 vec![
                     "rift",

--- a/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
+++ b/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
@@ -45,7 +45,7 @@ async fn intercepts_external_config_cdn_without_mitmproxy() {
     // 3. Start the intercept listener. An embedder would also expose the admin API by building the
     //    admin server `with_intercept(...)`; here we drive the rule store directly.
     let resolver = Arc::new(SniCertResolver::new(ca));
-    let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules)
+    let listener = InterceptListener::bind("127.0.0.1:0".parse().unwrap(), resolver, rules, None)
         .await
         .expect("bind intercept listener");
 

--- a/crates/rift-http-proxy/tests/issue_878_intercept_proxy_auth.rs
+++ b/crates/rift-http-proxy/tests/issue_878_intercept_proxy_auth.rs
@@ -1,0 +1,462 @@
+//! Issue #878: the intercept listener is a TLS-MITM forward proxy that had no authentication of any
+//! kind, on a host defaulting to `0.0.0.0`. Anyone who could reach the port could route traffic
+//! through it and be served forged certificates from Rift's CA — which, if that CA is installed
+//! anywhere (the entire point of the feature), are trusted.
+//!
+//! Auth is **opt-in**: no credential configured behaves exactly as before, because the listener is
+//! off unless asked for and most uses are loopback test rigs. `--require-admin-auth` (#863) is what
+//! makes the exposed case fail closed.
+//!
+//! The credential is `Proxy-Authorization`, not the admin `Authorization` header: the former is
+//! hop-by-hop and consumed here, the latter is end-to-end and would forward the admin API key to
+//! every intercepted origin.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Reserve a port, then release it, so a later bind attempt proves nothing else claimed it.
+fn free_port() -> u16 {
+    let probe = StdTcpListener::bind("0.0.0.0:0").expect("probe bind");
+    let port = probe.local_addr().expect("probe addr").port();
+    drop(probe);
+    port
+}
+
+/// Send a raw `CONNECT` and return the status line plus headers, without ever starting TLS.
+///
+/// Raw TCP rather than a proxy-aware client is deliberate: it is the only way to observe what the
+/// proxy answers *before* a handshake, which is the ordering AC6 turns on.
+async fn raw_connect(addr: SocketAddr, extra_headers: &str) -> String {
+    let mut stream = TcpStream::connect(addr).await.expect("connect to proxy");
+    let req = format!(
+        "CONNECT cdn.example.com:443 HTTP/1.1\r\nHost: cdn.example.com:443\r\n{extra_headers}\r\n"
+    );
+    stream
+        .write_all(req.as_bytes())
+        .await
+        .expect("write CONNECT");
+
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+    // Read until the header terminator or EOF; the proxy closes after a 407.
+    loop {
+        match stream.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+fn basic(user: &str, pass: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"))
+}
+
+async fn start_with(args: &[&str]) -> rift_http_proxy::server::RunningServer {
+    let mut argv = vec!["rift", "--port", "0", "--metrics-port", "0"];
+    argv.extend_from_slice(args);
+    ServerBuilder::from_cli(Cli::parse_from(argv))
+        .start()
+        .await
+        .expect("server starts")
+}
+
+// AC2: the compatibility guarantee. With no credential configured the listener behaves exactly as
+// it always has — a regression here breaks every existing intercept user for a risk they may not
+// have, which is why auth is opt-in rather than default-on.
+#[tokio::test]
+async fn without_a_credential_the_proxy_is_open_exactly_as_before() {
+    let server = start_with(&["--local-only", "--intercept-port", "0"]).await;
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let resp = raw_connect(intercept, "").await;
+    assert!(
+        resp.starts_with("HTTP/1.1 200"),
+        "an unauthenticated proxy must still establish the tunnel, got: {resp:?}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC3 + AC6. Two assertions, and the second is the load-bearing one: TLS cannot begin before the
+// `200 Connection Established`, because the client only sends a ClientHello after it. So proving the
+// response is a 407 and never a 200 proves no handshake ran — hence no leaf certificate was minted
+// for an arbitrary SNI at the request of an unauthenticated caller. That ordering is the whole point
+// of checking before the 200 rather than after.
+#[tokio::test]
+async fn a_missing_credential_is_407_before_any_certificate_is_minted() {
+    let server = start_with(&[
+        "--local-only",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ])
+    .await;
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let resp = raw_connect(intercept, "").await;
+    assert!(
+        resp.starts_with("HTTP/1.1 407"),
+        "a missing credential must be refused, got: {resp:?}"
+    );
+    assert!(
+        resp.to_ascii_lowercase()
+            .contains("proxy-authenticate: basic"),
+        "the 407 must carry a Proxy-Authenticate challenge, got: {resp:?}"
+    );
+    assert!(
+        !resp.contains("200 Connection Established"),
+        "the refusal must precede the tunnel, so no certificate is ever minted: {resp:?}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC4: a wrong credential is refused like a missing one — and must not leak whether the username
+// existed.
+#[tokio::test]
+async fn a_wrong_credential_is_407() {
+    let server = start_with(&[
+        "--local-only",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ])
+    .await;
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let header = format!("Proxy-Authorization: Basic {}\r\n", basic("u", "wrong"));
+    let resp = raw_connect(intercept, &header).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 407"),
+        "a wrong credential must be refused, got: {resp:?}"
+    );
+
+    server.shutdown().await;
+}
+
+// A non-Basic scheme must not be waved through — a classifier that cannot read the credential
+// treats it as absent, never as valid.
+#[tokio::test]
+async fn a_non_basic_scheme_is_407() {
+    let server = start_with(&[
+        "--local-only",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ])
+    .await;
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let resp = raw_connect(intercept, "Proxy-Authorization: Bearer abc123\r\n").await;
+    assert!(
+        resp.starts_with("HTTP/1.1 407"),
+        "an unsupported scheme must be refused, not accepted: {resp:?}"
+    );
+
+    server.shutdown().await;
+}
+
+// AC5: the correct credential opens the tunnel, and the intercept feature still works end to end
+// (a rule installed through the admin API is served over the authenticated tunnel).
+#[tokio::test]
+async fn the_correct_credential_opens_the_tunnel_and_rules_still_serve() {
+    let server = start_with(&[
+        "--local-only",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ])
+    .await;
+    let admin = server.admin_addr();
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let ca_pem = reqwest::get(format!("http://{admin}/intercept/ca.pem"))
+        .await
+        .expect("ca.pem")
+        .text()
+        .await
+        .expect("ca.pem body");
+
+    let rule =
+        r#"{"host":"cdn.example.com","action":{"serve":{"statusCode":418,"body":"authed"}}}"#;
+    let created = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept/rules"))
+        .body(rule)
+        .send()
+        .await
+        .expect("add rule");
+    assert_eq!(created.status(), 201);
+
+    let client = reqwest::Client::builder()
+        .proxy(
+            reqwest::Proxy::https(format!("http://{intercept}"))
+                .expect("proxy")
+                .basic_auth("u", "p"),
+        )
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).expect("ca"))
+        .build()
+        .expect("client");
+
+    let resp = client
+        .get("https://cdn.example.com/config.json")
+        .send()
+        .await
+        .expect("intercepted through an authenticated proxy");
+    assert_eq!(resp.status(), 418);
+    assert_eq!(resp.text().await.expect("body"), "authed");
+
+    server.shutdown().await;
+}
+
+// AC7: #863's strict flag must cover this listener too. Without this the flag keeps under-delivering
+// — an operator who set it would get an authenticated admin plane beside an open MITM proxy. The
+// metrics-port probe mirrors #863's own test: the refusal must leave nothing bound.
+#[tokio::test]
+async fn require_admin_auth_refuses_an_exposed_intercept_with_no_credential() {
+    let metrics_port = free_port();
+    let cli = Cli::parse_from([
+        "rift",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "0",
+        "--metrics-port",
+        &metrics_port.to_string(),
+        "--api-key",
+        "s3cr3t",
+        "--require-admin-auth",
+        "--intercept-port",
+        "0",
+    ]);
+    let err =
+        ServerBuilder::from_cli(cli).start().await.err().expect(
+            "an exposed keyless intercept listener must be refused under --require-admin-auth",
+        );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--intercept-auth"),
+        "the refusal must name the remedy, got: {msg}"
+    );
+
+    StdTcpListener::bind(SocketAddr::from(([0, 0, 0, 0], metrics_port))).unwrap_or_else(|e| {
+        panic!("the refusal must precede any bind, but port {metrics_port} is held: {e}")
+    });
+}
+
+// AC8: the same configuration with a credential starts — the flag gates on authentication, not on
+// the address, exactly as it does for the admin plane.
+#[tokio::test]
+async fn require_admin_auth_accepts_an_exposed_intercept_with_a_credential() {
+    let server = start_with(&[
+        "--host",
+        "0.0.0.0",
+        "--api-key",
+        "s3cr3t",
+        "--require-admin-auth",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ])
+    .await;
+    assert!(server.intercept_addr().is_some());
+    server.shutdown().await;
+}
+
+// AC9: a malformed `--intercept-auth` is a startup error, not a silently-disabled gate. An operator
+// who wrote the value wrong must not end up with an open proxy believing it is closed.
+#[tokio::test]
+async fn a_malformed_intercept_auth_is_a_startup_error() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "no-colon-here",
+    ]);
+    let err = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .err()
+        .expect("a value with no `:` must be rejected");
+    assert!(
+        err.to_string().contains("--intercept-auth"),
+        "the error must name the flag, got: {err}"
+    );
+}
+
+// AC1: the blank-credential rejection, which had no test at all until this one — the `.trim()`
+// guard could have been deleted and every other test here would still have passed. It is the #844
+// failure mode one listener over: a blank secret switches the gate on and then admits everyone,
+// leaving an operator believing a credential is in force.
+#[tokio::test]
+async fn a_blank_half_of_the_credential_is_a_startup_error() {
+    for bad in ["u:", ":p", ":", "u:   ", "   :p"] {
+        let cli = Cli::parse_from([
+            "rift",
+            "--local-only",
+            "--port",
+            "0",
+            "--metrics-port",
+            "0",
+            "--intercept-port",
+            "0",
+            "--intercept-auth",
+            bad,
+        ]);
+        let err = ServerBuilder::from_cli(cli)
+            .start()
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("`{bad}` must be rejected: a blank half admits everyone"));
+        assert!(
+            err.to_string().contains("--intercept-auth"),
+            "the error must name the flag, got: {err}"
+        );
+    }
+}
+
+// A colon is legal *inside* the password — `split_once` takes the first one. Locked in because the
+// obvious "simplification" (`split(':')` with two parts expected) silently breaks it.
+#[tokio::test]
+async fn a_password_may_contain_a_colon() {
+    let server = start_with(&[
+        "--local-only",
+        "--intercept-port",
+        "0",
+        "--intercept-auth",
+        "u:pa:ss",
+    ])
+    .await;
+    let intercept = server.intercept_addr().expect("intercept bound");
+
+    let header = format!("Proxy-Authorization: Basic {}\r\n", basic("u", "pa:ss"));
+    let resp = raw_connect(intercept, &header).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 200"),
+        "the first colon splits user from pass; the rest belongs to the password: {resp:?}"
+    );
+
+    server.shutdown().await;
+}
+
+// Blocker found in review: a credential with no listener to guard reads as protection but is not.
+// The operator sets it, nothing starts at boot, and a later `POST /intercept` brings up an OPEN
+// proxy. Refused for the same reason a blank secret is.
+#[tokio::test]
+async fn intercept_auth_without_a_port_is_a_startup_error() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--intercept-auth",
+        "u:p",
+    ]);
+    let err = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .err()
+        .expect("a credential guarding nothing must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--intercept-port"),
+        "the error must say which listener is missing, got: {msg}"
+    );
+}
+
+// AC7 at the door review found uncovered: the listener can be started long after boot over
+// `POST /intercept`, and `--require-admin-auth` must cover that too. Checking only at startup let an
+// operator who set the strict flag still end up with an open MITM proxy on every interface — the
+// exact "authenticated admin plane beside an open MITM proxy" this issue exists to close.
+#[tokio::test]
+async fn require_admin_auth_refuses_a_runtime_started_exposed_intercept() {
+    let server = start_with(&[
+        "--host",
+        "0.0.0.0",
+        "--api-key",
+        "s3cr3t",
+        "--require-admin-auth",
+    ])
+    .await;
+    let admin = server.admin_addr();
+
+    let refused = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept"))
+        .header("authorization", "s3cr3t")
+        .json(&serde_json::json!({"host": "0.0.0.0", "port": 0}))
+        .send()
+        .await
+        .expect("POST /intercept");
+    assert_eq!(
+        refused.status(),
+        403,
+        "a keyless off-host listener started at runtime must be refused under --require-admin-auth"
+    );
+
+    // The same request WITH a credential is allowed — the flag gates on authentication, not on the
+    // address, at every door.
+    let allowed = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept"))
+        .header("authorization", "s3cr3t")
+        .json(&serde_json::json!({
+            "host": "0.0.0.0", "port": 0,
+            "auth": {"username": "ci", "password": "s3cr3t"}
+        }))
+        .send()
+        .await
+        .expect("POST /intercept with auth");
+    assert_eq!(
+        allowed.status(),
+        201,
+        "an authenticated listener is allowed"
+    );
+
+    server.shutdown().await;
+}
+
+// The admin-API door's own blank-credential rejection — previously untested on that door, and it is
+// the door a caller other than the operator can reach.
+#[tokio::test]
+async fn the_admin_api_rejects_a_blank_credential() {
+    let server = start_with(&["--local-only"]).await;
+    let admin = server.admin_addr();
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{admin}/intercept"))
+        .json(&serde_json::json!({
+            "port": 0, "auth": {"username": "ci", "password": "   "}
+        }))
+        .send()
+        .await
+        .expect("POST /intercept");
+    assert_eq!(
+        resp.status(),
+        400,
+        "a blank password must be refused at the admin door too"
+    );
+
+    server.shutdown().await;
+}

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -151,6 +151,7 @@ Options:
       --default-tls-key <FILE>     Default TLS private key (PEM), paired with --default-tls-cert
       --no-self-signed-tls         Disable the self-signed fallback; an HTTPS imposter with no cert is an error
       --intercept-port <PORT>      Start the TLS-MITM intercept/redirect proxy on this port (epic #394); off when unset
+      --intercept-auth <USER:PASS>  Require Proxy-Authorization: Basic on every CONNECT to the intercept proxy; open when unset
       --intercept-ca-cert <FILE>   PEM CA certificate for interception (with --intercept-ca-key); a CA is generated if omitted
       --intercept-ca-key <FILE>    PEM CA private key for interception (required with --intercept-ca-cert)
       --intercept-ca-cert-pem <PEM>  Inline PEM CA certificate for interception (with --intercept-ca-key-pem); mutually exclusive with file paths
@@ -177,6 +178,36 @@ it starts the listener **with its rules already installed**, so a container need
 call. The block and these `--intercept-*` flags are two spellings of one listener — supplying both
 is a startup error rather than a silent precedence guess, so pick one. (Each flag also has a
 `RIFT_INTERCEPT_*` environment variable, which counts as supplying it.)
+
+#### The intercept proxy is unauthenticated unless you say otherwise
+
+The listener has **no credential by default** — it is off unless asked for, and most uses are a
+loopback test rig where auth is pure friction. But it is a TLS-MITM proxy: anyone who can reach the
+port can route traffic through it and be served certificates forged by Rift's CA, which are trusted
+wherever that CA is installed — and installing it is the whole point of the feature. On a shared or
+LAN-reachable host, set a credential:
+
+```bash
+rift-http-proxy --intercept-port 8888 --intercept-auth ci:s3cr3t
+```
+
+Every `CONNECT` must then carry `Proxy-Authorization: Basic <base64(user:pass)>`; anything else gets
+`407 Proxy Authentication Required`. Standard clients do this for you —
+`HTTPS_PROXY=http://ci:s3cr3t@host:8888`, `curl -x http://ci:s3cr3t@host:8888`, or a JVM
+`Authenticator`. A value with no `:`, or with a blank half, is a startup error rather than a
+silently-disabled gate — as is `--intercept-auth` without `--intercept-port`, which would otherwise
+read as protection while guarding nothing.
+
+**On a shared host prefer `RIFT_INTERCEPT_AUTH`**: a value passed on the command line is visible to
+anyone who can run `ps`.
+
+Note this is **`Proxy-Authorization`, not the admin `--api-key`**. The two are different credentials
+on purpose: `Proxy-Authorization` is hop-by-hop and is consumed here, whereas `Authorization` is
+end-to-end and would be forwarded to every intercepted origin — sending your admin key onward to the
+very servers you are intercepting.
+
+`--require-admin-auth` covers this listener too: a non-loopback intercept bind with no credential
+warns by default and refuses to start under that flag.
 
 ### API-key authentication
 
@@ -295,6 +326,7 @@ Environment variables override CLI defaults:
 | `RIFT_DEFAULT_TLS_KEY` | Default TLS private key (PEM) | |
 | `RIFT_NO_SELF_SIGNED_TLS` | Disable self-signed TLS fallback (`true`/`false`) | `false` |
 | `RIFT_INTERCEPT_PORT` | Start the intercept/TLS-MITM proxy on this port (epic #394) | |
+| `RIFT_INTERCEPT_AUTH` | `user:pass` required in `Proxy-Authorization` on every `CONNECT` to the intercept proxy (env alias of `--intercept-auth`); open when unset | |
 | `RIFT_INTERCEPT_CA_CERT` | PEM CA certificate **file** for interception (with `RIFT_INTERCEPT_CA_KEY`) | |
 | `RIFT_INTERCEPT_CA_KEY` | PEM CA private key **file** for interception | |
 | `RIFT_INTERCEPT_CA_CERT_PEM` | Inline PEM CA certificate (the bytes, not a path; with `RIFT_INTERCEPT_CA_KEY_PEM`) — mutually exclusive with the `_CA_CERT`/`_CA_KEY` file pair | |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -45,9 +45,14 @@ docker run -v $(pwd)/imposters.json:/imposters.json \
 | Key | Purpose |
 |---|---|
 | `imposters` | The imposters to create — the Mountebank format above. |
-| `intercept` | *Optional, Rift extension.* Declares the [HTTPS intercept listener](../features/intercept-proxy.md#declare-it-in-the-config-file) and its rules, so a container needs no post-boot admin call to install them. |
+| `intercept` | *Optional, Rift extension.* Declares the [HTTPS intercept listener](../features/intercept-proxy.md#declare-it-in-the-config-file) and its rules, so a container needs no post-boot admin call to install them. Its keys are `host`, `port`, the CA pair (`caCertPath`/`caKeyPath` **or** `caCertPem`/`caKeyPem`), `returnCaKey`, `rules`, and `auth`. |
 
 A file may also be a single imposter object (`{"port": 4545, ...}`) or a bare array of them; those
+`intercept.auth` (issue #878) is `{"username": "…", "password": "…"}` and requires
+`Proxy-Authorization: Basic …` on every `CONNECT` to the listener. Omit it and the proxy is open —
+see [Authenticating the proxy](../features/intercept-proxy.md#authenticating-the-proxy) for why that
+matters on a shared host. A blank username or password is a startup error, not a disabled gate.
+
 shapes have nowhere to put an `intercept` block, so declaring one there is a startup error naming
 the fix rather than a block that silently does nothing.
 

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -165,7 +165,7 @@ per handle; `rift_stop_intercept` stops it, and `rift_stop` shuts it down with t
 
 | Function | Signature | Returns |
 |---|---|---|
-| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, both CA pairs supplied, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null,"caCertPem":null,"caKeyPem":null,"returnCaKey":false}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. Supply the CA as files (`caCertPath`/`caKeyPath`) **or** inline PEM bytes (`caCertPem`/`caKeyPem`, issue #593 — each pair both-or-neither, mutually exclusive). `"returnCaKey":true` (only with no CA source) mints a fresh CA and adds `"caCertPem"`/`"caKeyPem"` to the response once — CA private-key material, treat as secret. |
+| `rift_start_intercept` | `char* rift_start_intercept(RiftHandle* h, const char* options_json)` | JSON `{"interceptPort","interceptUrl"}` (**caller frees**), or `NULL` on error (bad JSON, bind failure, half-configured CA pair, both CA pairs supplied, CA load failure, already started). `options_json`: `{"host":"127.0.0.1","port":0,"caCertPath":null,"caKeyPath":null,"caCertPem":null,"caKeyPem":null,"returnCaKey":false,"auth":null}` (port 0 = OS-assigned); `NULL`/`{}` for defaults. Supply the CA as files (`caCertPath`/`caKeyPath`) **or** inline PEM bytes (`caCertPem`/`caKeyPem`, issue #593 — each pair both-or-neither, mutually exclusive). `"returnCaKey":true` (only with no CA source) mints a fresh CA and adds `"caCertPem"`/`"caKeyPem"` to the response once — CA private-key material, treat as secret. |
 | `rift_stop_intercept` | `int rift_stop_intercept(RiftHandle* h)` | `0` on success (**including** the idempotent nothing-running case), `-1` only on a null handle / caught panic. Stops the listener, releases its port, and drops its rules + CA — RFC-003 parity with `DELETE /intercept`. A later `rift_start_intercept` without CA paths mints a fresh CA. |
 | `rift_intercept_add_rules` | `int rift_intercept_add_rules(RiftHandle* h, const char* rules_json)` | `0`/`-1`. One rule (object) or many (array), same shape as `/intercept/rules`. |
 | `rift_intercept_list_rules` | `char* rift_intercept_list_rules(RiftHandle* h)` | The current rules as a JSON array (**caller frees**), or `NULL` on error. |
@@ -199,6 +199,18 @@ return its cert **and** key once in the response (`caCertPem`/`caKeyPem`), for a
 start with `returnCaKey`, persist the pair, then supply it back via `caCertPem`/`caKeyPem` on later
 starts. The returned `caKeyPem` is CA private-key material — treat it as secret. Combining
 `returnCaKey` with any supplied CA source is a hard error.
+
+`auth` (issue #878) requires `Proxy-Authorization: Basic <base64(user:pass)>` on every `CONNECT`:
+`{"auth":{"username":"ci","password":"s3cr3t"}}`. Omit it and the proxy is open, which is what it
+has always been. A blank username or password is rejected at start — a blank secret would switch the
+gate on and then admit everyone. Bear in mind what this listener is: a TLS-MITM proxy serving
+certificates forged by a CA your clients are asked to trust, so an unauthenticated one reachable
+off-host is worth more care than an unauthenticated admin plane, not less.
+
+Unlike `rift_serve_admin`'s options (see [#877](#detecting-which-options-an-engine-accepts)), this
+struct has always used `deny_unknown_fields` — so sending `auth` to an engine that predates it is a
+**hard error naming the field**, not a silent ignore. That makes it deterministically detectable;
+state the required engine release (0.17.0+) in any SDK that offers it.
 
 `interceptUrl`/`interceptPort` in the response are derived from the listener's **actual bound
 address** (v0.11.2, #425/#426) — not hardcoded to `127.0.0.1`. A loopback `host` (the default)

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -55,9 +55,45 @@ use rift_http_proxy::intercept_rules::InterceptRules;
 let ca = Arc::new(CertificateAuthority::generate()?);      // or CertificateAuthority::load_pem(cert, key)
 let rules = InterceptRules::new();
 let resolver = Arc::new(SniCertResolver::new(ca.clone())); // mints one leaf per SNI host
-let listener = InterceptListener::bind("127.0.0.1:0".parse()?, resolver, rules.clone()).await?;
+// `None` = no proxy credential (open). Pass `Some(InterceptAuth { .. })` to require
+// `Proxy-Authorization: Basic …` on every CONNECT (issue #878).
+let listener =
+    InterceptListener::bind("127.0.0.1:0".parse()?, resolver, rules.clone(), None).await?;
 // Point the SUT at `listener.local_addr()` as its HTTPS proxy, trusting `ca`.
 ```
+
+### Authenticating the proxy
+
+**The listener is open unless you give it a credential.** That is deliberate — it is off until you
+start it, and most uses are a loopback test rig — but be clear about what it is: a TLS-MITM proxy
+that serves certificates forged by a CA you have asked your clients to trust. On loopback that is
+fine. Anywhere reachable by others it is not, because reaching the port is the only thing standing
+between someone and a trusted forged certificate for any host they name.
+
+Set a credential with `--intercept-auth user:pass` (`RIFT_INTERCEPT_AUTH`), the `auth` key on the
+config-file block, `POST /intercept`'s body, or `rift_start_intercept`'s options:
+
+```json
+{ "port": 8888, "auth": { "username": "ci", "password": "s3cr3t" } }
+```
+
+Every `CONNECT` must then carry `Proxy-Authorization: Basic <base64(user:pass)>`; anything else is
+answered `407 Proxy Authentication Required` with a `Proxy-Authenticate` challenge — **before** the
+TLS handshake, so an unauthenticated caller never causes a certificate to be minted. Standard
+clients handle this: `HTTPS_PROXY=http://ci:s3cr3t@host:8888`, `curl -x`, a JVM `Authenticator`.
+
+This is a *separate* credential from the admin `--api-key`, on purpose. `Proxy-Authorization` is
+hop-by-hop and is consumed by the proxy; `Authorization` is end-to-end and would be forwarded to
+every intercepted origin, handing your admin key to the very servers you are intercepting.
+
+`--require-admin-auth` covers this listener too, at **every** door on the standalone binary — the
+flag, the config block, and a listener started at runtime over `POST /intercept` (which answers
+`403` rather than starting an exposed keyless one). A non-loopback bind with no credential warns by
+default and refuses under the flag.
+
+Embedders driving `rift_start_intercept` over the C-ABI get the **warning** but not the refusal: the
+policy travels on the process's `InterceptControl`, which the standalone binary sets from the flag
+and an embedded host currently does not. Set `auth` explicitly if you bind off-host.
 
 To expose the `/intercept` routes over the admin API, build the admin server
 `with_intercept(control)` where `control: InterceptControl` is the shared lifecycle slot (see


### PR DESCRIPTION
## Summary

The intercept listener is a TLS-MITM forward proxy that exposed no authentication mechanism and bound to the admin host (default 0.0.0.0), allowing unauthenticated access to mint trusted certificates. Adds optional Basic proxy auth via --intercept-auth, config-block auth, POST /intercept auth, and rift_start_intercept auth fields. Returns 407 before TLS handshake to prevent certificate minting. Uses Proxy-Authorization (hop-by-hop) instead of Authorization (end-to-end) to avoid forwarding to origins.

Inert by default — no existing intercept users break. --require-admin-auth now covers the intercept listener at every entry point.

Closes #878