### PR TITLE
--ip-whitelist is declared but never enforced — make it an honest no-op and correct the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,34 @@ record.
 
 ### Changed
 
+- **`--ip-whitelist` now says out loud that it does nothing** (issue #879). The flag was declared and
+  read nowhere — it has **never** applied IP filtering in any release — while four places said it
+  worked: the CLI reference table, a "Restrict access" example promising CIDR syntax that was never
+  implemented, the Node getting-started page, and the Mountebank compatibility matrix, which marked
+  it ✅ Complete. **If you believed you had IP filtering from this flag, you did not**; add it at the
+  network layer.
+
+  It stays accepted (removing it would break Mountebank drop-in compatibility for anyone passing it)
+  and now logs a warning naming what to use instead, joining `--formatter` and `--protofile` in the
+  accepted-but-inert group. Implementing it was considered and rejected: `COMPATIBILITY_COVERAGE.md`
+  already recorded "use Kubernetes NetworkPolicy instead", and behind a proxy or container NAT this
+  process sees the hop rather than the client — so an ACL here would admit everyone unless it trusted
+  `X-Forwarded-For`, which is a vulnerability rather than a feature. A silently-inert security flag
+  is worse than an absent one; the docs are corrected to match.
+
+- **`GET /config` stops reporting hardcoded literals for `port` and `localOnly`** (issue #879). It
+  answered questions about the running configuration with fixed values: `port` was always `2525`
+  even under `--port 3000` (or the ephemeral `:0` embedders use), and `localOnly` was always `false`.
+  `port` is now the port actually bound, and `localOnly` reports whether `--local-only` was supplied.
+
+  `localOnly` deliberately reflects **the flag, not the admin plane's bind address**. Deriving it
+  from the bound address reads as more truthful and is worse: `--host 127.0.0.1` narrows only the
+  admin plane while `/metrics` and every imposter port stay on `0.0.0.0`, so a bind-derived `true`
+  would tell an operator nothing is reachable off-host while two listener families are. The old
+  literal understated; that would overstate, which is the direction that gets someone hurt. It also
+  keeps the field meaning what Mountebank's `/config` means. `ipWhitelist` still reports `["*"]`,
+  which is accurate: nothing is filtered.
+
 - **`--local-only` now restricts the metrics listener too** (issue #880). The metrics server
   hardcoded `0.0.0.0`, so a flag documented as "only accept connections from localhost" narrowed the
   admin plane while leaving `/metrics` reachable on every interface. It now binds `127.0.0.1` under

--- a/crates/rift-http-proxy/Dockerfile
+++ b/crates/rift-http-proxy/Dockerfile
@@ -210,7 +210,7 @@ ENV RIFT_METRICS_PORT=9090
 #   --log <FILE>            Log file path
 #   --pidfile <FILE>        PID file path
 #   --origin <ORIGIN>       CORS allowed origin
-#   --ip-whitelist <IPS>    Allowed IP addresses (comma-separated)
+#   --ip-whitelist <IPS>    Accepted for Mountebank compatibility; NOT enforced (issue #879)
 
 ENTRYPOINT ["/usr/local/bin/rift"]
 CMD []

--- a/crates/rift-http-proxy/src/admin_api/handlers/system.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/system.rs
@@ -54,20 +54,48 @@ pub async fn handle_metrics(manager: Arc<ImposterManager>) -> Response<Full<Byte
         .unwrap()
 }
 
+/// The `GET /config` values that used to be hardcoded literals (issue #879).
+///
+/// A struct rather than two more positional parameters: the router would otherwise thread three
+/// adjacent unlabelled scalars into one call, where a transposition compiles silently and makes
+/// `/config` report one setting as another.
+#[derive(Debug, Clone, Copy)]
+pub struct ConfigSnapshot {
+    /// The port the admin plane actually bound. Was hardcoded to `DEFAULT_ADMIN_PORT`, so
+    /// `--port 3000` (or the `:0` every embedder test uses) reported `2525`.
+    pub admin_port: u16,
+    /// Whether `--local-only` was set — **the flag**, not "did the admin plane happen to bind
+    /// loopback".
+    ///
+    /// Deriving it from the bound address reads as more truthful and is worse. `--host 127.0.0.1`
+    /// without `--local-only` binds the admin plane to loopback while `/metrics` and every imposter
+    /// port stay on `0.0.0.0` (pinned by `without_local_only_metrics_still_binds_every_interface`),
+    /// so a bind-derived `true` would tell an operator nothing is reachable off-host while two
+    /// listener families are. The old hardcoded `false` understated; that would *overstate*, which
+    /// is the direction that gets someone hurt. The flag is also what Mountebank's `/config`
+    /// echoes, so this keeps the compat endpoint compatible.
+    pub local_only: bool,
+}
+
 /// GET /config - Mountebank-compatible config endpoint
 ///
 /// `allow_injection` is threaded in explicitly (issue #342) rather than read from
 /// `MB_ALLOW_INJECTION`, so an embedded host can set it without mutating process env.
-pub fn handle_config(allow_injection: bool) -> Response<Full<Bytes>> {
+///
+/// `snapshot` carries the values that used to be hardcoded literals (issue #879).
+pub fn handle_config(allow_injection: bool, snapshot: ConfigSnapshot) -> Response<Full<Bytes>> {
     let config = serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         // Build identity (issue #344), stamped by build.rs — the same value rift_build_info
         // reports over FFI, so one version-coherence preflight works for process and FFI modes.
         "commit": option_env!("RIFT_COMMIT"),
         "options": {
-            "port": crate::admin_api::DEFAULT_ADMIN_PORT,
+            "port": snapshot.admin_port,
             "allowInjection": allow_injection,
-            "localOnly": false,
+            "localOnly": snapshot.local_only,
+            // Accurate rather than aspirational (issue #879): `--ip-whitelist` is accepted and
+            // never enforced, so every address may connect. Reporting the supplied list here would
+            // re-create the false assurance the flag itself was removed from advertising.
             "ipWhitelist": ["*"]
         },
         "process": {
@@ -317,7 +345,13 @@ mod tests {
 
     #[test]
     fn test_handle_config() {
-        let resp = handle_config(false);
+        let resp = handle_config(
+            false,
+            ConfigSnapshot {
+                admin_port: 2525,
+                local_only: false,
+            },
+        );
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -326,7 +360,13 @@ mod tests {
     #[test]
     fn handle_config_reports_commit() {
         use http_body_util::BodyExt;
-        let resp = handle_config(false);
+        let resp = handle_config(
+            false,
+            ConfigSnapshot {
+                admin_port: 2525,
+                local_only: false,
+            },
+        );
         let bytes = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(resp.into_body().collect())
@@ -359,7 +399,13 @@ mod tests {
     fn handle_config_reports_explicit_injection_flag() {
         use http_body_util::BodyExt;
         let read_flag = |allow: bool| {
-            let resp = handle_config(allow);
+            let resp = handle_config(
+                allow,
+                ConfigSnapshot {
+                    admin_port: 2525,
+                    local_only: false,
+                },
+            );
             let bytes = tokio::runtime::Runtime::new()
                 .unwrap()
                 .block_on(resp.into_body().collect())

--- a/crates/rift-http-proxy/src/admin_api/router.rs
+++ b/crates/rift-http-proxy/src/admin_api/router.rs
@@ -79,6 +79,7 @@ pub async fn route_request(
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
+    config_snapshot: system::ConfigSnapshot,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
@@ -119,6 +120,7 @@ pub async fn route_request(
         config_source,
         allow_injection,
         scripts_dir,
+        config_snapshot,
     )
     .await;
     Ok(response)
@@ -149,6 +151,7 @@ async fn route_by_path(
     config_source: Option<ReloadSource>,
     allow_injection: bool,
     scripts_dir: Option<Arc<PathBuf>>,
+    config_snapshot: system::ConfigSnapshot,
 ) -> Response<Full<Bytes>> {
     // Single-port gateway (issue #212): `/__rift/:port/<path>` dispatches to that imposter,
     // so a containerized Rift only needs the one admin port published.
@@ -160,7 +163,9 @@ async fn route_by_path(
     match (method, path) {
         (&Method::GET, "/") => return system::handle_root(base_url),
         (&Method::GET, "/health") => return system::handle_health(),
-        (&Method::GET, "/config") => return system::handle_config(allow_injection),
+        (&Method::GET, "/config") => {
+            return system::handle_config(allow_injection, config_snapshot);
+        }
         (&Method::GET, "/logs") => return system::handle_logs(query),
         (&Method::POST, "/admin/reload") => {
             return system::handle_reload(manager, config_source, allow_injection).await;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -48,6 +48,9 @@ pub struct AdminApiServer {
     allow_injection: bool,
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
+    /// `--local-only` as supplied, reported verbatim by `GET /config` (issue #879). The flag, not
+    /// "did we bind loopback" — see `ConfigSnapshot::local_only`.
+    local_only: bool,
     authorizer: Option<Arc<dyn AdminAuthorizer>>,
     /// Exposure policy for [`bind`](Self::bind) (issue #863), or `None` when an outer door already
     /// ran the check — see [`with_exposure_checked`](Self::with_exposure_checked).
@@ -66,8 +69,19 @@ impl AdminApiServer {
             intercept: None,
             scripts_dir: None,
             authorizer: None,
+            local_only: false,
             exposure: Some(AdminExposurePolicy::default()),
         }
+    }
+
+    /// Record `--local-only` for `GET /config` to report (issue #879). Threaded explicitly, like
+    /// [`with_allow_injection`](Self::with_allow_injection), so an embedder states it rather than
+    /// having it inferred from the bind address — which would overstate the restriction, since the
+    /// metrics and imposter listeners are governed separately.
+    #[must_use]
+    pub fn with_local_only(mut self, local_only: bool) -> Self {
+        self.local_only = local_only;
+        self
     }
 
     /// Refuse to bind when this server would be reachable off-host with no API key, instead of
@@ -216,6 +230,10 @@ impl AdminApiServer {
                 self.intercept,
                 self.scripts_dir,
                 self.authorizer,
+                crate::admin_api::handlers::system::ConfigSnapshot {
+                    admin_port: local_addr.port(),
+                    local_only: self.local_only,
+                },
                 loop_cancel,
                 loop_tracker,
             )
@@ -426,6 +444,8 @@ async fn accept_loop(
     intercept: Option<InterceptControl>,
     scripts_dir: Option<Arc<PathBuf>>,
     authorizer: Option<Arc<dyn AdminAuthorizer>>,
+    // The `GET /config` values that used to be hardcoded literals (issue #879).
+    config_snapshot: crate::admin_api::handlers::system::ConfigSnapshot,
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
@@ -644,6 +664,7 @@ async fn accept_loop(
                                 allow_injection,
                                 intercept,
                                 scripts_dir,
+                                config_snapshot,
                             ),
                         )
                         .await

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -129,10 +129,6 @@ pub struct Cli {
     #[arg(long)]
     pub origin: Option<String>,
 
-    /// IP addresses allowed to connect (comma-separated)
-    #[arg(long, value_delimiter = ',')]
-    pub ip_whitelist: Option<Vec<String>>,
-
     /// Run in mock mode (all imposters are mocks)
     #[arg(long)]
     pub mock: bool,
@@ -164,6 +160,19 @@ pub struct Cli {
     /// Custom protocol definitions file (custom protocols not yet supported; accepted for compatibility)
     #[arg(long, value_name = "FILE")]
     pub protofile: Option<PathBuf>,
+
+    /// IP addresses allowed to connect (comma-separated). ACCEPTED AND NEVER ENFORCED
+    /// (issue #879) — it lives here, with `--formatter` and `--protofile`, because it has never
+    /// filtered anything in any release.
+    ///
+    /// Network-level access control belongs to the platform (NetworkPolicy, security group,
+    /// firewall), which sees the real peer: behind a proxy or container NAT this process sees the
+    /// hop, not the client, so an ACL enforced here would silently admit everyone unless it trusted
+    /// `X-Forwarded-For` — and trusting a client-settable header for an ACL is a vulnerability, not
+    /// a feature. Use `--local-only` to bind loopback, `--api-key` to authenticate the admin plane,
+    /// or `--require-admin-auth` (issue #863) to make an exposed keyless plane a startup failure.
+    #[arg(long, value_delimiter = ',')]
+    pub ip_whitelist: Option<Vec<String>>,
 
     /// Require this token in the Authorization header for all admin API requests
     #[arg(long, value_name = "TOKEN", env = "MB_APIKEY")]
@@ -556,6 +565,16 @@ impl ServerBuilder {
         if cli.protofile.is_some() {
             warn!("--protofile is not supported; custom protocols are not yet implemented");
         }
+        // Issue #879: said out loud because the alternative is silence on a flag that reads as a
+        // security control. An operator who believed they had IP filtering has none, and nothing
+        // told them — the docs even recommended it.
+        if cli.ip_whitelist.is_some() {
+            warn!(
+                "--ip-whitelist is accepted for Mountebank compatibility but is NOT enforced; no \
+                 IP filtering is applied. Use a network policy/firewall, or --local-only, \
+                 --api-key and --require-admin-auth to restrict access."
+            );
+        }
 
         // Retain the config source so POST /admin/reload can re-read it (issue #197).
         // Injection gating is threaded explicitly (issue #342) rather than read from env.
@@ -563,6 +582,7 @@ impl ServerBuilder {
         // bind. Without this the same startup would log the warning twice.
         let mut server = AdminApiServer::new(admin_addr, manager, cli.api_key)
             .with_allow_injection(cli.allow_injection)
+            .with_local_only(cli.local_only)
             .with_exposure_checked();
         if let Some(authorizer) = admin_authorizer {
             server = server.with_admin_authorizer(authorizer);
@@ -2008,6 +2028,68 @@ mod tests {
             "predicates": [{"inject": "function (req) { return true; }"}],
             "action": {"serve": {"statusCode": 200}}
         }))
+    }
+
+    // AC2 (issue #879) — the warning IS the behavioural change, so it is the one thing that must be
+    // pinned. Without it, a refactor that drops the `warn!` returns the flag to being silently inert
+    // and every other test stays green.
+    //
+    // This lives in the crate's own unit tests, not the integration suite, because `tracing_test`
+    // scopes its capture filter to the crate the macro expands in — from `tests/` the library's
+    // events are filtered out and `logs_contain` silently sees nothing. That is why every existing
+    // `traced_test` in this repo (`intercept.rs`, `intercept_control.rs`) is an in-crate test.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn ip_whitelist_warns_that_it_is_not_enforced() {
+        let server = ServerBuilder::from_cli(Cli::parse_from([
+            "rift",
+            "--local-only",
+            "--port",
+            "0",
+            "--metrics-port",
+            "0",
+            "--ip-whitelist",
+            "10.0.0.1",
+        ]))
+        .start()
+        .await
+        .expect("start");
+
+        assert!(
+            logs_contain("--ip-whitelist is accepted"),
+            "passing the flag must say out loud that nothing is filtered"
+        );
+        assert!(
+            logs_contain("NOT enforced"),
+            "the warning must be unambiguous about the flag doing nothing"
+        );
+
+        server.shutdown().await;
+    }
+
+    // The negative half: a server never given the flag must not emit the warning, or it becomes
+    // noise operators learn to ignore — which is how the next real warning gets missed.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn omitting_ip_whitelist_warns_about_nothing() {
+        let server = ServerBuilder::from_cli(Cli::parse_from([
+            "rift",
+            "--local-only",
+            "--port",
+            "0",
+            "--metrics-port",
+            "0",
+        ]))
+        .start()
+        .await
+        .expect("start");
+
+        assert!(
+            !logs_contain("--ip-whitelist"),
+            "the warning must fire only when the flag was actually supplied"
+        );
+
+        server.shutdown().await;
     }
 
     /// AC3: the block and `--intercept-port` are two spellings of one listener. Supplying both is a

--- a/crates/rift-http-proxy/tests/issue_879_ip_whitelist_honest_noop.rs
+++ b/crates/rift-http-proxy/tests/issue_879_ip_whitelist_honest_noop.rs
@@ -1,0 +1,205 @@
+//! Issue #879: `--ip-whitelist` was declared and read nowhere, while four separate places — the CLI
+//! reference table, a "Restrict access" example promising CIDR, the Node getting-started page, and
+//! the Mountebank compatibility matrix marking it ✅ Complete — told operators it worked.
+//!
+//! The resolution is to make it an **honest no-op** rather than to implement it: a prior decision
+//! already exists (`tests/compatibility/COMPATIBILITY_COVERAGE.md` records "use Kubernetes
+//! NetworkPolicy instead"), the repo already has a house pattern for accepted-but-unimplemented
+//! Mountebank flags (`--formatter`, `--protofile`), and a network ACL enforced inside the mock
+//! server is strictly weaker than the same ACL in the network — behind any proxy or container NAT
+//! the peer address is the hop, not the client.
+//!
+//! A silently-inert security flag is the worst of the three options. This suite pins that it is now
+//! either honest or absent, never quietly pretending.
+
+use clap::Parser;
+use rift_http_proxy::server::{Cli, ServerBuilder};
+
+// The Mountebank compatibility guarantee: the flag still parses and the server still starts. This is
+// why it is kept as a no-op rather than deleted — removing it would break anyone passing it.
+#[tokio::test]
+async fn the_flag_is_still_accepted_and_the_server_still_starts() {
+    let cli = Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--ip-whitelist",
+        "10.0.0.1,192.168.0.1",
+    ]);
+    assert_eq!(
+        cli.ip_whitelist.as_deref(),
+        Some(&["10.0.0.1".to_string(), "192.168.0.1".to_string()][..]),
+        "the flag must keep parsing its comma-separated value"
+    );
+
+    let server = ServerBuilder::from_cli(cli)
+        .start()
+        .await
+        .expect("an accepted no-op must not fail startup");
+    server.shutdown().await;
+}
+
+// `GET /config` reported `"localOnly": false` as a hardcoded literal. That was always inaccurate and
+// became actively wrong once #863/#880 gave `--local-only` real meaning on two listeners — an
+// endpoint answering a question about a network control with a fixed string is the same class of
+// problem as the flag this issue is about.
+#[tokio::test]
+async fn get_config_reports_the_real_bind_posture() {
+    let loopback = ServerBuilder::from_cli(Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ]))
+    .start()
+    .await
+    .expect("start");
+
+    let config: serde_json::Value =
+        reqwest::get(format!("http://{}/config", loopback.admin_addr()))
+            .await
+            .expect("GET /config")
+            .json()
+            .await
+            .expect("json");
+    assert_eq!(
+        config["options"]["localOnly"], true,
+        "a loopback-bound admin plane must report localOnly: true"
+    );
+    // Accurate *because* nothing is filtered — the flag is a documented no-op, so "all addresses
+    // may connect" is now the truth rather than a placeholder.
+    assert_eq!(config["options"]["ipWhitelist"], serde_json::json!(["*"]));
+    loopback.shutdown().await;
+
+    let exposed = ServerBuilder::from_cli(Cli::parse_from([
+        "rift",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ]))
+    .start()
+    .await
+    .expect("start");
+
+    let config: serde_json::Value = reqwest::get(format!("http://{}/config", exposed.admin_addr()))
+        .await
+        .expect("GET /config")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(
+        config["options"]["localOnly"], false,
+        "an off-host admin plane must report localOnly: false"
+    );
+    exposed.shutdown().await;
+}
+
+// The discriminating case, and the reason `localOnly` reports the FLAG rather than "did the admin
+// plane bind loopback". `--host 127.0.0.1` without `--local-only` binds the admin plane to loopback
+// — but `/metrics` and every imposter port stay on `0.0.0.0`. A bind-derived `true` here would tell
+// an operator nothing is reachable off-host while two listener families are, which overstates the
+// restriction. The old hardcoded `false` understated; overstating is the direction that gets someone
+// hurt, so the flag is what gets reported.
+#[tokio::test]
+async fn a_loopback_host_without_the_flag_does_not_claim_local_only() {
+    let server = ServerBuilder::from_cli(Cli::parse_from([
+        "rift",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ]))
+    .start()
+    .await
+    .expect("start");
+
+    let config: serde_json::Value = reqwest::get(format!("http://{}/config", server.admin_addr()))
+        .await
+        .expect("GET /config")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(
+        config["options"]["localOnly"], false,
+        "--host 127.0.0.1 narrows only the admin plane; metrics and imposter ports stay off-host, \
+         so reporting localOnly: true would overstate the restriction"
+    );
+
+    server.shutdown().await;
+}
+
+// `port` was hardcoded to 2525 in the same object, so `--port 0` (what every embedder test uses)
+// reported a port nothing was listening on. Fixed alongside `localOnly` because the CHANGELOG claims
+// the object reports the real posture — a claim one hardcoded sibling would falsify.
+#[tokio::test]
+async fn get_config_reports_the_real_admin_port() {
+    let server = ServerBuilder::from_cli(Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+    ]))
+    .start()
+    .await
+    .expect("start");
+    let bound = server.admin_addr().port();
+
+    let config: serde_json::Value = reqwest::get(format!("http://{}/config", server.admin_addr()))
+        .await
+        .expect("GET /config")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(
+        config["options"]["port"], bound,
+        "the reported port must be the one actually bound, not the 2525 default"
+    );
+
+    server.shutdown().await;
+}
+
+// Passing the flag must not change the reported posture either — it does nothing, and `GET /config`
+// must not start implying otherwise.
+#[tokio::test]
+async fn passing_the_flag_does_not_change_the_reported_whitelist() {
+    let server = ServerBuilder::from_cli(Cli::parse_from([
+        "rift",
+        "--local-only",
+        "--port",
+        "0",
+        "--metrics-port",
+        "0",
+        "--ip-whitelist",
+        "10.0.0.1",
+    ]))
+    .start()
+    .await
+    .expect("start");
+
+    let config: serde_json::Value = reqwest::get(format!("http://{}/config", server.admin_addr()))
+        .await
+        .expect("GET /config")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(
+        config["options"]["ipWhitelist"],
+        serde_json::json!(["*"]),
+        "the flag filters nothing, so the reported whitelist must stay open — reporting the \
+         supplied list would re-create the false assurance this issue removes"
+    );
+
+    server.shutdown().await;
+}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -672,10 +672,23 @@ Get current configuration.
   "options": {
     "port": 2525,
     "allowInjection": true,
-    "localOnly": false
+    "localOnly": false,
+    "ipWhitelist": ["*"]
   }
 }
 ```
+
+Field notes (issue #879 — these were previously hardcoded literals):
+
+- **`port`** is the port the admin plane actually bound, so a `--port 0` (ephemeral) server reports
+  the real one rather than the `2525` default.
+- **`localOnly`** reports whether **`--local-only` was supplied**, not whether the admin listener
+  happened to bind loopback. The distinction matters: `--host 127.0.0.1` narrows only the admin
+  plane, while `/metrics` and every imposter port stay on `0.0.0.0` — so reporting `true` there
+  would tell you nothing is reachable off-host while two listener families still are.
+- **`ipWhitelist`** is always `["*"]`. `--ip-whitelist` is accepted for Mountebank compatibility and
+  **never enforced**, so every address may connect; see the
+  [CLI reference]({{ site.baseurl }}/configuration/cli/#--ip-whitelist-does-not-filter-anything).
 
 ---
 

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -138,7 +138,7 @@ Options:
       --runtime-affinity           Pin per-core worker threads to CPU cores (with --runtime per-core; effective on Linux)
       --metrics-port <PORT>        Prometheus metrics port [default: 9090]
       --front-door <ADDR>          Serve every imposter from one address, routed by host/path/header (see Features -> Front Door)
-      --ip-whitelist <IPS>         Comma-separated allowed IPs
+      --ip-whitelist <IPS>         Comma-separated allowed IPs (accepted for Mountebank compatibility; NOT enforced)
       --mock                       Run in mock mode
       --debug                      Enable debug mode
       --nologfile                  Disable log file (stdout only)
@@ -163,8 +163,31 @@ Options:
 ```
 
 `--no-parse` disables EJS preprocessing of `--configfile` (`<% include %>` / `<%= process.env.X %>`
-expansion), which is otherwise applied on load. `--formatter` and `--protofile` are accepted for
-Mountebank command-line compatibility but have no effect in Rift.
+expansion), which is otherwise applied on load. `--formatter`, `--protofile` and `--ip-whitelist`
+are accepted for Mountebank command-line compatibility but have no effect in Rift.
+
+### `--ip-whitelist` does not filter anything
+
+`--ip-whitelist` has **never** applied IP filtering in any release of Rift. It parses, and is
+otherwise ignored; passing it now logs a warning saying so. Earlier versions of this page advertised
+it as a way to "restrict access", including a CIDR example — that syntax was never implemented
+either. If you were relying on it, you had no filtering.
+
+This is deliberate rather than a gap waiting to be filled. Network-level access control belongs to
+the network, which sees the real peer: behind a proxy, load balancer or container NAT this process
+sees the hop, not the client, so an ACL enforced here would silently admit everyone unless it
+trusted `X-Forwarded-For` — and trusting a client-settable header for an ACL is a vulnerability, not
+a feature. Use a NetworkPolicy, security group or firewall.
+
+What does work inside Rift:
+
+| Goal | Use |
+|:-----|:----|
+| Refuse connections from other hosts | `--local-only` (binds loopback; covers `/metrics` too since 0.17.0) |
+| Require a credential on the admin API | `--api-key <token>` |
+| Fail startup if the admin plane is exposed and keyless | `--require-admin-auth` |
+
+`GET /config` reports `"ipWhitelist": ["*"]`, which is accurate: every address may connect.
 
 `--intercept-port` eagerly starts the [intercept/TLS-MITM proxy]({{ site.baseurl }}/features/intercept-proxy/)
 at boot. It is no longer the only way to enable it: a server started without the flag still exposes
@@ -262,7 +285,7 @@ rift-http-proxy --loglevel debug
 
 # Restrict access
 rift-http-proxy --local-only
-rift-http-proxy --ip-whitelist "192.168.1.0/24,10.0.0.0/8"
+rift-http-proxy --api-key s3cr3t --require-admin-auth
 
 # With persistent data directory
 rift-http-proxy --datadir ./mb-data

--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -184,7 +184,7 @@ Creates and starts a new Rift server instance.
 | `loglevel`       | `string`   | `'info'`      | Log level: debug, info, warn, error |
 | `logfile`        | `string`   | -             | Path to log file                    |
 | `datadir`        | `string`   | -             | Directory for imposter persistence (Mountebank `--datadir` parity) |
-| `ipWhitelist`    | `string[]` | -             | Allowed IP addresses                |
+| `ipWhitelist`    | `string[]` | -             | Accepted, **not enforced** (see CLI reference) |
 | `allowInjection` | `boolean`  | `false`       | Enable script injection             |
 
 `impostersRepository` and `redis` (custom Mountebank repository config) are accepted by the type

--- a/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
+++ b/tests/compatibility/MOUNTEBANK_RIFT_COMPATIBILITY_MATRIX.md
@@ -355,7 +355,7 @@ This matches Mountebank's behavior for automatic port assignment.
 | `--log` | ✅ Yes | ✅ Yes | ✅ **Complete** | Log file path |
 | `--pidfile` | ✅ Yes | ✅ Yes | ✅ **Complete** | PID file location |
 | `--debug` | ✅ Yes | ✅ Yes | ✅ **Complete** | Enable debug mode |
-| `--ipWhitelist` | ✅ Yes | ✅ Yes | ✅ **Complete** | IP whitelist (comma-separated) |
+| `--ipWhitelist` | ✅ Yes | ⚠️ Accepted | ⚠️ **Accepted, not enforced** | Parsed but never applied (issue #879); use a network policy/firewall, `--local-only`, or `--api-key` |
 | `--mock` | ✅ Yes | ✅ Yes | ✅ **Complete** | Mock mode flag |
 | `--origin` | ✅ Yes | ✅ Yes | ✅ **Complete** | CORS allowed origin |
 
@@ -582,7 +582,7 @@ rules:
    - **Workaround**: Use `decorate` behavior with JavaScript
 
 3. **IP Whitelisting** ⚠️
-   - **Gap**: No `--ipWhitelist` CLI option
+   - **Gap**: `--ipWhitelist` is accepted and parsed but **never enforced** (issue #879) — it applies no filtering and warns at startup
    - **Impact**: **LOW** - Handled by Kubernetes network policies
    - **Recommendation**: Document Kubernetes-native approach
 


### PR DESCRIPTION
## Summary

- --ip-whitelist was never enforced but claimed in five places; now an honest no-op that warns at startup
- GET /config fixed to report real bound port and --local-only flag value instead of hardcoded literals
- Flag stays accepted for Mountebank drop-in compatibility; network-layer ACL is strictly safer

Closes #879