### PR TITLE
feat(admin-api): export classify + AuthzTarget so an embedder's own admin front can reuse route classification (U-9 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,22 @@ record.
   from your own `tokio::spawn`ed task reports `None`. The admin SSE bus (`/events`) is **not**
   attributed — only the in-process listener is. See `docs/embedding/spi.md`.
 
+- **Admin route classification is now public — `admin_api::authz::{classify, AuthzTarget,
+  SCOPE_HEADER}`** (issue #887). The `AdminAuthorizer` hook (#854) is only usable when upstream
+  parses your routes, so an embedder that terminates some admin routes itself and proxies the rest —
+  a shape `ServerBuilder`/`RunningServer` already invite — had to assemble the
+  action/port/space/params tuple by hand. That means a second route parser, and this codebase has
+  already shipped the bug that follows: a classifier that filtered empty path segments (hyper does
+  not normalise `//`) saw a different route from the one dispatched, so
+  `PUT /imposters/:port/scenarios//state` mutated a scenario it had never classified.
+
+  `classify` is the same pure `(method, path) -> Option<AuthzTarget>` upstream calls, sharing the
+  router's own parser; `SCOPE_HEADER` replaces a copied `"x-rift-scope"` literal. `AuthzTarget` is
+  `#[non_exhaustive]` for the same reason `EventContext` is — you only ever read one back from
+  `classify`, so the next piece of route metadata worth handing an authorizer must not be a second
+  break to the same seam. Export only — no behaviour change, and nothing changes for an embedder
+  whose requests flow through upstream's request loop. See `docs/embedding/spi.md`.
+
 ### Security
 
 - **The TLS intercept proxy was reachable off-host with no authentication** (issue #878). Every

--- a/crates/rift-http-proxy/src/admin_api/authz.rs
+++ b/crates/rift-http-proxy/src/admin_api/authz.rs
@@ -8,21 +8,55 @@
 //! dispatch: the mapping from route to permission is the security-relevant part, and it should be
 //! testable without standing up a server or a manager.
 //!
+//! This module is public (issue #887) for the embedder that terminates some admin routes itself
+//! and proxies the rest — a shape `ServerBuilder`/`RunningServer` already invite. Such a host gets
+//! no classification for free from upstream's `service_fn`, and reimplementing it re-runs an
+//! experiment already run here once: a second parser that filtered empty path segments,
+//! while the router does not, so `PUT /imposters/:port/scenarios//state` dispatched a mutation
+//! that the classifier had never seen. Under `/imposters` that is now unrepresentable — [`classify`]
+//! calls the router's own parser — which is precisely the property a hand-written copy loses.
+//!
 //! [`AdminAuthorizer`]: rift_mock_core::extensions::authz::AdminAuthorizer
 
 use crate::admin_api::router::ImposterRoute;
 use hyper::Method;
 use rift_mock_core::extensions::authz::actions;
 
+/// Header carrying the embedder-defined scope selector handed to an [`AdminAuthorizer`]
+/// (issue #854). Upstream never parses or interprets the value — it exists because an authorizer
+/// often cannot derive the target from the port alone (`POST /imposters` has no port yet).
+///
+/// Public so an embedder's own admin front reads the same header rather than a copied literal
+/// (issue #887). It is caller-asserted: any authenticated caller can set it to any value.
+///
+/// [`AdminAuthorizer`]: rift_mock_core::extensions::authz::AdminAuthorizer
+pub const SCOPE_HEADER: &str = "x-rift-scope";
+
 /// A route as the authorizer needs to see it: what is being attempted, and against what.
 ///
 /// Owns its param strings because they are borrowed slices of a path that the caller may not keep
 /// alive; [`AuthzRequest`](rift_mock_core::extensions::authz::AuthzRequest) borrows from this.
+///
+/// `#[non_exhaustive]` for the same reason [`EventContext`] carries it: this is a produced-by-
+/// upstream, read-by-the-embedder struct on an opt-in seam, so the next piece of route metadata
+/// worth handing an authorizer must not be a breaking change to everyone who destructures one.
+/// Reading fields and matching with `..` are unaffected.
+///
+/// [`EventContext`]: rift_mock_core::imposter::EventContext
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct AuthzTarget {
+    /// The action being attempted, e.g. `"imposter.write"` — one of [`actions`].
+    ///
+    /// [`actions`]: rift_mock_core::extensions::authz::actions
     pub action: &'static str,
+    /// The imposter port the route targets. `None` for system routes and for collection routes
+    /// that name no port yet (`POST /imposters`).
     pub port: Option<u16>,
+    /// The flow/space identifier, for the correlated-isolation routes.
     pub space: Option<String>,
+    /// Every path param the router extracted, including `port` and `space` when present, so an
+    /// authorizer can key on a route's own vocabulary without re-parsing the path.
     pub params: Vec<(&'static str, String)>,
 }
 
@@ -74,6 +108,27 @@ fn imposter_action(method: &Method) -> &'static str {
 /// handler and changes nothing, so there is no action to authorize. Note the consequence — an
 /// authenticated caller can still distinguish a 404 from a 403, so the hook bounds what a
 /// principal can *do*, not what it can learn about which routes exist.
+///
+/// # Examples
+///
+/// An embedder fronting the admin API classifies a parameterised route the same way upstream does,
+/// and reads the params the handler will act on:
+///
+/// ```
+/// use hyper::Method;
+/// use rift_http_proxy::admin_api::authz::classify;
+/// use rift_http_proxy::extensions::authz::actions;
+///
+/// let target = classify(&Method::PUT, "/imposters/4545/scenarios/checkout/state")
+///     .expect("a dispatchable admin route classifies");
+///
+/// assert_eq!(target.action, actions::IMPOSTER_WRITE);
+/// assert_eq!(target.port, Some(4545));
+/// assert!(target.params.contains(&("scenario", "checkout".to_string())));
+///
+/// // Data-plane traffic is deliberately not admin-gated.
+/// assert_eq!(classify(&Method::GET, "/__rift/4545/orders"), None);
+/// ```
 #[must_use]
 pub fn classify(method: &Method, path: &str) -> Option<AuthzTarget> {
     // Belt-and-braces, and deliberately kept as such: `/__rift/...` matches none of the branches
@@ -321,6 +376,34 @@ mod tests {
                 .params
                 .contains(&("scenario", "checkout".to_string()))
         );
+    }
+
+    #[test]
+    fn empty_segments_are_classified_rather_than_filtered_away() {
+        // The regression that makes a single parser non-negotiable, pinned. Hyper does not
+        // normalise `//`, so a classifier that filtered empty segments saw a different route from
+        // the one the router dispatched: the mutation ran, authorized as something else or never
+        // classified at all. Reintroducing the filter makes the first `expect` panic (no route
+        // matches `["scenarios", "state"]`) and the second assert read `Some("stubs")`.
+        let scenario = classify(&Method::PUT, "/imposters/4545/scenarios//state")
+            .expect("the router dispatches this, so it must classify");
+        assert_eq!(scenario.action, actions::IMPOSTER_WRITE);
+        assert!(scenario.params.contains(&("scenario", String::new())));
+
+        let space = classify(&Method::POST, "/imposters/4545/spaces//stubs")
+            .expect("the router dispatches this, so it must classify");
+        assert_eq!(space.space.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn the_flow_state_branch_filters_empty_segments_exactly_as_its_router_twin_does() {
+        // `classify_admin_flow_state` is the one branch that does NOT delegate to the router — it
+        // hand-copies `route_admin_flow_state`, filter included. They agree today; this pins the
+        // agreement, because that is the branch where the divergence above could come back.
+        let t = classify(&Method::DELETE, "/admin/imposters/4545/flow-state//cart")
+            .expect("the filter collapses the empty segment, so this is the 3-segment route");
+        assert_eq!(t.space.as_deref(), Some("cart"));
+        assert!(!t.params.iter().any(|(name, _)| *name == "key"));
     }
 
     #[test]

--- a/crates/rift-http-proxy/src/admin_api/mod.rs
+++ b/crates/rift-http-proxy/src/admin_api/mod.rs
@@ -8,7 +8,11 @@
 //!
 //! The API listens on a configurable port (default: 2525).
 
-pub(crate) mod authz;
+// Public because the `AdminAuthorizer` hook (#854) is only usable when upstream parses your
+// routes. An embedder that terminates some admin routes itself needs the same classifier, and the
+// alternative — a second route parser — is the divergence `authz`'s own doc comment records as a
+// shipped security bug (issue #887).
+pub mod authz;
 mod handlers;
 mod request_filter;
 mod router;

--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -34,11 +34,6 @@ use tracing::{debug, error, info, warn};
 /// Bounded grace given to in-flight connections on `shutdown()` before the wait is abandoned.
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
-/// Header carrying the embedder-defined scope selector handed to an [`AdminAuthorizer`]
-/// (issue #854). Upstream never parses or interprets the value — it exists because an authorizer
-/// often cannot derive the target from the port alone (`POST /imposters` has no port yet).
-const SCOPE_HEADER: &str = "x-rift-scope";
-
 /// Admin API server for Rift
 pub struct AdminApiServer {
     addr: SocketAddr,
@@ -626,7 +621,7 @@ async fn accept_loop(
                                 space: target.space.as_deref(),
                                 scope: req
                                     .headers()
-                                    .get(SCOPE_HEADER)
+                                    .get(authz::SCOPE_HEADER)
                                     .and_then(|v| v.to_str().ok()),
                                 params: &params,
                             });

--- a/crates/rift-http-proxy/tests/issue_887_authz_classify_export.rs
+++ b/crates/rift-http-proxy/tests/issue_887_authz_classify_export.rs
@@ -1,0 +1,45 @@
+//! Issue #887: the admin route classifier is reachable from outside the crate.
+//!
+//! The `AdminAuthorizer` hook (#854) is only usable when upstream parses your routes. An embedder
+//! that terminates some admin routes itself and proxies the rest has to build the
+//! action/port/space/params tuple to consult its own authorizer — and doing that by hand means a
+//! second route parser, which is the divergence `admin_api::authz` exists to prevent.
+//!
+//! These tests exercise the export the way an embedder would: through the public path only, with
+//! no `pub(crate)` reach-in. If `authz` were private again, this file would not compile.
+
+use hyper::Method;
+use rift_http_proxy::admin_api::authz::{AuthzTarget, SCOPE_HEADER, classify};
+use rift_mock_core::extensions::authz::actions;
+
+#[test]
+fn a_parameterised_route_classifies_and_exposes_its_params() {
+    let target: AuthzTarget = classify(&Method::PUT, "/imposters/4545/stubs/by-id/abc123")
+        .expect("a dispatchable admin route classifies");
+
+    assert_eq!(target.action, actions::IMPOSTER_WRITE);
+    assert_eq!(target.port, Some(4545));
+    assert!(target.params.contains(&("port", "4545".to_string())));
+    assert!(target.params.contains(&("stubId", "abc123".to_string())));
+}
+
+#[test]
+fn space_routes_expose_the_flow_id_to_an_embedder() {
+    let target = classify(&Method::POST, "/imposters/4545/spaces/flow-9/stubs")
+        .expect("space route classifies");
+
+    assert_eq!(target.space.as_deref(), Some("flow-9"));
+    assert_eq!(target.port, Some(4545));
+}
+
+#[test]
+fn the_data_plane_is_not_an_authorizable_route() {
+    // An embedder's own front must reach the same conclusion upstream does: gateway traffic is
+    // app-under-test traffic and is deliberately not admin-gated.
+    assert_eq!(classify(&Method::GET, "/__rift/4545/orders"), None);
+}
+
+#[test]
+fn the_scope_header_name_is_a_constant_rather_than_a_string_to_copy() {
+    assert_eq!(SCOPE_HEADER, "x-rift-scope");
+}

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -378,6 +378,43 @@ The data plane is never authorized. Gateway traffic (`/__rift/...`) skips this h
 reason it skips the api key — it is app-under-test traffic, and requiring an admin identity for it
 would force the application to carry the admin credential.
 
+### Fronting the admin API yourself
+
+Everything above assumes your requests reach upstream's own request loop, which parses the route and
+calls the hook for you. If instead you **terminate some admin routes yourself** and proxy the rest,
+you have no parsed route to authorize against — so call the same classifier upstream does:
+
+```rust
+use rift_http_proxy::admin_api::authz::{SCOPE_HEADER, classify};
+use rift_mock_core::extensions::authz::AuthzRequest;
+
+// `None` = not an authorizable admin route: the data plane (`/__rift/...`), or a path that
+// matches no route at all and so reaches no handler.
+if let Some(target) = classify(req.method(), req.uri().path()) {
+    let params: Vec<(&str, &str)> = target
+        .params
+        .iter()
+        .map(|(name, value)| (*name, value.as_str()))
+        .collect();
+    let decision = my_authorizer.authorize(AuthzRequest {
+        credential: req.headers().get("authorization").and_then(|v| v.to_str().ok()),
+        action: target.action,
+        port: target.port,
+        space: target.space.as_deref(),
+        scope: req.headers().get(SCOPE_HEADER).and_then(|v| v.to_str().ok()),
+        params: &params,
+    });
+}
+```
+
+Do not write a second parser for this. Two parsers diverging is a silent bypass, and this codebase
+has already shipped it: a classifier that filtered empty path segments — which hyper does not
+normalise — saw a different route from the one dispatched, so `PUT /imposters/:port/scenarios//state`
+mutated a scenario the classifier had never seen. Under `/imposters` that is now unrepresentable,
+because `classify` calls the router's own parser and matches its route enum exhaustively — which is
+exactly the property a hand-written copy gives up. `SCOPE_HEADER` likewise spares you a copied
+header literal.
+
 ## Backend errors and annotations
 
 A custom backend signals unavailability by attaching `BackendUnavailable` to a failed operation's


### PR DESCRIPTION
Exports admin_api::authz types for embedders to reuse route classification in their own admin front-end implementations. The classify function, AuthzTarget struct (marked #[non_exhaustive]), and SCOPE_HEADER constant are now public.

Includes a new integration test that compile-pins external reachability and a unit test that pins the //-empty-segment regression from #608/#610/#611. The docs/embedding/spi.md gained a "Fronting the admin API yourself" section.

This is an export-only change with no behavior modifications.

Closes #887

Milestone: none (standalone)