### PR TITLE
fix(docs): broken ignored doctest in ResponseExt::into_boxed

### DIFF
--- a/crates/rift-mock-core/src/proxy/response_ext.rs
+++ b/crates/rift-mock-core/src/proxy/response_ext.rs
@@ -19,7 +19,16 @@ pub trait ResponseExt {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// `response_ext` is a private module with no re-export, so `ResponseExt` has no path
+    /// from outside this crate — and since doctests compile as a separate crate, neither
+    /// `crate::` nor any external path can resolve to it. The example below is illustrative
+    /// of crate-internal use only; behaviour is covered by the unit tests in this file.
+    ///
+    /// ```text
+    /// use http_body_util::Full;
+    /// use hyper::Response;
+    /// use hyper::body::Bytes;
+    ///
     /// use crate::proxy::response_ext::ResponseExt;
     ///
     /// let response = Response::new(Full::new(Bytes::from("hello")));


### PR DESCRIPTION
Converts the ResponseExt::into_boxed example from \`\`\`ignore to \`\`\`text,
removing a permanently-skipped doctest that could never have compiled (doctests
are a separate crate; the private module has no re-export). Behaviour is covered
by three existing unit tests in the same file.

Doctest counts: before = 1 test / 1 ignored; after = 0 tests / 0 ignored.

All checks pass: clippy -D warnings, fmt, and 1312 lib tests. This is a pure
doc-comment change with no logic or API modifications.

Related to #888 / PR #894 (doctest CI gate) but does not depend on it.

Closes #893