### PR TITLE
fix(docs): every hand-written cross-reference on the docs site 404s (no pretty permalinks, no link gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,29 @@ jobs:
           ./scripts/verify-feature-propagation.sh --self-test
           ./scripts/verify-feature-propagation.sh
 
+  docs-links:
+    name: Docs Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Issue #898: the docs shipped with 156 dead cross-references because the authored URL shape
+      # (`/features/spaces/`) never matched the built one (`features/spaces.html`). Source-level
+      # checks cannot see that — the links are well-formed, and the just-the-docs nav is generated
+      # from `page.url` so it stayed correct and hid the breakage. The site has to be built and its
+      # links resolved the way GitHub Pages serves them, which is what this gate does.
+      - name: Build the docs site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      # --self-test first proves the checker isn't a no-op: it must reject the #898 layout.
+      - name: Verify every internal docs link resolves
+        run: |
+          ./scripts/verify-docs-links.sh --self-test
+          ./scripts/verify-docs-links.sh ./_site
+
   benchmark-scripts:
     name: Benchmark Scripts
     runs-on: ubuntu-latest

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,14 @@ description: High-performance Mountebank-compatible HTTP/HTTPS mock server writt
 baseurl: "/rift"
 url: "https://achird-labs.github.io"
 
+# Every hand-written cross-reference in docs/ is of the form
+# `{{ site.baseurl }}/features/spaces/` — a trailing-slash URL. Jekyll's default
+# permalink emits `features/spaces.html`, which GitHub Pages does NOT serve at
+# `features/spaces/`, so all 156 of those links 404'd (the nav was unaffected:
+# just-the-docs builds it from `page.url`, which stayed correct). `pretty` emits
+# `features/spaces/index.html` so the authored URL shape is the served one.
+permalink: pretty
+
 # Theme
 remote_theme: just-the-docs/just-the-docs
 color_scheme: dark

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -15,7 +15,7 @@ How Rift relates to the other mock servers you might be choosing between.
 For Mountebank, the relationship is different in kind: Rift implements Mountebank's admin API
 and loads its `imposters.json` unchanged, so the relevant page is
 [Mountebank Compatibility]({{ site.baseurl }}/mountebank/) rather than a comparison, plus the
-[migration guide]({{ site.baseurl }}/getting-started/migration).
+[migration guide]({{ site.baseurl }}/getting-started/migration/).
 
 ---
 

--- a/docs/comparisons/wiremock.md
+++ b/docs/comparisons/wiremock.md
@@ -225,7 +225,7 @@ organisations running more than one language.
 
 There is no config compatibility between WireMock and Rift, so this is genuine translation
 work, not a drop-in. (If you are coming from **Mountebank**, it *is* a drop-in — see the
-[migration guide]({{ site.baseurl }}/getting-started/migration).)
+[migration guide]({{ site.baseurl }}/getting-started/migration/).)
 
 ### Concept mapping
 

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -259,7 +259,7 @@ A rule matches an intercepted request by **host** (exact, case-insensitive; omit
 
 Body predicates see a request body that is not valid UTF-8 (protobuf, gzip, an image upload) as
 its **standard base64 encoding** (with padding) — the same convention as
-[binary recorded requests]({{ site.baseurl }}/mountebank/imposters) and binary responses. Write
+[binary recorded requests]({{ site.baseurl }}/mountebank/imposters/) and binary responses. Write
 the predicate against the base64 string, e.g.
 `{ "equals": { "body": "H4sIAAAAAAAA/w==" } }`. A valid-UTF-8 (text or JSON) body is matched
 as-is, unchanged. Forwarding always relays the raw bytes regardless of classification.

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -78,7 +78,7 @@ config.request.headers     // { "content-type": "application/json" }
 config.request.body        // Request body (string or parsed object)
 ```
 
-> Path parameters (`request.pathParams`, from a stub's [`routePattern`](../configuration/native/#route-patterns-routepattern)) are exposed to the `_rift.script` engines — Rhai and JavaScript — not to this Mountebank `inject` `config.request` object.
+> Path parameters (`request.pathParams`, from a stub's [`routePattern`]({{ site.baseurl }}/configuration/native/#route-patterns-routepattern)) are exposed to the `_rift.script` engines — Rhai and JavaScript — not to this Mountebank `inject` `config.request` object.
 
 ### State Object
 

--- a/docs/mountebank/index.md
+++ b/docs/mountebank/index.md
@@ -11,7 +11,7 @@ permalink: /mountebank/
 Rift implements the [Mountebank](http://www.mbtest.org/) REST API and configuration format. This allows you to use Rift as a drop-in replacement for Mountebank with significantly better performance.
 
 **Scope:** Rift imposters are **HTTP/HTTPS only**. Mountebank also supports `tcp` and `smtp`
-imposters, which Rift rejects — see the [migration guide]({{ site.baseurl }}/getting-started/migration)
+imposters, which Rift rejects — see the [migration guide]({{ site.baseurl }}/getting-started/migration/)
 for the full compatibility table before you migrate. (This is separate from TCP *fault injection*,
 which HTTP imposters do support.)
 

--- a/scripts/verify-docs-links.sh
+++ b/scripts/verify-docs-links.sh
@@ -100,16 +100,26 @@ for root, _, files in os.walk(site):
             href = href.strip()
             if not href or href.startswith("#") or EXTERNAL.match(href):
                 continue
-            path = unquote(urljoin(page_url, href).split("#")[0].split("?")[0])
-            if baseurl:
-                if path == baseurl:
-                    path = "/"
-                elif path.startswith(baseurl + "/"):
-                    path = path[len(baseurl):]
-                else:
-                    # Absolute link that ignores baseurl — cannot resolve once deployed.
-                    broken.append((page_url, href, "outside baseurl"))
-                    continue
+            target = href.split("#")[0].split("?")[0]
+            if not target:
+                continue
+            if target.startswith("/"):
+                # Absolute: written with the baseurl, which is not part of the file layout.
+                if baseurl:
+                    if target == baseurl:
+                        target = "/"
+                    elif target.startswith(baseurl + "/"):
+                        target = target[len(baseurl):]
+                    else:
+                        # An absolute link that omits the baseurl cannot resolve once deployed.
+                        broken.append((page_url, href, "outside baseurl"))
+                        continue
+            else:
+                # Relative: the browser resolves it against the *served* URL, so the baseurl
+                # cancels out on both sides and `page_url` (already site-root-relative) is the
+                # correct base. Stripping a baseurl here would be wrong — there is none to strip.
+                target = urljoin(page_url, target)
+            path = unquote(target)
             if not resolves(path):
                 broken.append((page_url, href, "404"))
 
@@ -136,10 +146,13 @@ self_test() {
   printf '<a href="/rift/features/spaces/">spaces</a>' > "$tmp/broken/index.html"
   printf 'spaces' > "$tmp/broken/features/spaces.html"
 
-  # The same link under `permalink: pretty` — served by the directory index.
-  mkdir -p "$tmp/fixed/features/spaces"
-  printf '<a href="/rift/features/spaces/">spaces</a>' > "$tmp/fixed/index.html"
-  printf 'spaces' > "$tmp/fixed/features/spaces/index.html"
+  # The same link under `permalink: pretty` — served by the directory index. Also covers the two
+  # relative-link shapes the docs actually use: a relative link carries no baseurl, so resolving it
+  # as though it did reports a false 404 (which is exactly what this checker did on first run).
+  mkdir -p "$tmp/fixed/features/spaces" "$tmp/fixed/performance"
+  printf '<a href="/rift/features/spaces/">abs</a><a href="performance/">rel</a>' > "$tmp/fixed/index.html"
+  printf '<a href="../../performance/">up</a>' > "$tmp/fixed/features/spaces/index.html"
+  printf 'perf' > "$tmp/fixed/performance/index.html"
 
   if check_site "$tmp/broken" "/rift" >/dev/null 2>&1; then
     echo "verify-docs-links --self-test: FAILED — checker passed the known-broken #898 layout." >&2

--- a/scripts/verify-docs-links.sh
+++ b/scripts/verify-docs-links.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Docs internal-link gate (issue #898).
+#
+# Resolves every internal link in the *built* docs site the way GitHub Pages actually serves it,
+# and fails if any of them would 404. This is the gate that was missing when the whole site
+# shipped with 156 dead cross-references: `docs/_config.yml` emitted `features/spaces.html` while
+# every hand-written link pointed at `features/spaces/`, and nothing noticed — the just-the-docs
+# navigation is generated from `page.url`, so the theme's own links stayed correct and the site
+# looked navigable. Only links a human wrote were broken.
+#
+# Checking the *sources* would not have caught it: `{{ site.baseurl }}/features/spaces/` is a
+# perfectly well-formed link. The bug only exists in the relationship between the authored URL and
+# the file layout Jekyll produces, so the check has to run against the built output.
+#
+# Pages' resolution rules, which this reproduces:
+#   - `/path/`      -> requires `path/index.html`
+#   - `/path`       -> `path`, `path.html`, or `path/index.html` (the last via a 301 to `/path/`)
+#   - `/path.html`  -> requires that exact file
+#
+# Scope: internal links only. External URLs are not fetched (flaky, and not this gate's job), and
+# `#fragment` targets are not resolved — this catches dead *pages*, not dead anchors.
+#
+# Usage:
+#   scripts/verify-docs-links.sh [site-dir]     # check a built site (default: _site)
+#   scripts/verify-docs-links.sh --self-test    # prove the checker flags the #898 layout
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Overridable so the self-test can point the checker at fixtures.
+BASEURL="${BASEURL:-$(grep -E '^baseurl:' "$repo_root/docs/_config.yml" | sed -E 's/^baseurl:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')}"
+
+check_site() {
+  local site_dir="$1" baseurl="$2"
+  SITE_DIR="$site_dir" BASEURL="$baseurl" python3 - <<'PY'
+import os, re, sys
+from html.parser import HTMLParser
+from urllib.parse import unquote, urljoin
+
+site = os.path.abspath(os.environ["SITE_DIR"])
+baseurl = os.environ["BASEURL"].rstrip("/")
+
+if not os.path.isdir(site):
+    sys.exit(f"verify-docs-links: site dir not found: {site}\nBuild it first (see .github/workflows/ci.yml).")
+
+EXTERNAL = re.compile(r"^(?:[a-z][a-z0-9+.-]*:|//)", re.I)
+
+
+class Links(HTMLParser):
+    """Collect href/src targets. Regex over HTML misses attribute quoting edge cases."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.found = []
+
+    def handle_starttag(self, tag, attrs):
+        attr = {"a": "href", "link": "href", "img": "src", "script": "src"}.get(tag)
+        if not attr:
+            return
+        for k, v in attrs:
+            if k == attr and v:
+                self.found.append(v)
+
+
+def resolves(path: str) -> bool:
+    """Does `path` (site-root-relative, already stripped of baseurl) resolve on GitHub Pages?"""
+    target = os.path.normpath(os.path.join(site, path.lstrip("/")))
+    # normpath collapses `..`; a link that escapes the site root can never resolve.
+    if not (target == site or target.startswith(site + os.sep)):
+        return False
+    if path.endswith("/"):
+        # Trailing slash is served *only* by a directory index. This is the #898 case:
+        # `features/spaces.html` exists but `features/spaces/` is a 404.
+        return os.path.isfile(os.path.join(target, "index.html"))
+    return (
+        os.path.isfile(target)
+        or os.path.isfile(target + ".html")
+        or os.path.isfile(os.path.join(target, "index.html"))
+    )
+
+
+broken = []
+pages = 0
+for root, _, files in os.walk(site):
+    for name in files:
+        if not name.endswith(".html"):
+            continue
+        pages += 1
+        page = os.path.join(root, name)
+        # The URL this file is served at, so relative links resolve from the right place.
+        page_url = "/" + os.path.relpath(page, site).replace(os.sep, "/")
+
+        parser = Links()
+        with open(page, encoding="utf-8", errors="replace") as fh:
+            parser.feed(fh.read())
+
+        for href in parser.found:
+            href = href.strip()
+            if not href or href.startswith("#") or EXTERNAL.match(href):
+                continue
+            path = unquote(urljoin(page_url, href).split("#")[0].split("?")[0])
+            if baseurl:
+                if path == baseurl:
+                    path = "/"
+                elif path.startswith(baseurl + "/"):
+                    path = path[len(baseurl):]
+                else:
+                    # Absolute link that ignores baseurl — cannot resolve once deployed.
+                    broken.append((page_url, href, "outside baseurl"))
+                    continue
+            if not resolves(path):
+                broken.append((page_url, href, "404"))
+
+if broken:
+    print(f"verify-docs-links: {len(broken)} broken internal link(s) across {pages} page(s):\n")
+    for page_url, href, why in sorted(set(broken)):
+        print(f"  {page_url}\n      -> {href}  [{why}]")
+    print("\nA trailing-slash link needs a directory index. If these are all `/foo/` links whose")
+    print("files are `foo.html`, the site is missing `permalink: pretty` in docs/_config.yml.")
+    sys.exit(1)
+
+print(f"verify-docs-links: OK — every internal link across {pages} page(s) resolves.")
+PY
+}
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # The exact #898 layout: the page is built as `features/spaces.html`, the link points at
+  # `features/spaces/`. Live, this is a 404.
+  mkdir -p "$tmp/broken/features"
+  printf '<a href="/rift/features/spaces/">spaces</a>' > "$tmp/broken/index.html"
+  printf 'spaces' > "$tmp/broken/features/spaces.html"
+
+  # The same link under `permalink: pretty` — served by the directory index.
+  mkdir -p "$tmp/fixed/features/spaces"
+  printf '<a href="/rift/features/spaces/">spaces</a>' > "$tmp/fixed/index.html"
+  printf 'spaces' > "$tmp/fixed/features/spaces/index.html"
+
+  if check_site "$tmp/broken" "/rift" >/dev/null 2>&1; then
+    echo "verify-docs-links --self-test: FAILED — checker passed the known-broken #898 layout." >&2
+    return 1
+  fi
+  if ! check_site "$tmp/fixed" "/rift" >/dev/null 2>&1; then
+    echo "verify-docs-links --self-test: FAILED — checker rejected a correctly-built site." >&2
+    return 1
+  fi
+  echo "verify-docs-links --self-test: OK — flags the #898 layout, accepts the fixed one."
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+else
+  check_site "${1:-$repo_root/_site}" "$BASEURL"
+fi


### PR DESCRIPTION
Sets `permalink: pretty` so the docs site serves the trailing-slash URL shape all 183 of its
hand-written cross-references are authored against — 156 of which currently 404, including the
WireMock page linked from `README.md:72`. Adds a CI gate that builds the site and resolves every
internal link the way GitHub Pages does, so this cannot recur.

Closes #898

## Why it was invisible

The just-the-docs navigation is generated from `page.url`, so every link the *theme* produced was
correct and only links a *human* wrote were broken. The site looked navigable.

## Why the gate builds the site

`{{ site.baseurl }}/features/spaces/` is a perfectly well-formed link — nothing is wrong at the
source level. The defect exists only in the relationship between the authored URL and the file
layout Jekyll produces, so the check has to run against built output. `scripts/verify-docs-links.sh`
reproduces Pages' resolution rules:

| link | resolves via |
|---|---|
| `/path/` | `path/index.html` only |
| `/path` | `path`, `path.html`, or `path/index.html` (301) |
| `/path.html` | that exact file |

Following the repo's verifier convention, it has a `--self-test` that plants the #898 layout and
asserts the checker rejects it, so the gate cannot silently become a no-op.

## Verification

Run against a mirror of the **currently deployed** site, the checker reports the live breakage at
full scale — 242 broken page links, of which ~146 are the real cross-references (the remainder are
nav links to two pages the mirror could not fetch). `--self-test` passes; `shellcheck` is clean.

The end-to-end proof is this PR's own `Docs Links` job: it builds the site with the new config and
fails if `permalink: pretty` did not actually fix it. There is no local Jekyll toolchain (no
Gemfile; the site builds via `actions/jekyll-build-pages@v1`), so CI is the first real build.

## Trade-off

`.html` URLs stop resolving. Nothing in the repo points at them (0 occurrences) and the nav
regenerates itself, so the only casualties are externally bookmarked `.html` links.

## Out of scope

`docs/assets/images/logo.png` is configured in `_config.yml` but does not exist and 404s live. The
theme renders it as a CSS background rather than an `<img>`, so the gate does not catch it. Worth a
separate issue.