### PR TITLE
docs: add the Go SDK, and correct the Scala backend list

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ See the [rift-java docs](https://achird-labs.github.io/rift-java/) for the full 
 ### Scala
 
 For Scala 3, use the official [rift-scala](https://github.com/achird-labs/rift-scala) SDK. It is
-effect-library-native — ZIO, Cats Effect 3 / FS2, Kyo, or no effect system at all — over the same
+effect-library-native — ZIO, Cats Effect 3 / FS2, or no effect system at all — over the same
 four transports (embedded, connect, spawn, container):
 
 ```scala
@@ -259,6 +259,39 @@ It also ships a [zio-bdd](https://github.com/EtaCassiopeia/zio-bdd) `MockControl
 against zio-bdd's published conformance catalogue. See the
 [rift-scala docs](https://achird-labs.github.io/rift-scala/).
 
+### Go
+
+For Go projects, use the official [rift-go](https://github.com/achird-labs/rift-go) SDK. It runs the
+engine three ways — embedded in-process, connected to any running admin endpoint, or as a managed
+spawned binary — with a fluent DSL plus `testing.T` helpers.
+
+The embedded transport loads the engine through
+[purego](https://github.com/ebitengine/purego) rather than cgo, so **`CGO_ENABLED=0` keeps
+working**: no C toolchain, no cross-compilation penalty, and nothing about a consumer's build
+changes by depending on it.
+
+```bash
+go get github.com/achird-labs/rift-go
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+```
+
+```go
+func TestUserLookup(t *testing.T) {
+    users := rifttest.Imposter(t, rift.NewImposter("users").
+        Stub(rift.OnGet("/api/users/1").
+            Return(rift.OKJSON(map[string]rift.JSON{"id": 1, "name": "Alice"}))))
+
+    callSUT(t, users.BaseURL())               // point your SUT at users.BaseURL()
+
+    rifttest.AssertReceived(t, users, rift.OnGet("/api/users/1"), rift.Once())
+}
+```
+
+Assertion counting runs through the engine's own predicate evaluator, so `xpath`, `jsonpath` and
+`inject` predicates mean the same thing in a verification as in a stub — and a failure reports the
+nearest non-matching request with the clauses it failed. See the
+[rift-go docs](https://achird-labs.github.io/rift-go/).
+
 ---
 
 ## Documentation
@@ -269,6 +302,7 @@ against zio-bdd's published conformance catalogue. See the
 - [Node.js Integration](https://achird-labs.github.io/rift/getting-started/nodejs/) - npm package for Node.js
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
+- [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)
 - [Migration Guide](https://achird-labs.github.io/rift/getting-started/migration) - Using Rift with Mountebank configs
 
 ### Mountebank Compatibility

--- a/docs/comparisons/wiremock.md
+++ b/docs/comparisons/wiremock.md
@@ -91,8 +91,8 @@ ecosystems:
 |:--|:--|:--|
 | Java / JVM | Panama FFM | JUnit 5, Spring, Testcontainers |
 | Node / TypeScript | koffi | Vitest, Jest testkits |
-| Go | purego (**no cgo**) | testing helpers |
-| Scala 3 | via rift-java | ZIO, Cats Effect 3 / FS2, Kyo, pure |
+| Go | purego (**no cgo**) | `testing.T` helpers |
+| Scala 3 | via rift-java | ZIO, Cats Effect 3 / FS2, pure |
 
 A JVM library cannot become a Go library. If your organisation runs more than one language,
 the practical outcome today is several mocking tools with incompatible fixtures — and a

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -107,6 +107,34 @@ running admin endpoint. See the
 [rift-java documentation](https://achird-labs.github.io/rift-java/) for the JUnit 5, Spring, and
 Testcontainers integrations.
 
+### Go
+
+For Go projects, add the official [rift-go](https://github.com/achird-labs/rift-go) SDK and fetch
+the native library once:
+
+```bash
+go get github.com/achird-labs/rift-go
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+```
+
+Usage:
+
+```go
+func TestUserLookup(t *testing.T) {
+    users := rifttest.Imposter(t, rift.NewImposter("users").
+        Stub(rift.OnGet("/api/users/1").Return(rift.OKJSON(`{"id":1}`))))
+
+    callSUT(t, users.BaseURL())
+
+    rifttest.AssertReceived(t, users, rift.OnGet("/api/users/1"), rift.Once())
+}
+```
+
+The engine runs in-process through [purego](https://github.com/ebitengine/purego) rather than cgo,
+so `CGO_ENABLED=0` keeps working and no C toolchain is needed. `rift.Spawn(ctx, …)` manages a
+binary instead, and `rift.Connect(url, …)` targets any running admin endpoint — neither needs the
+native library. See the [rift-go documentation](https://achird-labs.github.io/rift-go/).
+
 ---
 
 ## Verify Installation
@@ -209,6 +237,7 @@ Example `imposters.json`:
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
+- [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)
 - [Predicates Guide]({{ site.baseurl }}/mountebank/predicates/) - Request matching
 - [Responses Guide]({{ site.baseurl }}/mountebank/responses/) - Response configuration
 - [Migration Guide]({{ site.baseurl }}/getting-started/migration/) - Switching from Mountebank

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,6 +150,36 @@ See the [rift-java documentation](https://achird-labs.github.io/rift-java/) for 
 surface, and the [BOM](https://github.com/achird-labs/rift-java/blob/master/rift-java-bom/README.md)
 for version-pinning every module at once.
 
+### Go Integration
+
+For Go projects, use the official [rift-go](https://github.com/achird-labs/rift-go) SDK. It runs the
+engine three ways — embedded in-process, connected to any running admin endpoint, or as a managed
+spawned binary — with a fluent DSL plus `testing.T` helpers.
+
+The embedded transport loads the engine through
+[purego](https://github.com/ebitengine/purego) rather than cgo, so **`CGO_ENABLED=0` keeps
+working**: no C toolchain, and cross-compilation is unaffected.
+
+```bash
+go get github.com/achird-labs/rift-go
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+```
+
+```go
+func TestUserLookup(t *testing.T) {
+    users := rifttest.Imposter(t, rift.NewImposter("users").
+        Stub(rift.OnGet("/api/users/1").
+            Return(rift.OKJSON(map[string]rift.JSON{"id": 1, "name": "Alice"}))))
+
+    callSUT(t, users.BaseURL())
+
+    rifttest.AssertReceived(t, users, rift.OnGet("/api/users/1"), rift.Once())
+}
+```
+
+See the [rift-go documentation](https://achird-labs.github.io/rift-go/) for the full feature
+surface.
+
 ---
 
 ## Documentation
@@ -160,6 +190,7 @@ for version-pinning every module at once.
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
+- [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)
 - [Migration from Mountebank]({{ site.baseurl }}/getting-started/migration/) - Switch from Mountebank to Rift
 
 ### Concepts


### PR DESCRIPTION
rift-go shipped ([rift-go#11](https://github.com/achird-labs/rift-go/pull/11)), so
the engine's docs should say so.

## Adds the Go SDK

A Go section in the README, the docs landing page, and the getting-started guide —
matching how Node, Java and Scala are already presented — plus a link in each
"Documentation" index.

The purego / no-cgo property is stated explicitly rather than buried: it is what
makes depending on the SDK invisible to a consumer's build, and it is the first
thing a Go reader will check.

## Corrects the Scala backend list

Drops **Kyo** from three places. rift-scala M4 shipped ZIO, Cats Effect 3 / FS2
and a pure backend; the Kyo backend is un-milestoned and unstarted
([rift-scala#11](https://github.com/achird-labs/rift-scala/issues/11)), so listing
it promised something that does not exist.

- `README.md` — Scala section
- `docs/comparisons/wiremock.md` — the polyglot embedding table

That table's **Go** row already claimed "purego (no cgo), testing helpers" — a
forward-looking claim that was false until rift-go#11 merged. It is now accurate.
`docs/embedding/ffi.md` and `docs/embedding/sdk-conformance.md` likewise already
referenced rift-go in anticipation; both are now true rather than aspirational.

## Verification

`scripts/verify-docs-coverage.sh` passes: 44 flags, 34 env vars, 7 subcommands all
documented.

Note the known gap that gate does not close — it checks CLI flags, env vars and
subcommands, **not** config-file keys. Nothing here touches the config schema.
