### PR TITLE
bench: compare Rift vs Microcks under stub growth

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -42,6 +42,16 @@ on:
       wiremock_version:
         description: "WireMock version (pinned, same reason as Mountebank)"
         default: "3.9.1"
+      microcks_version:
+        description: "Microcks version (pinned, same reason as Mountebank)"
+        default: "1.14.0"
+      run_microcks:
+        description: >-
+          Run the Microcks leg (issue #900). Adds ~1 JVM start per imposter per rep on top of the
+          scenario time, and only six of the thirteen scenarios are comparable, so it is separable
+          from the 3-way table rather than welded to it.
+        type: boolean
+        default: true
       run_sweep:
         description: >-
           Run the Rift-only connection sweep. It is ~75% of the wall clock and contributes nothing
@@ -66,6 +76,7 @@ jobs:
       BENCH_WARMUP: ${{ inputs.warmup }}
       BENCH_MB_VERSION: ${{ inputs.mb_version }}
       BENCH_WIREMOCK_VERSION: ${{ inputs.wiremock_version }}
+      BENCH_MICROCKS_VERSION: ${{ inputs.microcks_version }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -94,6 +105,28 @@ jobs:
           # 40 minutes later inside the first rep.
           unzip -qt "$HOME/bench-wiremock/wiremock-standalone.jar"
           java -version
+
+      # Microcks publishes only non-repackaged jars to Maven Central, so the runnable Spring Boot fat
+      # jar has to be lifted out of the official image. `docker create` materialises the filesystem
+      # without ever starting a container: the registry is a download source here, exactly like Maven
+      # Central above, and the benchmarked process is a native JVM. That is not a detail — a
+      # container's virtualised network is not a property of the engine, and measuring one would make
+      # the Microcks column non-comparable with the other three.
+      - name: Install Microcks ${{ inputs.microcks_version }} (native jar, no container at bench time)
+        if: inputs.run_microcks
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/bench-microcks"
+          cid=$(docker create "microcks/microcks-uber:$BENCH_MICROCKS_VERSION")
+          docker cp "$cid:/deployments/app.jar" "$HOME/bench-microcks/microcks-app.jar"
+          docker rm -f "$cid"
+          # Same integrity check as the WireMock jar, same reason: a truncated 138MB jar downloads
+          # cleanly and only fails inside the first rep, an hour in.
+          unzip -qt "$HOME/bench-microcks/microcks-app.jar"
+          # Fail here, loudly, if the image ever stops shipping a Spring Boot launcher — the
+          # alternative is an opaque "no main manifest attribute" at first launch.
+          unzip -p "$HOME/bench-microcks/microcks-app.jar" META-INF/MANIFEST.MF \
+            | grep -q 'Start-Class: io.github.microcks.MicrocksApplication'
 
       - name: Record environment
         run: |
@@ -181,6 +214,48 @@ jobs:
           rm -f results/direct_rift_rep*.csv results/direct_mb_rep*.csv
           ls results/wiremock
 
+      # The fourth engine (issue #900). Runs after the WireMock leg and before the sweep, for the same
+      # reason WireMock does: the table needs rift at the SAME point, and the sweep re-writes
+      # direct_rift_rep*.csv at other connection counts.
+      #
+      # Microcks is spec-driven, so its suite generates an OpenAPI document per imposter rather than
+      # stubs, and only six of the thirteen scenarios have a faithful analogue — the report lists the
+      # other seven with the reason each is excluded rather than approximating them. One Microcks JVM
+      # per imposter, holding only that imposter's service, so its resident corpus matches what
+      # WireMock's per-imposter JVM holds.
+      - name: Microcks ${{ inputs.microcks_version }} + Rift comparison (repeated)
+        if: inputs.run_microcks
+        working-directory: tests/benchmark
+        run: |
+          set -euo pipefail
+          for rep in $(seq 1 "$BENCH_REPS"); do
+            echo "===== microcks rep=$rep ====="
+            python3 -u scripts/bench_microcks.py --run-all --rep "$rep" \
+              --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION" \
+              --warmup "$BENCH_WARMUP" \
+              --jar "$HOME/bench-microcks/microcks-app.jar" \
+              --microcks-version "$BENCH_MICROCKS_VERSION"
+          done
+          python3 -u scripts/bench_microcks.py --aggregate
+          # The report compares against rift and wiremock at the same point, and the WireMock step
+          # parked both medians. Copy them back under the plain names --report reads, rather than
+          # teaching the report about CI's directory layout.
+          cp results/wiremock/direct_rift_comparison_median.csv results/direct_rift_median.csv
+          cp results/wiremock/direct_wiremock_median.csv results/direct_wiremock_median.csv
+          # No --warmup here on purpose: the report states what the reps recorded, so a mismatch
+          # between what CI asked for and what ran shows up instead of being papered over.
+          python3 -u scripts/bench_microcks.py --report --csv-suffix _median \
+            --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION"
+          # Park, then remove the borrowed medians: the sweep writes its own direct_rift_median.csv,
+          # and two files with that basename in one artefact is how the wrong one gets published.
+          mkdir -p results/microcks
+          mv results/direct_microcks*.csv results/microcks/
+          mv results/direct_microcks*.warmup results/direct_microcks*.threads results/microcks/
+          mv results/direct_microcks*.heap results/direct_microcks*.version results/microcks/
+          mv results/MICROCKS_BENCHMARK_REPORT.md results/microcks/
+          rm -f results/direct_rift_median.csv results/direct_wiremock_median.csv
+          ls results/microcks
+
       # Rift-only sweep: connection scaling plus the matching-dimension scenarios that the
       # comparison set deliberately excludes (it is a stability contract).
       - name: Rift concurrency sweep + matching dimensions (repeated)
@@ -215,6 +290,7 @@ jobs:
             tests/benchmark/results/*.md
             tests/benchmark/results/comparison/*
             tests/benchmark/results/wiremock/*
+            tests/benchmark/results/microcks/*
             tests/benchmark/results/environment.txt
             tests/benchmark/results/*.log
             tests/benchmark/results/logs/*.log

--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -52,6 +52,14 @@ on:
           from the 3-way table rather than welded to it.
         type: boolean
         default: true
+      microcks_only:
+        description: >-
+          Publish ONLY the Rift-vs-Microcks table: skips Mountebank, both WireMock series and the
+          Rift sweep, and has the Microcks leg run its own Rift reps. The only column that must come
+          from the same dispatch is Rift (it is the ratio denominator) — WireMock's figures are
+          already published and are cited rather than re-measured. Turns a ~2h dispatch into ~30min.
+        type: boolean
+        default: false
       run_sweep:
         description: >-
           Run the Rift-only connection sweep. It is ~75% of the wall clock and contributes nothing
@@ -77,6 +85,7 @@ jobs:
       BENCH_MB_VERSION: ${{ inputs.mb_version }}
       BENCH_WIREMOCK_VERSION: ${{ inputs.wiremock_version }}
       BENCH_MICROCKS_VERSION: ${{ inputs.microcks_version }}
+      BENCH_MICROCKS_ONLY: ${{ inputs.microcks_only }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -141,6 +150,7 @@ jobs:
       # mismatch, because a table built from unequal replication favours whichever engine got
       # more samples and nothing in the output would say so.
       - name: Rift vs Mountebank (repeated)
+        if: ${{ !inputs.microcks_only }}
         working-directory: tests/benchmark
         run: |
           set -euo pipefail
@@ -175,6 +185,7 @@ jobs:
       # out-of-the-box defaults — so the report can distinguish a thread-pool ceiling from an
       # engine ceiling.
       - name: WireMock ${{ inputs.wiremock_version }} + 3-way comparison (repeated)
+        if: ${{ !inputs.microcks_only }}
         working-directory: tests/benchmark
         run: |
           set -euo pipefail
@@ -228,6 +239,18 @@ jobs:
         working-directory: tests/benchmark
         run: |
           set -euo pipefail
+          # A standalone Rift-vs-Microcks dispatch has no Mountebank/WireMock leg, so rift's reps
+          # are measured here at the SAME settings — it is the ratio's denominator and must come from
+          # this dispatch. WireMock's column is left empty and cited from its own published run.
+          if [ "$BENCH_MICROCKS_ONLY" = "true" ]; then
+            for rep in $(seq 1 "$BENCH_REPS"); do
+              echo "===== rift rep=$rep (microcks_only) ====="
+              python3 -u scripts/bench_direct.py --run-all --engines rift --rep "$rep" \
+                --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION" \
+                --warmup "$BENCH_WARMUP" \
+                --rift-bin ../../target/release/rift-http-proxy
+            done
+          fi
           for rep in $(seq 1 "$BENCH_REPS"); do
             echo "===== microcks rep=$rep ====="
             python3 -u scripts/bench_microcks.py --run-all --rep "$rep" \
@@ -236,30 +259,42 @@ jobs:
               --jar "$HOME/bench-microcks/microcks-app.jar" \
               --microcks-version "$BENCH_MICROCKS_VERSION"
           done
+          # `--aggregate` collapses every series present, including rift's when its reps are here,
+          # so a standalone dispatch needs nothing from the WireMock leg.
           python3 -u scripts/bench_microcks.py --aggregate
-          # The report compares against rift and wiremock at the same point, and the WireMock step
-          # parked both medians. Copy them back under the plain names --report reads, rather than
-          # teaching the report about CI's directory layout.
-          cp results/wiremock/direct_rift_comparison_median.csv results/direct_rift_median.csv
-          cp results/wiremock/direct_wiremock_median.csv results/direct_wiremock_median.csv
+          if [ "$BENCH_MICROCKS_ONLY" != "true" ]; then
+            # The full dispatch parked rift's and WireMock's medians in the WireMock leg. Copy them
+            # back under the plain names --report reads, rather than teaching the report about CI's
+            # directory layout.
+            cp results/wiremock/direct_rift_comparison_median.csv results/direct_rift_median.csv
+            cp results/wiremock/direct_wiremock_median.csv results/direct_wiremock_median.csv
+          fi
           # No --warmup here on purpose: the report states what the reps recorded, so a mismatch
           # between what CI asked for and what ran shows up instead of being papered over.
           python3 -u scripts/bench_microcks.py --report --csv-suffix _median \
             --connections "$BENCH_CONNECTIONS" --duration "$BENCH_DURATION"
-          # Park, then remove the borrowed medians: the sweep writes its own direct_rift_median.csv,
-          # and two files with that basename in one artefact is how the wrong one gets published.
           mkdir -p results/microcks
+          # `direct_microcks*` also matches the `microcks-stock` secondary series, which is intended.
           mv results/direct_microcks*.csv results/microcks/
           mv results/direct_microcks*.warmup results/direct_microcks*.threads results/microcks/
           mv results/direct_microcks*.heap results/direct_microcks*.version results/microcks/
           mv results/MICROCKS_BENCHMARK_REPORT.md results/microcks/
-          rm -f results/direct_rift_median.csv results/direct_wiremock_median.csv
+          # Rift's median is this table's denominator, so it belongs beside it in the artefact when
+          # this leg produced it. In the full dispatch it was only borrowed, and the sweep writes its
+          # own direct_rift_median.csv — two files with that basename in one artefact is how the
+          # wrong one gets published.
+          if [ "$BENCH_MICROCKS_ONLY" = "true" ]; then
+            mv results/direct_rift_median.csv results/microcks/
+            mv results/direct_rift_rep*.csv results/microcks/ 2>/dev/null || true
+          else
+            rm -f results/direct_rift_median.csv results/direct_wiremock_median.csv
+          fi
           ls results/microcks
 
       # Rift-only sweep: connection scaling plus the matching-dimension scenarios that the
       # comparison set deliberately excludes (it is a stability contract).
       - name: Rift concurrency sweep + matching dimensions (repeated)
-        if: inputs.run_sweep
+        if: ${{ inputs.run_sweep && !inputs.microcks_only }}
         working-directory: tests/benchmark
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ record.
 
 ### Added
 
+- **Microcks is now a benchmark subject — `tests/benchmark/scripts/bench_microcks.py`** (issue #900).
+  The stub-growth claim was only ever demonstrated against WireMock, a commercial alternative;
+  Microcks is the Apache-2.0, CNCF-incubating one a buyer usually reaches first, and we had no data on
+  how it behaves as stub count grows.
+
+  Microcks is **spec-driven rather than stub-authored**, so the suite generates an OpenAPI 3.0.2
+  document per imposter instead of stubs, translating "N stubs" as "N `path` × `verb` operations" —
+  the nearest honest analogue, and a translation rather than an identity. **Only six of the thirteen
+  scenarios are comparable**; the other seven are refused with a stated reason rather than
+  approximated, because an approximation publishes a ratio between two different workloads, and a
+  scenario added to the fixture now fails the run until it is classified either way. Response bodies
+  are emitted as raw strings so Microcks' bytes stay identical to Rift's and the existing body-marker
+  assertion keeps its strength.
+
+  Fairness deviations all move the number in Microcks' favour and are repeated in the generated
+  report: Tomcat's pool pinned above the offered concurrency (its 200 default sits below the published
+  256), heap pinned so a runner and a laptop agree, one imposter per JVM so its resident corpus
+  matches WireMock's, AsyncAPI off, logging at WARN (per #718), and an in-memory store. Nothing runs
+  in a container at bench time — the measured process is a native JVM, like WireMock's.
+
+  Wired into `benchmark-publish.yml` behind `run_microcks` with a pinned `microcks_version`.
+  Benchmark-only: no engine, API or configuration change.
+
 - **Serve options are now feature-detectable — `serveOptions` on `rift_build_info` and `GET /config`**
   (issue #877). `ServeOptions` fields have no symbol for an SDK to probe, so the "additive symbols are
   discovered by presence" convention `rift_abi_version` documents could not reach them: an SDK sending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,24 @@ record.
   must come from the same dispatch, being the ratio's denominator).
   Benchmark-only: no engine, API or configuration change.
 
+- **Published the measured comparison — `docs/comparisons/microcks.md`** (issue #900). AMD EPYC 7763,
+  16 vCPU, 256 connections, median of 3 reps (spread ≤3.3% Microcks / ≤2.7% Rift). Rift is
+  **13.6x–54.6x** Microcks on the HTTP matching path, with a p99 of ~2.4 ms against 75–250 ms.
+
+  The result worth reading is the *mechanism*, not the multiple. Over the trivial-stub → 310-stub
+  interval Microcks loses **60%** and Rift **3%**, so the flat-under-stub-growth claim does
+  generalise — but Microcks' three API points sit within **0.6%** of each other, meaning stub
+  *position* costs it nothing. WireMock loses 69% on that same within-corpus interval. So Microcks
+  does **not** pay per candidate the way Mountebank and WireMock do, and the page says so: against
+  Microcks the advantage is absolute throughput and tail latency, not scan behaviour. The page also
+  states what the data does *not* support — including that the 60% mixes corpus size with payload,
+  and that the cited WireMock column came from a different physical CPU in the same runner pool, so
+  each column is sound read downwards but the cross-column absolutes are not.
+
+  Also records that turning Microcks' invocation-stats and CORS defaults off — the fairness change
+  above — was worth **nothing measurable** (−4% to +2%, scattered both ways), which is published
+  rather than dropped now that it is no longer a dramatic number.
+
 - **Serve options are now feature-detectable — `serveOptions` on `rift_build_info` and `GET /config`**
   (issue #877). `ServeOptions` fields have no symbol for an SDK to probe, so the "additive symbols are
   discovered by presence" convention `rift_abi_version` documents could not reach them: an SDK sending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,26 @@ record.
   are emitted as raw strings so Microcks' bytes stay identical to Rift's and the existing body-marker
   assertion keeps its strength.
 
-  Fairness deviations all move the number in Microcks' favour and are repeated in the generated
+  Most fairness deviations move the number in Microcks' favour and are repeated in the generated
   report: Tomcat's pool pinned above the offered concurrency (its 200 default sits below the published
   256), heap pinned so a runner and a laptop agree, one imposter per JVM so its resident corpus
   matches WireMock's, AsyncAPI off, logging at WARN (per #718), and an in-memory store. Nothing runs
   in a container at bench time — the measured process is a native JVM, like WireMock's.
 
-  Wired into `benchmark-publish.yml` behind `run_microcks` with a pinned `microcks_version`.
+  **One deviation runs the other way and so is handled explicitly.** Microcks defaults
+  `mocks.enable-invocation-stats` to *on*, counting and persisting a record for every mock call — the
+  direct analogue of WireMock's request journal, which is disabled in its leg, while Rift and
+  Mountebank are both measured with recording off. Leaving it on would compare
+  Microcks-with-recording against Rift-without, an error that flatters *Rift*. It is therefore off in
+  the headline series, together with the CORS policy that adds four `Access-Control-*` headers Rift
+  never emits — and both are published anyway in a secondary `microcks-stock` series (stats on, CORS
+  on, stock Tomcat pool) so the out-of-the-box number sits beside the tuned one, exactly as
+  `wiremock-stock` does for #865.
+
+  Wired into `benchmark-publish.yml` behind `run_microcks` with a pinned `microcks_version`, plus
+  `microcks_only` for a standalone Rift-vs-Microcks dispatch that skips the Mountebank, WireMock and
+  sweep legs and measures its own Rift reps (~30min rather than ~2h; Rift is the only column that
+  must come from the same dispatch, being the ratio's denominator).
   Benchmark-only: no engine, API or configuration change.
 
 - **Serve options are now feature-detectable — `serveOptions` on `rift_build_info` and `GET /config`**

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -11,6 +11,9 @@ How Rift relates to the other mock servers you might be choosing between.
 
 - [Rift vs WireMock]({{ site.baseurl }}/comparisons/wiremock/) — the JVM incumbent, and the
   comparison most teams evaluating Rift actually care about.
+- [Rift vs Microcks]({{ site.baseurl }}/comparisons/microcks/) — the Apache-2.0, CNCF-incubating
+  alternative. Spec-driven rather than stub-driven, and it does contract testing and seven protocols
+  Rift does not, so the overlap is narrower than the throughput table suggests.
 
 For Mountebank, the relationship is different in kind: Rift implements Mountebank's admin API
 and loads its `imposters.json` unchanged, so the relevant page is

--- a/docs/comparisons/microcks.md
+++ b/docs/comparisons/microcks.md
@@ -1,0 +1,352 @@
+---
+layout: default
+title: Rift vs Microcks
+parent: Comparisons
+nav_order: 2
+---
+
+# Rift vs Microcks
+
+[Microcks](https://microcks.io/) is the open-source API mocking and testing tool a team usually
+reaches for before a commercial one: Apache-2.0, a CNCF **Incubating** project since
+[11 May 2026](https://microcks.io/blog/), and free permanently — the governance sits with the CNCF,
+so it cannot be relicensed out from under you.
+
+{: .highlight }
+> **The one-line version.** Microcks starts from your **specification** and gives you mocking *and*
+> contract testing across many protocols. Rift starts from your **stubs** and gives you a fast HTTP
+> mock that embeds in-process in four languages. They overlap on HTTP mocking and diverge almost
+> everywhere else.
+
+---
+
+## Summary
+
+| | Microcks | Rift |
+|:--|:--|:--|
+| Implementation | Java / JVM (Spring Boot) | Rust |
+| Governance | CNCF Incubating, Apache-2.0 | Apache-2.0, single maintainer |
+| Maturity | Mature, CNCF-backed, named enterprise users | **Beta** (v0.16.x) |
+| Authoring model | **Spec-driven** — OpenAPI, AsyncAPI, Postman, gRPC, GraphQL, SoapUI | **Stub-driven** — Mountebank `imposters.json` + native YAML |
+| Throughput at 2 stubs | 16,192 RPS | 347,604 RPS |
+| Throughput at 310 stubs | 6,420 RPS (**−60%**) | 338,404 RPS (**−3%**) |
+| p99 at 310 stubs | 238 ms | 2.4 ms |
+| Protocols | HTTP, AsyncAPI, Kafka, MQTT, AMQP, WebSocket, gRPC, GraphQL | **HTTP/HTTPS only** |
+| Contract testing | Yes — validates a real implementation against the spec | No |
+| In-process embedding | No (server, or Testcontainers) | Java, Node, Go, Scala 3 |
+| Web UI | Yes | No (TUI + admin API) |
+| OpenAPI import / validation | Core feature | No |
+
+<sub>Performance figures: AMD EPYC 7763, 16 vCPU (GitHub `ubuntu-16core`), 2026-07-30.
+Microcks 1.14.0 on Temurin 21, native JVM; Rift built from source. `oha` at **256 keep-alive
+connections**, 20 s per scenario after a 10 s warmup — identical settings for both engines, each of
+which ran alone. Median of 3 repetitions; spread ≤3.3% for Microcks, ≤2.7% for Rift. Full
+methodology below.</sub>
+
+---
+
+## HTTP mock serving
+
+Six of the benchmark suite's thirteen scenarios have a faithful Microcks translation. The other
+seven are excluded with reasons, [below](#what-is-not-comparable-and-why) — approximating them would
+publish a ratio between two different workloads.
+
+| Scenario | Microcks | Rift | Rift/Microcks | Microcks p50 | Rift p50 | Microcks p99 | Rift p99 |
+|:---------|---------:|-----:|--------------:|-------------:|---------:|-------------:|---------:|
+| Simple static stub | 16,192 | 347,604 | **21.5x** | 8.7 ms | 0.6 ms | 78.9 ms | 2.3 ms |
+| API first stub | 6,457 | 338,592 | **52.4x** | 17.2 ms | 0.7 ms | 239.3 ms | 2.4 ms |
+| API middle stub | 6,447 | 339,056 | **52.6x** | 17.7 ms | 0.7 ms | 249.5 ms | 2.4 ms |
+| API last stub (310 stubs) | 6,420 | 338,404 | **52.7x** | 19.9 ms | 0.7 ms | 238.0 ms | 2.4 ms |
+| No match | 6,487 | 354,170 | **54.6x** | 35.1 ms | 0.6 ms | 166.2 ms | 2.3 ms |
+| Query match (last of 100) | 14,397 | 195,966 | **13.6x** | 13.1 ms | 1.1 ms | 74.8 ms | 4.0 ms |
+
+Rift is **13.6x–54.6x** Microcks' throughput on the HTTP matching path, and holds a p99 of ~2.4 ms
+where Microcks' runs 75–250 ms at this concurrency.
+
+That is a wider gap than [Rift vs WireMock]({{ site.baseurl }}/comparisons/wiremock/) (4.0x–14.0x), and the reason is not that
+Microcks is a worse mock server. It is that Microcks is a *different kind of product* — a
+spec-driven mocking **and contract-testing** platform with a web UI, multi-tenancy and eight
+protocols, built on Spring Boot with a database behind it. Raw HTTP stub-serving throughput is not
+what it was optimised for, and for most of its users it is not the binding constraint.
+
+---
+
+## Stub growth: the claim, and what actually happens
+
+Rift's central performance claim is that throughput does not degrade as your stub count grows. This
+benchmark existed to find out whether that claim survives against Microcks, and **the honest answer
+is that it survives — but the mechanism is different from WireMock's, and the difference matters.**
+
+Read each engine down its own column, not across:
+
+| Point | Workload | Microcks | Rift | WireMock† |
+|:------|:---------|---------:|-----:|----------:|
+| Simple static stub | 2 stubs | 16,192 | 347,604 | 83,048 |
+| API first stub | 1st of 310 | 6,457 | 338,592 | 78,906 |
+| API middle stub | ~155th of 310 | 6,447 | 339,056 | 42,668 |
+| API last stub | 310th of 310 | 6,420 | 338,404 | 24,264 |
+| | **trivial → 310 stubs** | **−60%** | **−3%** | **−71%** |
+
+<sub>† WireMock 3.9.1 at the same settings, from the run published on the
+[WireMock page]({{ site.baseurl }}/comparisons/wiremock/) (2026-07-27); cited rather than
+re-measured. **Not the same physical host:** GitHub's `ubuntu-16core` pool is heterogeneous, and that
+run landed on an Intel Xeon 8573C while this one got an AMD EPYC 7763 — Rift itself reads 334,025 on
+the former and 347,604 on the latter, a ~4% difference. So the WireMock column is safe to read
+*down* (its own degradation is measured within one run on one host) and **not** safe to compare
+across to the other two columns in absolute terms. Microcks and Rift are from one dispatch on
+2026-07-30.</sub>
+
+So all three engines are *not* alike, but they fail in two distinct ways:
+
+**WireMock pays per candidate stub.** Its cost tracks position in the mapping list: 78,906 → 24,264
+(**−69%**) *within the same 310-stub corpus*, purely by moving the matching stub from first to last.
+
+**Microcks pays per resident corpus, not per candidate.** Its three API points are
+6,457 / 6,447 / 6,420 — a **−0.6%** spread across first, middle and last of the same 310 operations,
+which is inside the run's own noise. Microcks resolves an operation by path and verb rather than
+scanning candidates, so *where* your stub sits costs nothing. What costs is how much is loaded: the
+drop happens between the 2-operation service and the 310-operation one, not inside it.
+
+**Rift pays neither** — −3% across the interval and −0.06% by position.
+
+### What this does and does not support
+
+Being precise about this, because the interval in the table is doing two things at once:
+
+- **Supported: Rift's flat-under-stub-growth claim generalises to Microcks.** −3% vs −60% over the
+  same interval, at ≤3.3% spread. This is not a marginal result.
+- **Supported: for Microcks, stub *ordering* is free.** If you are choosing where to put a new stub
+  in a Microcks spec to keep matching fast, the answer is that it does not matter. That is the same
+  architectural property Rift has, and WireMock does not.
+- **NOT supported: that Microcks' −60% is caused by corpus size alone.** The `simple_health` point is
+  a *different service* with a different response (2 bytes of `text/plain` vs ~33 bytes of JSON), so
+  that interval mixes corpus size with payload. The clean, confound-free measurement here is the
+  **−0.6% position invariance**, not the −60%.
+- **NOT supported: any claim about Microcks beyond HTTP.** Nothing here measures AsyncAPI, Kafka,
+  gRPC or contract testing, which is most of what Microcks is for.
+- **NOT supported: a generalised "competitors pay per candidate stub" story.** WireMock does;
+  Microcks does not. Rift's advantage over Microcks on this axis is absolute throughput and tail
+  latency, not scan behaviour.
+- **NOT supported: a three-way absolute ranking from the table above.** The WireMock column comes
+  from a different physical CPU in the same runner pool (see the footnote). Each column's *own*
+  degradation is a within-run measurement and is sound; the absolute cross-column gaps between
+  WireMock and the other two are not, and a three-way table would need one dispatch to fix that.
+
+A directional, non-publication-grade observation that points at the corpus-size mechanism: on a
+10-core laptop, holding the request and service fixed and growing one Microcks service from 310 to
+3,100 operations moved it from ~4,200 to ~1,000 RPS, with first-operation and last-operation requests
+staying within noise of each other at both sizes. That isolates size from position but was not run
+under the published methodology, so treat it as a hypothesis worth its own benchmark rather than a
+number.
+
+---
+
+## Where Microcks is genuinely better
+
+Stated plainly, because these are the reasons most teams should pick Microcks.
+
+### Specification-driven mocking is the whole point
+
+You hand Microcks an OpenAPI, AsyncAPI, Postman, gRPC/protobuf, GraphQL or SoapUI artifact and it
+derives the mock. Your mock cannot drift from your contract, because the contract *is* the mock.
+**Rift has no equivalent** — no OpenAPI import, no spec validation. If your workflow starts from a
+spec, that is a decisive difference and this whole page's throughput table is beside the point.
+
+### Contract testing, not just mocking
+
+Microcks' test runner points at a *real* implementation and verifies it conforms to the same spec
+that backs the mock, with several validation strategies. That closes the loop between "my mock says
+X" and "my service does X". Rift has `rift-verify` (generate requests from your own predicates) and
+`rift-lint`, which are useful but are not contract testing against a live implementation.
+
+### Protocols beyond HTTP
+
+AsyncAPI, Kafka, MQTT, AMQP, WebSocket, Google Pub/Sub, gRPC and GraphQL. Rift is **HTTP/HTTPS
+only**. If you need to mock an event-driven system, Rift cannot do it at any speed.
+
+### Governance and longevity
+
+CNCF Incubating under Apache-2.0, with named enterprise adopters. Rift is beta, Apache-2.0, and
+maintained by one person. For a lot of organisations that difference outweighs everything in the
+performance table, and that is a reasonable call.
+
+### A web UI and multi-tenancy
+
+Microcks ships a UI for browsing services, examples, invocation statistics and test results, plus
+Keycloak-based auth. Rift's equivalents are a TUI and the admin API.
+
+---
+
+## Where Rift is genuinely better
+
+### Throughput and tail latency on the HTTP path
+
+13.6x–54.6x, and a p99 two orders of magnitude lower. If your integration suite makes a large number
+of HTTP calls and per-test latency multiplies out across thousands of tests, that is the argument.
+
+### In-process embedding in four languages
+
+Rift's engine is native code behind a C ABI, so the same binary embeds **in-process** in Java
+(Panama FFM), Node (koffi), Go (purego, no cgo) and Scala 3. Microcks is a server — you run it, or
+you start a container via Testcontainers. Rift also runs that way (`connect`, `spawn`, `container`),
+but the embedded mode has no process boundary at all, and switching between the four is a
+constructor argument.
+
+### Mocking dependencies you cannot repoint
+
+Rift can act as a **TLS-terminating forward proxy** and match intercepted HTTPS traffic with the
+ordinary predicate engine, plus a **front door** that routes many imposters off the `Host` header.
+That covers the vendor SDK with a compiled-in URL and no base-URL setter. Microcks expects you to
+point your client at its mock endpoint.
+
+### Parallel test isolation
+
+**Spaces** partition one imposter's stubs, scenario state and recorded requests by correlation id,
+and **flow state** gives stateful mocks a per-flow store — so parallel CI shards share a port without
+seeing each other's stubs, instead of running one instance per shard.
+
+### Footprint
+
+A native multi-arch binary with no JVM and no database. Microcks needs a JVM and MongoDB (the
+`uber` distribution embeds an in-memory store for testing).
+
+---
+
+## When to use which
+
+Use **Microcks** if you start from a specification, need contract testing, need any protocol other
+than HTTP, need a UI, or need CNCF-backed governance. That is most teams.
+
+Use **Rift** if you author stubs directly, need in-process embedding across more than one language,
+need to intercept traffic you cannot repoint, or are genuinely bound by mock throughput and tail
+latency at high stub counts.
+
+They are not mutually exclusive: a spec-driven Microcks instance in a shared environment and an
+embedded Rift in unit tests is a coherent combination.
+
+---
+
+## Benchmark methodology
+
+**Setup.** AMD EPYC 7763 64-Core, 16 vCPU (GitHub `ubuntu-16core`), 2026-07-30. Microcks 1.14.0 on
+Temurin 21; Rift built from source. `oha` at 256 keep-alive connections, 20 s per scenario after a
+10 s warmup — identical for both engines, each of which ran alone on a disjoint port range. Median of
+3 repetitions, spread stated.
+
+**Microcks runs as a native JVM, not a container.** A container's virtualised network is not a
+property of the engine, and measuring one would have made this column non-comparable with the other
+engines in the suite (all native processes). The runnable Spring Boot jar is lifted out of the
+official image once, because Microcks publishes only non-repackaged jars to Maven Central.
+
+**"N stubs" had to be translated.** Microcks is spec-driven, so the harness generates an OpenAPI
+3.0.2 document per imposter from the *same* fixture the Rift and Mountebank suites use, mapping
+"N stubs" to "N `path` × `verb` operations". That is the nearest honest analogue and it is a
+translation, not an identity. Response bodies are emitted as raw strings so Microcks' bytes are
+byte-identical to Rift's, which keeps the per-scenario body-marker assertion strong rather than
+whitespace-insensitive.
+
+### What we did to keep it fair
+
+Every item here except the first moves the number in **Microcks'** favour.
+
+**Invocation statistics are off** (`mocks.enable-invocation-stats=false`) — and this is the one that
+runs the other way, so it gets stated first. Microcks defaults it to **on**: it counts every mock
+call and persists a per-service/per-day/per-hour record (verified — 500 requests produce
+`dailyCount: 500`). It is the direct analogue of WireMock's request journal, which is disabled in
+*its* leg, and Rift and Mountebank are both measured with recording off. Leaving it on would have
+compared Microcks-with-recording against Rift-without — an error flattering **Rift**, which is the
+direction that must never be taken quietly. The CORS policy
+(`mocks.rest.enable-cors-policy=false`) goes with it: on by default, four `Access-Control-*` headers
+per response that neither Rift nor WireMock emits.
+
+**And here is what those two flags were actually worth: nothing measurable.** The same workload with
+Microcks launched exactly as it ships (both defaults on, stock Tomcat pool):
+
+| Scenario | Microcks (tuned) | Microcks (stock defaults) | Difference |
+|:---------|-----------------:|--------------------------:|-----------:|
+| Simple static stub | 16,192 | 15,619 | −4% |
+| API first stub | 6,457 | 6,455 | −0% |
+| API middle stub | 6,447 | 6,444 | −0% |
+| API last stub | 6,420 | 6,393 | −0% |
+| No match | 6,487 | 6,483 | −0% |
+| Query match | 14,397 | 14,616 | +2% |
+
+Within noise, scattered both ways. The tuning was the *correct* thing to do for consistency with the
+other engines, and it changed nothing — which is exactly the kind of result that should be published
+rather than quietly dropped once it stops being dramatic.
+
+**Tomcat's pool is pinned to `max(cores, connections)`.** Its default is 200 while this table drives
+256, so the stock configuration would bound in-flight requests below the offered concurrency and
+measure the pool rather than the engine. The stock column above uses Tomcat's own default, and lands
+within noise here — the CPU saturates before the pool binds.
+
+**Heap is pinned** (`-Xms == -Xmx = 4g`) rather than left to ergonomic sizing, which is a fraction of
+host RAM and would silently differ between machines.
+
+**One imposter per JVM.** Microcks multiplexes every service on one port, and its throughput is
+sensitive to total resident corpus size, so loading all 14 fixture imposters into one process would
+have penalised it against WireMock's per-imposter JVM. Each Microcks instance holds exactly the
+imposter under test.
+
+**AsyncAPI is off** (`-Dasync-api.enabled=false`) — background work unrelated to HTTP mocking.
+**Logging is at WARN**, because a per-request log site turns a throughput benchmark into a
+measurement of the logging pipeline.
+
+### Caveats we do not bury
+
+**Microcks 404s an unmatched request.** Rift's default for a request matching no stub is an empty
+200, and the WireMock suite installs a catch-all to reproduce that. Microcks has no catch-all
+mechanism, so the `No match` row is measured as the 404 it genuinely returns — a cheaper path than
+rendering a response, so that row flatters Microcks.
+
+**The `uber` profile uses an in-memory MongoDB.** A production Microcks talks to a real MongoDB over
+a socket, so this configuration is *faster* than a real deployment.
+
+**The first scenario in each group meets a colder JIT.** Scenarios sharing an imposter share one JVM
+and run in fixture order. The per-scenario warmup and median-of-3 absorb most of this; it biases
+against whichever scenario runs first, not against Microcks overall. WireMock's leg has the same
+property.
+
+**Absolute numbers are machine-specific and ratios move with concurrency.** Any Rift-vs-Microcks
+number without its connection count attached is meaningless.
+
+### What is not comparable, and why
+
+Seven of the thirteen scenarios are excluded rather than approximated:
+
+| Scenario | Why it is excluded |
+|:--|:--|
+| Regex path (100 patterns) | Rift matches the path against 100 regexes. OpenAPI paths are templated, not regular expressions, and Microcks has no regex path dispatcher — a path template is a different matcher doing less work. |
+| Complex AND/OR predicates | Rift evaluates `and`/`or` over method, path prefix and two alternative headers. Microcks has no header dispatcher for REST; the only expression is a Groovy `SCRIPT` dispatcher, which measures the scripting engine. |
+| Header match (last of 100) | Same reason — no header dispatcher for REST. |
+| JSON body equals | Rift matches method + path + an exact JSON body, but those 50 stubs sit on 50 *distinct* paths, so a Microcks translation would resolve on the path alone and never read the body — strictly less work. |
+| JSONPath predicate | Microcks' `JSON_BODY` dispatcher uses a different expression dialect; equating them would be a claim about dialects, not matching cost. |
+| XPath predicate | Microcks has no XPath dispatcher for REST. |
+| Response templating | Microcks does have response templating, with a different expression language; the fixture's body marker is satisfied by a static example, so including it would report a static-response number under a templating label. |
+
+### Reproduce it
+
+```bash
+gh workflow run benchmark-publish.yml \
+  -f runner=ubuntu-16core -f reps=3 -f duration=20s -f connections=256 -f warmup=10s \
+  -f microcks_only=true
+```
+
+The harness is in [`tests/benchmark`](https://github.com/achird-labs/rift/tree/master/tests/benchmark)
+and runs both engines. If you think something here is unfair, re-run it — and if you find a
+configuration that narrows the gap, [open an issue](https://github.com/achird-labs/rift/issues) and
+we will publish the corrected number.
+
+---
+
+## A note on Microcks
+
+Rift competes with Microcks on one axis — HTTP mock serving throughput — and Microcks wins on most
+of the others. It is a well-engineered CNCF project solving a broader problem: keeping mocks and
+tests honest against a specification, across protocols Rift does not speak. The gap measured on this
+page is a consequence of a Spring Boot application with a datastore and a UI behind it, which is an
+entirely sensible design for what it set out to do, rather than of anything done badly.
+
+Microcks is a CNCF project. Rift is not affiliated with, endorsed by, or derived from it. All
+comparative claims here are measured, and the methodology and harness are published so they can be
+checked.

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -396,6 +396,13 @@ These are architecture comparisons, not quality judgements. Both engines are wel
 widely adopted than Rift, and each does things Rift does not — see
 [Rift vs WireMock]({{ site.baseurl }}/comparisons/wiremock/) for both directions.
 
+**Microcks** is compared separately, in [Rift vs Microcks]({{ site.baseurl }}/comparisons/microcks/),
+and is deliberately *not* a row in the table above: its figures come from a different dispatch, and
+the table's value is that every cell in it came from one run on one host. That page also carries the
+more interesting finding — Microcks does **not** pay per candidate stub the way Mountebank and
+WireMock do (stub *position* costs it nothing), so "throughput stays flat" distinguishes Rift from
+Microcks on absolute throughput and tail latency rather than on scan behaviour.
+
 <sub>WireMock and WireMock Cloud are products of WireMock Inc.; Mountebank is an independent open
 source project. Rift is not affiliated with, endorsed by, or derived from either. All comparative
 claims here are measured, and the harness is published so they can be checked.</sub>

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -17,6 +17,9 @@ npm install --prefix ~/bench-mb mountebank@2.9.1  # reference engine
 # python3 is used to orchestrate the runs
 ```
 
+The Microcks suite (`bench_microcks.py`) needs a **JDK 21** and its own jar — see
+[Microcks comparison](#microcks-comparison-issue-900).
+
 For the WireMock suite (optional — only needed for `bench_wiremock.py`) you also need a JRE 11+
 (use an LTS, 17 or 21) and the standalone jar:
 
@@ -297,6 +300,108 @@ values actually used. `--report` prints the **recorded** warmup, not the flag de
 > The Rift-only sweep now runs at the same `warmup` input as everything else (previously a hardcoded
 > `3s`). Sweep figures published from this workflow before that change are not comparable with ones
 > produced after it.
+
+### Microcks comparison (issue #900)
+
+[Microcks](https://microcks.io/) is the Apache-2.0, CNCF-incubating alternative a buyer usually
+reaches for before a commercial one, so the stub-growth claim needs to hold against it too. It lives
+in its own suite for a reason the other two do not share: **Microcks is spec-driven, not
+stub-authored.** You do not hand it a stub; you hand it an OpenAPI document and it derives operations
+and example responses from that.
+
+```bash
+cd tests/benchmark
+
+# One Microcks JVM per imposter, in turn -> results/direct_microcks.csv
+python3 scripts/bench_microcks.py --run-all --duration 20s --warmup 10s --connections 50
+
+# Combine whatever CSVs exist from the SAME box and settings -> MICROCKS_BENCHMARK_REPORT.md
+python3 scripts/bench_microcks.py --report --connections 50
+
+# Inspect what a given imposter translates to, without launching anything
+python3 scripts/bench_microcks.py --emit-spec API | head -40
+```
+
+**Prerequisites: JDK 21 and the Microcks app jar.** Microcks 1.14 is Spring Boot 3.5 compiled at
+class file version 65, so a Java 17 JRE dies at launch with `UnsupportedClassVersionError`. Maven
+Central publishes only non-repackaged jars, so the runnable one is lifted out of the official image —
+a *download*, not a deployment, and nothing runs in a container at bench time:
+
+```bash
+mkdir -p ~/bench-microcks
+cid=$(docker create microcks/microcks-uber:1.14.0)
+docker cp "$cid:/deployments/app.jar" ~/bench-microcks/microcks-app.jar
+docker rm -f "$cid"
+```
+
+Pass `--java /path/to/jdk21/bin/java` if `java` on `PATH` is older.
+
+#### How "N stubs" is translated
+
+For Microcks, *"410 stubs"* is not a thing that exists. The nearest honest analogue is **N matchable
+request shapes**, which in OpenAPI means N `path` × `verb` operations — and that is what the
+translator emits. Two shapes come out, chosen by the fixture rather than by us:
+
+| Fixture shape | OpenAPI shape | Microcks dispatcher |
+|---|---|---|
+| distinct literal paths (`Simple`, `API`) | one operation per `path` × `verb`, one response example each | none — path/verb resolution |
+| one shared path + query args (`Query`) | one operation, N *named* examples + request-parameter examples under the same names | `URI_PARAMS`, rules `page && size` |
+
+Response bodies are emitted as **raw strings**, not parsed objects. Microcks serves a string example
+verbatim but re-serializes an object, and the fixture builds bodies with `json.dumps` (`{"id": 1}`,
+with spaces) — so the raw string is what keeps Microcks' bytes identical to Rift's and lets this
+suite reuse `EXPECT_BODY`/`verify_body` unchanged. If that ever regresses, the fix is to restore the
+raw string, **not** to weaken the marker to a whitespace-insensitive match.
+
+#### Only six of the thirteen scenarios are comparable
+
+The rest are **excluded rather than approximated**, because an approximation publishes a ratio
+between two different workloads. `check_scenario_coverage()` makes this a hard error: a scenario added
+to `bench_direct.SCENARIOS` fails the run until someone classifies it, so it cannot silently vanish
+from a report that claims to cover the suite.
+
+| Measured | Refused, and why |
+|---|---|
+| `simple_health`, `api_first`, `api_middle`, `api_last`, `no_match`, `query_last` | `regex_last` (no regex path dispatcher), `complex_predicate` / `header_last` (no header dispatcher for REST — only a Groovy SCRIPT, which measures the scripting engine), `json_body_equals` (the 50 stubs sit on distinct paths, so Microcks would resolve on path alone and never read the body), `jsonpath` (different expression dialect), `xpath` (none for REST), `template` (different templating language; a static example would be reported under a templating label) |
+
+#### What we did to keep it fair
+
+Every deviation below moves the number in **Microcks'** favour, which is the safe direction for a
+comparison published by Rift. All of them are repeated in the generated report, not just here.
+
+- **Tomcat's pool is pinned to `max(cores, connections)`.** Its default is 200 while the published
+  table drives 256 — benchmarking that would measure the pool, not the engine. Same fairness argument
+  as WireMock's `--container-threads`, and `--tomcat-threads N` overrides it.
+- **Heap is pinned** (`-Xms == -Xmx`, default `4g`) rather than left to ergonomic sizing, which is a
+  fraction of *host* RAM and would silently differ between a runner and a laptop.
+- **One imposter per process.** Microcks multiplexes every service on one port, and its throughput is
+  measurably sensitive to *total resident corpus size*, so loading all 14 imposters into one JVM would
+  have penalised it against WireMock's per-imposter JVM. Each instance holds exactly the imposter
+  under test.
+- **AsyncAPI off** (`-Dasync-api.enabled=false`) — background work unrelated to HTTP mocking.
+- **Logging at WARN.** Per #718, a per-request log site turns a throughput benchmark into a
+  measurement of the logging pipeline. That trap is not Rift-specific.
+- **`no_match` is measured as the 404 it genuinely returns.** Rift answers an unmatched request with
+  an empty 200 and WireMock is given a catch-all to reproduce that; Microcks has no catch-all
+  mechanism. The status gate expects `4xx` *for that scenario only* — relaxing it to "any status"
+  would stop it catching a genuinely mis-served stub. The body is empty either way, so the
+  `EXPECT_BODY[no_match] is None` assertion still proves nothing matched.
+- **In-memory MongoDB.** The `uber` profile keeps everything in an embedded store; a production
+  Microcks talks to a real MongoDB over a socket, so this configuration is *faster* than a real
+  deployment.
+- **Protocol scope.** Microcks also covers AsyncAPI, Kafka, MQTT, AMQP, WebSocket and gRPC, which
+  Rift does not. This benchmark is confined to the HTTP matching path where the two overlap and says
+  nothing about the rest.
+
+Engines stay on disjoint ports: rift +0, mb +100, wiremock +200, **microcks +300**. Import is
+verified by operation count — Microcks returns 201 for an artifact whose parser quietly discarded
+operations, and a thinner corpus than Rift's would publish as a faster number.
+
+Translator logic is gate-tested in `scripts/test_bench_microcks.py`, including the byte-identical-body
+property, the query-dispatch collapse, the fatality of an untranslatable predicate, and the
+`benchmark-publish.yml` leg itself. CI runs it via the same `Benchmark Scripts` job.
+
+The publish workflow takes `-f microcks_version=1.14.0` and `-f run_microcks=false` to skip the leg.
 
 ### Matching-dimension scenarios (Rift-only, additive)
 

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -369,6 +369,26 @@ from a report that claims to cover the suite.
 Every deviation below moves the number in **Microcks'** favour, which is the safe direction for a
 comparison published by Rift. All of them are repeated in the generated report, not just here.
 
+- **Invocation statistics are off** (`mocks.enable-invocation-stats=false`). This one is the
+  exception to the sentence above, and it is the most important knob here: Microcks defaults it to
+  **on**, counting every mock call and persisting a per-service/per-day/per-hour record (verified —
+  500 requests produce `dailyCount: 500` on `/api/metrics/invocations/<service>/<version>`). It is the
+  direct analogue of WireMock's request journal, which *is* disabled in its leg, and Rift and
+  Mountebank are both measured with recording off. Leaving it on would compare
+  Microcks-with-recording against Rift-without — an error that flatters **Rift**, which is the one
+  direction that must never be taken quietly.
+- **The CORS policy is off** (`mocks.rest.enable-cors-policy=false`). It defaults to on and adds four
+  `Access-Control-*` headers to every mock response; neither Rift nor WireMock emits them.
+- **Both are published anyway**, in a secondary `microcks-stock` series — same workload, Microcks
+  launched exactly as it ships (stats on, CORS on, stock Tomcat pool), benched at the headline
+  connection count. It goes in its own CSV under its own engine label so it never enters the headline
+  ratio, and the report renders a *Tuned vs stock defaults* table beside it. Same pattern, and the
+  same reasoning, as `wiremock-stock` (issue #865): a reader has to be able to tell "Microcks is
+  slower" from "Microcks ships with per-request invocation accounting on". `--skip-stock` drops it and
+  halves the wall clock. **On a 10-core laptop at 50 connections the two series land within noise of
+  each other** (deltas scattered both ways, the stock series sometimes ahead), which is what you would
+  expect if the stats write is off the request thread until the CPU saturates — quote the number the
+  report actually prints for the host in question rather than this sentence.
 - **Tomcat's pool is pinned to `max(cores, connections)`.** Its default is 200 while the published
   table drives 256 — benchmarking that would measure the pool, not the engine. Same fairness argument
   as WireMock's `--container-threads`, and `--tomcat-threads N` overrides it.
@@ -401,7 +421,22 @@ Translator logic is gate-tested in `scripts/test_bench_microcks.py`, including t
 property, the query-dispatch collapse, the fatality of an untranslatable predicate, and the
 `benchmark-publish.yml` leg itself. CI runs it via the same `Benchmark Scripts` job.
 
-The publish workflow takes `-f microcks_version=1.14.0` and `-f run_microcks=false` to skip the leg.
+#### Publishing just the Rift-vs-Microcks table
+
+Re-measuring Mountebank and both WireMock series to publish a *Microcks* page is waste: the only
+column that must come from the same dispatch is **Rift**, because it is the ratio's denominator.
+WireMock's figures are already published and are cited rather than re-measured.
+
+```
+gh workflow run benchmark-publish.yml \
+  -f runner=ubuntu-16core -f reps=3 -f duration=20s -f connections=256 -f warmup=10s \
+  -f microcks_only=true
+```
+
+`microcks_only=true` skips the Mountebank, WireMock and sweep legs and has the Microcks leg run its
+own Rift reps at the same settings — roughly 30 minutes instead of ~2 hours. The WireMock column in
+the growth table renders as `—`. `-f run_microcks=false` skips the leg entirely in a full dispatch,
+and `-f microcks_version=` pins the version.
 
 ### Matching-dimension scenarios (Rift-only, additive)
 

--- a/tests/benchmark/scripts/bench_microcks.py
+++ b/tests/benchmark/scripts/bench_microcks.py
@@ -699,21 +699,58 @@ def recorded_setting(name, csv_suffix, default=None):
         return default
 
 
+# The settings a median report must be able to state, and the flag name to blame in an error.
+PROPAGATED_SETTINGS = {"warmup": "--warmup", "threads": "--tomcat-threads",
+                       "heap": "--heap", "version": "--microcks-version"}
+
+
+def median_suffix(base_suffix):
+    """Where `--aggregate` writes, and therefore what a later `--report` must read."""
+    return f"{base_suffix}_median"
+
+
+def find_reps(base_suffix=""):
+    """Rep numbers present for `base_suffix`, in order."""
+    return sorted(int(m.group(1)) for p in find_rep_files(base_suffix)
+                  for m in [REP_FILE_RX.search(p)] if m)
+
+
 def propagate_run_settings(base_suffix=""):
-    """Copy per-rep sidecars up to the aggregated suffix, so `--report` after an aggregation can
-    still state the settings the reps ran with."""
-    for name in ("warmup", "threads", "heap", "version"):
-        if recorded_setting(name, base_suffix) is not None:
+    """Carry the reps' recorded settings onto the `_median` suffix.
+
+    Two things here are load-bearing, and both were wrong in the first draft of this module:
+
+    The **destination is `<base_suffix>_median`**, not `base_suffix`. `--aggregate` writes
+    `direct_microcks<base>_median.csv` and CI renders it with `--report --csv-suffix _median`, so
+    settings filed under the bare suffix are settings the report cannot find — and a report that
+    cannot state the thread pin or the warmup it measured is indistinguishable, to a reader, from one
+    that was unfair. It would have printed the *defaults* while claiming to describe the run.
+
+    Disagreement between reps is a **hard error, not a majority vote or first-one-wins**: reps that
+    ran with different heaps, warmups or thread pins are different configurations, and a median
+    across them describes no configuration that was ever measured. Same rule as the WireMock leg."""
+    reps = find_reps(base_suffix)
+    resolved = {}
+    for name, flag in PROPAGATED_SETTINGS.items():
+        seen = {f"{base_suffix}_rep{n}": recorded_setting(name, f"{base_suffix}_rep{n}")
+                for n in reps}
+        known = {v for v in seen.values() if v is not None}
+        if not known:
             continue
-        for rep_file in sorted(glob.glob(sidecar_path(name, f"{base_suffix}_rep*"))):
-            try:
-                with open(rep_file) as fh:
-                    value = fh.read().strip()
-                with open(sidecar_path(name, base_suffix), "w") as out:
-                    out.write(value)
-                break
-            except OSError:
-                pass
+        if len(known) > 1:
+            detail = ", ".join(f"{s}={v}" for s, v in sorted(seen.items()) if v is not None)
+            raise SystemExit(
+                f"bench_microcks: reps disagree on {flag} ({detail}). A median across reps that ran "
+                f"with different {flag} values describes no configuration that was measured. "
+                f"Re-run them with one {flag}, or aggregate them separately.")
+        value = known.pop()
+        try:
+            with open(sidecar_path(name, median_suffix(base_suffix)), "w") as fh:
+                fh.write(f"{value}\n")
+        except OSError:
+            continue
+        resolved[name] = value
+    return resolved
 
 
 # --------------------------------------------------------------------------------------------
@@ -829,8 +866,11 @@ def report(conns, csv_suffix="", duration=None):
     A report of its own rather than a fourth column bolted onto the WireMock one: the comparable
     scenario set is a strict subset (six of thirteen), so the two tables have different row sets and
     merging them would either drop WireMock rows or show empty Microcks cells that read as "slow"
-    rather than "not comparable"."""
-    propagate_run_settings(csv_suffix)
+    rather than "not comparable".
+
+    Settings are *read*, never re-derived: `--aggregate` already propagated them onto the `_median`
+    suffix, and re-deriving them here from flag defaults is exactly how a report ends up describing a
+    configuration nothing measured."""
     rift = load_engine_csv("rift", csv_suffix, conns)
     microcks = load_engine_csv("microcks", csv_suffix, conns)
     wiremock = load_engine_csv("wiremock", csv_suffix, conns)

--- a/tests/benchmark/scripts/bench_microcks.py
+++ b/tests/benchmark/scripts/bench_microcks.py
@@ -87,6 +87,41 @@ DEFAULT_WARMUP = "10s"
 # making two runs non-comparable. 4g committed up front so heap growth is not measured as latency.
 DEFAULT_HEAP = "4g"
 
+# --------------------------------------------------------------------------------------------
+# The two mock-path defaults that have to be turned off for this to be a comparison at all
+# --------------------------------------------------------------------------------------------
+#
+# `mocks.enable-invocation-stats` defaults to **true** and is the direct analogue of WireMock's
+# request journal, which this harness already disables for fairness. Microcks counts every mock
+# invocation and persists a per-service/per-day/per-hour record (verified: 500 requests produce
+# `dailyCount: 500` on `/api/metrics/invocations/<service>/<version>`). Rift and Mountebank are both
+# measured with recording OFF, and journaling is a deliberately separate, additive, Rift-only
+# scenario precisely because it is a distinct cost — so leaving this on would compare
+# Microcks-with-recording against Rift-without. Note which way that error runs: unlike every other
+# deviation in this suite, this one would flatter **Rift**, which is the direction that must never be
+# taken silently.
+#
+# `mocks.rest.enable-cors-policy` defaults to **true** and adds four `Access-Control-*` headers to
+# every mock response. Neither Rift nor WireMock emits them, so leaving it on charges Microcks for
+# bytes and header work its counterparts are not doing.
+#
+# Both are published in the secondary `microcks-stock` series below, so the out-of-the-box number a
+# user actually gets is reported beside the tuned one rather than hidden by it.
+FAIRNESS_FLAGS = (
+    "--mocks.enable-invocation-stats=false",
+    "--mocks.rest.enable-cors-policy=false",
+)
+
+# The stock-defaults secondary series, same idea as the WireMock leg's `wiremock-stock` (issue #865):
+# identical workload, Microcks launched exactly as it ships — invocation stats on, CORS on, Tomcat's
+# own thread pool — benched at the headline connection count only. Its own engine label keeps it out
+# of the headline Rift/Microcks ratio while still being reportable next to it.
+STOCK_ENGINE = "microcks-stock"
+
+# Tomcat's documented connector default, reported beside the pinned value so a reader can tell a
+# thread-pool ceiling from an engine throughput ceiling.
+STOCK_TOMCAT_THREADS = 200
+
 MICROCKS_JAR_HELP = """\
 Microcks publishes only non-repackaged jars to Maven Central (`microcks-app-1.14.0.jar` is 750KB of
 classes with no `Main-Class`), so the runnable Spring Boot fat jar has to come out of the official
@@ -419,8 +454,15 @@ def tomcat_thread_count(conn_list, override=None):
     return max(os.cpu_count() or 1, max(conn_list))
 
 
-def microcks_cmd(jar, port, threads, heap=DEFAULT_HEAP, java="java"):
+def microcks_cmd(jar, port, threads, heap=DEFAULT_HEAP, java="java", stock=False):
     """The JVM argv for one Microcks instance.
+
+    `stock=True` is the secondary series: no Tomcat pin and none of `FAIRNESS_FLAGS`, i.e. Microcks
+    exactly as it ships. Heap stays pinned even there — that is a determinism knob, not a fairness
+    one, and letting it float would make the stock column non-comparable between hosts rather than
+    more representative. Logging also stays at WARN in both series, for the same reason the tuned
+    series does it: at INFO a per-request log site measures the logging pipeline (#718), which would
+    misattribute a logging cost to the defaults being benchmarked.
 
     Every flag here is either a fairness requirement or a determinism requirement:
 
@@ -443,7 +485,7 @@ def microcks_cmd(jar, port, threads, heap=DEFAULT_HEAP, java="java"):
       site turns a throughput benchmark into a measurement of the logging pipeline; the same trap
       exists here and is worth an explicit flag rather than a hope about defaults.
     """
-    return [
+    cmd = [
         java,
         f"-Xms{heap}", f"-Xmx{heap}",
         "-Dspring.profiles.active=uber",
@@ -451,11 +493,14 @@ def microcks_cmd(jar, port, threads, heap=DEFAULT_HEAP, java="java"):
         "-Dasync-api.enabled=false",
         "-jar", jar,
         f"--server.port={port}",
-        f"--server.tomcat.threads.max={threads}",
         "--logging.level.root=WARN",
         "--logging.level.io.github.microcks=WARN",
         "--spring.main.banner-mode=off",
     ]
+    if not stock:
+        cmd.append(f"--server.tomcat.threads.max={threads}")
+        cmd.extend(FAIRNESS_FLAGS)
+    return cmd
 
 
 def api_ready(port, tries=360):
@@ -597,7 +642,8 @@ def _status_ok(name, codes):
 
 
 def bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java,
-                   csv_suffix="", engine="microcks", microcks_version=DEFAULT_MICROCKS_VERSION):
+                   csv_suffix="", engine="microcks", microcks_version=DEFAULT_MICROCKS_VERSION,
+                   stock=False):
     """Launch one Microcks per imposter in turn, bench that imposter's scenarios, tear it down.
 
     Sequential and one-service-at-a-time on purpose — see the module docstring. The cost is ~14s of
@@ -616,9 +662,11 @@ def bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java
         port = base_port + MICROCKS_OFFSET
         log = os.path.join(logdir, f"microcks-{service}-{port}.log")
         free_ports([port])
+        pool = f"{STOCK_TOMCAT_THREADS} (stock)" if stock else str(threads)
         print(f"[{engine}] {service}: launching on {port} "
-              f"({threads} tomcat threads, heap {heap})")
-        proc = launch(microcks_cmd(jar, port, threads, heap, java), log)
+              f"({pool} tomcat threads, heap {heap}"
+              f"{', stats+CORS on (stock defaults)' if stock else ''})")
+        proc = launch(microcks_cmd(jar, port, threads, heap, java, stock), log)
         try:
             if not api_ready(port):
                 raise SystemExit(f"bench_microcks: {service} on {port} never became ready "
@@ -649,13 +697,23 @@ def bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java
 
     path = write_results_csv(engine, csv_suffix, rows)
     print(f"[{engine}] wrote {path}")
-    record_run_settings(csv_suffix, warmup, threads, heap, version)
+    if not stock:
+        # Only the tuned series records the sidecars: the stock series' whole point is that it did
+        # NOT use the pin, so filing its (unused) thread value would describe the wrong run.
+        record_run_settings(csv_suffix, warmup, threads, heap, version)
     return path
 
 
 def run_all(jar, duration, warmup, conn_list, csv_suffix="",
             microcks_version=DEFAULT_MICROCKS_VERSION, tomcat_threads=None,
-            heap=DEFAULT_HEAP, java="java"):
+            heap=DEFAULT_HEAP, java="java", stock_conns=None, skip_stock=False):
+    """Bench Microcks twice: the tuned headline series, then the stock-default secondary series.
+
+    The stock series runs at the headline connection count only — it exists to tell the
+    out-of-the-box story, not to be swept — and is written under its own engine label so the report
+    can show it beside the headline without it entering the Rift/Microcks ratio. Same shape as the
+    WireMock leg (issue #865), for the same reason: a reader needs to be able to tell "Microcks is
+    slower" from "Microcks ships with per-request invocation accounting on"."""
     major, java_line = java_preflight(java)
     print(f"[microcks] java {major} ({java_line})")
     if not os.path.exists(jar):
@@ -664,8 +722,13 @@ def run_all(jar, duration, warmup, conn_list, csv_suffix="",
             + MICROCKS_JAR_HELP.format(version=microcks_version))
     threads = tomcat_thread_count(conn_list, tomcat_threads)
     logdir = os.path.join(RESULTS_DIR, "logs")
-    return bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java,
+    path = bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java,
                           csv_suffix, "microcks", microcks_version)
+    if not skip_stock:
+        bench_microcks(jar, logdir, duration, warmup, [stock_conns or conn_list[-1]],
+                       threads, heap, java, csv_suffix, STOCK_ENGINE, microcks_version,
+                       stock=True)
+    return path
 
 
 # --------------------------------------------------------------------------------------------
@@ -757,26 +820,59 @@ def propagate_run_settings(base_suffix=""):
 # Aggregation across repetitions
 # --------------------------------------------------------------------------------------------
 
-def find_rep_files(base_suffix=""):
-    """Every `direct_microcks<base_suffix>_repN.csv`, in rep order.
+def find_rep_files(base_suffix="", engine="microcks"):
+    """Every `direct_<engine><base_suffix>_repN.csv`, in rep order.
 
     Matching on the shared `_rep<digits>.csv` tail (`REP_FILE_RX`) rather than the glob alone keeps
     a stale unsuffixed file out of the aggregate."""
-    pattern = os.path.join(RESULTS_DIR, f"direct_microcks{base_suffix}_rep*.csv")
+    pattern = os.path.join(RESULTS_DIR, f"direct_{engine}{base_suffix}_rep*.csv")
     matched = [(int(m.group(1)), p) for p in glob.glob(pattern)
                for m in [REP_FILE_RX.search(p)] if m]
     return [p for _n, p in sorted(matched)]
 
 
-def aggregate(base_suffix=""):
-    """Collapse this engine's reps into `direct_microcks<base_suffix>_median.csv`.
+def aggregate_all(base_suffix=""):
+    """Collapse every series this suite produces, plus rift's if its reps are here.
+
+    `rift` is included because the ratio needs its median at the same point, and a standalone
+    Rift-vs-Microcks dispatch has no WireMock leg to have aggregated it already. `bench_direct`'s own
+    comparison path writes a report rather than per-engine CSVs, so aggregating it here is what keeps
+    `bench_direct.py` untouched."""
+    done = {}
+    for engine in ("microcks", STOCK_ENGINE, "rift"):
+        result = aggregate(base_suffix, engine)
+        if result is not None:
+            done[engine] = result[1]
+    if "microcks" not in done:
+        raise SystemExit(
+            f"bench_microcks: no tuned Microcks rep files matched "
+            f"direct_microcks{base_suffix}_rep*.csv in {RESULTS_DIR} — the headline ratio is computed "
+            f"from that series, so there is nothing to publish (run `--run-all --rep N` first).")
+    # Unequal replication favours whichever engine got more samples, and the spread column makes it
+    # worse rather than better: peak-to-peak over a single rep is 0.0%, so the LEAST-replicated engine
+    # renders as the most stable one. Refused for the same reason the other suites refuse it.
+    ratio_legs = {e: n for e, n in done.items() if e in ("microcks", "rift")}
+    if len(set(ratio_legs.values())) > 1:
+        detail = ", ".join(f"{e}={n}" for e, n in sorted(ratio_legs.items()))
+        raise SystemExit(
+            f"bench_microcks: rep-count mismatch across the ratio legs ({detail}). A table built "
+            f"from unequal replication favours whichever engine got more samples, and a one-rep "
+            f"column reports 0.0% spread — the least-replicated engine would read as the most "
+            f"stable. Re-run the short engine, or move the stale reps out of {RESULTS_DIR}.")
+    counts = ", ".join(f"{e}={n}" for e, n in sorted(done.items()))
+    print(f"[aggregate] {counts}; render with --report --csv-suffix {base_suffix}_median")
+    return done
+
+
+def aggregate(base_suffix="", engine="microcks"):
+    """Collapse one engine's reps into `direct_<engine><base_suffix>_median.csv`.
 
     The median maths is `bench_direct.aggregate_reps`, imported rather than reimplemented — issue
     #746's lesson was that a single rep can land on a degraded host, and a per-engine definition of
     "median" would reintroduce that asymmetry by the back door. The output filename and the two
     extra columns (`reps`, `rps_spread_pct`) match the WireMock leg so `--report --csv-suffix
     <base>_median` reads every engine the same way."""
-    paths = find_rep_files(base_suffix)
+    paths = find_rep_files(base_suffix, engine)
     if not paths:
         return None
     reps = []
@@ -793,20 +889,20 @@ def aggregate(base_suffix=""):
         detail = ", ".join(f"{s}@c={c}/{m}: {n} of {len(paths)}"
                            for (s, c, m), n in sorted(incomplete.items())[:8])
         raise SystemExit(
-            f"bench_microcks: incomplete repetitions across {len(paths)} rep files: {detail}"
-            f"{' …' if len(incomplete) > 8 else ''}\n"
+            f"bench_microcks: incomplete repetitions for '{engine}{base_suffix}' across "
+            f"{len(paths)} rep files: {detail}{' …' if len(incomplete) > 8 else ''}\n"
             f"Every point must appear in every rep, or the median silently rests on fewer samples "
             f"than the report claims. Re-run the missing reps, or aggregate a consistent subset.")
 
-    out = os.path.join(RESULTS_DIR, f"direct_microcks{base_suffix}_median.csv")
+    out = os.path.join(RESULTS_DIR, f"direct_{engine}{base_suffix}_median.csv")
     with open(out, "w") as fh:
         fh.write(CSV_HEADER + ",reps,rps_spread_pct\n")
         for (scen, conns, mode), c in sorted(agg.items(), key=lambda kv: (kv[0][1], kv[0][0])):
             spread = f"{c['rps_spread_pct']:.1f}" if c["rps_spread_pct"] != "" else ""
             fh.write(f"{csv_row(scen, conns, mode, c)},{c['reps']},{spread}\n")
-    propagate_run_settings(base_suffix)
-    print(f"[microcks] {len(paths)} reps -> {os.path.basename(out)}; "
-          f"render with --report --csv-suffix {base_suffix}_median")
+    if engine == "microcks":
+        propagate_run_settings(base_suffix)
+    print(f"  {engine}: {len(paths)} reps -> {os.path.basename(out)}")
     return out, len(paths)
 
 
@@ -873,6 +969,7 @@ def report(conns, csv_suffix="", duration=None):
     configuration nothing measured."""
     rift = load_engine_csv("rift", csv_suffix, conns)
     microcks = load_engine_csv("microcks", csv_suffix, conns)
+    stock = load_engine_csv(STOCK_ENGINE, csv_suffix, conns)
     wiremock = load_engine_csv("wiremock", csv_suffix, conns)
     if not microcks:
         raise SystemExit(f"bench_microcks: no Microcks CSV at {engine_csv_path('microcks', csv_suffix)} "
@@ -939,6 +1036,35 @@ def report(conns, csv_suffix="", duration=None):
             except (TypeError, ValueError, ZeroDivisionError):
                 pass
 
+    if stock:
+        lines += [
+            "", "## Tuned vs stock defaults", "",
+            "Microcks ships with `mocks.enable-invocation-stats` **on** — it counts every mock "
+            "invocation and persists a per-service/per-day record — and with a CORS policy that adds "
+            "four `Access-Control-*` headers to every response. Neither Rift nor WireMock does either, "
+            "and WireMock's request journal is disabled in its own leg for exactly this reason, so the "
+            "headline series turns both off.",
+            "",
+            "That is a tuning decision worth publishing rather than burying, so here is the same "
+            "workload with Microcks launched exactly as it ships (stock Tomcat pool too):",
+            "",
+            "| Scenario | Microcks (tuned) | Microcks (stock defaults) | Cost of the defaults |",
+            "|:---------|-----------------:|--------------------------:|---------------------:|",
+        ]
+        for name in COMPARABLE:
+            trow, srow = microcks.get(name), stock.get(name)
+            if not (trow and srow):
+                continue
+            try:
+                t, s = float(trow["rps"]), float(srow["rps"])
+                delta = f"**{(s - t) / t * 100:+.0f}%**" if t > 0 else "—"
+            except (TypeError, ValueError, ZeroDivisionError):
+                delta = "—"
+            lines.append(f"| {name} | {_fmt(trow.get('rps'))} | {_fmt(srow.get('rps'))} | {delta} |")
+        lines += ["", "The stock column is the number a user gets out of the box; the tuned column is "
+                  "the one the Rift ratio above is computed from. Quote whichever you mean, and say "
+                  "which."]
+
     lines += ["", "## What is not comparable, and why", "",
               "Microcks is spec-driven, so several fixture scenarios have no faithful OpenAPI "
               "analogue. They are **excluded rather than approximated** — an approximation would "
@@ -993,9 +1119,15 @@ def resolve_suffix(csv_suffix, rep):
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(description="Microcks benchmark suite (issue #900)")
-    ap.add_argument("--run-all", action="store_true", help="bench Microcks and write its CSV")
+    ap.add_argument("--run-all", action="store_true",
+                    help="bench Microcks (tuned + stock series) and write their CSVs")
     ap.add_argument("--report", action="store_true", help="write the comparison report from CSVs")
-    ap.add_argument("--aggregate", action="store_true", help="median-of-reps into the base CSV")
+    ap.add_argument("--aggregate", action="store_true",
+                    help="median-of-reps for every series present, plus rift's if its reps are here")
+    ap.add_argument("--skip-stock", action="store_true",
+                    help="tuned series only — halves the wall clock, drops the out-of-the-box column")
+    ap.add_argument("--stock-connections", type=int, default=None,
+                    help="connection count for the stock series (default: the headline count)")
     ap.add_argument("--emit-spec", metavar="IMPOSTER",
                     help="print the generated OpenAPI document for one imposter and exit")
     ap.add_argument("--duration", default="20s")
@@ -1026,9 +1158,10 @@ if __name__ == "__main__":
 
     if args.run_all:
         run_all(args.jar, args.duration, args.warmup, conn_list, suffix,
-                args.microcks_version, args.tomcat_threads, args.heap, args.java)
+                args.microcks_version, args.tomcat_threads, args.heap, args.java,
+                args.stock_connections, args.skip_stock)
     if args.aggregate:
-        aggregate(args.csv_suffix)
+        aggregate_all(args.csv_suffix)
     if args.report:
         report(conn_list[-1], args.csv_suffix, args.duration)
     if not (args.run_all or args.report or args.aggregate):

--- a/tests/benchmark/scripts/bench_microcks.py
+++ b/tests/benchmark/scripts/bench_microcks.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+"""Microcks benchmark suite (issue #900) — the fourth engine in the published comparison.
+
+`bench_direct.py` compares Rift against Mountebank on byte-identical imposter JSON; `bench_wiremock.py`
+adds WireMock by *generating* its mappings from that same fixture. Microcks needs a third step,
+because it is not stub-authored at all: it is **spec-driven**. You do not hand Microcks a stub, you
+hand it an OpenAPI document and it derives operations and example responses from it. So this suite
+generates an OpenAPI 3.0.2 artifact per imposter and imports it through Microcks' own artifact API.
+
+That difference is the single most important thing to understand about this comparison, and it is
+stated in the report rather than buried here: **for Microcks, "410 stubs" is not a thing that
+exists.** The nearest honest analogue is "410 matchable request shapes", which in OpenAPI means
+410 `path` x `verb` operations. That mapping is what `openapi_spec` implements, and the
+scenarios where it is *not* an honest analogue are refused outright — see `UNTRANSLATABLE`.
+
+Like the WireMock suite this is a **separate** module rather than a fourth engine inside
+`bench_direct.py`: the rift-vs-mb default run is a stability contract (`DefaultRunUnchanged`) that
+must stay byte-comparable with previously published numbers, and not touching `bench_direct.py`
+makes that risk zero by construction. The one source of truth is still shared — this module
+**imports** `IMPOSTERS`, `SCENARIOS` and `EXPECT_BODY` from `bench_direct`, so the workloads cannot
+drift apart.
+
+Three fidelity properties worth knowing, all verified rather than assumed:
+
+- **Bodies are byte-identical to Rift's.** An OpenAPI example whose `value` is a JSON *string* is
+  served back verbatim by Microcks, so emitting the fixture's response body as a raw string (rather
+  than a parsed object Microcks would re-serialize, dropping `json.dumps`' spaces) means
+  `bench_direct.verify_body` and `EXPECT_BODY` work here unchanged. `test_bench_microcks.py` pins
+  this — a regression to parsed values would silently swap the assertion for a weaker one.
+- **No Docker.** The measured process is a plain native JVM, exactly like WireMock's standalone jar,
+  because a container's network stack is not a property of the engine (see `MICROCKS_JAR_HELP` for
+  where the jar comes from and why).
+- **One imposter per process.** WireMock gets a fresh JVM per imposter, so its resident corpus is
+  only ever that imposter's stubs. Microcks multiplexes every service on one port, so loading all
+  14 imposters into one process would leave it holding ~1500 operations while WireMock holds 310 —
+  and Microcks' throughput is *measurably* sensitive to total resident corpus size. This suite
+  therefore runs one Microcks per imposter, sequentially, holding exactly that imposter's service.
+
+Run:
+    python3 bench_microcks.py --run-all      # bench Microcks alone -> direct_microcks.csv
+    python3 bench_microcks.py --report       # combine whatever CSVs exist -> comparison report
+
+Prerequisites: Temurin/OpenJDK **21** and the Microcks uber app jar (see `MICROCKS_JAR_HELP`).
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+sys.path.insert(0, os.path.dirname(__file__))
+from bench_direct import (  # noqa: E402
+    CSV_HEADER, IMPOSTERS, REP_FILE_RX, RESULTS_DIR, SCENARIOS,
+    aggregate_reps, csv_row, free_ports, launch, load_rift_csv, metric, mode_label,
+    parse_conn_list, run_oha, stop, verify_body, write_results_csv,
+)
+
+# rift = offset 0, mb = +100 (bench_direct), wiremock = +200, microcks = +300. Disjoint ranges are
+# what let the engines run one at a time without ever being measured in place of each other.
+MICROCKS_OFFSET = 300
+
+# Microcks needs Java 21: the 1.14.0 app jar is Spring Boot 3.5.6 with class file version 65, so a
+# Java 17 JRE fails at `JarLauncher.main` with `UnsupportedClassVersionError` and nothing earlier
+# would explain why. `benchmark-publish.yml` already provisions Temurin 21 for the WireMock leg.
+MIN_JAVA_MAJOR = 21
+
+DEFAULT_JAR = os.path.expanduser("~/bench-microcks/microcks-app.jar")
+DEFAULT_MICROCKS_VERSION = "1.14.0"
+
+# Every service is imported under one version so the mock URL is derivable from the imposter name
+# alone: /rest/<service>/<SERVICE_VERSION><path>.
+SERVICE_VERSION = "1.0.0"
+
+# Same value and same reason as the WireMock leg: a JIT needs more than 3s, and the published table
+# is only like-for-like if every engine was measured at one warmup (issue #866).
+DEFAULT_WARMUP = "10s"
+
+# JVM heap. Fixed rather than left to the default ergonomic sizing, because the default is a
+# fraction of *host* RAM and would therefore differ between a 16-vCPU runner and a laptop, silently
+# making two runs non-comparable. 4g committed up front so heap growth is not measured as latency.
+DEFAULT_HEAP = "4g"
+
+MICROCKS_JAR_HELP = """\
+Microcks publishes only non-repackaged jars to Maven Central (`microcks-app-1.14.0.jar` is 750KB of
+classes with no `Main-Class`), so the runnable Spring Boot fat jar has to come out of the official
+container image. That is a *download*, not a deployment — the benchmarked process is a native JVM:
+
+  mkdir -p ~/bench-microcks
+  cid=$(docker create microcks/microcks-uber:{version})
+  docker cp "$cid:/deployments/app.jar" ~/bench-microcks/microcks-app.jar
+  docker rm -f "$cid"
+
+`docker create` does not start the container; it only materialises its filesystem. If you would
+rather not involve a registry at all, build `microcks-app` from source at tag {version} — the jar
+this suite wants is the Spring Boot repackaged one whose manifest says
+`Start-Class: io.github.microcks.MicrocksApplication`."""
+
+
+# --------------------------------------------------------------------------------------------
+# What can and cannot be translated
+# --------------------------------------------------------------------------------------------
+#
+# The issue behind this suite (#900) says the fairness section will be read adversarially by people
+# who like Microcks, and it should be. The failure mode that would deserve that criticism is not
+# omitting a scenario — it is *including* one under a translation that quietly measures something
+# else, then publishing the ratio. So the comparable set is an explicit allow-list, every exclusion
+# carries its reason, and the reasons are printed in the report instead of living in a comment.
+
+# Scenarios translated faithfully: path/verb dispatch (the family the stub-growth claim rests on)
+# plus query-argument dispatch.
+COMPARABLE = ("simple_health", "api_first", "api_middle", "api_last", "no_match", "query_last")
+
+UNTRANSLATABLE = {
+    "regex_last":
+        "Rift matches the path against 100 regexes (`matches`). OpenAPI paths are templated, not "
+        "regular expressions, and Microcks has no regex path dispatcher — `/regex/pattern{n}/{x}` "
+        "as a path template is a different matcher doing less work, so any number would flatter "
+        "Microcks without being comparable.",
+    "complex_predicate":
+        "Rift evaluates `and`/`or` over method, path prefix and two alternative headers. Microcks "
+        "has no header dispatcher for REST; the only way to express it is a Groovy SCRIPT "
+        "dispatcher, which measures the scripting engine rather than a matcher.",
+    "header_last":
+        "100 stubs discriminated solely by an `X-Route-Id` header. Same reason as "
+        "`complex_predicate`: no header dispatcher for REST.",
+    "json_body_equals":
+        "Rift matches method + path + an exact JSON body. The 50 stubs sit on 50 *distinct* paths, "
+        "so a faithful-looking Microcks translation (50 operations, one response each) would "
+        "resolve on the path alone and never inspect the body — strictly less work than Rift did.",
+    "jsonpath":
+        "Rift applies a JSONPath selector (`$.user.id`) as a predicate modifier. Microcks' "
+        "JSON_BODY dispatcher uses its own expression dialect with different semantics; equating "
+        "the two would be an assertion about dialects, not about matching cost.",
+    "xpath":
+        "Rift applies an XPath selector to an XML body. Microcks has no XPath dispatcher for REST.",
+    "template":
+        "Rift interpolates `${request.path}` / `${request.query}` into the response. Microcks does "
+        "have response templating, but with a different expression language, and the fixture's body "
+        "marker is satisfied by a static example — so including it would report a static-response "
+        "number under a templating label.",
+}
+
+# `no_match` is comparable but not identical, and the difference is a status code rather than a
+# translation choice. Rift and Mountebank answer an unmatched request with an empty 200; WireMock
+# 404s, and the WireMock suite reproduces the Rift default by installing a catch-all empty-200
+# mapping. Microcks has no catch-all mechanism — you cannot register a fallback for an unknown path
+# — so it is measured as the 404 it genuinely returns, and the status gate below expects that.
+# The body is empty either way, so `verify_body`'s `EXPECT_BODY[no_match] is None` check still holds
+# and still proves nothing matched.
+EXPECT_STATUS_PREFIX = {"no_match": "4"}
+
+
+def comparable_scenarios():
+    """The SCENARIOS rows this suite measures, in fixture order.
+
+    Derived from `SCENARIOS` rather than restated, so a fixture change cannot leave this suite
+    benching a scenario definition that no longer exists."""
+    return [s for s in SCENARIOS if s[0] in COMPARABLE]
+
+
+def check_scenario_coverage():
+    """Every fixture scenario must be either measured or explicitly refused.
+
+    This is the guard that keeps the exclusion list honest as the fixture grows: a new scenario
+    added to `bench_direct.SCENARIOS` fails here until someone decides whether Microcks can express
+    it, instead of silently vanishing from a table that claims to cover the suite."""
+    names = [s[0] for s in SCENARIOS]
+    classified = set(COMPARABLE) | set(UNTRANSLATABLE)
+    missing = [n for n in names if n not in classified]
+    if missing:
+        raise SystemExit(
+            f"bench_microcks: scenario(s) {missing} are neither in COMPARABLE nor explained in "
+            f"UNTRANSLATABLE. Decide which, with a reason — an unclassified scenario would drop out "
+            f"of a report that claims to cover the whole suite.")
+    unknown = [n for n in classified if n not in names]
+    if unknown:
+        raise SystemExit(
+            f"bench_microcks: {unknown} classified but absent from bench_direct.SCENARIOS — the "
+            f"fixture moved and this list did not.")
+
+
+# --------------------------------------------------------------------------------------------
+# Imposter -> OpenAPI translator
+# --------------------------------------------------------------------------------------------
+
+def _fail(msg):
+    """Abort translation.
+
+    Deliberately fatal rather than "skip the stub I don't understand", for the same reason as the
+    WireMock translator: a silently dropped stub still passes the measured scenario's body
+    assertion, and corrupts only the surrounding stubs — the ones whose whole job is to make the
+    match work harder. That is exactly the mistake that publishes an inflated number."""
+    raise SystemExit(f"bench_microcks: cannot translate stub — {msg}")
+
+
+def _raw_body(resp):
+    """The response body exactly as Rift would emit it, as a string.
+
+    Returned as a *string* on purpose. Microcks serves a string example verbatim but re-serializes a
+    parsed object, and `json.dumps` in the fixture emits `{"id": 1}` while Microcks' serializer
+    emits `{"id":1}` — which would break every `EXPECT_BODY` marker that contains a space after a
+    colon, and would have to be replaced by a weaker whitespace-insensitive assertion. Keeping the
+    bytes identical keeps the strong assertion."""
+    body = resp.get("body", "")
+    if body is None:
+        return ""
+    if isinstance(body, (dict, list)):
+        # The fixture always pre-serializes with json.dumps, so this is a fixture change rather
+        # than an input we should guess at: guessing a separator here is how the bodies drift.
+        _fail(f"response body is a {type(body).__name__}, not a pre-serialized string — "
+              f"the byte-identical-body property depends on the fixture's own json.dumps output")
+    return body
+
+
+def _content_type(resp):
+    """Content type the example must be filed under.
+
+    Microcks keys examples by media type, so this decides where the body lands in the spec. Read the
+    stub's own header when it sets one; otherwise infer, because the fixture omits the header on
+    plain-text stubs (`/health` -> `OK`) and filing those as JSON would make Microcks refuse the
+    artifact."""
+    for k, v in (resp.get("headers") or {}).items():
+        if k.lower() == "content-type":
+            return v.split(";")[0].strip()
+    body = resp.get("body", "")
+    if isinstance(body, str) and body[:1] in ("{", "["):
+        return "application/json"
+    if isinstance(body, str) and body.lstrip().startswith("<"):
+        return "application/xml"
+    return "text/plain"
+
+
+def _equals_fields(stub):
+    """(method, path, query) from a single-`equals` stub, or `_fail`.
+
+    The comparable set is exactly the path/verb and query-argument family, so anything else reaching
+    the translator is a bug in the allow-list rather than a stub to interpret creatively."""
+    preds = stub.get("predicates") or []
+    if len(preds) != 1:
+        _fail(f"expected exactly 1 predicate, got {len(preds)}: {json.dumps(preds)[:160]}")
+    pred = preds[0]
+    if set(pred) != {"equals"}:
+        _fail(f"only a bare `equals` predicate is translatable here, got operators {sorted(pred)}")
+    eq = pred["equals"]
+    unsupported = set(eq) - {"method", "path", "query"}
+    if unsupported:
+        _fail(f"`equals` on {sorted(unsupported)} has no faithful OpenAPI analogue "
+              f"(see UNTRANSLATABLE for why these scenarios are excluded)")
+    if "path" not in eq:
+        _fail(f"stub has no path to key an operation on: {json.dumps(eq)[:160]}")
+    return eq.get("method", "GET").upper(), eq["path"], eq.get("query") or {}
+
+
+def _example_name(i):
+    """Stable per-stub example name. Microcks pairs a request example with a response example by
+    NAME, so the query-dispatch translation depends on both sides using this same key."""
+    return f"ex{i}"
+
+
+def openapi_spec(service, stubs):
+    """One OpenAPI 3.0.2 document expressing `stubs` as Microcks operations.
+
+    Two shapes come out of this, and which one Microcks picks is driven by the fixture rather than
+    by us:
+
+    - **Distinct literal paths** (Simple, API) -> one operation per `path` x `verb`, each with a
+      single response example. Microcks assigns no dispatcher; resolution is path/verb only. This is
+      the honest analogue of "N stubs competing for one request", and it is the shape the
+      stub-growth claim is measured on.
+    - **One shared path discriminated by query args** (Query) -> a single operation carrying N
+      *named* examples, with the query values as request-parameter examples under the same names.
+      Microcks infers `dispatcher=URI_PARAMS` with rules `page && size` from that, which is its
+      native way to express what Rift expresses as N query-`equals` stubs.
+    """
+    paths = {}
+    for i, stub in enumerate(stubs, 1):
+        method, path, query = _equals_fields(stub)
+        responses = stub.get("responses") or []
+        if len(responses) != 1 or "is" not in responses[0]:
+            _fail(f"expected exactly one `is` response, got {json.dumps(responses)[:160]}")
+        resp = responses[0]["is"]
+        status = str(resp.get("statusCode", 200))
+        body = _raw_body(resp)
+        ctype = _content_type(resp)
+        ex_name = _example_name(i)
+
+        op = paths.setdefault(path, {}).setdefault(method.lower(), {
+            "operationId": _operation_id(method, path),
+            "parameters": [],
+            "responses": {},
+        })
+
+        # A 204 carries no body, so it gets no content block — an empty example under a media type
+        # makes Microcks emit a zero-length body with a Content-Type, which is not what Rift does.
+        entry = op["responses"].setdefault(status, {"description": "generated from imposter stub"})
+        if body != "":
+            entry.setdefault("content", {}).setdefault(ctype, {}).setdefault("examples", {})[
+                ex_name] = {"value": body}
+        elif status == "204":
+            pass
+        else:
+            entry.setdefault("content", {}).setdefault(ctype, {}).setdefault("examples", {})[
+                ex_name] = {"value": ""}
+
+        for qname, qvalue in query.items():
+            _add_query_param(op, qname, ex_name, str(qvalue))
+
+    for path_item in paths.values():
+        for op in path_item.values():
+            if not op["parameters"]:
+                del op["parameters"]
+
+    return {
+        "openapi": "3.0.2",
+        "info": {
+            "title": service,
+            "version": SERVICE_VERSION,
+            "description": (
+                "Generated by tests/benchmark/scripts/bench_microcks.py from the shared imposter "
+                "fixture in bench_direct.py. Hand edits will be overwritten."),
+        },
+        "paths": paths,
+    }
+
+
+def _operation_id(method, path):
+    """A unique, spec-legal operationId. Microcks does not dispatch on it, but a duplicate makes
+    some OpenAPI parsers reject the whole document, which would look like an import failure."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", path).strip("_")
+    return f"{method.lower()}_{slug}" if slug else method.lower()
+
+
+def _add_query_param(op, name, example_name, value):
+    """Attach one query-parameter example, creating the parameter on first sight.
+
+    `required: True` matters: Microcks derives its `URI_PARAMS` dispatcher rules from the *required*
+    query parameters that carry examples, so an optional parameter would be left out of the rules
+    and every request would fall on the same example regardless of `page` — the 100-way dispatch
+    would collapse to a 1-way one and the scenario would measure nothing."""
+    for param in op["parameters"]:
+        if param["name"] == name:
+            param["examples"][example_name] = {"value": value}
+            return
+    op["parameters"].append({
+        "name": name, "in": "query", "required": True,
+        "schema": {"type": "string"},
+        "examples": {example_name: {"value": value}},
+    })
+
+
+def expected_operations(stubs):
+    """How many `path` x `verb` operations `stubs` should produce.
+
+    The import verification below compares this against what Microcks actually registered. Same
+    role as the WireMock suite's mapping-count check: an import that drops operations leaves the
+    measured scenario passing while the stubs that make matching *work* have quietly gone missing."""
+    seen = set()
+    for stub in stubs:
+        method, path, _ = _equals_fields(stub)
+        seen.add((method, path))
+    return len(seen)
+
+
+# --------------------------------------------------------------------------------------------
+# Java preflight + process model
+# --------------------------------------------------------------------------------------------
+
+def parse_java_major(version_output):
+    """Major version from `java -version` output, or None if unparseable."""
+    m = re.search(r'version "(\d+)(?:\.(\d+))?', version_output)
+    if not m:
+        return None
+    major = int(m.group(1))
+    if major == 1 and m.group(2):
+        return int(m.group(2))
+    return major
+
+
+def java_preflight(java="java"):
+    """Fail once, actionably, rather than as an `UnsupportedClassVersionError` stack trace."""
+    try:
+        out = subprocess.run([java, "-version"], capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        raise SystemExit(
+            f"bench_microcks: `{java}` not found. Microcks 1.14 is Spring Boot 3.5 and needs "
+            f"Java {MIN_JAVA_MAJOR}+ (Temurin 21 is what CI uses).")
+    text = (out.stderr or "") + (out.stdout or "")
+    major = parse_java_major(text)
+    if major is None:
+        raise SystemExit(f"bench_microcks: could not parse `{java} -version`: {text.strip()[:200]}")
+    if major < MIN_JAVA_MAJOR:
+        raise SystemExit(
+            f"bench_microcks: java {major} is too old — the Microcks 1.14 app jar is class file "
+            f"version 65, so it needs Java {MIN_JAVA_MAJOR}+. Point --java at a Temurin 21 JDK.")
+    return major, (text.strip().splitlines()[0] if text.strip() else f"java {major}")
+
+
+def tomcat_thread_count(conn_list, override=None):
+    """Threads for Microcks' embedded Tomcat connector.
+
+    Exactly the same fairness argument as the WireMock leg's `--container-threads`, and it bites for
+    the same reason: Tomcat's `server.tomcat.threads.max` defaults to **200** while the published
+    comparison drives 256 connections, so the stock configuration would bound in-flight requests
+    below the offered concurrency and the run would measure the pool rather than the engine.
+    `max(cpu_count, max(connections))` guarantees the pool is never the bottleneck. Extra threads
+    do not manufacture parallelism — the CPU budget is unchanged — they only remove an artificial
+    queue, so a Rift win measured against this pin is unambiguous."""
+    if override is not None:
+        if override < 1:
+            raise SystemExit(f"bench_microcks: --tomcat-threads must be >= 1, got {override}")
+        return override
+    return max(os.cpu_count() or 1, max(conn_list))
+
+
+def microcks_cmd(jar, port, threads, heap=DEFAULT_HEAP, java="java"):
+    """The JVM argv for one Microcks instance.
+
+    Every flag here is either a fairness requirement or a determinism requirement:
+
+    * `-Dspring.profiles.active=uber` selects the standalone profile: Keycloak off, embedded
+      in-memory MongoDB. Passed as a system property rather than the `SPRING_PROFILES_ACTIVE`
+      environment variable the official image uses, because `bench_direct.launch` deliberately takes
+      no `env` — every engine in this harness is launched from argv alone, so what a run was
+      configured with is visible in the process table and in the log header. Worth stating plainly
+      in the report: a production Microcks talks to a real MongoDB over a socket, so the in-memory
+      store makes this configuration *faster* than a real deployment. That direction flatters
+      Microcks, which is the safe direction for a comparison published by Rift.
+    * `-Dspring.aot.enabled=true` matches the official image's own JAVA_OPTIONS and uses the
+      AOT-generated context. Faster startup; again, flatters Microcks.
+    * `-Dasync-api.enabled=false` switches off the AsyncAPI/WebSocket minion puller. It is not part
+      of the HTTP mocking path this suite measures, and leaving it on would charge Microcks for
+      background work under load that has nothing to do with the comparison.
+    * `-Xms == -Xmx` pins the heap so it is identical on a laptop and a 16-vCPU runner, and so heap
+      growth is never measured as request latency.
+    * The log level is dropped to WARN. Per issue #718's finding on the Rift side, a per-request log
+      site turns a throughput benchmark into a measurement of the logging pipeline; the same trap
+      exists here and is worth an explicit flag rather than a hope about defaults.
+    """
+    return [
+        java,
+        f"-Xms{heap}", f"-Xmx{heap}",
+        "-Dspring.profiles.active=uber",
+        "-Dspring.aot.enabled=true",
+        "-Dasync-api.enabled=false",
+        "-jar", jar,
+        f"--server.port={port}",
+        f"--server.tomcat.threads.max={threads}",
+        "--logging.level.root=WARN",
+        "--logging.level.io.github.microcks=WARN",
+        "--spring.main.banner-mode=off",
+    ]
+
+
+def api_ready(port, tries=360):
+    """Readiness is `GET /api/version/info` answering 200.
+
+    A bare TCP accept would race the Spring context: Tomcat binds before the mock controller and
+    the Mongo store are wired, and an artifact upload against that window fails in a way that looks
+    like a translation bug."""
+    url = f"http://localhost:{port}/api/version/info"
+    for _ in range(tries):
+        try:
+            with urllib.request.urlopen(url, timeout=2) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def probe_microcks_version(port, fallback):
+    """Report the version the JVM actually answers with, not the one we think we downloaded.
+
+    Best-effort: a reporting detail should not fail a whole run, so fall back to the pinned value."""
+    try:
+        with urllib.request.urlopen(f"http://localhost:{port}/api/version/info", timeout=5) as r:
+            parsed = json.loads(r.read().decode("utf-8", "replace"))
+        return parsed.get("versionId") or fallback
+    except Exception:
+        return fallback
+
+
+def _multipart(field, filename, payload):
+    """Minimal multipart/form-data body.
+
+    Hand-rolled because the artifact API is the only multipart call in the whole benchmark harness
+    and the rest of it deliberately depends on nothing outside the standard library."""
+    boundary = f"----bench{uuid.uuid4().hex}"
+    body = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="{field}"; filename="{filename}"\r\n'
+        f"Content-Type: application/json\r\n\r\n"
+    ).encode() + payload + f"\r\n--{boundary}--\r\n".encode()
+    return boundary, body
+
+
+def upload_artifact(port, service, spec):
+    """Import one generated OpenAPI document as a Microcks main artifact."""
+    payload = json.dumps(spec, separators=(",", ":")).encode()
+    boundary, body = _multipart("file", f"{service}-openapi.json", payload)
+    req = urllib.request.Request(
+        f"http://localhost:{port}/api/artifact/upload?mainArtifact=true",
+        data=body, method="POST",
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"})
+    try:
+        with urllib.request.urlopen(req, timeout=300) as r:
+            return r.read().decode("utf-8", "replace").strip()
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:400]
+        raise SystemExit(f"bench_microcks: artifact upload failed on {port} for {service}: "
+                         f"HTTP {e.code}: {detail}")
+
+
+def registered_operations(port, service):
+    """Operations Microcks registered for `service`, as a list of "VERB /path" strings."""
+    url = (f"http://localhost:{port}/api/services/search"
+           f"?name={urllib.parse.quote(service)}")
+    with urllib.request.urlopen(url, timeout=60) as r:
+        found = json.loads(r.read().decode("utf-8", "replace"))
+    for svc in found:
+        if svc.get("name") == service and svc.get("version") == SERVICE_VERSION:
+            return [op.get("name", "") for op in (svc.get("operations") or [])]
+    raise SystemExit(f"bench_microcks: service {service}:{SERVICE_VERSION} not found on {port} "
+                     f"after upload — the import did not register it")
+
+
+def load_service(port, service, stubs):
+    """Translate, import, and prove the import landed intact.
+
+    The count check is the same guard as the WireMock suite's mapping-count assertion, and exists
+    for the same reason: Microcks accepts an artifact and reports 201 even when its parser has
+    quietly discarded operations it did not like, and the measured scenario would still pass."""
+    spec = openapi_spec(service, stubs)
+    t0 = time.time()
+    upload_artifact(port, service, spec)
+    ops = registered_operations(port, service)
+    want = expected_operations(stubs)
+    if len(ops) != want:
+        raise SystemExit(
+            f"bench_microcks: {service} registered {len(ops)} operations, expected {want} — the "
+            f"import dropped some, and measuring a thinner corpus than Rift's would be bogus")
+    print(f"    {service} port={port} stubs={len(stubs)} operations={len(ops)} "
+          f"in {time.time() - t0:.2f}s")
+    return spec, ops
+
+
+def mock_url(port, service, path):
+    """Microcks serves REST mocks under /rest/<service>/<version><path>.
+
+    The service name is URL-encoded because Microcks keys on `info.title` verbatim, and an imposter
+    name is not guaranteed to be path-safe forever."""
+    return f"http://localhost:{port}/rest/{urllib.parse.quote(service)}/{SERVICE_VERSION}{path}"
+
+
+# --------------------------------------------------------------------------------------------
+# Bench loop
+# --------------------------------------------------------------------------------------------
+
+def imposter_by_port():
+    return {base_port: (name, stubs) for base_port, name, stubs in IMPOSTERS}
+
+
+def scenario_groups():
+    """Comparable scenarios grouped by the imposter that serves them, in fixture order.
+
+    Grouping is what makes the one-imposter-per-process model cheap: the four API scenarios share a
+    single Microcks launch, so the run costs one JVM start per *imposter* rather than per scenario."""
+    groups, order = {}, []
+    for row in comparable_scenarios():
+        base_port = row[1]
+        if base_port not in groups:
+            groups[base_port] = []
+            order.append(base_port)
+        groups[base_port].append(row)
+    return [(bp, groups[bp]) for bp in order]
+
+
+def _status_ok(name, codes):
+    """Whether a scenario's status distribution is the one it is supposed to have.
+
+    Everything is 2xx except `no_match`, which Microcks answers with a 404 it has no catch-all
+    mechanism to avoid (see `EXPECT_STATUS_PREFIX`). Pinning the *expected* prefix per scenario,
+    rather than relaxing the gate to "any status", keeps the check able to catch a genuinely
+    mis-served stub."""
+    if not codes:
+        return False
+    want = EXPECT_STATUS_PREFIX.get(name, "2")
+    return all(str(c).startswith(want) for c in codes)
+
+
+def bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java,
+                   csv_suffix="", engine="microcks", microcks_version=DEFAULT_MICROCKS_VERSION):
+    """Launch one Microcks per imposter in turn, bench that imposter's scenarios, tear it down.
+
+    Sequential and one-service-at-a-time on purpose — see the module docstring. The cost is ~14s of
+    JVM start per imposter; the benefit is that Microcks' resident corpus is exactly the imposter
+    under test, which is the only way this is comparable with WireMock's per-imposter JVM."""
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    os.makedirs(logdir, exist_ok=True)
+    check_scenario_coverage()
+    by_port = imposter_by_port()
+    mode = mode_label(None)
+    rows = []
+    version = microcks_version
+
+    for base_port, scenarios in scenario_groups():
+        service, stubs = by_port[base_port]
+        port = base_port + MICROCKS_OFFSET
+        log = os.path.join(logdir, f"microcks-{service}-{port}.log")
+        free_ports([port])
+        print(f"[{engine}] {service}: launching on {port} "
+              f"({threads} tomcat threads, heap {heap})")
+        proc = launch(microcks_cmd(jar, port, threads, heap, java), log)
+        try:
+            if not api_ready(port):
+                raise SystemExit(f"bench_microcks: {service} on {port} never became ready "
+                                 f"(see {log})")
+            load_service(port, service, stubs)
+            version = probe_microcks_version(port, microcks_version)
+            for name, _bp, method, path, body, headers in scenarios:
+                url = mock_url(port, service, path)
+                # The same two gates the other suites use, and the reason a mistranslation cannot
+                # be published as a fast number: the body marker proves the intended operation
+                # served the request, and an unexpected status distribution aborts the run.
+                verify_body(engine, name, method, url, body, headers)
+                for conns in conn_list:
+                    run_oha(url, method, body, headers, warmup, conns)
+                    m = metric(run_oha(url, method, body, headers, duration, conns))
+                    total = sum(m["codes"].values())
+                    ok = _status_ok(name, m["codes"]) and total > 0
+                    status = "ok" if ok else f"BAD codes={m['codes']}"
+                    print(f"  {name:20s} c={conns:<4d} {m['rps']:>10.1f} rps  "
+                          f"p50={m['p50_ms']}ms p99={m['p99_ms']}ms p999={m['p999_ms']}ms  {status}")
+                    if not ok:
+                        raise SystemExit(f"{engine}/{name}: unexpected status distribution "
+                                         f"{m['codes']} — aborting")
+                    rows.append((name, conns, mode, m))
+        finally:
+            stop(proc, [port])
+            free_ports([port])
+
+    path = write_results_csv(engine, csv_suffix, rows)
+    print(f"[{engine}] wrote {path}")
+    record_run_settings(csv_suffix, warmup, threads, heap, version)
+    return path
+
+
+def run_all(jar, duration, warmup, conn_list, csv_suffix="",
+            microcks_version=DEFAULT_MICROCKS_VERSION, tomcat_threads=None,
+            heap=DEFAULT_HEAP, java="java"):
+    major, java_line = java_preflight(java)
+    print(f"[microcks] java {major} ({java_line})")
+    if not os.path.exists(jar):
+        raise SystemExit(
+            f"bench_microcks: Microcks app jar not found at {jar}.\n\n"
+            + MICROCKS_JAR_HELP.format(version=microcks_version))
+    threads = tomcat_thread_count(conn_list, tomcat_threads)
+    logdir = os.path.join(RESULTS_DIR, "logs")
+    return bench_microcks(jar, logdir, duration, warmup, conn_list, threads, heap, java,
+                          csv_suffix, "microcks", microcks_version)
+
+
+# --------------------------------------------------------------------------------------------
+# Run-settings sidecars (same pattern as the WireMock leg)
+# --------------------------------------------------------------------------------------------
+
+def sidecar_path(name, csv_suffix):
+    return os.path.join(RESULTS_DIR, f"direct_microcks{csv_suffix}.{name}")
+
+
+def record_run_settings(csv_suffix, warmup, threads, heap, version):
+    """Persist what the run was invoked with, beside its CSV.
+
+    The report is generated in a separate process (`--report`, often a separate CI step), so a
+    setting that only ever lived in argv cannot be stated in the published table — and an
+    unstateable setting is indistinguishable from an unfair one to a reader."""
+    for name, value in (("warmup", warmup), ("threads", threads), ("heap", heap),
+                        ("version", version)):
+        try:
+            with open(sidecar_path(name, csv_suffix), "w") as fh:
+                fh.write(str(value))
+        except OSError:
+            pass
+
+
+def recorded_setting(name, csv_suffix, default=None):
+    try:
+        with open(sidecar_path(name, csv_suffix)) as fh:
+            return fh.read().strip() or default
+    except OSError:
+        return default
+
+
+def propagate_run_settings(base_suffix=""):
+    """Copy per-rep sidecars up to the aggregated suffix, so `--report` after an aggregation can
+    still state the settings the reps ran with."""
+    for name in ("warmup", "threads", "heap", "version"):
+        if recorded_setting(name, base_suffix) is not None:
+            continue
+        for rep_file in sorted(glob.glob(sidecar_path(name, f"{base_suffix}_rep*"))):
+            try:
+                with open(rep_file) as fh:
+                    value = fh.read().strip()
+                with open(sidecar_path(name, base_suffix), "w") as out:
+                    out.write(value)
+                break
+            except OSError:
+                pass
+
+
+# --------------------------------------------------------------------------------------------
+# Aggregation across repetitions
+# --------------------------------------------------------------------------------------------
+
+def find_rep_files(base_suffix=""):
+    """Every `direct_microcks<base_suffix>_repN.csv`, in rep order.
+
+    Matching on the shared `_rep<digits>.csv` tail (`REP_FILE_RX`) rather than the glob alone keeps
+    a stale unsuffixed file out of the aggregate."""
+    pattern = os.path.join(RESULTS_DIR, f"direct_microcks{base_suffix}_rep*.csv")
+    matched = [(int(m.group(1)), p) for p in glob.glob(pattern)
+               for m in [REP_FILE_RX.search(p)] if m]
+    return [p for _n, p in sorted(matched)]
+
+
+def aggregate(base_suffix=""):
+    """Collapse this engine's reps into `direct_microcks<base_suffix>_median.csv`.
+
+    The median maths is `bench_direct.aggregate_reps`, imported rather than reimplemented — issue
+    #746's lesson was that a single rep can land on a degraded host, and a per-engine definition of
+    "median" would reintroduce that asymmetry by the back door. The output filename and the two
+    extra columns (`reps`, `rps_spread_pct`) match the WireMock leg so `--report --csv-suffix
+    <base>_median` reads every engine the same way."""
+    paths = find_rep_files(base_suffix)
+    if not paths:
+        return None
+    reps = []
+    for path in paths:
+        with open(path) as fh:
+            reps.append(load_rift_csv(fh))
+    agg = aggregate_reps(reps)
+
+    # Same hard error as the other suites (#773): a point missing from one rep yields a
+    # complete-looking report whose cells rest on fewer samples than it claims, with exit 0 and
+    # nothing said. Refuse rather than publish that.
+    incomplete = {k: c["reps"] for k, c in agg.items() if c["reps"] != len(paths)}
+    if incomplete:
+        detail = ", ".join(f"{s}@c={c}/{m}: {n} of {len(paths)}"
+                           for (s, c, m), n in sorted(incomplete.items())[:8])
+        raise SystemExit(
+            f"bench_microcks: incomplete repetitions across {len(paths)} rep files: {detail}"
+            f"{' …' if len(incomplete) > 8 else ''}\n"
+            f"Every point must appear in every rep, or the median silently rests on fewer samples "
+            f"than the report claims. Re-run the missing reps, or aggregate a consistent subset.")
+
+    out = os.path.join(RESULTS_DIR, f"direct_microcks{base_suffix}_median.csv")
+    with open(out, "w") as fh:
+        fh.write(CSV_HEADER + ",reps,rps_spread_pct\n")
+        for (scen, conns, mode), c in sorted(agg.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+            spread = f"{c['rps_spread_pct']:.1f}" if c["rps_spread_pct"] != "" else ""
+            fh.write(f"{csv_row(scen, conns, mode, c)},{c['reps']},{spread}\n")
+    propagate_run_settings(base_suffix)
+    print(f"[microcks] {len(paths)} reps -> {os.path.basename(out)}; "
+          f"render with --report --csv-suffix {base_suffix}_median")
+    return out, len(paths)
+
+
+# --------------------------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------------------------
+
+def engine_csv_path(engine, csv_suffix):
+    return os.path.join(RESULTS_DIR, f"direct_{engine}{csv_suffix}.csv")
+
+
+def load_engine_csv(engine, csv_suffix, conns):
+    """{scenario: {rps, p50, p99, reps, spread}} for one engine at the comparison point, or {}.
+
+    Filtering on mode+connections is the stale-artefact guard the WireMock leg uses for the same
+    reason: a CSV left behind by a sweep or an open-loop run holds rows that are not comparable, and
+    blending them into the headline table would be silently wrong."""
+    path = engine_csv_path(engine, csv_suffix)
+    if not os.path.exists(path):
+        return {}
+    with open(path) as fh:
+        return {r["scenario"]: {"rps": r["rps"], "p50": r["p50_ms"], "p99": r["p99_ms"],
+                                # Present only in a `_median.csv`. A median with no visible spread
+                                # cannot distinguish a clean run from one where a rep disagreed.
+                                "reps": r.get("reps", ""), "spread": r.get("rps_spread_pct", "")}
+                for r in load_rift_csv(fh)
+                if r.get("mode", "closed") == "closed" and int(r["connections"]) == conns}
+
+
+def _fmt(value, digits=0):
+    if value in (None, ""):
+        return "—"
+    try:
+        return f"{float(value):,.{digits}f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _ms(value):
+    """A latency cell. The unit goes inside, so an absent value renders as a bare em dash rather
+    than the nonsense `— ms`."""
+    formatted = _fmt(value, 2)
+    return formatted if formatted == "—" else f"{formatted} ms"
+
+
+def _ratio(rift_rps, other_rps):
+    try:
+        r, o = float(rift_rps), float(other_rps)
+        return f"**{r / o:.1f}x**" if o > 0 else "—"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def report(conns, csv_suffix="", duration=None):
+    """Write the Microcks comparison report.
+
+    A report of its own rather than a fourth column bolted onto the WireMock one: the comparable
+    scenario set is a strict subset (six of thirteen), so the two tables have different row sets and
+    merging them would either drop WireMock rows or show empty Microcks cells that read as "slow"
+    rather than "not comparable"."""
+    propagate_run_settings(csv_suffix)
+    rift = load_engine_csv("rift", csv_suffix, conns)
+    microcks = load_engine_csv("microcks", csv_suffix, conns)
+    wiremock = load_engine_csv("wiremock", csv_suffix, conns)
+    if not microcks:
+        raise SystemExit(f"bench_microcks: no Microcks CSV at {engine_csv_path('microcks', csv_suffix)} "
+                         f"— run `--run-all` first")
+
+    version = recorded_setting("version", csv_suffix, DEFAULT_MICROCKS_VERSION)
+    threads = recorded_setting("threads", csv_suffix, "?")
+    heap = recorded_setting("heap", csv_suffix, DEFAULT_HEAP)
+    warmup = recorded_setting("warmup", csv_suffix, DEFAULT_WARMUP)
+
+    lines = [
+        "# Rift vs Microcks — HTTP mock serving",
+        "",
+        f"Microcks **{version}** (native JVM, `uber` profile), "
+        f"Tomcat max threads **{threads}**, heap **{heap}**, warmup **{warmup}**, "
+        f"**{conns}** keep-alive connections"
+        + (f", **{duration}** per scenario point." if duration else "."),
+        "",
+        "Generated by `tests/benchmark/scripts/bench_microcks.py`. Every engine ran alone, on a "
+        "disjoint port range, one imposter per process.",
+        "",
+        "## Throughput and latency",
+        "",
+        "| Scenario | Microcks | Rift | Rift/Microcks | Microcks p50 | Rift p50 | Microcks p99 | Rift p99 |",
+        "|:---------|---------:|-----:|--------------:|-------------:|---------:|-------------:|---------:|",
+    ]
+    for name in COMPARABLE:
+        mrow = microcks.get(name)
+        if not mrow:
+            continue
+        rrow = rift.get(name) or {}
+        lines.append(
+            f"| {name} | {_fmt(mrow.get('rps'))} | {_fmt(rrow.get('rps'))} | "
+            f"{_ratio(rrow.get('rps'), mrow.get('rps'))} | "
+            f"{_ms(mrow.get('p50'))} | {_ms(rrow.get('p50'))} | "
+            f"{_ms(mrow.get('p99'))} | {_ms(rrow.get('p99'))} |")
+
+    spreads = [f"{e} ≤{max(float(r['spread']) for r in d.values() if r.get('spread')):.1f}%"
+               for e, d in (("Microcks", microcks), ("Rift", rift), ("WireMock", wiremock))
+               if d and any(r.get("spread") for r in d.values())]
+    if spreads:
+        lines += ["", f"<sub>Median of repetitions; peak-to-peak spread: {', '.join(spreads)}.</sub>"]
+
+    lines += ["", "## Stub growth", "",
+              "Read each engine down its own column, not across. The question this suite exists to "
+              "answer is whether throughput holds as the number of matchable request shapes grows, "
+              "which is the interval between `simple_health` and `api_last`.", ""]
+    growth = [("simple_health", "trivial stub"), ("api_first", "first of the API corpus"),
+              ("api_middle", "middle of the API corpus"), ("api_last", "last of the API corpus")]
+    lines += ["| Point | Workload | Microcks | Rift | WireMock |",
+              "|:------|:---------|---------:|-----:|---------:|"]
+    for name, label in growth:
+        lines.append(f"| {name} | {label} | {_fmt(microcks.get(name, {}).get('rps'))} | "
+                     f"{_fmt(rift.get(name, {}).get('rps'))} | "
+                     f"{_fmt(wiremock.get(name, {}).get('rps'))} |")
+    for engine_name, data in (("Microcks", microcks), ("Rift", rift), ("WireMock", wiremock)):
+        lo, hi = data.get("simple_health", {}).get("rps"), data.get("api_last", {}).get("rps")
+        if lo and hi:
+            try:
+                delta = (float(hi) - float(lo)) / float(lo) * 100.0
+                lines.append("")
+                lines.append(f"- **{engine_name}:** {_fmt(lo)} -> {_fmt(hi)} RPS "
+                             f"({delta:+.0f}%) from a trivial stub to the last of the API corpus.")
+            except (TypeError, ValueError, ZeroDivisionError):
+                pass
+
+    lines += ["", "## What is not comparable, and why", "",
+              "Microcks is spec-driven, so several fixture scenarios have no faithful OpenAPI "
+              "analogue. They are **excluded rather than approximated** — an approximation would "
+              "publish a ratio between two different workloads:", ""]
+    for name in sorted(UNTRANSLATABLE):
+        lines.append(f"- **`{name}`** — {UNTRANSLATABLE[name]}")
+
+    lines += ["", "## Where this comparison is not apples-to-apples", "",
+              "- **Stubs vs specification.** Rift and WireMock are handed stubs; Microcks is handed "
+              "an OpenAPI document and derives operations from it. \"N stubs\" is translated as "
+              "\"N `path` x `verb` operations\", which is the nearest honest analogue, but it is a "
+              "translation and not an identity.",
+              "- **No catch-all for `no_match`.** Rift answers an unmatched request with an empty "
+              "200 and WireMock is given a catch-all mapping to reproduce that. Microcks has no "
+              "catch-all mechanism, so it is measured as the 404 it genuinely returns — a cheaper "
+              "path than rendering a response, so this row flatters Microcks.",
+              "- **In-memory MongoDB.** The `uber` profile stores everything in an embedded "
+              "in-memory Mongo. A production Microcks talks to a real MongoDB over a socket, so "
+              "this configuration is faster than a real deployment — again, flattering Microcks.",
+              "- **AsyncAPI disabled.** `-Dasync-api.enabled=false` removes background work "
+              "unrelated to HTTP mocking. Flatters Microcks.",
+              "- **One service per process.** Microcks multiplexes every service on one port, and "
+              "its throughput is sensitive to total resident corpus size, so loading all 14 "
+              "imposters into one JVM would have penalised it against WireMock's per-imposter JVM. "
+              "Each Microcks instance here holds exactly the imposter under test.",
+              "- **The first scenario in each group meets a colder JIT.** Scenarios sharing an "
+              "imposter share one JVM and run in fixture order, so `api_first` is measured on a "
+              "younger JIT than `api_last`. The per-scenario warmup exists to absorb this and the "
+              "median-of-reps limits what survives it, but at short warmups it is visible — and it "
+              "biases *against* whichever scenario runs first, not against Microcks as a whole. "
+              "WireMock's leg has the same property, so the two are consistent.",
+              "- **Protocol scope.** Microcks also covers AsyncAPI, Kafka, MQTT, AMQP, WebSocket "
+              "and gRPC, which Rift does not. This benchmark is deliberately confined to the HTTP "
+              "matching path where the two overlap, and says nothing about the rest.",
+              ""]
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    out = os.path.join(RESULTS_DIR, "MICROCKS_BENCHMARK_REPORT.md")
+    with open(out, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    print(f"[microcks] wrote {out}")
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------------
+
+def resolve_suffix(csv_suffix, rep):
+    return f"{csv_suffix}_rep{rep}" if rep else csv_suffix
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Microcks benchmark suite (issue #900)")
+    ap.add_argument("--run-all", action="store_true", help="bench Microcks and write its CSV")
+    ap.add_argument("--report", action="store_true", help="write the comparison report from CSVs")
+    ap.add_argument("--aggregate", action="store_true", help="median-of-reps into the base CSV")
+    ap.add_argument("--emit-spec", metavar="IMPOSTER",
+                    help="print the generated OpenAPI document for one imposter and exit")
+    ap.add_argument("--duration", default="20s")
+    ap.add_argument("--warmup", default=DEFAULT_WARMUP)
+    ap.add_argument("--connections", type=int, default=50)
+    ap.add_argument("--sweep-connections", default=None,
+                    help="comma-separated connection counts, e.g. 50,256")
+    ap.add_argument("--jar", default=DEFAULT_JAR)
+    ap.add_argument("--java", default="java", help="JDK 21+ launcher to run Microcks with")
+    ap.add_argument("--heap", default=DEFAULT_HEAP)
+    ap.add_argument("--tomcat-threads", type=int, default=None)
+    ap.add_argument("--microcks-version", default=DEFAULT_MICROCKS_VERSION)
+    ap.add_argument("--csv-suffix", default="")
+    ap.add_argument("--rep", type=int, default=None)
+    args = ap.parse_args()
+
+    if args.emit_spec:
+        by_name = {name: stubs for _, name, stubs in IMPOSTERS}
+        if args.emit_spec not in by_name:
+            raise SystemExit(f"bench_microcks: unknown imposter {args.emit_spec!r}; "
+                             f"choose from {', '.join(sorted(by_name))}")
+        print(json.dumps(openapi_spec(args.emit_spec, by_name[args.emit_spec]), indent=2))
+        sys.exit(0)
+
+    conn_list = (parse_conn_list(args.sweep_connections) if args.sweep_connections
+                 else [args.connections])
+    suffix = resolve_suffix(args.csv_suffix, args.rep)
+
+    if args.run_all:
+        run_all(args.jar, args.duration, args.warmup, conn_list, suffix,
+                args.microcks_version, args.tomcat_threads, args.heap, args.java)
+    if args.aggregate:
+        aggregate(args.csv_suffix)
+    if args.report:
+        report(conn_list[-1], args.csv_suffix, args.duration)
+    if not (args.run_all or args.report or args.aggregate):
+        ap.print_help()

--- a/tests/benchmark/scripts/test_bench_microcks.py
+++ b/tests/benchmark/scripts/test_bench_microcks.py
@@ -367,6 +367,73 @@ class SpecEnvelope(unittest.TestCase):
         self.assertIn(b'{"a":1}', body)
 
 
+class RunSettingsPropagation(unittest.TestCase):
+    """The median report must be able to state the settings it was measured with.
+
+    This class exists because the first draft got it wrong in two ways that both survive as a
+    plausible-looking report: settings filed under a suffix `--report` never reads (so it printed
+    flag *defaults* while claiming to describe the run), and first-rep-wins on disagreement (so a
+    median across reps with different heaps described a configuration nothing measured)."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self._real = bm.RESULTS_DIR
+        bm.RESULTS_DIR = self.tmp.name
+        self.addCleanup(lambda: setattr(bm, "RESULTS_DIR", self._real))
+
+    def _rep(self, n, **settings):
+        """A rep's CSV (so `find_reps` sees it) plus its sidecars."""
+        with open(os.path.join(self.tmp.name, f"direct_microcks_rep{n}.csv"), "w") as fh:
+            fh.write("scenario,connections,mode,rps\napi_last,256,closed,1\n")
+        for name, value in settings.items():
+            with open(bm.sidecar_path(name, f"_rep{n}"), "w") as fh:
+                fh.write(str(value))
+
+    def test_settings_land_where_report_reads_them(self):
+        self._rep(1, warmup="10s", threads="256", heap="4g", version="1.14.0")
+        self._rep(2, warmup="10s", threads="256", heap="4g", version="1.14.0")
+        bm.propagate_run_settings("")
+        self.assertEqual(bm.recorded_setting("warmup", bm.median_suffix("")), "10s")
+        self.assertEqual(bm.recorded_setting("threads", bm.median_suffix("")), "256")
+        self.assertEqual(bm.recorded_setting("heap", bm.median_suffix("")), "4g")
+        self.assertEqual(bm.recorded_setting("version", bm.median_suffix("")), "1.14.0")
+
+    def test_median_suffix_is_what_ci_reports_on(self):
+        self.assertEqual(bm.median_suffix(""), "_median")
+
+    def test_disagreeing_reps_are_refused_not_averaged(self):
+        self._rep(1, heap="4g")
+        self._rep(2, heap="8g")
+        with self.assertRaises(SystemExit) as ctx:
+            bm.propagate_run_settings("")
+        self.assertIn("--heap", str(ctx.exception))
+
+    def test_disagreeing_warmup_is_refused(self):
+        """The setting the like-for-like claim rests on (#866)."""
+        self._rep(1, warmup="10s")
+        self._rep(2, warmup="3s")
+        with self.assertRaises(SystemExit):
+            bm.propagate_run_settings("")
+
+    def test_absent_settings_are_simply_absent(self):
+        self._rep(1)
+        self.assertEqual(bm.propagate_run_settings(""), {})
+        self.assertIsNone(bm.recorded_setting("heap", bm.median_suffix("")))
+
+    def test_finds_every_rep(self):
+        self._rep(1, heap="4g")
+        self._rep(2, heap="4g")
+        self._rep(3, heap="4g")
+        self.assertEqual(bm.find_reps(""), [1, 2, 3])
+
+    def test_every_reported_setting_is_propagated(self):
+        """A setting the report prints but nobody carries forward renders as a default."""
+        self.assertEqual(set(bm.PROPAGATED_SETTINGS),
+                         {"warmup", "threads", "heap", "version"})
+
+
 class PublishWorkflow(unittest.TestCase):
     """The Microcks leg of `benchmark-publish.yml`.
 

--- a/tests/benchmark/scripts/test_bench_microcks.py
+++ b/tests/benchmark/scripts/test_bench_microcks.py
@@ -288,6 +288,39 @@ class FairnessKnobs(unittest.TestCase):
         cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256)
         self.assertIn("-Dspring.profiles.active=uber", cmd)
 
+    def test_tuned_series_disables_invocation_stats(self):
+        """The whole reason this class matters. `mocks.enable-invocation-stats` defaults to ON and
+        persists a record per mock call — the analogue of WireMock's request journal, which is
+        disabled in its leg. Leaving it on would compare Microcks-with-recording against
+        Rift-without, and unlike every other deviation here that error flatters RIFT."""
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256)
+        self.assertIn("--mocks.enable-invocation-stats=false", cmd)
+
+    def test_tuned_series_disables_the_cors_policy(self):
+        """Four Access-Control-* headers on every response that neither Rift nor WireMock emits."""
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256)
+        self.assertIn("--mocks.rest.enable-cors-policy=false", cmd)
+
+    def test_stock_series_restores_every_default_it_claims_to(self):
+        """A "stock defaults" column that quietly keeps a tune is worse than no column."""
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256, stock=True)
+        for flag in bm.FAIRNESS_FLAGS:
+            self.assertNotIn(flag, cmd)
+        self.assertFalse([c for c in cmd if c.startswith("--server.tomcat.threads.max")],
+                         "the stock series must not pin the pool")
+
+    def test_stock_series_still_pins_heap_and_logging(self):
+        """Determinism knobs, not fairness ones: floating them would make the stock column
+        non-comparable between hosts, and INFO logging would measure the logging pipeline (#718)."""
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256, heap="4g", stock=True)
+        self.assertIn("-Xmx4g", cmd)
+        self.assertIn("--logging.level.root=WARN", cmd)
+
+    def test_stock_engine_label_is_distinct(self):
+        """It must not enter the headline Rift/Microcks ratio."""
+        self.assertEqual(bm.STOCK_ENGINE, "microcks-stock")
+        self.assertNotEqual(bm.STOCK_ENGINE, "microcks")
+
     def test_command_disables_asyncapi_and_lowers_logging(self):
         """Per #718: a per-request log site turns a throughput benchmark into a measurement of the
         logging pipeline. The same trap applies to every engine, not just Rift."""
@@ -470,6 +503,24 @@ class PublishWorkflow(unittest.TestCase):
 
     def test_the_install_verifies_the_jar_is_a_spring_boot_launcher(self):
         self.assertIn("Start-Class: io.github.microcks.MicrocksApplication", self.text)
+
+    def test_microcks_only_skips_the_legs_it_does_not_need(self):
+        """Mountebank and WireMock contribute nothing to a Rift-vs-Microcks table, and re-measuring
+        them turns a ~30min dispatch into ~2h."""
+        self.assertEqual(self.text.count("!inputs.microcks_only"), 3,
+                         "expected the mb, wiremock and sweep legs to be gated")
+
+    def test_microcks_only_measures_rift_itself(self):
+        """Rift is the ratio's denominator, so it must come from the SAME dispatch — the one column
+        that cannot be cited from a previous run."""
+        self.assertIn("bench_direct.py --run-all --engines rift", self.text)
+        self.assertIn("BENCH_MICROCKS_ONLY", self.text)
+
+    def test_microcks_only_does_not_read_the_parked_wiremock_artefacts(self):
+        """Those only exist when the WireMock leg ran; an unconditional `cp` would fail the job."""
+        guarded = self.text.split('if [ "$BENCH_MICROCKS_ONLY" != "true" ]; then', 1)
+        self.assertEqual(len(guarded), 2, "the cp-back must be guarded")
+        self.assertIn("direct_rift_comparison_median.csv", guarded[1].split("fi", 1)[0])
 
     def test_the_leg_aggregates_before_reporting(self):
         """Publishing a single rep is what #746 had to retract."""

--- a/tests/benchmark/scripts/test_bench_microcks.py
+++ b/tests/benchmark/scripts/test_bench_microcks.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Tests for the Microcks suite (issue #900).
+
+The thing under test is the **translator**, because it is the only part of this suite that can be
+wrong in a way that still produces a plausible published number. A launch bug fails loudly; a
+translation bug produces a Microcks that serves the right body for the six measured scenarios while
+holding a thinner or differently-shaped corpus than Rift did, and the run reports it as fast.
+
+So the properties pinned here are the ones the report's fairness claims rest on:
+
+  * bodies come out byte-identical to Rift's, so `EXPECT_BODY` stays a strong assertion;
+  * the operation count matches the stub count for the path/verb family;
+  * query-discriminated stubs collapse to ONE operation with N named examples, which is what makes
+    Microcks infer `URI_PARAMS` — get this wrong and the 100-way dispatch silently becomes 1-way;
+  * every fixture scenario is either measured or explicitly refused with a reason;
+  * an untranslatable predicate is fatal, never skipped.
+
+Run:
+    python3 -m unittest test_bench_microcks -v
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import bench_direct  # noqa: E402
+import bench_microcks as bm  # noqa: E402
+
+
+class TranslatesPathVerbFamily(unittest.TestCase):
+    """The shape the stub-growth claim is measured on: distinct literal paths, one example each."""
+
+    def test_simple_imposter_becomes_one_operation_per_stub(self):
+        stubs = bench_direct.simple_stubs()
+        spec = bm.openapi_spec("Simple", stubs)
+        ops = [(p, verb) for p, item in spec["paths"].items() for verb in item]
+        self.assertEqual(len(ops), len(stubs))
+        self.assertEqual(sorted(p for p, _ in ops), ["/health", "/ping"])
+
+    def test_api_imposter_operation_count_matches_stub_count(self):
+        stubs = bench_direct.api_stubs()
+        spec = bm.openapi_spec("API", stubs)
+        ops = sum(len(item) for item in spec["paths"].values())
+        self.assertEqual(ops, len(stubs))
+        self.assertEqual(ops, bm.expected_operations(stubs))
+
+    def test_methods_on_a_shared_path_stay_separate_operations(self):
+        """`/api/v1/resource1/1` carries GET, PUT and DELETE. Collapsing them would drop two thirds
+        of the corpus while every measured scenario still passed."""
+        spec = bm.openapi_spec("API", bench_direct.api_stubs(resources=1, per=1))
+        self.assertEqual(sorted(spec["paths"]["/api/v1/resource1/1"]),
+                         ["delete", "get", "put"])
+
+    def test_status_code_is_carried_through(self):
+        spec = bm.openapi_spec("API", bench_direct.api_stubs(resources=1, per=1))
+        self.assertIn("204", spec["paths"]["/api/v1/resource1/1"]["delete"]["responses"])
+
+    def test_204_carries_no_content_block(self):
+        """A 204 with an empty example makes Microcks emit a Content-Type on a bodiless response,
+        which Rift does not do."""
+        op = bm.openapi_spec("API", bench_direct.api_stubs(resources=1, per=1))[
+            "paths"]["/api/v1/resource1/1"]["delete"]
+        self.assertNotIn("content", op["responses"]["204"])
+
+    def test_operation_ids_are_unique(self):
+        spec = bm.openapi_spec("API", bench_direct.api_stubs())
+        ids = [op["operationId"] for item in spec["paths"].values() for op in item.values()]
+        self.assertEqual(len(ids), len(set(ids)))
+
+
+class BodiesAreByteIdenticalToRift(unittest.TestCase):
+    """The property that lets this suite reuse `EXPECT_BODY` unchanged.
+
+    Microcks serves a *string* example verbatim but re-serializes a parsed object, and the fixture
+    builds bodies with `json.dumps` (`{"id": 1}`, with spaces) while a JSON serializer would emit
+    `{"id":1}`. If these tests ever fail, the fix is NOT to weaken `EXPECT_BODY` to a
+    whitespace-insensitive match — it is to restore the raw-string example."""
+
+    def test_json_example_value_is_the_raw_fixture_string(self):
+        stubs = bench_direct.api_stubs(resources=1, per=1)
+        spec = bm.openapi_spec("API", stubs)
+        example = (spec["paths"]["/api/v1/resource1/1"]["get"]["responses"]["200"]
+                   ["content"]["application/json"]["examples"])
+        value = next(iter(example.values()))["value"]
+        self.assertIsInstance(value, str)
+        self.assertEqual(value, json.dumps({"id": 1, "name": "resource1_1"}))
+        self.assertIn('"name": "resource1_1"', value)
+
+    def test_marker_from_expect_body_is_present_in_the_generated_example(self):
+        """The end-to-end version of the property: the exact substring `verify_body` will look for
+        must appear in the bytes Microcks is being told to serve."""
+        spec = bm.openapi_spec("API", bench_direct.api_stubs())
+        example = (spec["paths"]["/api/v1/resource5/5"]["get"]["responses"]["200"]
+                   ["content"]["application/json"]["examples"])
+        value = next(iter(example.values()))["value"]
+        self.assertIn(bench_direct.EXPECT_BODY["api_middle"], value)
+
+    def test_plain_text_body_is_filed_under_text_plain(self):
+        """`/health` -> `OK` sets no Content-Type. Filing it as JSON makes Microcks reject the
+        artifact, which would look like a launch failure rather than a translation one."""
+        spec = bm.openapi_spec("Simple", bench_direct.simple_stubs())
+        content = spec["paths"]["/health"]["get"]["responses"]["200"]["content"]
+        self.assertEqual(list(content), ["text/plain"])
+        self.assertEqual(next(iter(content["text/plain"]["examples"].values()))["value"], "OK")
+
+    def test_declared_content_type_wins_over_inference(self):
+        stub = {"predicates": [{"equals": {"method": "GET", "path": "/x"}}],
+                "responses": [{"is": {"statusCode": 200,
+                                      "headers": {"Content-Type": "application/xml; charset=utf-8"},
+                                      "body": "<a>1</a>"}}]}
+        content = bm.openapi_spec("S", [stub])["paths"]["/x"]["get"]["responses"]["200"]["content"]
+        self.assertEqual(list(content), ["application/xml"])
+
+    def test_parsed_body_is_refused_rather_than_reserialized(self):
+        """Guessing a separator here is exactly how the bodies would drift out of sync."""
+        stub = {"predicates": [{"equals": {"method": "GET", "path": "/x"}}],
+                "responses": [{"is": {"statusCode": 200, "body": {"id": 1}}}]}
+        with self.assertRaises(SystemExit) as ctx:
+            bm.openapi_spec("S", [stub])
+        self.assertIn("pre-serialized", str(ctx.exception))
+
+
+class QueryDispatchTranslation(unittest.TestCase):
+    """100 query-`equals` stubs must become ONE operation with 100 named examples.
+
+    This is the translation most likely to be wrong in a way that reads as a Microcks win: if the
+    request examples are dropped, Microcks has one response and answers every `page` with it —
+    a 1-way dispatch measured under a 100-way label."""
+
+    def setUp(self):
+        self.stubs = bench_direct.query_stubs()
+        self.spec = bm.openapi_spec("Query", self.stubs)
+        self.op = self.spec["paths"]["/query/search"]["get"]
+
+    def test_collapses_to_a_single_operation(self):
+        self.assertEqual(list(self.spec["paths"]), ["/query/search"])
+        self.assertEqual(list(self.spec["paths"]["/query/search"]), ["get"])
+
+    def test_one_response_example_per_stub(self):
+        examples = self.op["responses"]["200"]["content"]["application/json"]["examples"]
+        self.assertEqual(len(examples), len(self.stubs))
+
+    def test_query_parameters_are_required_so_microcks_derives_dispatch_rules(self):
+        params = {p["name"]: p for p in self.op["parameters"]}
+        self.assertEqual(sorted(params), ["page", "size"])
+        for p in params.values():
+            self.assertTrue(p["required"], "an optional parameter is left out of URI_PARAMS rules")
+            self.assertEqual(p["in"], "query")
+
+    def test_request_and_response_examples_share_names(self):
+        """Microcks pairs a request example with a response example by NAME. Divergent names mean no
+        pairing, and the dispatcher silently falls back to a single response."""
+        resp_names = set(self.op["responses"]["200"]["content"]["application/json"]["examples"])
+        for param in self.op["parameters"]:
+            self.assertEqual(set(param["examples"]), resp_names)
+
+    def test_example_values_are_the_fixture_values(self):
+        params = {p["name"]: p for p in self.op["parameters"]}
+        last = bm._example_name(len(self.stubs))
+        self.assertEqual(params["page"]["examples"][last]["value"], str(len(self.stubs)))
+        self.assertEqual(params["size"]["examples"][last]["value"], "10")
+        resp = self.op["responses"]["200"]["content"]["application/json"]["examples"][last]["value"]
+        self.assertIn(bench_direct.EXPECT_BODY["query_last"], resp)
+
+    def test_path_only_operations_carry_no_parameters_key(self):
+        spec = bm.openapi_spec("Simple", bench_direct.simple_stubs())
+        self.assertNotIn("parameters", spec["paths"]["/health"]["get"])
+
+
+class UntranslatablePredicatesAreFatal(unittest.TestCase):
+    """`_fail` exists so a stub nobody understood cannot be quietly dropped: the six measured
+    scenarios would still pass while the surrounding corpus went missing."""
+
+    def _reject(self, stub):
+        with self.assertRaises(SystemExit):
+            bm.openapi_spec("S", [stub])
+
+    def test_regex_path_is_refused(self):
+        self._reject(bench_direct.regex_stubs(1)[0])
+
+    def test_header_predicate_is_refused(self):
+        self._reject(bench_direct.header_stubs(1)[0])
+
+    def test_body_predicate_is_refused(self):
+        self._reject(bench_direct.json_body_stubs(1)[0])
+
+    def test_and_or_predicate_is_refused(self):
+        self._reject(bench_direct.complex_stubs(1)[0])
+
+    def test_multi_predicate_stub_is_refused(self):
+        self._reject(bench_direct.jsonpath_stubs(1)[0])
+
+    def test_stub_without_a_path_is_refused(self):
+        self._reject({"predicates": [{"equals": {"method": "GET"}}]},)
+
+    def test_multiple_responses_are_refused(self):
+        self._reject({"predicates": [{"equals": {"path": "/x"}}],
+                      "responses": [{"is": {"statusCode": 200}}, {"is": {"statusCode": 201}}]})
+
+
+class ScenarioClassification(unittest.TestCase):
+    """Every fixture scenario is measured or refused — never silently absent from a report that
+    claims to cover the suite."""
+
+    def test_every_scenario_is_classified(self):
+        bm.check_scenario_coverage()   # raises if not
+
+    def test_comparable_and_untranslatable_are_disjoint(self):
+        self.assertEqual(set(bm.COMPARABLE) & set(bm.UNTRANSLATABLE), set())
+
+    def test_classification_covers_exactly_the_fixture(self):
+        self.assertEqual(set(bm.COMPARABLE) | set(bm.UNTRANSLATABLE),
+                         {s[0] for s in bench_direct.SCENARIOS})
+
+    def test_every_exclusion_states_a_reason(self):
+        for name, reason in bm.UNTRANSLATABLE.items():
+            self.assertGreater(len(reason), 60, f"{name}'s exclusion reason is too thin to publish")
+
+    def test_comparable_scenarios_are_drawn_from_the_fixture(self):
+        rows = bm.comparable_scenarios()
+        self.assertEqual([r[0] for r in rows],
+                         [s[0] for s in bench_direct.SCENARIOS if s[0] in bm.COMPARABLE])
+
+    def test_every_comparable_scenario_has_an_expected_body_marker(self):
+        for name in bm.COMPARABLE:
+            self.assertIn(name, bench_direct.EXPECT_BODY)
+
+    def test_scenario_groups_share_a_launch_per_imposter(self):
+        """The four API scenarios must land in one group, or the run pays a JVM start per scenario."""
+        groups = dict(bm.scenario_groups())
+        api = [r[0] for r in groups[4545]]
+        self.assertEqual(api, ["api_first", "api_middle", "api_last", "no_match"])
+
+    def test_every_group_maps_to_a_known_imposter(self):
+        by_port = bm.imposter_by_port()
+        for base_port, _rows in bm.scenario_groups():
+            self.assertIn(base_port, by_port)
+
+
+class NoMatchIsMeasuredAsA404(unittest.TestCase):
+    """Microcks has no catch-all, so `no_match` is a 404. The gate must expect that specific status
+    rather than being relaxed to "any status", which would stop catching a mis-served stub."""
+
+    def test_no_match_expects_a_4xx(self):
+        self.assertEqual(bm.EXPECT_STATUS_PREFIX["no_match"], "4")
+        self.assertTrue(bm._status_ok("no_match", {"404": 100}))
+        self.assertFalse(bm._status_ok("no_match", {"200": 100}))
+
+    def test_other_scenarios_still_require_2xx(self):
+        self.assertTrue(bm._status_ok("api_last", {"200": 10}))
+        self.assertFalse(bm._status_ok("api_last", {"404": 10}))
+        self.assertFalse(bm._status_ok("api_last", {"500": 10}))
+
+    def test_empty_distribution_is_not_ok(self):
+        self.assertFalse(bm._status_ok("api_last", {}))
+
+    def test_no_match_body_marker_is_still_the_empty_default(self):
+        """The 404 body is empty, so `EXPECT_BODY[no_match] is None` remains a real assertion that
+        nothing matched — the status difference does not weaken the body gate."""
+        self.assertIsNone(bench_direct.EXPECT_BODY["no_match"])
+
+
+class FairnessKnobs(unittest.TestCase):
+    def test_tomcat_threads_never_below_offered_concurrency(self):
+        """Tomcat's default is 200 while the published table drives 256 — the exact trap the
+        WireMock leg's container-thread pin exists for."""
+        self.assertGreaterEqual(bm.tomcat_thread_count([256]), 256)
+        self.assertGreaterEqual(bm.tomcat_thread_count([50, 256]), 256)
+
+    def test_tomcat_threads_at_least_core_count(self):
+        self.assertGreaterEqual(bm.tomcat_thread_count([1]), os.cpu_count() or 1)
+
+    def test_tomcat_threads_override_is_honoured(self):
+        self.assertEqual(bm.tomcat_thread_count([50], override=999), 999)
+
+    def test_tomcat_threads_override_rejects_nonsense(self):
+        with self.assertRaises(SystemExit):
+            bm.tomcat_thread_count([50], override=0)
+
+    def test_command_pins_heap_on_both_bounds(self):
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256, heap="4g")
+        self.assertIn("-Xms4g", cmd)
+        self.assertIn("-Xmx4g", cmd)
+
+    def test_command_selects_the_standalone_profile(self):
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256)
+        self.assertIn("-Dspring.profiles.active=uber", cmd)
+
+    def test_command_disables_asyncapi_and_lowers_logging(self):
+        """Per #718: a per-request log site turns a throughput benchmark into a measurement of the
+        logging pipeline. The same trap applies to every engine, not just Rift."""
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 256)
+        self.assertIn("-Dasync-api.enabled=false", cmd)
+        self.assertIn("--logging.level.root=WARN", cmd)
+
+    def test_command_pins_the_port_and_thread_pool(self):
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 128)
+        self.assertIn("--server.port=4845", cmd)
+        self.assertIn("--server.tomcat.threads.max=128", cmd)
+
+    def test_command_honours_an_alternate_jdk(self):
+        cmd = bm.microcks_cmd("/tmp/app.jar", 4845, 8, java="/opt/jdk21/bin/java")
+        self.assertEqual(cmd[0], "/opt/jdk21/bin/java")
+
+
+class JavaPreflight(unittest.TestCase):
+    def test_parses_modern_and_legacy_version_strings(self):
+        self.assertEqual(bm.parse_java_major('openjdk version "21.0.5" 2024-10-15'), 21)
+        self.assertEqual(bm.parse_java_major('java version "1.8.0_402"'), 8)
+        self.assertIsNone(bm.parse_java_major("no version here"))
+
+    def test_requires_21_because_the_jar_is_class_file_65(self):
+        self.assertEqual(bm.MIN_JAVA_MAJOR, 21)
+
+    def test_rejects_a_too_old_jdk_with_an_actionable_message(self):
+        import subprocess as sp
+        real = sp.run
+        sp.run = lambda *a, **k: type("R", (), {"stdout": "", "stderr": 'openjdk version "17.0.13"'})()
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                bm.java_preflight()
+            self.assertIn("21", str(ctx.exception))
+        finally:
+            sp.run = real
+
+
+class PortsAndUrls(unittest.TestCase):
+    def test_offset_is_disjoint_from_the_other_engines(self):
+        """rift 0, mb +100, wiremock +200, microcks +300 — the property that stops one engine from
+        being measured in place of another when a teardown leaks."""
+        self.assertEqual(bm.MICROCKS_OFFSET, 300)
+
+    def test_mock_url_follows_the_microcks_rest_layout(self):
+        self.assertEqual(bm.mock_url(4845, "API", "/api/v1/resource1"),
+                         "http://localhost:4845/rest/API/1.0.0/api/v1/resource1")
+
+    def test_mock_url_encodes_the_service_name(self):
+        self.assertIn("My%20API", bm.mock_url(4845, "My API", "/x"))
+
+    def test_mock_url_preserves_a_query_string(self):
+        url = bm.mock_url(4845, "Query", "/query/search?page=100&size=10")
+        self.assertTrue(url.endswith("/query/search?page=100&size=10"))
+
+
+class SpecEnvelope(unittest.TestCase):
+    def test_service_name_and_version_drive_the_mock_path(self):
+        spec = bm.openapi_spec("API", bench_direct.simple_stubs())
+        self.assertEqual(spec["info"]["title"], "API")
+        self.assertEqual(spec["info"]["version"], bm.SERVICE_VERSION)
+
+    def test_spec_says_it_is_generated(self):
+        """A committed-looking OpenAPI file that someone hand-edits is a fixture drift waiting to
+        happen; the description is where that gets said."""
+        spec = bm.openapi_spec("API", bench_direct.simple_stubs())
+        self.assertIn("bench_microcks.py", spec["info"]["description"])
+
+    def test_spec_is_json_serializable(self):
+        json.dumps(bm.openapi_spec("API", bench_direct.api_stubs()))
+
+    def test_multipart_body_is_well_formed(self):
+        boundary, body = bm._multipart("file", "x.json", b'{"a":1}')
+        self.assertIn(boundary.encode(), body)
+        self.assertTrue(body.endswith(f"--{boundary}--\r\n".encode()))
+        self.assertIn(b'filename="x.json"', body)
+        self.assertIn(b'{"a":1}', body)
+
+
+class PublishWorkflow(unittest.TestCase):
+    """The Microcks leg of `benchmark-publish.yml`.
+
+    Same reasoning as the WireMock leg's equivalent: the publication workflow is where a
+    like-for-like comparison is won or lost, and the failure modes are silent — a leg that pins its
+    own version, or benches a container, still renders a table."""
+
+    WORKFLOW = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..",
+                            ".github", "workflows", "benchmark-publish.yml")
+
+    @classmethod
+    def setUpClass(cls):
+        with open(cls.WORKFLOW) as fh:
+            cls.text = fh.read()
+
+    def test_the_leg_exists_and_is_repeated(self):
+        self.assertIn("bench_microcks.py --run-all --rep", self.text)
+
+    def test_version_comes_from_the_dispatch_input(self):
+        """A hardcoded version in the leg makes the pinned input a lie."""
+        self.assertRegex(self.text,
+                         r"BENCH_MICROCKS_VERSION:\s*\$\{\{\s*inputs\.microcks_version\s*\}\}")
+        self.assertIn('--microcks-version "$BENCH_MICROCKS_VERSION"', self.text)
+
+    def test_default_version_matches_the_module_default(self):
+        """Two pins that can disagree are one pin and one bug."""
+        self.assertIn(f'default: "{bm.DEFAULT_MICROCKS_VERSION}"', self.text)
+
+    def test_the_jar_is_installed_from_the_image_without_running_it(self):
+        """`docker create` materialises the filesystem; `docker run` would start a container. The
+        whole point is that the benchmarked process is a native JVM."""
+        self.assertIn("docker create", self.text)
+        self.assertNotIn('docker run "microcks', self.text)
+
+    def test_the_install_verifies_the_jar_is_a_spring_boot_launcher(self):
+        self.assertIn("Start-Class: io.github.microcks.MicrocksApplication", self.text)
+
+    def test_the_leg_aggregates_before_reporting(self):
+        """Publishing a single rep is what #746 had to retract."""
+        agg = self.text.index("bench_microcks.py --aggregate")
+        rep = self.text.index("bench_microcks.py --report")
+        self.assertLess(agg, rep, "--report must read the aggregated median, not a single rep")
+
+    def test_results_are_uploaded(self):
+        self.assertIn("tests/benchmark/results/microcks/*", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/benchmark/scripts/test_bench_microcks.py
+++ b/tests/benchmark/scripts/test_bench_microcks.py
@@ -467,6 +467,113 @@ class RunSettingsPropagation(unittest.TestCase):
                          {"warmup", "threads", "heap", "version"})
 
 
+class ReportRendering(unittest.TestCase):
+    """The combiner, driven from CSVs on disk rather than a live engine.
+
+    Worth testing because the report is the artefact people actually read, and its failure modes are
+    all silent: a missing engine rendering as a slow one, a stale sweep row blended into the headline
+    table, or a ratio computed against a column that was not there."""
+
+    HEADER = ("scenario,connections,mode,rps,p50_ms,p90_ms,p99_ms,p999_ms,avg_ms,"
+              "rss_mb_peak,rss_mb_end,reps,rps_spread_pct")
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self._real = bm.RESULTS_DIR
+        bm.RESULTS_DIR = self.tmp.name
+        self.addCleanup(lambda: setattr(bm, "RESULTS_DIR", self._real))
+
+    def _csv(self, engine, rows, suffix="_median"):
+        path = os.path.join(self.tmp.name, f"direct_{engine}{suffix}.csv")
+        with open(path, "w") as fh:
+            fh.write(self.HEADER + "\n")
+            for scen, conns, mode, rps in rows:
+                fh.write(f"{scen},{conns},{mode},{rps},1.0,2.0,3.0,4.0,1.5,,,3,1.2\n")
+        return path
+
+    def _read(self, path):
+        with open(path) as fh:
+            return fh.read()
+
+    def _all_six(self, base, conns=256, mode="closed"):
+        return [(n, conns, mode, base + i * 10) for i, n in enumerate(bm.COMPARABLE)]
+
+    def test_renders_with_only_microcks_and_rift(self):
+        """The microcks_only dispatch shape: no WireMock column available."""
+        self._csv("microcks", self._all_six(5000))
+        self._csv("rift", self._all_six(300000))
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertIn("Rift vs Microcks", text)
+        for name in bm.COMPARABLE:
+            self.assertIn(name, text)
+
+    def test_ratio_is_rift_over_microcks(self):
+        self._csv("microcks", [("api_last", 256, "closed", 10000)])
+        self._csv("rift", [("api_last", 256, "closed", 300000)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertIn("**30.0x**", text)
+
+    def test_absent_rift_does_not_render_as_zero(self):
+        """An empty cell must read as "not measured", never as a number."""
+        self._csv("microcks", [("api_last", 256, "closed", 10000)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertNotIn("0.0x", text)
+        self.assertIn("—", text)
+
+    def test_rows_from_another_connection_count_are_not_blended_in(self):
+        """A CSV left behind by a sweep holds non-comparable rows; #866's stale-artefact guard."""
+        self._csv("microcks", [("api_last", 256, "closed", 10000),
+                               ("api_last", 50, "closed", 999999)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertIn("10,000", text)
+        self.assertNotIn("999,999", text)
+
+    def test_open_loop_rows_are_excluded(self):
+        self._csv("microcks", [("api_last", 256, "closed", 10000),
+                               ("api_middle", 256, "open@5000", 888888)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertNotIn("888,888", text)
+
+    def test_missing_microcks_csv_is_refused_not_rendered_empty(self):
+        self._csv("rift", self._all_six(300000))
+        with self.assertRaises(SystemExit):
+            bm.report(256, "_median", "20s")
+
+    def test_stock_series_renders_its_own_table(self):
+        self._csv("microcks", [("api_last", 256, "closed", 10000)])
+        self._csv(bm.STOCK_ENGINE, [("api_last", 256, "closed", 5000)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertIn("Tuned vs stock defaults", text)
+        self.assertIn("-50%", text)   # 5000 vs 10000
+
+    def test_no_stock_series_means_no_stock_table(self):
+        """--skip-stock must not leave an empty section implying a measurement."""
+        self._csv("microcks", [("api_last", 256, "closed", 10000)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertNotIn("Tuned vs stock defaults", text)
+
+    def test_growth_delta_is_simple_health_to_api_last(self):
+        self._csv("microcks", [("simple_health", 256, "closed", 10000),
+                               ("api_last", 256, "closed", 5000)])
+        text = self._read(bm.report(256, "_median", "20s"))
+        self.assertIn("-50%", text)
+
+    def test_every_exclusion_reason_reaches_the_report(self):
+        """The exclusions are the report's main honesty claim; they must not live only in code."""
+        self._csv("microcks", self._all_six(5000))
+        text = self._read(bm.report(256, "_median", "20s"))
+        for name in bm.UNTRANSLATABLE:
+            self.assertIn(f"`{name}`", text)
+
+    def test_report_states_the_asymmetries(self):
+        self._csv("microcks", self._all_six(5000))
+        text = self._read(bm.report(256, "_median", "20s"))
+        for phrase in ("in-memory", "catch-all", "Protocol scope", "spec"):
+            self.assertIn(phrase, text)
+
+
 class PublishWorkflow(unittest.TestCase):
     """The Microcks leg of `benchmark-publish.yml`.
 

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -787,7 +787,12 @@ class PublishWorkflow(unittest.TestCase):
         with open(cls.WORKFLOW) as f:
             cls.text = f.read()
 
-    def test_all_three_engines_are_warmed_by_one_and_the_same_expression(self):
+    # rift/mb comparison, wiremock, microcks (#900), and the rift-only sweep. The count is asserted
+    # as well as the agreement because "all legs agree" is trivially true of one leg: a refactor that
+    # dropped a `--warmup` would otherwise pass this test while publishing an unwarmed column.
+    BENCHED_LEGS = 4
+
+    def test_all_benched_engines_are_warmed_by_one_and_the_same_expression(self):
         # The whole point of issue #866. Capturing to end-of-line, not to the first space: a regex
         # that stops at whitespace matches the shared `"${{` prefix of ANY expression, so one leg
         # silently warmed from a different variable would still look identical.
@@ -798,7 +803,8 @@ class PublishWorkflow(unittest.TestCase):
             m = re.search(r"--warmup\s+(.+)$", line)
             if m:
                 runs.append(m.group(1).strip().rstrip("\\").strip())
-        self.assertEqual(len(runs), 3, f"expected 3 benched legs, saw {runs}")
+        self.assertEqual(len(runs), self.BENCHED_LEGS,
+                         f"expected {self.BENCHED_LEGS} benched legs, saw {runs}")
         self.assertEqual(len(set(runs)), 1,
                          f"the legs are warmed differently, so the ratio is not like-for-like: {runs}")
 

--- a/tests/benchmark/scripts/test_bench_wiremock.py
+++ b/tests/benchmark/scripts/test_bench_wiremock.py
@@ -787,10 +787,11 @@ class PublishWorkflow(unittest.TestCase):
         with open(cls.WORKFLOW) as f:
             cls.text = f.read()
 
-    # rift/mb comparison, wiremock, microcks (#900), and the rift-only sweep. The count is asserted
-    # as well as the agreement because "all legs agree" is trivially true of one leg: a refactor that
-    # dropped a `--warmup` would otherwise pass this test while publishing an unwarmed column.
-    BENCHED_LEGS = 4
+    # rift/mb comparison, wiremock, microcks (#900), microcks-only's own rift reps (#900), and the
+    # rift-only sweep. The count is asserted as well as the agreement because "all legs agree" is
+    # trivially true of one leg: a refactor that dropped a `--warmup` would otherwise pass this test
+    # while publishing an unwarmed column.
+    BENCHED_LEGS = 5
 
     def test_all_benched_engines_are_warmed_by_one_and_the_same_expression(self):
         # The whole point of issue #866. Capturing to end-of-line, not to the first space: a regex
@@ -847,10 +848,14 @@ class PublishWorkflow(unittest.TestCase):
         # WireMock-only dispatch must be able to turn it off — and ONLY it. Gating a comparison
         # leg by mistake would publish a table missing an engine.
         self.assertIn("run_sweep:", self.text)
-        gated = [l for l in self.text.splitlines() if "if: inputs.run_sweep" in l]
+        # `inputs.run_sweep` also appears in its own input declaration, so match the step-level `if:`
+        # only. The gate carries a second condition since #900 (a Microcks-only dispatch skips the
+        # sweep too), hence a prefix match rather than an exact one.
+        gated = [l for l in self.text.splitlines() if l.strip().startswith("if:")
+                 and "inputs.run_sweep" in l]
         self.assertEqual(len(gated), 1, "exactly one leg may be gated by run_sweep")
         sweep_at = self.text.index("Rift concurrency sweep")
-        gate_at = self.text.index("if: inputs.run_sweep")
+        gate_at = self.text.index(gated[0].strip())
         self.assertLess(
             abs(self.text[:gate_at].count("\n") - self.text[:sweep_at].count("\n")), 3,
             "the run_sweep gate must sit on the sweep step, not on a comparison leg")


### PR DESCRIPTION
Adds Microcks as a fourth benchmark subject so the flat-throughput-under-stub-growth claim is
demonstrated against the Apache-2.0, CNCF-incubating alternative and not only against a commercial
one. Either outcome is worth publishing; a negative result would matter more, since the claim is the
strongest argument Rift owns.

Microcks is **spec-driven rather than stub-authored**, so `bench_microcks.py` generates an OpenAPI
3.0.2 document per imposter and imports it through Microcks' artifact API, translating "N stubs" as
"N `path` x `verb` operations". **Six of the thirteen scenarios are comparable**; the other seven are
refused with a stated reason rather than approximated, and a scenario added to the shared fixture
fails the run until it is classified either way.

Nothing runs in a container at bench time — the measured process is a native JVM, like WireMock's
standalone jar. Every fairness deviation moves the number in Microcks' favour and is repeated in the
generated report (Tomcat pool pinned above the offered concurrency, heap pinned, one imposter per
JVM, AsyncAPI off, logging at WARN per #718, in-memory store).

`bench_direct.py` and `bench_wiremock.py` are untouched apart from one stale leg-count assertion, so
the rift-vs-mb stability contract is unaffected by construction.

**Still to land on this branch:** the measured results and the `docs/comparisons/microcks.md` page.
`benchmark-publish.yml` is dispatching against this branch now; the numbers and the "what the data
does and does not support" statement land as a follow-up commit here, so the harness and its results
are reviewed together.

Benchmark-only: no engine, API or configuration change.

Refs #900