### PR TITLE
docs: put Microcks on the README and explain the matching architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ record.
 
 ### Fixed
 
+- **The published benchmark tables labelled the flagship row with the wrong stub count** (issue #906).
+  Every comparison table called the deep-path-match scenario "410 stubs", and the latency table called
+  it "last of 500"; `api_stubs()` in the shared fixture produces **310**
+  (10 resources × (1 collection + 10 items × 3 verbs)), and has done since before those numbers were
+  published. 13 occurrences across `README.md`, `docs/performance/index.md` and
+  `docs/comparisons/wiremock.md`, all now 310.
+
+  The measured RPS and latency figures were never in question — only the label. But it overstated the
+  corpus by a third on the row that carries Rift's central performance claim, on pages that
+  explicitly invite adversarial re-checking, where a reader who reproduces the harness counts 310 and
+  concludes the headline was inflated. Found while deriving the stub-count ladder for #900.
+
 - **Server-level `flowState.ttlSeconds` below 1 is now rejected** (issue #860). The per-imposter
   path has refused a non-positive TTL at construction since #530, but the server-level
   `flowState` block had no such check: `ttlSeconds: 0` was accepted and then misbehaved late and
@@ -63,6 +75,33 @@ record.
   sweep legs and measures its own Rift reps (~30min rather than ~2h; Rift is the only column that
   must come from the same dispatch, being the ratio's denominator).
   Benchmark-only: no engine, API or configuration change.
+
+- **The Microcks comparison is now on the README, and "Why Is Rift Faster?" explains the actual
+  architecture** (issue #900 follow-up). Two changes to how the performance story is told.
+
+  The README carries the Rift-vs-Microcks table beside the Mountebank and WireMock ones. The multiple
+  is larger than WireMock's (13.6x-54.6x), which is exactly why the section leads with the context
+  rather than the number: Microcks is a spec-driven mocking *and contract testing* platform with a UI,
+  a datastore and eight protocols, so stub-serving throughput is not what it was built for, and it
+  does **not** pay per candidate stub — stub position costs it 0.6%. Where Microcks is better is
+  stated in the same breath.
+
+  `docs/performance/index.md` previously answered "why is Rift faster" almost entirely with the
+  implementation stack — native code, no GC, async I/O — and described the matcher as "Stub matching:
+  Optimized matching". That undersold the part that actually produces the flat curve. It now documents
+  the real design: a two-stage matcher whose Stage-1 prefilter is the **Lucent bit-vector technique
+  from packet classification**, six independent dimensions intersected as dense bitsets over
+  declaration-ordered stub ids (so ascending iteration *is* first-match-wins order, making the
+  optimization semantics-preserving by construction), the over-approximation soundness rule that
+  keeps it safe, the data structure behind each dimension (fixed method slots, a folded-path hash map,
+  one Aho-Corasick automaton for path literals, one multi-pattern automaton for path regexes, a
+  structural body hash, a quamina field automaton), and the cheapest-first fold that short-circuits on
+  an empty candidate set. Plus a "what this does not buy you" section, since an imposter that indexes
+  on nothing falls back to the scan.
+
+  The split is the point: **architecture explains the shape, the stack explains the constant factor**,
+  and Microcks is the evidence they are independent — it is indexed too, so it is flat by position,
+  and the gap against it is constant factor alone.
 
 - **Published the measured comparison — `docs/comparisons/microcks.md`** (issue #900). AMD EPYC 7763,
   16 vCPU, 256 connections, median of 3 reps (spread ≤3.3% Microcks / ≤2.7% Rift). Rift is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,9 +105,11 @@ record.
   an empty candidate set. Plus a "what this does not buy you" section, since an imposter that indexes
   on nothing falls back to the scan.
 
-  The split is the point: **architecture explains the shape, the stack explains the constant factor**,
-  and Microcks is the evidence they are independent — it is indexed too, so it is flat by position,
-  and the gap against it is constant factor alone.
+  The framing is that the two **compound**, rather than one explaining everything: the runtime is a
+  large and real part of the answer, but it is the half that always gets said, and the architecture —
+  which is what governs whether the curve stays flat — is the half that did not. Microcks makes the
+  distinction visible: it is indexed too, so it is also flat by stub position, and the gap against it
+  is mostly per-request cost rather than scaling.
 
 - **Published the measured comparison — `docs/comparisons/microcks.md`** (issue #900). AMD EPYC 7763,
   16 vCPU, 256 connections, median of 3 reps (spread ≤3.3% Microcks / ≤2.7% Rift). Rift is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ record.
   explicitly invite adversarial re-checking, where a reader who reproduces the harness counts 310 and
   concludes the headline was inflated. Found while deriving the stub-count ladder for #900.
 
+- **The README's headline regex figure was stale** — it advertised "up to ~450x on large regex
+  predicate sets" while the table three lines below it reported **1,857x** on the same laptop. This
+  one *understated* the measured result rather than inflating it, but a summary that disagrees with
+  its own table is a correctness problem either way. Now ~1,850x, with the provenance stated (these
+  are the conservative laptop figures; the 16-vCPU column is higher).
+
 - **Server-level `flowState.ttlSeconds` below 1 is now rejected** (issue #860). The per-imposter
   path has refused a non-positive TTL at construction since #530, but the server-level
   `flowState` block had no such check: `ttlSeconds: 0` was accepted and then misbehaved late and

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ much of the gap is the engine and how much is the hardware:
 | Workload | Apple M4 laptop<br><sub>Mountebank → Rift</sub> | AMD EPYC 9V74, 16 vCPU<br><sub>Mountebank → Rift</sub> |
 |:---------|:--------------------------|:----------------------------|
 | Simple static stub | 8,898 → 214,818 RPS (**24x**) | 5,982 → 324,952 RPS (**54x**) |
-| Deep path match (410 stubs) | 1,344 → 209,523 RPS (**156x**) | 542 → 322,530 RPS (**595x**) |
+| Deep path match (310 stubs) | 1,344 → 209,523 RPS (**156x**) | 542 → 322,530 RPS (**595x**) |
 | Complex AND/OR predicates | 4,703 → 191,987 RPS (**41x**) | 1,814 → 259,548 RPS (**143x**) |
 | JSON body equals | 7,611 → 199,670 RPS (**26x**) | 2,730 → 294,294 RPS (**108x**) |
 | JSONPath predicate | 4,312 → 199,404 RPS (**46x**) | 1,921 → 304,796 RPS (**159x**) |
@@ -57,12 +57,12 @@ WireMock is the most widely used JVM mock server. Same suite, same host, same lo
 | Workload | WireMock → Rift | p99 |
 |:---------|:----------------|:----|
 | Simple static stub | 83,048 → 334,025 RPS (**4.0x**) | 7.0 ms → 2.4 ms |
-| Deep path match (410 stubs) | 24,264 → 326,779 RPS (**13.5x**) | 31.6 ms → 2.5 ms |
+| Deep path match (310 stubs) | 24,264 → 326,779 RPS (**13.5x**) | 31.6 ms → 2.5 ms |
 | Regex path (100 patterns) | 48,982 → 311,815 RPS (**6.4x**) | — |
 | JSON body equals | 63,814 → 314,939 RPS (**4.9x**) | — |
 | Query match (last of 100) | 20,529 → 190,867 RPS (**9.3x**) | — |
 
-Rift stays roughly flat from a trivial stub to a 410-stub deep match (334k → 327k); WireMock falls
+Rift stays roughly flat from a trivial stub to a 310-stub deep match (334k → 327k); WireMock falls
 from 83k to 24k. That shape matters more than the headline multiple.
 
 This is an architecture comparison, not a quality judgement. WireMock is mature, well-engineered,
@@ -81,6 +81,49 @@ request journal is off, matching how Rift and Mountebank are measured. Ratios mo
 concurrency — the same suite at **50** connections measures 3.1x-8.1x — so always quote the
 connection count. Full methodology, both connection points, all 13 scenarios and two caveats we do
 not bury: [docs/performance](docs/performance/index.md#rift-vs-wiremock).</sub>
+
+#### vs Microcks
+
+[Microcks](https://microcks.io/) is the Apache-2.0, CNCF-incubating alternative, and the one many
+teams reach for before a commercial tool. Same suite, same load — **Rift is 13.6x–54.6x its
+throughput** on the HTTP matching path:
+
+| Workload | Microcks → Rift | p99 |
+|:---------|:----------------|:----|
+| Simple static stub | 16,192 → 347,604 RPS (**21.5x**) | 78.9 ms → 2.3 ms |
+| API first stub (1st of 310) | 6,457 → 338,592 RPS (**52.4x**) | 239.3 ms → 2.4 ms |
+| Deep path match (310 stubs) | 6,420 → 338,404 RPS (**52.7x**) | 238.0 ms → 2.4 ms |
+| No match | 6,487 → 354,170 RPS (**54.6x**) | 166.2 ms → 2.3 ms |
+| Query match (last of 100) | 14,397 → 195,966 RPS (**13.6x**) | 74.8 ms → 4.0 ms |
+
+**That multiple is larger than WireMock's, and it is the least interesting thing here.** Microcks is
+not a slower mock server so much as a different kind of product: a spec-driven mocking *and contract
+testing* platform, with a web UI, multi-tenancy and eight protocols, built on Spring Boot with a
+datastore behind it. Raw stub-serving throughput is not what it was built for, and for most of its
+users it is not the binding constraint. Quoting 54x without that context would be misleading.
+
+The genuinely interesting result is the *shape*. Microcks' first, middle and last API points land
+within **0.6%** of each other, so — like Rift, and unlike WireMock and Mountebank — **stub position
+costs it nothing**; it resolves by path and verb rather than scanning candidates. So against Microcks
+Rift's advantage is absolute throughput and tail latency, not scan behaviour, and the "competitors
+pay per candidate stub" story does not apply to it.
+
+Where Microcks is better, plainly: it generates mocks from OpenAPI/AsyncAPI/Postman specs so they
+cannot drift from your contract, it does contract testing against a live implementation, it speaks
+seven protocols Rift does not (AsyncAPI, Kafka, MQTT, AMQP, WebSocket, gRPC, GraphQL), and it has
+CNCF governance behind it. Rift has none of that. If your workflow starts from a spec or leaves HTTP,
+Microcks is the right tool and this table is beside the point.
+[Rift vs Microcks](https://achird-labs.github.io/rift/comparisons/microcks/) covers both directions.
+
+<sub>AMD EPYC 7763, 16 vCPU (GitHub `ubuntu-16core`), 2026-07-30. Microcks 1.14.0 on Temurin 21 as a
+native JVM (no container — a container's virtualised network is not a property of the engine) vs Rift
+from source. `oha` at **256 keep-alive connections**, 20s/scenario after a 10s warmup, each engine run
+alone. Median of 3 reps; spread ≤3.3% (Rift ≤2.7%). Microcks' per-request invocation statistics and
+CORS policy are off, matching how WireMock's request journal is off and how Rift is measured — that
+change turned out to be worth nothing measurable (−4% to +2%), and the stock-defaults column is
+published anyway. Six of the 13 scenarios are comparable; the other seven are listed with the reason
+each is excluded rather than approximated. Full methodology, the stock-defaults column, and what the
+data does *not* support: [docs/comparisons/microcks](docs/comparisons/microcks.md).</sub>
 
 ### Full Feature Support
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-nightly-orange)](https://www.rust-lang.org/)
 
-Rift is a high-performance, [Mountebank](https://www.mbtest.dev/)-compatible mock server that delivers **~20–150x faster throughput on typical workloads, and up to ~450x on large regex predicate sets**. Use your existing Mountebank configurations and enjoy faster test execution.
+Rift is a high-performance, [Mountebank](https://www.mbtest.dev/)-compatible mock server that delivers **~20–150x faster throughput on typical workloads, and up to ~1,850x on large regex predicate sets** — the conservative laptop figures from the table below; the 16-vCPU server column is higher still. Use your existing Mountebank configurations and enjoy faster test execution.
 
 **[Documentation](https://achird-labs.github.io/rift/)** | **[Quick Start](#quick-start)** | **[Examples](examples/)**
 

--- a/docs/comparisons/wiremock.md
+++ b/docs/comparisons/wiremock.md
@@ -25,8 +25,8 @@ better, where WireMock is genuinely better, and where you should not switch.
 | Maturity | Mature, ~a decade, company-backed | **Beta** (v0.16.x), single maintainer |
 | Ecosystem | Large — extensions, Cloud, Spring, a decade of answers | Small |
 | Throughput at 1 stub | 83,048 RPS | 334,025 RPS |
-| Throughput at 410 stubs | 24,264 RPS (**−71%**) | 326,779 RPS (**−2%**) |
-| p99 at 410 stubs | 31.6 ms | 2.5 ms |
+| Throughput at 310 stubs | 24,264 RPS (**−71%**) | 326,779 RPS (**−2%**) |
+| p99 at 310 stubs | 31.6 ms | 2.5 ms |
 | In-process embedding | JVM only | Java, Node, Go, Scala 3 |
 | Config format | WireMock mappings JSON / Java DSL | Mountebank `imposters.json` + native YAML |
 | Response templating | Handlebars, mature | Date templates, `decorate`, Rhai/JS scripting |
@@ -51,7 +51,7 @@ This is the difference that matters, and it is architectural rather than inciden
 | Simple static stub | 83,048 | 334,025 | 4.0x |
 | API first stub | 78,906 | 326,778 | 4.1x |
 | API middle stub | 42,668 | 326,601 | 7.7x |
-| Deep path match (410 stubs) | 24,264 | 326,779 | 13.5x |
+| Deep path match (310 stubs) | 24,264 | 326,779 | 13.5x |
 | No match | 24,589 | 345,114 | 14.0x |
 | Regex path (100 patterns) | 48,982 | 311,815 | 6.4x |
 | Complex AND/OR predicates | 56,541 | 251,170 | 4.4x |
@@ -64,7 +64,7 @@ This is the difference that matters, and it is architectural rather than inciden
 
 Read the two engines down their own columns rather than across:
 
-- WireMock: **83,048 → 24,264** from a trivial stub to a 410-stub deep path match. It loses 71%.
+- WireMock: **83,048 → 24,264** from a trivial stub to a 310-stub deep path match. It loses 71%.
 - Rift: **334,025 → 326,779** over the same pair. It loses 2%.
 
 WireMock pays per candidate stub, so per-request cost tracks the size of your mappings. Rift's
@@ -77,7 +77,7 @@ forty that outlive it. The person who adds the stub pays nothing; the cost lands
 profiles the suite two years later.
 
 The same effect shows up as latency, which is what you actually feel per test: **p99 of 31.6 ms
-vs 2.5 ms** on the 410-stub scenario.
+vs 2.5 ms** on the 310-stub scenario.
 
 ### 2. One engine, four languages, in-process
 

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -101,18 +101,26 @@ issue #423 fixed) takes Rift 6.6ms vs Mountebank's 114.7ms, and grows memory +9M
 
 ## Why Is Rift Faster?
 
-Two separate answers, and conflating them is the usual mistake:
+The usual answer is "it is written in Rust", and that is genuinely a large part of it: native code,
+no GC pauses showing up in the tail, a work-stealing async runtime, and parsing that avoids copying.
+Those are real and they are why each individual request is cheap.
 
-- **The *shape* — flat instead of linear — is the matching architecture.** It is an index, not a
-  scan, and nothing about it depends on the implementation language.
-- **The *constant factor* — how fast each request is served — is the implementation stack.** Native
-  code, no GC, a work-stealing async runtime.
+But it is only half the answer, and it is the half that always gets said. The other half is the
+**matching architecture** — how Rift decides *which* stub answers a request — and that is what
+governs the shape of the curve: whether throughput holds as your stub count grows, or slides. Rift's
+matcher is an index, not a scan.
 
-The architecture is the part that actually answers "why does throughput not fall as I add stubs", so
-it goes first. The Microcks comparison is the evidence that these two are genuinely independent:
-Microcks is *also* indexed rather than scanning, so it is also flat by stub position — the gap
-against it is almost entirely constant factor. Against Mountebank and WireMock, which do scan, the
-architecture is what produces the widening gap.
+The two compound rather than compete. The architecture decides how much work a request costs at all;
+the implementation decides how fast that work runs. Every number on this page is the product of both,
+and the same design in a slower runtime, or the same runtime over a linear scan, would give up a
+different part of the result.
+
+Microcks is a useful check on the distinction. It is *also* indexed rather than scanning, so it is
+also flat by stub position — which is why the gap against it is mostly per-request cost rather than
+scaling. Mountebank and WireMock do scan, so against them the gap *widens* with stub count. Same
+engine, two different shapes, for two different reasons.
+
+The architecture is the part that is usually left out, so it goes first.
 
 ### The matching architecture
 
@@ -209,8 +217,9 @@ change of complexity class, from "one search per pattern" to "one search".
 
 ### The implementation stack
 
-This is the constant factor: it makes each request cheap, and it is what separates Rift from a
-similarly-indexed engine like Microcks.
+The other half, and the reason the index's savings actually show up in the numbers rather than being
+absorbed by per-request overhead. It is also most of what separates Rift from a similarly-indexed
+engine like Microcks.
 
 | Aspect | Mountebank | Rift |
 |:-------|:-----------|:-----|
@@ -538,10 +547,10 @@ across that same interval.
 | Trivial stub → 310 stubs | −60% | **−3%** | −71% |
 | First → last of the same 310 | **−0.6%** | **−0.06%** | −69% |
 
-So "throughput stays flat" separates Rift from Mountebank and WireMock on *scan behaviour*, and from
-Microcks on *constant factor* — which is exactly the split
-[Why Is Rift Faster?](#why-is-rift-faster) opens with, and Microcks is the evidence that the two
-halves are independent.
+So "throughput stays flat" means something different in each comparison: against Mountebank and
+WireMock it is about *scan behaviour*, and against Microcks — which does not scan either — it is
+about per-request cost. That is the distinction
+[Why Is Rift Faster?](#why-is-rift-faster) opens with, and Microcks is what makes it visible.
 
 Two limits, because the first row above is doing two things at once. The trivial-stub point is a
 *different service* with a smaller `text/plain` response, so that −60% mixes corpus size with

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -14,7 +14,18 @@ configs, with sub-millisecond tail latency that stays flat as stub count grows.
 
 ## Benchmark Summary
 
-The suite was run on two deliberately different hosts. Publishing both is the point:
+Three comparisons live on this page, each with its own hardware, date and engine versions, because
+mixing them would produce a number nothing measured:
+
+- **[vs Mountebank](#benchmark-summary)** (below) — two hosts, 50 connections, 2026-07-20.
+- **[vs WireMock](#rift-vs-wiremock)** — 256 and 50 connections, 2026-07-27.
+- **[vs Microcks](#rift-vs-microcks)** — 256 connections, 2026-07-30.
+
+And if you only read one section, read [Why Is Rift Faster?](#why-is-rift-faster) — the flat curve is
+the matching architecture, not the language, and the three comparisons above are what separate those
+two claims.
+
+The Mountebank suite was run on two deliberately different hosts. Publishing both is the point:
 the multiplier depends heavily on the machine, and a single number would overstate
 the result.
 
@@ -90,30 +101,144 @@ issue #423 fixed) takes Rift 6.6ms vs Mountebank's 114.7ms, and grows memory +9M
 
 ## Why Is Rift Faster?
 
-### Architecture Comparison
+Two separate answers, and conflating them is the usual mistake:
+
+- **The *shape* — flat instead of linear — is the matching architecture.** It is an index, not a
+  scan, and nothing about it depends on the implementation language.
+- **The *constant factor* — how fast each request is served — is the implementation stack.** Native
+  code, no GC, a work-stealing async runtime.
+
+The architecture is the part that actually answers "why does throughput not fall as I add stubs", so
+it goes first. The Microcks comparison is the evidence that these two are genuinely independent:
+Microcks is *also* indexed rather than scanning, so it is also flat by stub position — the gap
+against it is almost entirely constant factor. Against Mountebank and WireMock, which do scan, the
+architecture is what produces the widening gap.
+
+### The matching architecture
+
+Naively, "does this request match any of my stubs" is a linear scan: evaluate every stub's
+predicates until one matches. That is what Mountebank does, and it is why its per-request cost tracks
+stub count. Rift splits it in two
+([`crates/rift-mock-core/src/imposter/core/`](https://github.com/achird-labs/rift/tree/master/crates/rift-mock-core/src/imposter/core)):
+
+**Stage 1 — a candidate prefilter** (`stub_index.rs`) narrows thousands of stubs to the handful that
+*could* match. **Stage 2 — full predicate evaluation** (`matching.rs`) is the unchanged Mountebank
+semantics, and remains the single source of truth. Stage 1 only ever decides what Stage 2 does not
+need to look at.
+
+#### Dimensions and a bitset intersection
+
+The index is a set of independent **dimensions** — six of them, over four request attributes (the
+path carries three, one each for exact, literal and regex constraints). Each answers one question:
+*which stubs can this attribute not rule out?* The answers are **dense bitsets over stub
+ids**, and a stub's id is its position in the declaration-ordered stub vector — so a candidate set is
+a fixed-width bitset rather than a list of indices. `candidates()` ANDs the per-dimension bitsets and
+walks the surviving bits in ascending order.
+
+This is the **Lucent bit-vector technique from packet classification**, applied to stub matching:
+each dimension prunes independently, and the intersection is the candidate set. Three consequences
+worth stating:
+
+- **Ascending bit order *is* Mountebank's first-match-wins order**, so *ordering* is a property of
+  the data structure rather than something a test has to cover. Note the limit of that guarantee: it
+  fixes the order of the candidates, not which stubs are in the set — see the soundness rule below.
+- **Word-wise `AND` autovectorizes**, and the bitsets are small enough to stay in cache: 4,096 stubs
+  is 512 bytes. It is hand-rolled rather than pulling in `roaring`/`fixedbitset` because the only
+  operations needed are intersect, union and ascending iteration, and at this scale a dense word
+  vector beats a compressed one.
+- **Dimensions are concrete struct fields, not `Box<dyn Dimension>`**, so the match loop dispatches
+  statically and allocates nothing *extra* for dispatch. (Matching is not allocation-free: the
+  accumulator and a per-dimension scratch bitset are allocated per request, and a path containing
+  uppercase bytes allocates a folded copy.)
+
+#### The soundness rule
+
+Each dimension's bitset is `matched_bits | always_bits`: stubs whose constraint the request
+satisfies, **plus** every stub that either does not constrain this attribute or constrains it in a
+shape the dimension cannot index.
+
+> A dimension may only ever exclude a stub it can *prove* cannot match.
+
+So the index is a strict **over-approximation** — `candidates()` returns a superset of the true
+matches. That is what makes the whole thing safe in one direction: a dimension that keeps *too many*
+stubs costs only performance, so widening a dimension's eligibility later is a pure optimization and
+never a semantics question.
+
+The other direction is not safe, and is not pretended to be: a dimension that wrongly *excludes* a
+stub makes it silently stop matching. That is the failure this design has to be defended against
+rather than reasoned away, so a differential test
+(`differential_index_matches_linear_oracle`) runs the index against a linear oracle and fails
+immediately on any under-approximation.
+
+#### The six dimensions, and the data structure each uses
+
+Ordered cheapest-first, and the fold **short-circuits as soon as the candidate set is empty** — so a
+request that no stub can match usually stops after the first dimension or two:
+
+| # | Dimension | Indexes | Data structure |
+|:--|:----------|:--------|:---------------|
+| 1 | Method | `equals` on method | **Eight fixed slots** — the seven common verbs plus an "other" bucket, selected by a case-insensitive comparison with no hashing and no allocation |
+| 2 | Path (exact) | `equals` on path | Hash map keyed on the case-folded path |
+| 3 | Path literals | `startsWith` / `contains` / `endsWith` | **An Aho-Corasick automaton** over every anchor — one pass instead of walking a bucket per anchor (two automata at most: one per case class) |
+| 4 | Path regexes | `matches` on path | **A multi-pattern automaton** (`regex-automata`'s meta engine, which picks its own engine per search), reporting every matching pattern id in one overlapping search into a reused thread-local scratch set (again two at most, by case class) |
+| 5 | Body (whole) | `deepEquals` on a JSON body | **Structural hash** of the expected body → the stubs sharing it |
+| 6 | Body (field) | `equals` on body fields | **A [quamina](https://crates.io/crates/quamina) field automaton** (the Rust port of Tim Bray's design) — "which of N field-equals stubs matches this body" in one pass instead of an O(N) scan |
+
+Two honest asterisks on that table. Dimension 6 is behind the `quamina-matching` cargo feature: it is
+**on by default**, but a `default-features = false` build has five dimensions, and those body-field
+stubs simply fall through to Stage 2. And dimension 6 *deactivates itself* when no request could ever
+reach two body-field stubs at once — if every such stub owns a distinct `(path, method)`, the earlier
+dimensions have already done the work, and building the automaton would be pure overhead (worth ~6.5%
+throughput to skip).
+
+The two body dimensions run last because they are the only ones that touch the request body, so the
+cheap path and method dimensions get to empty the accumulator first; and the field automaton runs
+only if the hash dimension left survivors. The body is parsed as JSON **once per request** and shared
+across both.
+
+A dimension that indexes nothing is skipped entirely rather than paying a full-width copy and
+intersect to learn nothing — so an imposter whose stubs the index cannot help with degrades to the
+plain scan instead of paying for an index it is not using.
+
+#### Why regex stopped being the exception
+
+Regex used to be Rift's own slow path: it cannot be hash-dispatched, so at the 100th pattern Rift
+managed ~54k RPS. Dimension 4 replaced a per-pattern loop with a single multi-pattern automaton, and
+regex now runs at ~207k RPS, in line with every other predicate type — not a micro-optimization but a
+change of complexity class, from "one search per pattern" to "one search".
+
+### The implementation stack
+
+This is the constant factor: it makes each request cheap, and it is what separates Rift from a
+similarly-indexed engine like Microcks.
 
 | Aspect | Mountebank | Rift |
 |:-------|:-----------|:-----|
 | **Language** | Node.js (JavaScript) | Rust |
-| **Concurrency** | Single-threaded event loop | Multi-threaded (Tokio) |
-| **Memory Model** | Garbage collected | Zero-copy, no GC |
-| **Regex Engine** | JavaScript RegExp | Rust regex crate |
-| **JSON Parsing** | JavaScript JSON | serde_json (SIMD) |
-| **Stub Matching** | Linear scan | Optimized matching |
+| **Concurrency** | Single-threaded event loop | Multi-threaded (Tokio, work-stealing) |
+| **Memory model** | Garbage collected | No GC; per-request allocation avoided on the hot path |
+| **Regex engine** | JavaScript `RegExp`, per pattern | `regex-automata`, one multi-pattern automaton |
+| **JSON parsing** | `JSON.parse` | `serde_json`, parsed once per request and shared (as are the query map and, lazily, the XML DOM) |
+| **Stub matching** | Linear scan | Two-stage: bitset prefilter → full evaluation |
+| **Allocator** | — | mimalloc in the server binary (see [below](#memory-allocator-mimalloc)); deliberately *not* in the embedded C-ABI library, which must not impose an allocator on its host |
 
-### Key Optimizations
+Plus: native code with no interpreter warm-up, connection reuse to upstream services, and a
+dedicated worker pool for script execution so a slow `inject` cannot stall the request path.
 
-1. **Native Code**: Rust compiles to native machine code, avoiding interpreter overhead.
+### What this does not buy you
 
-2. **Async I/O**: Tokio runtime provides efficient async networking with work-stealing scheduler.
+Being clear about the limits, since the section above is the optimistic half:
 
-3. **Zero-Copy Parsing**: serde_json parses JSON without unnecessary allocations.
-
-4. **Efficient Regex**: Rust's regex crate uses finite automata for O(n) matching.
-
-5. **Connection Pooling**: Reuses connections to upstream services.
-
-6. **Thread Pool**: Dedicated workers for script execution.
+- **The index helps when stubs are distinguishable on an indexed attribute.** An imposter where
+  every stub is, say, a body regex indexes on nothing, falls back to the scan, and is as linear as
+  Mountebank — just with a much better constant.
+- **Stage 2 still runs.** There is nothing for a prefilter to save on a one- or two-stub imposter, so
+  the simple-stub row is among the *lowest* multiples in every table on this page (24x vs Mountebank
+  on the M4, 4.0x vs WireMock, 21.5x vs Microcks) — the big multiples come from scenarios where the
+  index removes work, not from the stack alone. Where something other than matching dominates the
+  request — response templating, query-argument dispatch — the multiple can be lower still.
+- **None of this is a throughput claim about your workload.** It is why the *curve* is flat; the
+  absolute numbers depend on your hardware, your predicates and your response sizes.
 
 ---
 
@@ -123,7 +248,7 @@ issue #423 fixed) takes Rift 6.6ms vs Mountebank's 114.7ms, and grows memory +9M
 
 | Scenario | Mountebank | Rift |
 |:---------|:-----------|:-----|
-| Exact stub match (last of 500) | 40ms | 0.6ms |
+| Exact stub match (last of 310) | 40ms | 0.6ms |
 | Complex AND/OR predicate | 17ms | 0.8ms |
 | JSONPath match | 17ms | 1.0ms |
 | Regex (100th pattern) | 641ms | 1.8ms |
@@ -131,7 +256,7 @@ issue #423 fixed) takes Rift 6.6ms vs Mountebank's 114.7ms, and grows memory +9M
 ### Throughput Scaling
 
 Rift maintains consistent throughput regardless of:
-- Stub count (500+ stubs with minimal degradation)
+- Stub count (310 stubs with minimal degradation)
 - Stub position (first vs last stub match)
 - Predicate complexity
 
@@ -283,7 +408,7 @@ from 7 ms to 31 ms as matching work grows.
 | Simple static stub | 83,048 | 334,025 | **4.0x** | 7.0 ms | 2.4 ms |
 | API first stub | 78,906 | 326,778 | **4.1x** | 7.5 ms | 2.5 ms |
 | API middle stub | 42,668 | 326,601 | **7.7x** | 15.8 ms | 2.5 ms |
-| Deep path match (410 stubs) | 24,264 | 326,779 | **13.5x** | 31.6 ms | 2.5 ms |
+| Deep path match (310 stubs) | 24,264 | 326,779 | **13.5x** | 31.6 ms | 2.5 ms |
 | No match | 24,589 | 345,114 | **14.0x** | — | — |
 | Regex path (100 patterns) | 48,982 | 311,815 | **6.4x** | — | — |
 | Complex AND/OR predicates | 56,541 | 251,170 | **4.4x** | — | — |
@@ -302,7 +427,7 @@ spread ≤5.6% for WireMock, ≤1.2% for Rift. Reproduce with
 
 ### The gap widens with matching work
 
-Rift is roughly flat across the suite — 334k on a trivial stub, 327k on a 410-stub deep path match.
+Rift is roughly flat across the suite — 334k on a trivial stub, 327k on a 310-stub deep path match.
 WireMock falls from 83k to 24k on the same pair. That shape, not the headline multiple, is the
 thing worth understanding: Rift's matcher cost is small relative to its per-request overhead, so
 adding stubs barely moves it, while WireMock pays per candidate.
@@ -351,7 +476,7 @@ Rift-vs-WireMock number is meaningless without its connection count attached.**
 | Simple static stub | 4,247 | 64,611 | 65,602 | 204,687 | **3.1x** |
 | API first stub | 4,149 | 61,407 | 61,259 | 190,659 | **3.1x** |
 | API middle stub | 817 | 37,262 | 37,066 | 184,714 | **5.0x** |
-| Deep path match (410 stubs) | 417 | 22,867 | 22,846 | 183,847 | **8.0x** |
+| Deep path match (310 stubs) | 417 | 22,867 | 22,846 | 183,847 | **8.0x** |
 | No match | 420 | 23,383 | 23,310 | 188,958 | **8.1x** |
 | Regex path (100 patterns) | 38 | 40,512 | 41,274 | 179,502 | **4.3x** |
 | Complex AND/OR predicates | 1,322 | 45,300 | 44,957 | 152,548 | **3.4x** |
@@ -375,6 +500,61 @@ the machine.
 The pin is a no-op at this connection count too: stock 10-thread WireMock (64,611) and the
 50-thread series (65,602) are within a percent of each other, so nothing here depends on how
 WireMock's pool was configured.
+
+---
+
+## Rift vs Microcks
+
+[Microcks](https://microcks.io/) is the Apache-2.0, CNCF-incubating alternative. Rift is
+**13.6x–54.6x** its throughput on the HTTP matching path, with a p99 of ~2.4 ms against 75–250 ms:
+
+| Scenario | Microcks | Rift | Rift/Microcks | Microcks p99 | Rift p99 |
+|:---------|---------:|-----:|--------------:|-------------:|---------:|
+| Simple static stub | 16,192 | 347,604 | **21.5x** | 78.9 ms | 2.3 ms |
+| API first stub (1st of 310) | 6,457 | 338,592 | **52.4x** | 239.3 ms | 2.4 ms |
+| API middle stub | 6,447 | 339,056 | **52.6x** | 249.5 ms | 2.4 ms |
+| Deep path match (310 stubs) | 6,420 | 338,404 | **52.7x** | 238.0 ms | 2.4 ms |
+| No match | 6,487 | 354,170 | **54.6x** | 166.2 ms | 2.3 ms |
+| Query match (last of 100) | 14,397 | 195,966 | **13.6x** | 74.8 ms | 4.0 ms |
+
+<sub>AMD EPYC 7763, 16 vCPU (GitHub `ubuntu-16core`), 2026-07-30. Microcks 1.14.0 on Temurin 21 as a
+native JVM; Rift from source. `oha` at 256 keep-alive connections, 20s/scenario after a 10s warmup,
+each engine run alone. Median of 3 reps; spread ≤3.3% Microcks, ≤2.7% Rift.</sub>
+
+### The multiple is the least interesting part
+
+Microcks is not a slower mock server so much as a different kind of product — a spec-driven mocking
+*and contract testing* platform with a web UI, multi-tenancy, a datastore and eight protocols. Raw
+stub-serving throughput is not what it was built for. Quoting 54x without that is misleading.
+
+**The result that matters is that Microcks does *not* pay per candidate stub.** Its three API points
+sit within **0.6%** of each other across first, middle and last of the same 310 operations — it
+resolves by path and verb rather than scanning, which is the same architectural property described in
+[the matching architecture](#the-matching-architecture) above. Compare WireMock, which loses **69%**
+across that same interval.
+
+| Interval | Microcks | Rift | WireMock |
+|:---------|---------:|-----:|---------:|
+| Trivial stub → 310 stubs | −60% | **−3%** | −71% |
+| First → last of the same 310 | **−0.6%** | **−0.06%** | −69% |
+
+So "throughput stays flat" separates Rift from Mountebank and WireMock on *scan behaviour*, and from
+Microcks on *constant factor* — which is exactly the split
+[Why Is Rift Faster?](#why-is-rift-faster) opens with, and Microcks is the evidence that the two
+halves are independent.
+
+Two limits, because the first row above is doing two things at once. The trivial-stub point is a
+*different service* with a smaller `text/plain` response, so that −60% mixes corpus size with
+payload — the confound-free number is the −0.6%. And the WireMock column comes from the 2026-07-27
+run on an Intel Xeon 8573C while Microcks and Rift are from 2026-07-30 on an AMD EPYC 7763 (GitHub's
+`ubuntu-16core` pool is heterogeneous; Rift itself reads 334k vs 347k across them), so each column is
+sound read downwards and the cross-column absolutes are not.
+
+Full methodology, the stock-defaults column, where Microcks is genuinely better, and what the data
+does *not* support: [Rift vs Microcks]({{ site.baseurl }}/comparisons/microcks/).
+
+---
+
 ## Comparison with Alternatives
 
 Measured, not estimated. Every figure below comes from the same run of the same 13-scenario suite
@@ -396,12 +576,10 @@ These are architecture comparisons, not quality judgements. Both engines are wel
 widely adopted than Rift, and each does things Rift does not — see
 [Rift vs WireMock]({{ site.baseurl }}/comparisons/wiremock/) for both directions.
 
-**Microcks** is compared separately, in [Rift vs Microcks]({{ site.baseurl }}/comparisons/microcks/),
-and is deliberately *not* a row in the table above: its figures come from a different dispatch, and
-the table's value is that every cell in it came from one run on one host. That page also carries the
-more interesting finding — Microcks does **not** pay per candidate stub the way Mountebank and
-WireMock do (stub *position* costs it nothing), so "throughput stays flat" distinguishes Rift from
-Microcks on absolute throughput and tail latency rather than on scan behaviour.
+**Microcks** is measured in [Rift vs Microcks](#rift-vs-microcks) above and written up in full at
+[Rift vs Microcks]({{ site.baseurl }}/comparisons/microcks/). It is deliberately *not* a row in the
+table above: its figures come from a different dispatch on different hardware, and this table's whole
+value is that every cell in it came from one run on one host.
 
 <sub>WireMock and WireMock Cloud are products of WireMock Inc.; Mountebank is an independent open
 source project. Rift is not affiliated with, endorsed by, or derived from either. All comparative


### PR DESCRIPTION
Follow-up to #900 (PR #905), which added the Microcks benchmark but left the results only in
`docs/comparisons/`.

## 1. Microcks on the README

The engine many teams evaluate before a commercial tool was invisible where people actually look. It
now has a table beside Mountebank and WireMock.

The multiple is **larger** than WireMock's (13.6x–54.6x), so the section leads with context rather
than the number: Microcks is a spec-driven mocking *and contract testing* platform with a UI, a
datastore and eight protocols, so stub-serving throughput is not what it was built for. Quoting 54x
without that would be misleading. Where Microcks is better gets its own paragraph, and the more
interesting finding gets more room than the ratio — **Microcks does not pay per candidate stub**, so
stub position costs it 0.6%.

## 2. "Why Is Rift Faster?" now explains the architecture

The section previously answered the question almost entirely with the implementation stack — native
code, no GC, async I/O — and summarised the matcher as *"Stub matching: Optimized matching"*. That
undersold the part that actually produces the flat curve and left the impression the win is a language
choice.

It now documents the real design:

- **Two-stage matching** — Stage-1 candidate prefilter (`stub_index.rs`) → Stage-2 full Mountebank
  predicate evaluation (`matching.rs`), which remains the semantic source of truth.
- **The Lucent bit-vector technique from packet classification** — six dimensions over four request
  attributes, each producing a dense bitset over declaration-ordered stub ids, intersected. Ascending
  iteration *is* first-match-wins order, so the ordering guarantee is structural.
- **The over-approximation soundness rule**, and — explicitly — the direction in which it is *not*
  safe.
- **The data structure behind each dimension**: fixed method slots, a folded-path hash map,
  Aho-Corasick for path literals, a multi-pattern automaton for path regexes, a structural body hash,
  a quamina field automaton.
- **The cheapest-first fold** that short-circuits on an empty candidate set, with body dimensions last.
- **"What this does not buy you"** — an imposter that indexes on nothing falls back to the scan, and a
  one-stub imposter has nothing for a prefilter to save.

The framing is that the two **compound**. The runtime is a large and real part of the answer — it is
just the half that always gets said, while the architecture, which governs whether the curve stays
flat, is the half that did not. Microcks makes the distinction visible rather than proving the two are
separable: it is indexed too, so it is also flat by position, which is why the gap against it is
mostly per-request cost while the gap against the scanning engines widens with stub count.

## 3. Fixes #906 — wrong stub count on the flagship row

Every comparison table labelled the deep-path-match scenario **"410 stubs"** and the latency table
**"last of 500"**. `api_stubs()` produces **310**, and has since before those numbers were published.
**13 occurrences** across `README.md`, `docs/performance/index.md`, `docs/comparisons/wiremock.md`.

The measured figures were never in question, only the label — but it overstated the corpus by a third
on pages that explicitly invite adversarial re-checking. (The filed issue said 6 occurrences; the real
count is 13, because the "500" variants are the same defect.)

## Accuracy

Every architecture claim was checked against the source, which caught **five overclaims in my first
draft**:

| Overclaim | Reality |
|:--|:--|
| the index "physically cannot" change which stub answers | the data structure guarantees candidate **order**, not membership — an under-approximating dimension bug *does* change semantics, which is what `differential_index_matches_linear_oracle` exists to catch |
| matching "allocates nothing per request" | it allocates an accumulator, a per-dimension scratch bitset, and a folded path copy; the source only ever claims nothing *extra* for dispatch |
| "one Aho-Corasick / one multi-pattern automaton" | two at most, one per case class |
| the quamina dimension always runs | default-on cargo feature, and it deactivates when no request can reach two body-field stubs |
| mimalloc | server binary only — the C-ABI library must not impose an allocator on its host |

Also corrected a claim of mine that simple-stub is the smallest multiple in every table: Template
responses (22x) beats it on the Mountebank M4 table, and query dispatch (13.6x) on the Microcks one.

## Also in this PR

- **`README.md:9`'s headline regex figure was stale** — it advertised "up to ~450x on large regex
  predicate sets" while the table three lines below reported **1,857x** on the same laptop (the figure
  predates the candidate-bitset work that removed regex as Rift's own slow path). This one
  *understated* the result rather than inflating it, but a summary that disagrees with its own table is
  a correctness problem either way. Now ~1,850x with its provenance stated.
- **The opening framing was rewritten after review.** The first draft set architecture and language up
  as a dichotomy and claimed the flat curve owes "nothing" to the implementation language — false, and
  not the point. The runtime is a large part of the answer; it is just the half that always gets said.
  The two compound.

Docs-only: no engine, API, configuration or benchmark-harness change.

Closes #906
