### PR TITLE
docs: point the downstream-consumer comments at rift-cluster

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/server.rs
+++ b/crates/rift-http-proxy/src/admin_api/server.rs
@@ -314,7 +314,7 @@ impl RunningAdminApi {
     /// The real [`bind`](AdminApiServer::bind) can only fail its accept loop by genuinely breaking
     /// the listener, so the exactly-once error delivery of [`wait`](Self::wait) / [`join`](Self::join)
     /// — and the [`ReleaseWaiters`] drop guard behind it — is otherwise unreachable from outside this
-    /// crate. An embedder that propagates a `RunningServer` outcome to process exit (rift-enterprise
+    /// crate. An embedder that propagates a `RunningServer` outcome to process exit (rift-cluster
     /// #42) needs to prove it reacts correctly, so pass a future that returns `Err`, or panics, and
     /// assert what your code does with it.
     ///

--- a/crates/rift-http-proxy/src/bootstrap.rs
+++ b/crates/rift-http-proxy/src/bootstrap.rs
@@ -2,7 +2,7 @@
 //!
 //! `--rcfile` defaults, `stop`/`restart` PID-file handling, and `--save` were originally private
 //! functions in the `rift` binary's `main.rs`. That made them unreachable from an alternative
-//! binary composed on top of this crate (e.g. rift-enterprise's `rift-ee-server`), which could
+//! binary composed on top of this crate (e.g. rift-cluster's `rift-cluster-server`), which could
 //! only get the same behaviour by copy-pasting the functions — a fork of behaviour that is meant
 //! to stay identical across binaries. Promoting them here, unchanged, gives every binary a single
 //! shared implementation instead.

--- a/crates/rift-http-proxy/src/server.rs
+++ b/crates/rift-http-proxy/src/server.rs
@@ -370,7 +370,7 @@ impl ServerBuilder {
     ///
     /// Repeatable. The `file:` and `https:` built-ins are always registered; claiming a scheme
     /// that is already taken is a startup error rather than a silent override, so an embedder
-    /// that shadows a built-in finds out immediately. This is the seam the enterprise
+    /// that shadows a built-in finds out immediately. This is the seam the cluster
     /// `git:`/`s3:`/`registry:` providers attach through.
     #[must_use]
     pub fn imposter_source(mut self, source: Arc<dyn ImposterSource>) -> Self {
@@ -737,7 +737,7 @@ impl RunningServer {
     /// testing what your code does when the admin plane dies (issue #825).
     ///
     /// An embedder that races [`wait`](Self::wait) and propagates the outcome to process exit
-    /// (rift-enterprise #42) cannot otherwise reach that `Err` path from outside this crate: the
+    /// (rift-cluster #42) cannot otherwise reach that `Err` path from outside this crate: the
     /// real accept loop only fails by genuinely breaking the listener. Pass a future returning
     /// `Err` (or one that panics) and assert your reaction.
     ///

--- a/crates/rift-http-proxy/src/sources.rs
+++ b/crates/rift-http-proxy/src/sources.rs
@@ -2,7 +2,7 @@
 //!
 //! A source is a scheme plus a way to turn a [`SourceRef`] into imposter configs. Two are built
 //! in — `file:` and `https:` — and embedders register their own with
-//! [`crate::server::ServerBuilder::imposter_source`]; that is how the enterprise `git:`/`s3:`/
+//! [`crate::server::ServerBuilder::imposter_source`]; that is how the cluster `git:`/`s3:`/
 //! `registry:` providers attach without this crate knowing they exist.
 //!
 //! Two properties are load-bearing and easy to lose in a refactor:
@@ -48,7 +48,7 @@ impl SourceRef {
     ///
     /// A bare path is `file`, so `--imposters mocks.json` works like `--configfile mocks.json`.
     /// The `://` form is checked before the bare `scheme:` form so that a compound scheme such as
-    /// `git+https://…` (an enterprise provider) resolves to `git+https` rather than to `git`.
+    /// `git+https://…` (a cluster provider) resolves to `git+https` rather than to `git`.
     pub fn scheme(&self) -> &str {
         match self.uri.split_once("://") {
             Some((scheme, _)) => scheme,
@@ -481,7 +481,7 @@ mod tests {
         assert_eq!(SourceRef::new("file:mocks.json").scheme(), "file");
         assert_eq!(SourceRef::new("https://h/i.json").scheme(), "https");
         assert_eq!(SourceRef::new("http://h/i.json").scheme(), "http");
-        // The enterprise providers (#136) ride the same dispatch; `git+https` must not be read
+        // The cluster providers (#136) ride the same dispatch; `git+https` must not be read
         // as `git`, or a compound scheme would collide with a plain one.
         assert_eq!(
             SourceRef::new("git+https://h/r#main:p").scheme(),

--- a/crates/rift-http-proxy/tests/bootstrap_seam.rs
+++ b/crates/rift-http-proxy/tests/bootstrap_seam.rs
@@ -1,5 +1,5 @@
 //! Issue #807: `--rcfile`, `stop`, `restart` and `save` were private functions in the `rift`
-//! binary's `main.rs`, so an alternative binary (rift-enterprise's `rift-ee-server`) could only
+//! binary's `main.rs`, so an alternative binary (rift-cluster's `rift-cluster-server`) could only
 //! reach them by copy-paste — forking behaviour that is meant to stay shared.
 //!
 //! This suite is deliberately an *integration* test: it compiles as an external crate, so it fails
@@ -559,7 +559,7 @@ fn stop_for_restart_stops_a_live_process() {
 //
 // This suite is an integration test on purpose: it compiles as an external crate, so it only
 // builds if the constructors are genuinely public under the `test-util` feature — which is the
-// property the issue is about (rift-enterprise could not reach the accept-loop Err path at all).
+// property the issue is about (rift-cluster could not reach the accept-loop Err path at all).
 
 #[tokio::test]
 async fn running_server_admin_failure_is_observable_by_an_embedder() {

--- a/crates/rift-http-proxy/tests/embedded_server.rs
+++ b/crates/rift-http-proxy/tests/embedded_server.rs
@@ -710,7 +710,7 @@ async fn running_server_wait_completes_when_shutdown_from_another_task() {
     assert!(waited.is_ok(), "a shutdown-driven exit is not an error");
 }
 
-// AC2: the rift-enterprise pattern — race wait() against a termination signal. The signal wins,
+// AC2: the rift-cluster pattern — race wait() against a termination signal. The signal wins,
 // and the arm that wins can still call shutdown(): proof the select! borrow has ended.
 #[tokio::test]
 async fn running_server_wait_loses_race_to_signal_then_shuts_down() {

--- a/crates/rift-mock-core/src/extensions/decorate.rs
+++ b/crates/rift-mock-core/src/extensions/decorate.rs
@@ -83,8 +83,8 @@ pub trait ResponseDecorator: Send + Sync {
 ///   ride inside the error object rather than being flattened into `message`, because naming
 ///   *which* backend failed is this door's whole purpose.
 /// - top-level `error`/`feature`/`detail` — the legacy 0.15.0 keys, **frozen**. Deprecated in
-///   0.16.0, removed in 0.17.0 by issue #801. They stay because `rift-enterprise` parses
-///   them today; dropping them here would break the distributed edition mid-bump.
+///   0.16.0, removed in 0.17.0 by issue #801. They stay because `rift-cluster` parses
+///   them today; dropping them here would break the cluster mid-bump.
 pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
     let (status, body) = match err.downcast_ref::<BackendUnavailable>() {
         Some(b) => (

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -281,7 +281,7 @@ impl Imposter {
     /// Normally always true. It is false only for an imposter registered under
     /// [`ImposterManager::with_serve_unbound`] (issue #143) after its port bind failed: it has no
     /// accept loop, but it is in the port map and therefore still answers every in-process route
-    /// (the gateway and, in the enterprise build, the front door) — both resolve through
+    /// (the gateway and, in the cluster build, the front door) — both resolve through
     /// `get_imposter`, and request handling reads none of the accept-loop machinery.
     ///
     /// Derived from [`Self::serve_handles`] rather than tracked in a separate flag: the manager

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -4517,7 +4517,7 @@ mod tests {
     }
 
     // =========================================================================
-    // Issue #143 (enterprise RFC-001 §7.4.6): serve an imposter whose port could
+    // Issue #143 (rift-cluster RFC-001 §7.4.6): serve an imposter whose port could
     // not be bound. Opt-in, apply-path only — a clustered node must keep serving
     // the imposter in-process (front door / gateway both resolve through the port
     // map) when an unrelated process holds its port on that one node.
@@ -4576,7 +4576,7 @@ mod tests {
 
         // AC1 + AC2: with the flag on, the imposter is registered in the port map (which is
         // what both in-process addressing routes resolve through) and the bind failure is
-        // still reported under `failed` — NOT `created`, so the enterprise gauge and the
+        // still reported under `failed` — NOT `created`, so the cluster gauge and the
         // `local-engine=` warning keep firing off exactly the field they already read.
         #[tokio::test]
         async fn an_unbound_apply_registers_the_imposter_and_reports_the_bind_failure() {
@@ -4612,7 +4612,7 @@ mod tests {
             assert!(
                 !report.created.contains(&19611),
                 "an unbound imposter is not a completed create — reporting it as one would \
-                 clear the enterprise apply-failure entry and the gauge with it"
+                 clear the cluster apply-failure entry and the gauge with it"
             );
             drop(blocker);
         }
@@ -4648,7 +4648,7 @@ mod tests {
             assert!(
                 report.created.contains(&19612),
                 "a successful rebind reports the port as created — that is what clears the \
-                 enterprise apply-failure entry and the gauge: {report:?}"
+                 cluster apply-failure entry and the gauge: {report:?}"
             );
             assert!(
                 failure_for(&report, 19612).is_none(),
@@ -4670,7 +4670,7 @@ mod tests {
             manager.delete_imposter(19612).await.expect("delete");
         }
 
-        // The rebind attempt must keep re-reporting while it keeps failing, so the enterprise
+        // The rebind attempt must keep re-reporting while it keeps failing, so the cluster
         // failure entry carries a current reason rather than a stale one from the first apply.
         #[tokio::test]
         async fn a_still_squatted_port_reports_the_failure_on_every_apply() {


### PR DESCRIPTION
Follows the rename of the private downstream repo `rift-enterprise` -> `rift-cluster` and its
Apache-2.0 relicence. The comments in this repo that name it as the downstream consumer were stale,
and "the distributed edition" named a paid edition that no longer exists.

GitHub redirects the old path, so **nothing here was broken** — which is exactly why it is worth
fixing rather than leaving. Per this project's own notes, an unnoticed redirect is how the
org-migration drift went undetected for a while.

## Changed (17 comment sites across 9 files)

| From | To |
|:--|:--|
| `rift-enterprise` | `rift-cluster` |
| `rift-ee-server` | `rift-cluster-server` |
| "the enterprise `git:`/`s3:`/`registry:` providers" | "the cluster providers" |
| "the enterprise build" / "gauge" / "apply-failure entry" | "the cluster …" |
| "would break the distributed edition mid-bump" | "would break the cluster mid-bump" |

Files: `rift-http-proxy` (`admin_api/server.rs`, `bootstrap.rs`, `server.rs`, `sources.rs`,
`tests/bootstrap_seam.rs`, `tests/embedded_server.rs`), `rift-mock-core`
(`extensions/decorate.rs`, `imposter/core/mod.rs`, `imposter/manager.rs`).

## Deliberately NOT changed

Six occurrences of "enterprise" stay, because there the word means something else entirely:

- **`benches/decision_cache_bench.rs` (x3) and `scripting/decision_cache.rs` (x1)** —
  `"tier": "enterprise"` is **customer-tier fixture data** inside sample request bodies. Renaming
  it would change what the benchmark and the test are matching on.
- **`docs/comparisons/microcks.md` (x2)** — "named enterprise users" / "named enterprise adopters"
  describes **Microcks' corporate adopters**, a fact about a third party.

## Verification

Comments only — no code, no public API, no test assertions, no behaviour.

- `cargo fmt --all --check` clean
- `cargo check --workspace --all-targets` clean (0 errors, 0 warnings)
