### PR TITLE
feat(journal): record why each request matched or did not

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1135,6 +1135,7 @@ mod requests_filter_tests {
             headers,
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 
@@ -1901,6 +1902,7 @@ mod verify_tests {
             headers: HashMap::new(),
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 
@@ -2091,6 +2093,7 @@ mod replace_all_tests {
                 headers: std::collections::HashMap::new(),
                 body: None,
                 timestamp: "2026-01-01T00:00:00Z".to_string(),
+                match_outcome: None,
             });
 
         let body = serde_json::json!({"imposters": [cfg]}).to_string();

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -166,6 +166,7 @@ mod tests {
             headers,
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 

--- a/crates/rift-http-proxy/tests/admin_sse.rs
+++ b/crates/rift-http-proxy/tests/admin_sse.rs
@@ -223,7 +223,10 @@ async fn request_event_matches_saved_requests() {
     assert_eq!(v["request"]["path"], "/hello");
     assert_eq!(v["request"]["method"], "GET");
 
-    // The embedded request JSON must equal the savedRequests projection.
+    // The embedded request JSON must equal the savedRequests projection — modulo `matchOutcome`.
+    // The event is published at RECORD time, before matching has run, so the outcome the journal
+    // entry later carries cannot be on the pushed copy. That one key is the only permitted
+    // difference; everything else must still be identical.
     let saved: serde_json::Value =
         reqwest::get(format!("http://{addr}/imposters/{iport}/savedRequests"))
             .await
@@ -231,8 +234,23 @@ async fn request_event_matches_saved_requests() {
             .json()
             .await
             .expect("saved json");
+    let mut entry = saved[0].clone();
+    let outcome = entry
+        .as_object_mut()
+        .expect("savedRequests entry is an object")
+        .remove("matchOutcome");
+    assert!(
+        outcome.is_some(),
+        "the journal entry carries a match outcome: {}",
+        saved[0]
+    );
+    assert!(
+        v["request"].get("matchOutcome").is_none(),
+        "the pushed copy predates the match, so it cannot carry an outcome: {}",
+        v["request"]
+    );
     assert_eq!(
-        v["request"], saved[0],
+        v["request"], entry,
         "SSE request JSON must equal the savedRequests entry"
     );
     running.shutdown().await;

--- a/crates/rift-mock-core/src/imposter/core/matching.rs
+++ b/crates/rift-mock-core/src/imposter/core/matching.rs
@@ -3,8 +3,56 @@
 //! Part of the `Imposter` implementation; see `core/mod.rs` for the struct definition.
 
 use super::*;
+use crate::imposter::predicates::stub_matches_explained;
+// The differential oracle below is the ONLY remaining caller of the boolean scan here — the live
+// path asks for the failing predicate's index instead (and discards it when untraced).
+#[cfg(test)]
+use crate::imposter::predicates::stub_matches_inner;
+use crate::imposter::types::{MAX_TRIED_STUBS, MatchOutcome, TriedStub, TriedWhy};
 use crate::util::FastMap;
 use std::hash::BuildHasher;
+
+/// The accumulating form of [`MatchOutcome`]'s `tried`/`triedOmitted`, built during the stub scan.
+///
+/// It exists separately from `MatchOutcome` because the verdict is not known until the scan ends:
+/// the scan can only record the candidates it rejects, and whether the pass matched (and which
+/// stub won) is supplied by [`Self::into_outcome`] afterwards. Only VISITED candidates land here —
+/// stubs the Stage-1 index ruled out are never evaluated, so there is no verdict to report for
+/// them.
+#[derive(Debug, Default)]
+pub(crate) struct MatchTrace {
+    tried: Vec<TriedStub>,
+    omitted: u32,
+}
+
+impl MatchTrace {
+    /// Record a rejected candidate, or — past the cap — count it.
+    fn reject(&mut self, stub_index: usize, stub: &Stub, why: TriedWhy) {
+        if self.tried.len() >= MAX_TRIED_STUBS {
+            self.omitted += 1;
+            return;
+        }
+        self.tried.push(TriedStub {
+            stub_index,
+            stub_id: stub.id.clone(),
+            why,
+        });
+    }
+
+    /// Seal the trace with the pass's verdict: `Some((stub, index))` is the winner, `None` a miss.
+    pub(crate) fn into_outcome(self, winner: Option<(&Stub, usize)>) -> MatchOutcome {
+        MatchOutcome {
+            matched: winner.is_some(),
+            stub_index: winner.map(|(_, index)| index),
+            stub_id: winner.and_then(|(stub, _)| stub.id.clone()),
+            tried: self.tried,
+            tried_omitted: self.omitted,
+        }
+    }
+}
+
+/// A matching pass's result and, when one was requested, the trace of the candidates it visited.
+type TracedMatch = (Option<(Arc<StubState>, usize)>, Option<MatchTrace>);
 
 impl Imposter {
     /// Find a matching stub for a request and return a cloned copy with its index.
@@ -40,6 +88,42 @@ impl Imposter {
     where
         SH: BuildHasher,
     {
+        Ok(self
+            .find_matching_stub_with_client_inner(
+                method,
+                path,
+                headers_map,
+                query,
+                body,
+                request_from,
+                client_ip,
+                false,
+            )?
+            .0)
+    }
+
+    /// Body of [`Self::find_matching_stub_with_client`], optionally recording WHY each visited
+    /// candidate fell out (see [`MatchTrace`]).
+    ///
+    /// `want_trace` is a parameter rather than a separate scan so the traced and untraced paths
+    /// can never diverge on which stub wins: tracing observes the one scan, it does not repeat it.
+    /// With `want_trace: false` nothing is allocated and the pass is the pre-existing one.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn find_matching_stub_with_client_inner<SH>(
+        &self,
+        method: &str,
+        path: &str,
+        headers_map: &HashMap<String, String, SH>,
+        query: Option<&str>,
+        body: Option<&str>,
+        request_from: Option<&str>,
+        client_ip: Option<&str>,
+        want_trace: bool,
+    ) -> anyhow::Result<TracedMatch>
+    where
+        SH: BuildHasher,
+    {
+        let mut trace = want_trace.then(MatchTrace::default);
         // Stage 1 (issues #292, #707): one wait-free load yields the stubs and the index built over
         // those exact stubs, so they are consistent by construction. Every dimension over-
         // approximates (stubs it can't index sit in its always-bits), so `candidates` is a superset
@@ -77,6 +161,9 @@ impl Imposter {
             if let Some(space) = &stub.space
                 && flow_id != *space
             {
+                if let Some(trace) = trace.as_mut() {
+                    trace.reject(stub_idx, stub, TriedWhy::SkippedSpace);
+                }
                 continue;
             }
             // Scenario FSM eligibility gate (before predicate precedence): a stub guarded by
@@ -85,10 +172,15 @@ impl Imposter {
             if let Some(required) = &stub.required_scenario_state {
                 let scenario = stub.scenario_name.as_deref().unwrap_or("");
                 if self.scenario_state(&flow_id, scenario)? != *required {
+                    if let Some(trace) = trace.as_mut() {
+                        trace.reject(stub_idx, stub, TriedWhy::SkippedScenarioState);
+                    }
                     continue;
                 }
             }
-            if stub_matches_inner(
+            // `stub_matches_inner` IS this call with the index discarded, so asking for the index
+            // unconditionally costs nothing and keeps one scan for both paths.
+            match stub_matches_explained(
                 &stub.predicates,
                 method,
                 path,
@@ -103,17 +195,24 @@ impl Imposter {
                 xml_dom.as_ref(),
                 Some(&query_map),
             )? {
-                // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
-                // The caller (`handler.rs`) holds the returned `Arc<StubState>` across `.await`
-                // points, so the arc-swap load guard must be released before returning (issue #291);
-                // the `Arc` lets it do so without a copy. Response-cycling state stays shared: the
-                // `cycler` is itself an `Arc`, so advancing it via this handle is visible through
-                // the stored stub, and an in-place replace swaps a new `Arc` while in-flight
-                // requests keep serving their snapshot.
-                return Ok(Some((Arc::clone(stub_state), stub_idx)));
+                None => {
+                    // Bump the refcount instead of deep-cloning the whole `StubState` (issue #287).
+                    // The caller (`handler.rs`) holds the returned `Arc<StubState>` across `.await`
+                    // points, so the arc-swap load guard must be released before returning (issue #291);
+                    // the `Arc` lets it do so without a copy. Response-cycling state stays shared: the
+                    // `cycler` is itself an `Arc`, so advancing it via this handle is visible through
+                    // the stored stub, and an in-place replace swaps a new `Arc` while in-flight
+                    // requests keep serving their snapshot.
+                    return Ok((Some((Arc::clone(stub_state), stub_idx)), trace));
+                }
+                Some(failed) => {
+                    if let Some(trace) = trace.as_mut() {
+                        trace.reject(stub_idx, stub, TriedWhy::FailedPredicate(failed));
+                    }
+                }
             }
         }
-        Ok(None)
+        Ok((None, trace))
     }
 
     /// As [`Self::find_matching_stub_with_client`], but bounded (issue #476): when the stub
@@ -142,6 +241,44 @@ impl Imposter {
         // `'static` worker closure when the snapshot needs offloading (inject/scenario-gate).
         SH: BuildHasher + Clone + Send + 'static,
     {
+        Ok(self
+            .find_matching_stub_with_client_bounded_inner(
+                method,
+                path,
+                headers_map,
+                query,
+                body,
+                request_from,
+                client_ip,
+                timeout,
+                false,
+            )
+            .await?
+            .0)
+    }
+
+    /// Body of [`Self::find_matching_stub_with_client_bounded`], optionally returning the trace of
+    /// the candidates the pass visited (see [`MatchTrace`]).
+    ///
+    /// Every bounding decision is unchanged — the same inline fast path, the same `spawn_blocking`
+    /// offload, the same deadline — because the trace is produced BY the scan rather than beside
+    /// it; it simply rides back out of the blocking task by value with the result.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn find_matching_stub_with_client_bounded_inner<SH>(
+        self: &Arc<Self>,
+        method: &str,
+        path: &str,
+        headers_map: &HashMap<String, String, SH>,
+        query: Option<&str>,
+        body: Option<&str>,
+        request_from: Option<&str>,
+        client_ip: Option<&str>,
+        timeout: std::time::Duration,
+        want_trace: bool,
+    ) -> anyhow::Result<TracedMatch>
+    where
+        SH: BuildHasher + Clone + Send + 'static,
+    {
         let snapshot = self.snapshot();
         let has_inject = snapshot.has_inject();
         // A scenario-gated stub reads flow state inside the matching pass; on a blocking backend
@@ -151,7 +288,7 @@ impl Imposter {
             has_inject || (snapshot.has_scenario_gate() && self.flow_store.is_blocking());
         drop(snapshot);
         if !needs_offload {
-            return self.find_matching_stub_with_client(
+            return self.find_matching_stub_with_client_inner(
                 method,
                 path,
                 headers_map,
@@ -159,6 +296,7 @@ impl Imposter {
                 body,
                 request_from,
                 client_ip,
+                want_trace,
             );
         }
 
@@ -171,7 +309,7 @@ impl Imposter {
         let request_from = request_from.map(str::to_string);
         let client_ip = client_ip.map(str::to_string);
         let handle = tokio::task::spawn_blocking(move || {
-            this.find_matching_stub_with_client(
+            this.find_matching_stub_with_client_inner(
                 &method,
                 &path,
                 &headers_map,
@@ -179,6 +317,7 @@ impl Imposter {
                 body.as_deref(),
                 request_from.as_deref(),
                 client_ip.as_deref(),
+                want_trace,
             )
         });
         // The wall-clock deadline exists to bound a runaway inject *script*. A blocking flow-store

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -6,13 +6,13 @@
 /// Default scenario state when a `(flow_id, scenario)` entry is absent (WireMock parity).
 pub const INITIAL_SCENARIO_STATE: &str = "Started";
 
-use super::predicates::stub_matches_inner;
 use super::response::{
     create_response_preview, create_stub_from_proxy_response, execute_stub_response_with_rift,
 };
 use super::types::{
     DebugImposter, DebugResponsePreview, DebugStubInfo, ImposterConfig, ImposterError,
-    ProxyResponse, RecordedRequest, ResponseMode, RiftResponseExtension, Stub, StubResponse,
+    MatchOutcome, ProxyResponse, RecordedRequest, ResponseMode, RiftResponseExtension, Stub,
+    StubResponse,
 };
 use crate::backends::InMemoryFlowStore;
 use crate::behaviors::{HasRepeatBehavior, RuleCycler};
@@ -1489,6 +1489,7 @@ mod tests {
             headers: std::collections::HashMap::new(),
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         };
 
         use crate::imposter::journal::MAX_RECORDED_REQUESTS;
@@ -1528,6 +1529,7 @@ mod tests {
                 headers,
                 body: None,
                 timestamp: "2026-01-01T00:00:00Z".to_string(),
+                match_outcome: None,
             }
         };
         imposter.record_request(req("A"));

--- a/crates/rift-mock-core/src/imposter/core/recording.rs
+++ b/crates/rift-mock-core/src/imposter/core/recording.rs
@@ -46,6 +46,17 @@ impl Imposter {
         }
     }
 
+    /// Attach a match outcome to the entry [`record_request`](Self::record_request) returned
+    /// `index` for, once this request's matching pass has finished.
+    ///
+    /// Infallible by design: see [`RequestJournal::attach_match`](crate::imposter::RequestJournal::attach_match)
+    /// for why a backend without indices, or an entry already evicted, is a no-op rather than an
+    /// error. Nothing about the response depends on it.
+    pub fn attach_match_outcome(&self, index: u64, outcome: MatchOutcome) {
+        self.journal
+            .attach_match(self.journal_port(), index, outcome);
+    }
+
     /// Read recorded requests with the backend's completeness flag intact, so embedders
     /// can observe a degraded read programmatically (issue #314).
     pub fn read_recorded_requests(&self) -> JournalRead {

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -319,6 +319,7 @@ mod tests {
             headers: hs,
             body: body.map(str::to_string),
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/events.rs
+++ b/crates/rift-mock-core/src/imposter/events.rs
@@ -178,6 +178,7 @@ mod tests {
             headers: Default::default(),
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -504,8 +504,11 @@ async fn handle_request_inner(
             },
         };
 
-    // Record request if enabled
-    if imposter.config.record_requests {
+    // Record request if enabled. The journal index is kept (not discarded as before) so this
+    // request's match outcome can be attached to that exact entry once matching has finished;
+    // `None` means there is no entry to annotate — recording is off, or the backend has no stable
+    // indices.
+    let journal_index = if imposter.config.record_requests {
         let recorded = RecordedRequest {
             request_from: client_addr.to_string(),
             method: method.clone(),
@@ -517,9 +520,13 @@ async fn handle_request_inner(
             body: body_string.as_deref().map(str::to_string),
             mode: body_mode.clone(),
             timestamp: chrono::Utc::now().to_rfc3339(),
+            // Filled in after the match, via `attach_match_outcome` below.
+            match_outcome: None,
         };
-        imposter.record_request(recorded);
-    }
+        imposter.record_request(recorded)
+    } else {
+        None
+    };
 
     // Find matching stub
     let method_str = method.as_str();
@@ -585,8 +592,12 @@ async fn handle_request_inner(
     // Get client address info for requestFrom, ip predicates
     let request_from = client_addr.to_string();
     let client_ip = client_addr.ip().to_string();
-    let mut matched = match imposter
-        .find_matching_stub_with_client_bounded(
+    // Trace the scan only when there is a journal entry to attach the outcome to: with no entry
+    // the trace would be built and thrown away. That also means an imposter with recording off
+    // pays exactly what it paid before.
+    let want_trace = journal_index.is_some();
+    let (mut matched, mut trace) = match imposter
+        .find_matching_stub_with_client_bounded_inner(
             method_str,
             path_str,
             &headers_clone,
@@ -595,13 +606,15 @@ async fn handle_request_inner(
             Some(&request_from),
             Some(&client_ip),
             script_timeout,
+            want_trace,
         )
         .await
     {
-        Ok(matched) => matched,
+        Ok(traced) => traced,
         // A backend consulted during matching failed (issue #318), or a predicate-`inject`
         // errored (issue #440): surface it, never fall through to "no match" (which would
-        // serve the wrong response).
+        // serve the wrong response). No outcome is attached — the pass produced no verdict, and
+        // an absent outcome says exactly that.
         Err(e) => return Ok(matcher_error_response(&e)),
     };
 
@@ -621,8 +634,10 @@ async fn handle_request_inner(
             path: path_str,
         };
         if interceptor.on_no_match(ctx).await == NoMatchDirective::RetryMatch {
-            matched = match imposter
-                .find_matching_stub_with_client_bounded(
+            // The retry's own trace replaces the first pass's: a rescued request is served as a
+            // normal match, so the outcome must describe the scan that actually decided it.
+            (matched, trace) = match imposter
+                .find_matching_stub_with_client_bounded_inner(
                     method_str,
                     path_str,
                     &headers_clone,
@@ -631,13 +646,22 @@ async fn handle_request_inner(
                     Some(&request_from),
                     Some(&client_ip),
                     script_timeout,
+                    want_trace,
                 )
                 .await
             {
-                Ok(m) => m,
+                Ok(traced) => traced,
                 Err(e) => return Ok(matcher_error_response(&e)),
             };
         }
+    }
+
+    // Attach once, from the FINAL match state — after any rescue, and never on the paths that
+    // returned above (the debug branch and a matcher error), where absence of an outcome is the
+    // honest report that none was reached.
+    if let (Some(index), Some(trace)) = (journal_index, trace) {
+        let winner = matched.as_ref().map(|(state, i)| (&state.stub, *i));
+        imposter.attach_match_outcome(index, trace.into_outcome(winner));
     }
 
     if let Some((stub_state, stub_index)) = matched {

--- a/crates/rift-mock-core/src/imposter/journal.rs
+++ b/crates/rift-mock-core/src/imposter/journal.rs
@@ -9,7 +9,7 @@
 //! is shared across imposters and keyed by port; imposter deletion clears its port slice so
 //! stale entries never resurrect on a later imposter reusing the port.
 
-use super::types::RecordedRequest;
+use super::types::{MatchOutcome, RecordedRequest};
 use parking_lot::RwLock;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -126,6 +126,24 @@ pub trait RequestJournal: Send + Sync {
     fn record_indexed(&self, port: u16, flow_id: &str, req: RecordedRequest) -> Option<u64> {
         self.record(port, flow_id, req);
         None
+    }
+
+    /// Attach a match outcome to an entry already recorded under `index`.
+    ///
+    /// The outcome is only known after matching, which is after the entry exists — so this is a
+    /// second write, not part of `record`. Two consequences are deliberate, and both are why this
+    /// returns nothing:
+    ///
+    /// * A backend with no stable indices (one that leaves [`record_indexed`](Self::record_indexed)
+    ///   at its default) has no way to address the entry, so the default here is a no-op. Such a
+    ///   backend simply never carries outcomes; nothing else about it changes.
+    /// * Attaching to an entry that is gone — evicted by the cap, or cleared between the record
+    ///   and the match — is not an error. The entry the annotation describes no longer exists, so
+    ///   there is nothing to say about it and nothing a caller could do.
+    ///
+    /// A diagnostic annotation must never be able to fail a request.
+    fn attach_match(&self, port: u16, index: u64, outcome: MatchOutcome) {
+        let _ = (port, index, outcome);
     }
 }
 
@@ -286,6 +304,16 @@ impl RequestJournal for LocalJournal {
     fn count(&self, port: u16) -> u64 {
         self.slot(port).count.load(Ordering::SeqCst)
     }
+
+    fn attach_match(&self, port: u16, index: u64, outcome: MatchOutcome) {
+        let slot = self.slot(port);
+        let mut entries = slot.entries.write();
+        // Indices are assigned under this same write lock, so the deque is always in strictly
+        // ascending index order — a binary search is exact here, not merely a heuristic.
+        if let Ok(position) = entries.binary_search_by(|(entry, _, _)| entry.cmp(&index)) {
+            entries[position].2.match_outcome = Some(outcome);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -303,6 +331,7 @@ mod tests {
             headers: Default::default(),
             body: None,
             timestamp: "t".into(),
+            match_outcome: None,
         }
     }
 
@@ -346,6 +375,47 @@ mod tests {
         // An always-false predicate yields nothing; always-true yields all.
         assert!(j.read_filtered(1, &|_| false).entries.is_empty());
         assert_eq!(j.read_filtered(1, &|_| true).entries.len(), 3);
+    }
+
+    fn outcome() -> MatchOutcome {
+        MatchOutcome {
+            matched: false,
+            stub_index: None,
+            stub_id: None,
+            tried: Vec::new(),
+            tried_omitted: 0,
+        }
+    }
+
+    // The outcome is attached AFTER the entry is recorded, so by the time it arrives the entry may
+    // legitimately be gone (evicted by the cap, or the whole port never recorded). Both are no-ops:
+    // a diagnostic annotation must never panic, and must never scribble on a neighbouring entry.
+    #[test]
+    fn attach_match_on_an_absent_entry_is_a_no_op() {
+        let j = LocalJournal::default();
+        for i in 0..(MAX_RECORDED_REQUESTS + 5) {
+            j.record_indexed(1, "f", req(&format!("/{i}")));
+        }
+        // Indices 1..=5 fell off the front; 6 is the oldest retained.
+        j.attach_match(1, 1, outcome());
+        j.attach_match(9999, 1, outcome());
+
+        let entries = j.read(1).entries;
+        assert_eq!(entries.len(), MAX_RECORDED_REQUESTS);
+        assert!(
+            entries.iter().all(|r| r.match_outcome.is_none()),
+            "attaching to an evicted index must not land on any surviving entry"
+        );
+
+        // Attaching to a live index still works, so the no-op above is about absence — not about
+        // attach being inert everywhere.
+        j.attach_match(1, 6, outcome());
+        let entries = j.read(1).entries;
+        assert!(entries[0].match_outcome.is_some(), "the addressed entry");
+        assert!(
+            entries[1..].iter().all(|r| r.match_outcome.is_none()),
+            "and only that entry"
+        );
     }
 
     // AC1: note_request counts even when nothing is recorded (recording off).

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -2397,6 +2397,7 @@ mod tests {
             headers: std::collections::HashMap::new(),
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/mod.rs
+++ b/crates/rift-mock-core/src/imposter/mod.rs
@@ -34,12 +34,13 @@ mod tests;
 #[allow(unused_imports)]
 pub use types::{
     DebugImposter, DebugMatchResult, DebugRequest, DebugResponse, DebugResponsePreview,
-    DebugStubInfo, ImposterConfig, ImposterError, IsResponse, PathRewrite, Predicate,
-    PredicateOperation, PredicateParameters, PredicateSelector, ProxyResponse, RecordedRequest,
-    ResponseMode, RiftConfig, RiftConnectionPoolConfig, RiftErrorFault, RiftFaultConfig,
-    RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig, RiftProxyConfig, RiftRedisConfig,
-    RiftResponseExtension, RiftScriptConfig, RiftScriptEngineConfig, RiftTcpFault,
-    RiftUpstreamConfig, Stub, StubResponse,
+    DebugStubInfo, ImposterConfig, ImposterError, IsResponse, MAX_TRIED_STUBS, MatchOutcome,
+    PathRewrite, Predicate, PredicateOperation, PredicateParameters, PredicateSelector,
+    ProxyResponse, RecordedRequest, ResponseMode, RiftConfig, RiftConnectionPoolConfig,
+    RiftErrorFault, RiftFaultConfig, RiftFlowStateConfig, RiftLatencyFault, RiftMetricsConfig,
+    RiftProxyConfig, RiftRedisConfig, RiftResponseExtension, RiftScriptConfig,
+    RiftScriptEngineConfig, RiftTcpFault, RiftUpstreamConfig, Stub, StubResponse, TriedStub,
+    TriedWhy,
 };
 
 // Re-export script `file:`/`ref:` resolution (issue #356)

--- a/crates/rift-mock-core/src/imposter/predicates/mod.rs
+++ b/crates/rift-mock-core/src/imposter/predicates/mod.rs
@@ -95,13 +95,58 @@ pub(crate) fn stub_matches_inner<SH>(
 where
     SH: BuildHasher,
 {
-    // If no predicates, match everything
-    if predicates.is_empty() {
-        return Ok(true);
-    }
+    Ok(stub_matches_explained(
+        predicates,
+        method,
+        path,
+        query,
+        headers,
+        body,
+        request_from,
+        client_ip,
+        form,
+        imposter_port,
+        body_json,
+        xml_dom,
+        query_map,
+    )?
+    .is_none())
+}
 
-    // All predicates must match (implicit AND)
-    for predicate in predicates {
+/// [`stub_matches_inner`]'s scan, reporting WHICH predicate rejected the stub: `Some(i)` is the
+/// position in `predicates` of the first predicate the request failed, `None` means every
+/// predicate passed (including the empty list, which matches everything).
+///
+/// This is the boolean scan, not a second one beside it — `stub_matches_inner` is defined in terms
+/// of it — so the answer can never disagree with the match itself. The index, not a field path, is
+/// the reportable datum: a predicate's field is a key inside its operation's map and `and`/`or`
+/// nest further, so there is no single path to name; the journal's consumer renders the predicate
+/// by indexing the stub config.
+///
+/// Predicates are implicitly AND-ed and the scan short-circuits, so predicates after the reported
+/// index were never evaluated.
+///
+/// See [`stub_matches`] for the `Err` contract (issue #440).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stub_matches_explained<SH>(
+    predicates: &[Predicate],
+    method: &str,
+    path: &str,
+    query: Option<&str>,
+    headers: &HashMap<String, String, SH>,
+    body: Option<&str>,
+    request_from: Option<&str>,
+    client_ip: Option<&str>,
+    form: Option<&FastMap<String, String>>,
+    imposter_port: u16,
+    body_json: Option<&serde_json::Value>,
+    xml_dom: Option<&LazyXmlDom<'_>>,
+    query_map: Option<&FastMap<String, String>>,
+) -> anyhow::Result<Option<usize>>
+where
+    SH: BuildHasher,
+{
+    for (index, predicate) in predicates.iter().enumerate() {
         if !predicate_matches_inner(
             predicate,
             method,
@@ -117,10 +162,10 @@ where
             xml_dom,
             query_map,
         )? {
-            return Ok(false);
+            return Ok(Some(index));
         }
     }
-    Ok(true)
+    Ok(None)
 }
 
 /// Parse query string for predicate matching, URL-decoding both keys and values
@@ -2579,5 +2624,96 @@ mod tests {
         assert!(run(PredicateOperation::Contains(path_field("api/users"))));
         assert!(run(PredicateOperation::StartsWith(path_field("/api"))));
         assert!(run(PredicateOperation::EndsWith(path_field("USERS"))));
+    }
+
+    // =========================================================================
+    // stub_matches_explained — the same scan, reporting WHICH predicate rejected
+    // =========================================================================
+
+    /// Run `stub_matches_explained` over `predicates` for `GET /api/users`, headerless.
+    fn explain(predicates: &[Predicate]) -> Option<usize> {
+        stub_matches_explained(
+            predicates,
+            "GET",
+            "/api/users",
+            None,
+            &empty_headers(),
+            None,
+            None,
+            None,
+            None,
+            0,
+            None,
+            None,
+            None,
+        )
+        .expect("no inject predicate, so this cannot fail")
+    }
+
+    fn path_equals(path: &str) -> Predicate {
+        make_predicate(PredicateOperation::Equals(
+            [("path".to_string(), json!(path))].into_iter().collect(),
+        ))
+    }
+
+    // An empty predicate list matches everything, so there is no failing predicate to name.
+    #[test]
+    fn explained_reports_no_failure_for_an_empty_predicate_list() {
+        assert_eq!(explain(&[]), None);
+    }
+
+    // The reported index is the FIRST failure's position, not merely "some failure": with two
+    // failing predicates behind one passing one, the middle index must come back.
+    #[test]
+    fn explained_reports_the_first_failing_predicate_index() {
+        let predicates = vec![
+            path_equals("/api/users"),
+            path_equals("/nope"),
+            path_equals("/also-nope"),
+        ];
+        assert_eq!(explain(&predicates), Some(1));
+        // Reordering moves the reported index with the failure — it is positional, not incidental.
+        let predicates = vec![path_equals("/nope"), path_equals("/api/users")];
+        assert_eq!(explain(&predicates), Some(0));
+        // All passing ⇒ no failure.
+        assert_eq!(explain(&[path_equals("/api/users")]), None);
+    }
+
+    // The explained scan must be the boolean scan: `stub_matches_inner` is defined in terms of it,
+    // so any divergence would silently change which stub matches.
+    #[test]
+    fn explained_agrees_with_stub_matches_inner() {
+        let fixtures: Vec<Vec<Predicate>> = vec![
+            vec![],
+            vec![path_equals("/api/users")],
+            vec![path_equals("/nope")],
+            vec![path_equals("/api/users"), path_equals("/nope")],
+            vec![make_predicate(PredicateOperation::Equals(
+                [("method".to_string(), json!("GET"))].into_iter().collect(),
+            ))],
+        ];
+        for predicates in &fixtures {
+            let boolean = stub_matches_inner(
+                predicates,
+                "GET",
+                "/api/users",
+                None,
+                &empty_headers(),
+                None,
+                None,
+                None,
+                None,
+                0,
+                None,
+                None,
+                None,
+            )
+            .expect("no inject predicate");
+            assert_eq!(
+                boolean,
+                explain(predicates).is_none(),
+                "explained and boolean scans disagreed on {predicates:?}"
+            );
+        }
     }
 }

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -97,6 +97,115 @@ pub struct RecordedRequest {
     #[serde(rename = "_mode", default, skip_serializing_if = "is_text_mode")]
     pub mode: ResponseMode,
     pub timestamp: String,
+    /// Why this request matched — or did not. Captured at request time and attached to this
+    /// entry once matching has finished, so an operator reading the journal can answer "why did
+    /// this not match?" without re-deriving the scan by hand.
+    ///
+    /// `None` (and therefore absent on the wire, like `_mode` above) whenever no outcome was
+    /// recorded: recording was off, the backend has no stable indices to attach to, the request
+    /// took the `X-Rift-Debug` path, or matching itself errored. Absence means "not recorded",
+    /// never "did not match".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_outcome: Option<MatchOutcome>,
+}
+
+/// Cap on the candidates named in [`MatchOutcome::tried`]; the rest are counted in
+/// [`MatchOutcome::tried_omitted`].
+///
+/// An outcome rides on every journal entry and the journal ring holds
+/// [`MAX_RECORDED_REQUESTS`](crate::imposter::MAX_RECORDED_REQUESTS) (10k) entries per port, so an
+/// uncapped list would let one imposter with a few hundred stubs multiply the journal's footprint
+/// by that stub count. Twenty-five is well past the point where reading the list by hand stops
+/// being how you diagnose a miss.
+pub const MAX_TRIED_STUBS: usize = 25;
+
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde's skip_serializing_if contract
+fn is_zero(count: &u32) -> bool {
+    *count == 0
+}
+
+/// The compact record of one request's match, attached to its journal entry.
+///
+/// `tried` lists only the candidates the matcher actually VISITED, in visit order. The Stage-1
+/// index (`core::stub_index`) prunes stubs it can prove cannot match before the scan begins, and
+/// those are never evaluated — listing them would claim a verdict the matcher never reached. A
+/// stub's absence from `tried` therefore means "ruled out by the index, or never reached because
+/// an earlier stub already won", not "passed".
+///
+/// A miss:
+///
+/// ```json
+/// { "matched": false,
+///   "tried": [{ "stubIndex": 0, "stubId": "users",
+///               "why": { "reason": "failedPredicate", "predicateIndex": 1 } }] }
+/// ```
+///
+/// A hit, where `tried` holds only the candidates visited BEFORE the winner:
+///
+/// ```json
+/// { "matched": true, "stubIndex": 2, "stubId": "fallback", "tried": [] }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchOutcome {
+    pub matched: bool,
+    /// Position of the winning stub in the imposter's stub list; absent when nothing matched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stub_index: Option<usize>,
+    /// The winning stub's `id`, when it declares one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stub_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tried: Vec<TriedStub>,
+    /// Candidates visited past [`MAX_TRIED_STUBS`] and therefore not named above. Counted rather
+    /// than dropped: a silently truncated `tried` would make "these are the stubs that were
+    /// tried" false with nothing on the wire to say so.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub tried_omitted: u32,
+}
+
+/// One candidate the matcher visited and did not serve, with the reason it fell out.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriedStub {
+    pub stub_index: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stub_id: Option<String>,
+    pub why: TriedWhy,
+}
+
+/// Why a visited candidate did not win.
+///
+/// Adjacently tagged, so every variant is one flat object with the same `reason` key and consumers
+/// can switch on it without type-testing the value:
+///
+/// ```json
+/// { "reason": "skippedSpace" }
+/// { "reason": "skippedScenarioState" }
+/// { "reason": "failedPredicate", "predicateIndex": 1 }
+/// ```
+///
+/// (An externally tagged enum would render the first two as the bare string `"skippedSpace"` and
+/// the third as `{ "failedPredicate": 1 }` — the same field alternating between a string and an
+/// object, which is exactly the shape that makes a consumer branch on JSON types.)
+///
+/// The failure datum is the predicate's INDEX in the stub's `predicates`, not a field path: a
+/// [`Predicate`]'s field is a key inside its operation's map (and `and`/`or`/`not` nest further),
+/// so there is no single path to name. A consumer renders the offending predicate by indexing the
+/// stub config it already has.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "reason", content = "predicateIndex", rename_all = "camelCase")]
+pub enum TriedWhy {
+    /// Correlated-isolation gate (issue #223): the stub is scoped to a space this request's
+    /// resolved `flow_id` is not. Never reached predicate evaluation.
+    SkippedSpace,
+    /// Scenario FSM gate: the stub's `requiredScenarioState` is not the current state. Never
+    /// reached predicate evaluation either.
+    SkippedScenarioState,
+    /// The first predicate (by position in the stub's `predicates`) that the request failed.
+    /// Predicates are implicitly AND-ed and the scan short-circuits, so later ones were never
+    /// evaluated.
+    FailedPredicate(usize),
 }
 
 // ============================================================================
@@ -2109,6 +2218,7 @@ mod tests {
             body: Some("hello".to_string()),
             mode: ResponseMode::Text,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         };
         let value = serde_json::to_value(&req).expect("serializes");
         assert!(
@@ -2131,10 +2241,34 @@ mod tests {
             body: Some("//4A".to_string()), // base64 of [0xFF, 0xFE, 0x00]
             mode: ResponseMode::Binary,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
         };
         let value = serde_json::to_value(&req).expect("serializes");
         assert_eq!(value["_mode"], "binary");
         assert_eq!(value["body"], "//4A");
+    }
+
+    // An entry with no recorded match outcome must serialize byte-identically to the shape that
+    // predates `matchOutcome` — no key at all. Asserted as exact bytes rather than key-by-key,
+    // because the wire compatibility claim is about the whole document, and field order is part
+    // of what consumers (and golden fixtures) see.
+    #[test]
+    fn recorded_request_without_match_outcome_serializes_unchanged() {
+        let req = RecordedRequest {
+            request_from: "127.0.0.1:1234".to_string(),
+            method: "POST".to_string(),
+            path: "/x".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: Some("hello".to_string()),
+            mode: ResponseMode::Text,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&req).expect("serializes"),
+            r#"{"requestFrom":"127.0.0.1:1234","method":"POST","path":"/x","query":{},"headers":{},"body":"hello","timestamp":"2026-01-01T00:00:00Z"}"#
+        );
     }
 
     // Issue #636: a recording written before `_mode` existed has no such key at all — it must

--- a/crates/rift-mock-core/tests/journal_match_outcome.rs
+++ b/crates/rift-mock-core/tests/journal_match_outcome.rs
@@ -1,0 +1,326 @@
+//! Match outcomes recorded alongside journal entries: an operator reading the request journal
+//! must be able to answer "why did this request not match?" without re-deriving the match by hand.
+//!
+//! These tests drive the real imposter serve loop end-to-end (`ImposterManager` + reqwest, the
+//! same pattern as `issue_636_binary_request_bodies.rs`) and assert the WIRE shape of
+//! `matchOutcome` on the recorded entry, because that projection is what an operator (and the
+//! admin API's `savedRequests`) actually sees.
+//!
+//! What is pinned here:
+//!   - a miss names every candidate the matcher VISITED, in visit order, with the index of the
+//!     predicate that rejected it
+//!   - a hit names the winner and only the candidates visited BEFORE it
+//!   - the two eligibility gates (space, scenario state) are reported as skips, not as failures
+//!   - the `tried` list is capped, with the overflow counted rather than silently dropped
+//!   - a `RetryMatch` rescue attaches the RESCUED outcome, not the first pass's miss
+//!   - `recordRequests: false` records nothing and attaches nothing
+
+use rift_mock_core::extensions::no_match::{NoMatchContext, NoMatchDirective, NoMatchInterceptor};
+use rift_mock_core::imposter::{ImposterManager, Stub};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn create(manager: &ImposterManager, cfg: serde_json::Value) -> u16 {
+    let config = serde_json::from_value(cfg).expect("valid imposter config");
+    let port = manager.create_imposter(config).await.expect("create");
+    // Give the listener a moment to bind before the request (matches the sibling HTTP tests).
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    port
+}
+
+/// Drive one GET, optionally carrying an `X-Want` header (the field every fixture below
+/// discriminates on — deliberately NOT path or method, so the Stage-1 index cannot prune any
+/// stub and every stub is genuinely visited).
+async fn get(port: u16, path: &str, want: Option<&str>) {
+    let mut req = reqwest::Client::new().get(format!("http://127.0.0.1:{port}{path}"));
+    if let Some(want) = want {
+        req = req.header("X-Want", want);
+    }
+    req.send().await.expect("send");
+}
+
+/// The `matchOutcome` of the port's single journal entry, as the JSON an operator would read.
+fn only_outcome(manager: &ImposterManager, port: u16) -> serde_json::Value {
+    let imposter = manager.get_imposter(port).expect("imposter exists");
+    let recorded = imposter.get_recorded_requests();
+    assert_eq!(recorded.len(), 1, "exactly one request was recorded");
+    let entry = serde_json::to_value(&recorded[0]).expect("serializes");
+    entry
+        .get("matchOutcome")
+        .cloned()
+        .unwrap_or_else(|| panic!("the journal entry must carry a matchOutcome: {entry}"))
+}
+
+// G1: a miss must name every candidate the matcher visited, in visit order, each with the index of
+// the predicate that rejected it. The first stub's rejecting predicate is its SECOND one, so this
+// also proves the index is the failing predicate's position and not merely always zero.
+#[tokio::test]
+async fn unmatched_request_records_each_failing_candidate_in_visit_order() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        json!({
+            "port": 0, "protocol": "http", "recordRequests": true,
+            "stubs": [
+                { "id": "first",
+                  "predicates": [
+                      { "equals": { "method": "GET" } },
+                      { "equals": { "headers": { "X-Want": "a" } } }],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                { "id": "second",
+                  "predicates": [{ "equals": { "headers": { "X-Want": "b" } } }],
+                  "responses": [{ "is": { "statusCode": 200 } }] }
+            ]
+        }),
+    )
+    .await;
+
+    get(port, "/x", Some("z")).await;
+
+    assert_eq!(
+        only_outcome(&manager, port),
+        json!({
+            "matched": false,
+            "tried": [
+                { "stubIndex": 0, "stubId": "first",
+                  "why": { "reason": "failedPredicate", "predicateIndex": 1 } },
+                { "stubIndex": 1, "stubId": "second",
+                  "why": { "reason": "failedPredicate", "predicateIndex": 0 } }
+            ]
+        })
+    );
+
+    manager.delete_all().await;
+}
+
+// G2: a hit names the winner and only the candidates visited BEFORE it — the winner itself is not
+// a "tried" entry, and nothing after it was ever evaluated (first-match-wins).
+#[tokio::test]
+async fn matched_request_records_the_winner_and_only_earlier_candidates() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        json!({
+            "port": 0, "protocol": "http", "recordRequests": true,
+            "stubs": [
+                { "predicates": [{ "equals": { "headers": { "X-Want": "a" } } }],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                { "id": "second",
+                  "predicates": [{ "equals": { "headers": { "X-Want": "b" } } }],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                { "id": "winner",
+                  "predicates": [{ "equals": { "headers": { "X-Want": "c" } } }],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                { "id": "never-reached",
+                  "predicates": [],
+                  "responses": [{ "is": { "statusCode": 200 } }] }
+            ]
+        }),
+    )
+    .await;
+
+    get(port, "/x", Some("c")).await;
+
+    assert_eq!(
+        only_outcome(&manager, port),
+        json!({
+            "matched": true,
+            "stubIndex": 2,
+            "stubId": "winner",
+            "tried": [
+                { "stubIndex": 0, "why": { "reason": "failedPredicate", "predicateIndex": 0 } },
+                { "stubIndex": 1, "stubId": "second",
+                  "why": { "reason": "failedPredicate", "predicateIndex": 0 } }
+            ]
+        })
+    );
+
+    manager.delete_all().await;
+}
+
+// G3: the two eligibility gates are reported as SKIPS with their own reasons. A gated stub never
+// reaches predicate evaluation, so reporting it as a failed predicate would be a lie about why it
+// did not participate.
+#[tokio::test]
+async fn gated_candidates_are_recorded_as_skips_with_their_reason() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        json!({
+            "port": 0, "protocol": "http", "recordRequests": true,
+            "stubs": [
+                // Scoped to a space no request on this port can resolve to (the default
+                // flowIdSource is the imposter port).
+                { "space": "someone-else", "predicates": [],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                // Gated on a scenario state the FSM is not in (it starts at "Started").
+                { "scenarioName": "s", "requiredScenarioState": "Done", "predicates": [],
+                  "responses": [{ "is": { "statusCode": 200 } }] },
+                { "id": "open", "predicates": [],
+                  "responses": [{ "is": { "statusCode": 200 } }] }
+            ]
+        }),
+    )
+    .await;
+
+    get(port, "/x", None).await;
+
+    assert_eq!(
+        only_outcome(&manager, port),
+        json!({
+            "matched": true,
+            "stubIndex": 2,
+            "stubId": "open",
+            "tried": [
+                { "stubIndex": 0, "why": { "reason": "skippedSpace" } },
+                { "stubIndex": 1, "why": { "reason": "skippedScenarioState" } }
+            ]
+        })
+    );
+
+    manager.delete_all().await;
+}
+
+// G4: the journal ring holds 10k entries per port, so an outcome cannot grow without bound. Past
+// the cap the list stops and the overflow is COUNTED — silently truncating would make "these are
+// the stubs that were tried" false without saying so.
+#[tokio::test]
+async fn tried_list_is_capped_with_the_overflow_counted() {
+    const CAP: usize = 25;
+    const STUBS: usize = CAP + 5;
+
+    let stubs: Vec<serde_json::Value> = (0..STUBS)
+        .map(|i| {
+            json!({
+                "predicates": [{ "equals": { "headers": { "X-Want": format!("v{i}") } } }],
+                "responses": [{ "is": { "statusCode": 200 } }]
+            })
+        })
+        .collect();
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        json!({ "port": 0, "protocol": "http", "recordRequests": true, "stubs": stubs }),
+    )
+    .await;
+
+    get(port, "/x", Some("matches-nothing")).await;
+
+    let outcome = only_outcome(&manager, port);
+    assert_eq!(outcome["matched"], false);
+    let tried = outcome["tried"].as_array().expect("tried is an array");
+    assert_eq!(tried.len(), CAP, "exactly the cap is retained");
+    assert_eq!(
+        tried[0]["stubIndex"], 0,
+        "retained from the START of the scan"
+    );
+    assert_eq!(tried[CAP - 1]["stubIndex"], CAP - 1);
+    assert_eq!(
+        outcome["triedOmitted"], 5,
+        "the visited-but-unlisted candidates are counted, not dropped: {outcome}"
+    );
+
+    manager.delete_all().await;
+}
+
+/// A no-match interceptor that installs a matching stub and asks for one retry, standing in for
+/// "the replicated config caught up" (the seam issue #819 added).
+struct Rescuer {
+    target: parking_lot::Mutex<Option<(Arc<ImposterManager>, u16)>>,
+}
+
+impl NoMatchInterceptor for Rescuer {
+    fn on_no_match<'a>(
+        &'a self,
+        _ctx: NoMatchContext<'a>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = NoMatchDirective> + Send + 'a>> {
+        let target = self.target.lock().clone();
+        Box::pin(async move {
+            if let Some((manager, port)) = target {
+                let stub: Stub = serde_json::from_value(json!({
+                    "id": "late",
+                    "predicates": [{ "equals": { "headers": { "X-Want": "late" } } }],
+                    "responses": [{ "is": { "statusCode": 200, "body": "rescued" } }]
+                }))
+                .expect("late stub");
+                manager.add_stub(port, stub, None).await.expect("add stub");
+            }
+            NoMatchDirective::RetryMatch
+        })
+    }
+}
+
+// G7: a rescued request is a match, so the attached outcome must be the RESCUED one. Attaching the
+// first pass's miss would tell an operator the request went unmatched when it was in fact served.
+#[tokio::test]
+async fn retry_match_rescue_attaches_the_rescued_outcome() {
+    let rescuer = Arc::new(Rescuer {
+        target: parking_lot::Mutex::new(None),
+    });
+    let manager = Arc::new(
+        ImposterManager::new()
+            .with_no_match_interceptor(Arc::clone(&rescuer) as Arc<dyn NoMatchInterceptor>),
+    );
+    let port = create(
+        &manager,
+        json!({ "port": 0, "protocol": "http", "recordRequests": true, "stubs": [] }),
+    )
+    .await;
+    // Armed after construction so the rescue mutates the manager actually serving the request.
+    *rescuer.target.lock() = Some((Arc::clone(&manager), port));
+
+    get(port, "/late", Some("late")).await;
+
+    assert_eq!(
+        only_outcome(&manager, port),
+        json!({ "matched": true, "stubIndex": 0, "stubId": "late" })
+    );
+
+    manager.delete_all().await;
+}
+
+// G8: with recording off there is no entry to annotate, so nothing is recorded and nothing is
+// attached — matching itself is untouched. Pins that the outcome capture never resurrects a
+// journal the operator turned off.
+#[tokio::test]
+async fn recording_off_leaves_the_journal_empty_and_matching_intact() {
+    let manager = ImposterManager::new();
+    let port = create(
+        &manager,
+        json!({
+            "port": 0, "protocol": "http", "recordRequests": false,
+            "stubs": [
+                { "predicates": [{ "equals": { "headers": { "X-Want": "a" } } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "no" } }] },
+                { "predicates": [{ "equals": { "headers": { "X-Want": "b" } } }],
+                  "responses": [{ "is": { "statusCode": 200, "body": "yes" } }] }
+            ]
+        }),
+    )
+    .await;
+
+    let body = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/x"))
+        .header("X-Want", "b")
+        .send()
+        .await
+        .expect("send")
+        .text()
+        .await
+        .expect("body");
+    assert_eq!(body, "yes", "matching is unaffected by the outcome capture");
+
+    let imposter = manager.get_imposter(port).expect("imposter exists");
+    assert!(
+        imposter.get_recorded_requests().is_empty(),
+        "recordRequests: false records nothing at all"
+    );
+    assert_eq!(
+        imposter.get_request_count(),
+        1,
+        "the request still counts toward numberOfRequests"
+    );
+
+    manager.delete_all().await;
+}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -390,10 +390,38 @@ Multiple `match` clauses are AND-ed together. `since` is applied first, then the
       "host": "localhost:4545",
       "user-agent": "curl/7.88.0"
     },
-    "timestamp": "2024-01-15T10:30:00.000Z"
+    "timestamp": "2024-01-15T10:30:00.000Z",
+    "matchOutcome": {
+      "matched": false,
+      "tried": [
+        { "stubIndex": 0, "stubId": "users",
+          "why": { "reason": "failedPredicate", "predicateIndex": 1 } },
+        { "stubIndex": 1, "why": { "reason": "skippedScenarioState" } }
+      ]
+    }
   }
 ]
 ```
+
+#### Why a request did not match
+
+`matchOutcome` answers that without re-deriving the scan by hand. On a hit it carries
+`matched: true` plus `stubIndex`/`stubId`; on a miss, `matched: false` and no winner.
+
+`tried` lists the candidates the matcher **visited**, in visit order — a stub the candidate index
+ruled out before the scan, or one sitting after the winner, is not listed, because no verdict was
+ever reached for it. Each entry says why that candidate fell out: `failedPredicate` with the
+position of the first predicate the request failed (predicates are AND-ed and the scan
+short-circuits, so later ones were never evaluated), or `skippedSpace` / `skippedScenarioState`
+for a stub whose eligibility gate excluded it before predicates ran at all.
+
+The list is capped at 25 entries; anything beyond that is counted in `triedOmitted` rather than
+silently dropped.
+
+The whole object is **absent** when no outcome was recorded — `recordRequests` was off (in which
+case there is no entry at all), a custom `RequestJournal` backend has no stable indices to attach
+to, the request took the `X-Rift-Debug` path, or matching itself errored. Absence means "not
+recorded", never "did not match".
 
 #### Tailing with a cursor
 


### PR DESCRIPTION
## What

An operator reading the request journal cannot answer the question it exists for: *why did this request 404?* The per-request `X-Rift-Debug` path evaluates a match and answers diagnostics instead of executing, but nothing records what the matcher decided for real traffic — `RecordedRequest` carries the request and nothing about its fate.

This PR records a compact `matchOutcome` alongside each journal entry, captured at request time:

```json
{
  "matched": false,
  "tried": [
    { "stubIndex": 0, "stubId": "health", "why": { "reason": "failedPredicate", "predicateIndex": 1 } },
    { "stubIndex": 2, "why": { "reason": "skippedScenarioState" } }
  ]
}
```

## Design notes

- **Visited candidates only.** The Stage-1 index prunes non-candidates before the matcher ever sees them, so "tried" lists what was actually evaluated — which is the honest answer to "what was tried". A matched entry carries `{matched, stubIndex, stubId}` plus any candidates visited before the winner.
- **`tried` is capped at 25 with `triedOmitted` counting the rest** — the journal is a 10k-entries-per-port ring, so per-entry payload is a real budget. Counted rather than silently truncated.
- **The failing predicate is reported by index.** `stub_matches_inner` is reimplemented over a new `stub_matches_explained` that returns the first failing predicate's position (one scan, same short-circuit); a consumer renders the predicate itself from the stub config. `TriedWhy` is adjacently tagged so every variant is one flat object under the same `reason` key.
- **`RequestJournal` grows `attach_match` with a default no-op.** Backends that do not index cannot attach; attaching to an evicted or cleared entry is a no-op, not an error. `LocalJournal` locates the entry by binary search on the strictly-ascending index column under the existing write lock.
- **The handler attaches once, after the no-match interceptor resolves.** A `RetryMatch` rescue attaches the rescued outcome — consistent with the existing contract that a rescued hit is indistinguishable downstream. The debug branch and a matcher error attach nothing: an absent `matchOutcome` means "no outcome recorded", which also covers every pre-upgrade entry.
- **Wire compatibility is pinned by test.** `match_outcome` is `Option` + `skip_serializing_if`, so an entry without an outcome serializes byte-identically to today (the `_mode` precedent). The SSE `request` event publishes at record time — before matching — so the parity test now compares the event against the `savedRequests` projection modulo the one `matchOutcome` key, with everything else still asserted identical. A follow-up could publish a separate match-outcome SSE event for live tails; deliberately not in this PR.

## Tests

Six-test integration binary (`journal_match_outcome.rs`) covering: failing-candidate order and predicate index, matched-winner shape, gate-skip reasons, the cap + omitted count, RetryMatch rescue, and recording-off leaving matching untouched. Unit tests pin the byte-identical no-outcome serialization, attach-to-absent-entry as no-op, and `stub_matches_explained`'s agreement with `stub_matches_inner`. The `savedRequests` docs page gains a `matchOutcome` section.

Full workspace: fmt, clippy (`--all-features` and the no-default-features lane), 1807 lib + 2395 integration tests green.

## Why now

The rift-cluster console's request log (rift-cluster#208) needs per-entry match diagnostics to answer "why did this 404" from recorded traffic; this is the engine half of that feature, consumable by any client of the journal endpoints.
