### PR TITLE
feat(mock-core): let a ProxyRecordingStore complete a claim after the stub is built, and own stub publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **A `ProxyRecordingStore` can now settle a claim *after* the generated stub exists, and own stub
+  publication outright** (issue #910). The trait's `record` is called before predicate generation,
+  which is invisible for the in-process `LocalProxyStore` but inverts the guarantee for an embedder
+  whose store publishes recordings to a shared or durable backend: it is asked to commit "this
+  signature is Recorded" at a point where the stub it must publish does not exist yet, so a failed
+  publication leaves the signature recorded with nothing to replay — and the trait offered no later
+  opportunity to commit.
+
+  Two defaulted additions close that: `complete(..., &StubPublication)` is called instead of
+  `record` whenever a stub was generated, after generation and before publication, so a store can
+  make "Recorded" strictly conditional on its own publication ack; and `publishes_stubs() -> bool`
+  makes the engine skip its in-process insertion entirely so the store is the sole publisher. The
+  `StubPublication` carries the stub plus the placement the engine resolved (`BeforeProxy` for
+  `proxyOnce`, `AfterProxyMerging` for `proxyAlways`) and the `proxy.to` anchor it is relative to,
+  so a publisher reproduces the engine's positions rather than re-deriving them and drifting.
+
+  Both default to today's behaviour — `complete` delegates to `record`, `publishes_stubs` is
+  `false` — so `LocalProxyStore` and every existing implementor are untouched and still compile.
+  See [SPI: publishing stubs from the store](docs/embedding/spi.md).
+
 ### Fixed
 
 - **The published benchmark tables labelled the flagship row with the wrong stub count** (issue #906).

--- a/crates/rift-mock-core/src/imposter/core/proxy.rs
+++ b/crates/rift-mock-core/src/imposter/core/proxy.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use crate::imposter::predicates::regex_cache::cached_regex;
+use crate::recording::{ClaimToken, StubPlacement, StubPublication};
 use std::hash::BuildHasher;
 
 /// Parts read from a successful upstream proxy response, before recording:
@@ -223,6 +224,19 @@ impl Imposter {
         });
     }
 
+    /// Resolve a proxy mode string to the placement its recorded stubs take.
+    ///
+    /// The single source of truth for that mapping: the engine's own insertion and the
+    /// [`StubPublication`] handed to a publishing store both go through here, so the position a
+    /// publisher is told to reproduce can never drift from the one the engine would use.
+    fn placement_for_mode(proxy_mode: &str) -> StubPlacement {
+        if proxy_mode == "proxyAlways" {
+            StubPlacement::AfterProxyMerging
+        } else {
+            StubPlacement::BeforeProxy
+        }
+    }
+
     /// Insert or append a generated stub based on proxy mode.
     ///
     /// Instead of trusting a previously-obtained stub index (which may be stale
@@ -232,6 +246,7 @@ impl Imposter {
     /// For proxyOnce: Insert new stub BEFORE the proxy stub (so it matches first next time)
     /// For proxyAlways: Append response to existing stub AFTER proxy stub, or insert new AFTER proxy
     pub fn insert_or_append_proxy_stub(&self, stub: Stub, proxy_to: &str, proxy_mode: &str) {
+        let placement = Self::placement_for_mode(proxy_mode);
         self.mutate_stubs(|stubs| {
             // Re-locate the proxy stub inside the write critical section to avoid stale-index races.
             let proxy_stub_index = stubs
@@ -244,7 +259,7 @@ impl Imposter {
                 })
                 .unwrap_or(stubs.len());
 
-            if proxy_mode == "proxyAlways" {
+            if placement == StubPlacement::AfterProxyMerging {
                 // For proxyAlways, recorded stubs go AFTER the proxy stub
                 // This ensures proxy always runs first and records each request
 
@@ -295,6 +310,44 @@ impl Imposter {
                 );
             }
         });
+    }
+
+    /// Settle a won proxy claim, offering the generated stub when one exists.
+    ///
+    /// A failed settle releases the claim so the signature stays retryable instead of wedging as
+    /// Recorded with nothing behind it (issue #315, and the publication-failure case of #910).
+    /// The caller keeps its upstream response either way: the upstream call succeeded, only
+    /// recording failed.
+    fn settle_proxy_claim(
+        &self,
+        port: u16,
+        signature: &RequestSignature,
+        token: ClaimToken,
+        resp: RecordedResponse,
+        publication: Option<&StubPublication<'_>>,
+    ) {
+        // The path is named in the warn below: for a publishing store a `complete` failure is a
+        // failed *publication*, which an operator has to correlate differently from a plain
+        // recording failure.
+        let (path, settled) = match publication {
+            Some(publication) => (
+                "complete",
+                self.proxy_store
+                    .complete(port, signature.clone(), token, resp, publication),
+            ),
+            None => (
+                "record",
+                self.proxy_store
+                    .record(port, signature.clone(), token, resp),
+            ),
+        };
+        if let Err(e) = settled {
+            warn!(
+                "Failed to settle proxy recording via {path}(), releasing claim so it stays \
+                 retryable: {e}"
+            );
+            self.proxy_store.release_claim(port, signature, token);
+        }
     }
 
     /// Forward a request through proxy and optionally record the response
@@ -460,32 +513,21 @@ impl Imposter {
             }
         };
 
-        // Record the response only if we hold a claim.
-        if let Some(token) = claim_token {
-            let recorded_response = RecordedResponse {
-                status,
-                headers: response_headers.clone(),
-                body: body_bytes.to_vec(),
-                latency_ms: if proxy_config.add_wait_behavior {
-                    Some(latency_ms)
-                } else {
-                    None
+        // Build the recording if we hold a claim, but do NOT settle the claim yet: a store that
+        // publishes stubs must be able to make "Recorded" conditional on publishing the stub, and
+        // the stub does not exist until predicate generation below has run (issue #910).
+        let mut recording = claim_token.map(|token| {
+            (
+                token,
+                RecordedResponse {
+                    status,
+                    headers: response_headers.clone(),
+                    body: body_bytes.to_vec(),
+                    latency_ms: proxy_config.add_wait_behavior.then_some(latency_ms),
+                    timestamp_secs: crate::util::unix_timestamp(),
                 },
-                timestamp_secs: crate::util::unix_timestamp(),
-            };
-
-            if let Err(e) =
-                self.proxy_store
-                    .record(port, signature.clone(), token, recorded_response)
-            {
-                // A failed record must release the claim, or the signature wedges for
-                // proxyOnce (issue #315) — symmetric with the upstream-failure path above.
-                warn!(
-                    "Failed to record proxy response, releasing claim so it stays retryable: {e}"
-                );
-                self.proxy_store.release_claim(port, &signature, token);
-            }
-        }
+            )
+        });
 
         // Generate and insert stub if predicateGenerators, addWaitBehavior, or addDecorateBehavior is configured
         // (Mountebank generates stubs automatically when these are enabled)
@@ -579,7 +621,34 @@ impl Imposter {
                     } else {
                         &proxy_config.mode
                     };
-                    self.insert_or_append_proxy_stub(new_stub, &proxy_config.to, mode);
+
+                    // Settle the claim now that the stub exists, and before it is published, so a
+                    // publishing store can refuse to commit "Recorded" if publication fails.
+                    let settled = if let Some((token, resp)) = recording.take() {
+                        let publication = StubPublication {
+                            stub: &new_stub,
+                            placement: Self::placement_for_mode(mode),
+                            proxy_to: &proxy_config.to,
+                        };
+                        self.settle_proxy_claim(port, &signature, token, resp, Some(&publication));
+                        true
+                    } else {
+                        false
+                    };
+
+                    // A store that publishes stubs is the only publisher; inserting locally too
+                    // would double-publish the recording (issue #910). When no claim was won there
+                    // was no `complete` call either, so nobody publishes this stub — say so, rather
+                    // than logging that the store took ownership of something it never saw.
+                    if self.proxy_store.publishes_stubs() {
+                        debug!(
+                            "Skipping local stub insertion for path {} (proxy store publishes \
+                             stubs; handed over: {settled})",
+                            uri.path()
+                        );
+                    } else {
+                        self.insert_or_append_proxy_stub(new_stub, &proxy_config.to, mode);
+                    }
                     debug!(
                         "Generated stub from proxy response for path {} (mode: {})",
                         uri.path(),
@@ -599,6 +668,12 @@ impl Imposter {
                         .push(("x-rift-generator-error".to_string(), token.to_string()));
                 }
             }
+        }
+
+        // No stub was generated — nothing configured to generate one, or generation failed — so
+        // there is nothing to publish and the claim settles through `record` exactly as before.
+        if let Some((token, resp)) = recording {
+            self.settle_proxy_claim(port, &signature, token, resp, None);
         }
 
         Ok((

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -4133,7 +4133,7 @@ mod tests {
         use super::*;
         use crate::recording::{
             ClaimOutcome, ClaimToken, LocalProxyStore, ProxyMode, ProxyRecordingStore,
-            ProxyStoreError, RecordedResponse, RequestSignature,
+            ProxyStoreError, RecordedResponse, RequestSignature, StubPlacement, StubPublication,
         };
 
         /// Delegates to a LocalProxyStore while recording every claim/release/clear it sees.
@@ -4358,6 +4358,382 @@ mod tests {
                 spy.releases.lock().is_empty(),
                 "no claim was granted, so nothing to release"
             );
+
+            manager.delete_all().await;
+        }
+
+        // =====================================================================
+        // Issue #910: complete-after-stub + store-owned stub publication
+        // =====================================================================
+
+        /// A store that settles claims through `complete` and can own stub publication.
+        /// `publishes` drives `publishes_stubs()`; `fail_complete` injects the publication-failed
+        /// path a distributed backend takes when it cannot commit the stub.
+        struct PublishingProxyStore {
+            inner: LocalProxyStore,
+            publishes: bool,
+            fail_complete: bool,
+            /// `(port, placement, proxy_to, stub)` for every completion the engine handed over.
+            completions: Mutex<Vec<(u16, StubPlacement, String, Stub)>>,
+            /// Recordings settled through the pre-#910 `record` path (no stub was generated).
+            records: Mutex<Vec<u16>>,
+            releases: Mutex<Vec<u16>>,
+        }
+
+        impl PublishingProxyStore {
+            fn new(publishes: bool, fail_complete: bool) -> Self {
+                Self {
+                    inner: LocalProxyStore::new(ProxyMode::ProxyOnce),
+                    publishes,
+                    fail_complete,
+                    completions: Mutex::new(Vec::new()),
+                    records: Mutex::new(Vec::new()),
+                    releases: Mutex::new(Vec::new()),
+                }
+            }
+        }
+
+        impl ProxyRecordingStore for PublishingProxyStore {
+            fn try_claim(
+                &self,
+                port: u16,
+                sig: &RequestSignature,
+            ) -> std::result::Result<ClaimOutcome, ProxyStoreError> {
+                self.inner.try_claim(port, sig)
+            }
+            fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken) {
+                self.releases.lock().push(port);
+                self.inner.release_claim(port, sig, token);
+            }
+            fn record(
+                &self,
+                port: u16,
+                sig: RequestSignature,
+                token: ClaimToken,
+                resp: RecordedResponse,
+            ) -> std::result::Result<(), ProxyStoreError> {
+                self.records.lock().push(port);
+                self.inner.record(port, sig, token, resp)
+            }
+            fn complete(
+                &self,
+                port: u16,
+                sig: RequestSignature,
+                token: ClaimToken,
+                resp: RecordedResponse,
+                publication: &StubPublication<'_>,
+            ) -> std::result::Result<(), ProxyStoreError> {
+                self.completions.lock().push((
+                    port,
+                    publication.placement,
+                    publication.proxy_to.to_string(),
+                    publication.stub.clone(),
+                ));
+                if self.fail_complete {
+                    return Err(ProxyStoreError::Unavailable("publication failed".into()));
+                }
+                self.inner.record(port, sig, token, resp)
+            }
+            fn publishes_stubs(&self) -> bool {
+                self.publishes
+            }
+            fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse> {
+                self.inner.lookup(port, sig)
+            }
+            fn clear(&self, port: u16) {
+                self.inner.clear(port);
+            }
+        }
+
+        /// A proxy imposter with `predicateGenerators`, so the engine builds a stub from the
+        /// proxied response and therefore reaches the publication seam. Returns the port.
+        async fn generating_proxy_imposter(manager: &ImposterManager, to: &str, mode: &str) -> u16 {
+            manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http",
+                    "stubs": [{ "responses": [{ "proxy": {
+                        "to": to,
+                        "mode": mode,
+                        "predicateGenerators": [{ "matches": { "path": true } }]
+                    } }] }]
+                })))
+                .await
+                .expect("create generating proxy imposter")
+        }
+
+        // AC3/AC4: with `publishes_stubs() == true` the engine performs no stub insertion of its
+        // own, and the store receives the built stub plus the resolved insertion intent.
+        #[tokio::test]
+        async fn publishing_store_owns_stub_insertion() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let to = format!("http://127.0.0.1:{up}");
+            let proxy_port = generating_proxy_imposter(&manager, &to, "proxyOnce").await;
+
+            let body = reqwest::get(format!("http://127.0.0.1:{proxy_port}/owned"))
+                .await
+                .expect("request")
+                .text()
+                .await
+                .expect("body");
+            assert_eq!(body, "UP");
+
+            {
+                let completions = spy.completions.lock();
+                assert_eq!(
+                    completions.len(),
+                    1,
+                    "the claim is settled through complete(), not record()"
+                );
+                assert_eq!(completions[0].0, proxy_port);
+                assert_eq!(
+                    completions[0].1,
+                    StubPlacement::BeforeProxy,
+                    "proxyOnce recordings belong before the proxy stub"
+                );
+                assert_eq!(
+                    completions[0].2, to,
+                    "the anchor the placement is relative to"
+                );
+                assert!(
+                    !completions[0].3.predicates.is_empty(),
+                    "the store receives the fully-built stub, generated predicates included"
+                );
+            }
+            assert!(
+                spy.records.lock().is_empty(),
+                "a generated stub settles via complete(), never via record()"
+            );
+
+            assert_eq!(
+                manager.get_imposter(proxy_port).unwrap().stub_count(),
+                1,
+                "the store owns publication; the engine inserted nothing locally"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC1: the default (`publishes_stubs() == false`) keeps the engine's own insertion, so a
+        // non-publishing store sees exactly today's behaviour.
+        #[tokio::test]
+        async fn non_publishing_store_keeps_engine_insertion() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(false, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let to = format!("http://127.0.0.1:{up}");
+            let proxy_port = generating_proxy_imposter(&manager, &to, "proxyOnce").await;
+
+            let body = reqwest::get(format!("http://127.0.0.1:{proxy_port}/kept"))
+                .await
+                .expect("request")
+                .text()
+                .await
+                .expect("body");
+            assert_eq!(body, "UP");
+
+            assert_eq!(spy.completions.lock().len(), 1);
+            assert_eq!(
+                manager.get_imposter(proxy_port).unwrap().stub_count(),
+                2,
+                "the engine still inserts the recorded stub next to the proxy stub"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC4: proxyAlways resolves to the after-the-proxy-stub, merge-on-equal-predicates intent,
+        // so a publisher never has to re-derive it from the mode string.
+        #[tokio::test]
+        async fn proxy_always_completion_carries_after_proxy_placement() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let to = format!("http://127.0.0.1:{up}");
+            let proxy_port = generating_proxy_imposter(&manager, &to, "proxyAlways").await;
+
+            let _ = reqwest::get(format!("http://127.0.0.1:{proxy_port}/always")).await;
+
+            {
+                let completions = spy.completions.lock();
+                assert_eq!(completions.len(), 1);
+                assert_eq!(
+                    completions[0].1,
+                    StubPlacement::AfterProxyMerging,
+                    "proxyAlways recordings belong after the proxy stub and merge on equal predicates"
+                );
+            }
+
+            manager.delete_all().await;
+        }
+
+        // AC6: a store that refuses to commit "Recorded" because its publication failed leaves the
+        // signature retryable — the claim is released, and the client still gets the upstream
+        // response because the upstream call itself succeeded.
+        #[tokio::test]
+        async fn complete_failure_releases_claim_end_to_end() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, true));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let to = format!("http://127.0.0.1:{up}");
+            let proxy_port = generating_proxy_imposter(&manager, &to, "proxyOnce").await;
+
+            for _ in 0..2 {
+                let body = reqwest::get(format!("http://127.0.0.1:{proxy_port}/unpublished"))
+                    .await
+                    .expect("request")
+                    .text()
+                    .await
+                    .expect("body");
+                assert_eq!(body, "UP", "the client still gets the upstream response");
+            }
+
+            assert_eq!(
+                spy.completions.lock().len(),
+                2,
+                "the second request could claim again, so the signature never wedged"
+            );
+            assert_eq!(
+                spy.releases.lock().len(),
+                2,
+                "a failed complete releases the claim, exactly as a failed record does"
+            );
+            assert!(
+                spy.lookup(
+                    proxy_port,
+                    &RequestSignature::new("GET", "/unpublished", None, &[])
+                )
+                .is_none(),
+                "nothing is recorded when publication failed"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC1/AC4: `addWaitBehavior` is the other way a stub gets generated, and it reaches the
+        // same seam — the store is handed the stub, latency included, not just for generators.
+        #[tokio::test]
+        async fn add_wait_behavior_alone_reaches_the_publication_seam() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let proxy_port = manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http",
+                    "stubs": [{ "responses": [{ "proxy": {
+                        "to": format!("http://127.0.0.1:{up}"),
+                        "mode": "proxyOnce",
+                        "addWaitBehavior": true
+                    } }] }]
+                })))
+                .await
+                .expect("create wait-behavior proxy imposter");
+
+            let _ = reqwest::get(format!("http://127.0.0.1:{proxy_port}/waited")).await;
+
+            {
+                let completions = spy.completions.lock();
+                assert_eq!(
+                    completions.len(),
+                    1,
+                    "addWaitBehavior generates a stub, so the claim settles via complete()"
+                );
+                let stub = serde_json::to_value(&completions[0].3).expect("stub serializes");
+                let behaviors = stub
+                    .pointer("/responses/0/behaviors")
+                    .and_then(serde_json::Value::as_array)
+                    .expect("the recorded stub carries behaviors");
+                assert!(
+                    behaviors.iter().any(|b| b.get("wait").is_some()),
+                    "the store receives the stub carrying the captured latency, not a bare shell"
+                );
+            }
+            assert!(spy.records.lock().is_empty());
+
+            manager.delete_all().await;
+        }
+
+        // AC1/AC6 + issue #498: when predicate generation FAILS there is no stub, so nothing may be
+        // published — the claim settles through `record` even for a publishing store, and the
+        // client still gets the generator-error marker.
+        #[cfg(feature = "javascript")]
+        #[tokio::test]
+        async fn failed_generation_settles_through_record_and_publishes_nothing() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let proxy_port = manager
+                .create_imposter(imposter_cfg(json!({
+                    "protocol": "http",
+                    "stubs": [{ "responses": [{ "proxy": {
+                        "to": format!("http://127.0.0.1:{up}"),
+                        "mode": "proxyOnce",
+                        "predicateGenerators": [
+                            { "inject": "function (config, logger, preds) { throw new Error('boom'); }" }
+                        ]
+                    } }] }]
+                })))
+                .await
+                .expect("create failing-generator proxy imposter");
+
+            let response = reqwest::get(format!("http://127.0.0.1:{proxy_port}/boom"))
+                .await
+                .expect("request");
+            assert!(
+                response.headers().contains_key("x-rift-generator-error"),
+                "the generation failure stays client-visible (issue #498)"
+            );
+
+            assert!(
+                spy.completions.lock().is_empty(),
+                "no stub was built, so nothing may be offered for publication"
+            );
+            assert_eq!(
+                spy.records.lock().len(),
+                1,
+                "the claim still settles exactly once, through record()"
+            );
+            assert_eq!(
+                manager.get_imposter(proxy_port).unwrap().stub_count(),
+                1,
+                "and no match-all stub is inserted locally either"
+            );
+
+            manager.delete_all().await;
+        }
+
+        // AC1: with no generators or behaviors configured no stub is built, so there is nothing to
+        // publish and the claim settles through the pre-#910 `record` path.
+        #[tokio::test]
+        async fn no_generated_stub_still_settles_through_record() {
+            raise_fd_limit();
+            let spy = Arc::new(PublishingProxyStore::new(true, false));
+            let manager = ImposterManager::new()
+                .with_proxy_store(spy.clone() as Arc<dyn ProxyRecordingStore>);
+            let up = upstream(&manager).await;
+            let proxy_port = proxy_imposter(&manager, &format!("http://127.0.0.1:{up}")).await;
+
+            let _ = reqwest::get(format!("http://127.0.0.1:{proxy_port}/plain")).await;
+
+            assert_eq!(
+                spy.records.lock().len(),
+                1,
+                "no stub to publish, so the recording settles via record()"
+            );
+            assert!(spy.completions.lock().is_empty());
 
             manager.delete_all().await;
         }

--- a/crates/rift-mock-core/src/recording/mod.rs
+++ b/crates/rift-mock-core/src/recording/mod.rs
@@ -26,7 +26,8 @@ mod types;
 // Re-export main types
 pub use mode::ProxyMode;
 pub use proxy_store::{
-    ClaimOutcome, ClaimToken, LocalProxyStore, ProxyRecordingStore, ProxyStoreError,
+    ClaimOutcome, ClaimToken, LocalProxyStore, ProxyRecordingStore, ProxyStoreError, StubPlacement,
+    StubPublication,
 };
 pub use store::RecordingStore;
 #[allow(unused_imports)]

--- a/crates/rift-mock-core/src/recording/proxy_store.rs
+++ b/crates/rift-mock-core/src/recording/proxy_store.rs
@@ -16,6 +16,7 @@
 
 use super::mode::ProxyMode;
 use super::types::{RecordedResponse, RequestSignature};
+use crate::imposter::Stub;
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -80,6 +81,47 @@ pub enum ProxyStoreError {
 /// Convenience alias for fallible proxy-store operations.
 pub type Result<T> = std::result::Result<T, ProxyStoreError>;
 
+/// Where a proxy-recorded stub belongs relative to the proxy stub that produced it.
+///
+/// These are engine semantics, not a hint: a store that publishes stubs itself
+/// ([`ProxyRecordingStore::publishes_stubs`]) has to reproduce them, and deriving them from the
+/// proxy mode independently is how a publisher silently drifts from the engine.
+///
+/// `#[non_exhaustive]`: a downstream publisher `match`es on this, and a future placement must not
+/// break every one of them — the same reasoning [`EventContext`](crate::imposter::EventContext)
+/// carries. Match with a `_` arm and treat an unknown placement as unpublishable rather than
+/// guessing a position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StubPlacement {
+    /// `proxyOnce`: insert **before** the proxy stub, so the recording matches first next time.
+    BeforeProxy,
+    /// `proxyAlways`: place **after** the proxy stub — so the proxy keeps running and recording —
+    /// merging the responses into an existing stub whose predicates are structurally equal and
+    /// non-empty (issue #611) instead of appending a duplicate.
+    AfterProxyMerging,
+}
+
+/// The stub the engine generated from a proxied response, together with where it belongs.
+///
+/// Handed to [`ProxyRecordingStore::complete`] before the stub is published, so a store can make
+/// its own "recorded" commit conditional on publishing this successfully.
+///
+/// `#[non_exhaustive]`: embedders only ever read this type — the engine is the sole constructor —
+/// so the context it will predictably grow must not become a breaking change to the seam whose
+/// premise is stability. Same reasoning as [`EventContext`](crate::imposter::EventContext).
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct StubPublication<'a> {
+    /// The generated stub, exactly as the engine would insert it.
+    pub stub: &'a Stub,
+    /// Where the stub belongs relative to the proxy stub named by [`proxy_to`](Self::proxy_to).
+    pub placement: StubPlacement,
+    /// `proxy.to` of the proxy stub this recording came from — the anchor
+    /// [`placement`](Self::placement) is relative to.
+    pub proxy_to: &'a str,
+}
+
 /// Pluggable proxy-recording backend, keyed by imposter port.
 pub trait ProxyRecordingStore: Send + Sync {
     /// First caller per `(port, signature)` wins the right to record once. Returns
@@ -107,6 +149,60 @@ pub trait ProxyRecordingStore: Send + Sync {
         token: ClaimToken,
         resp: RecordedResponse,
     ) -> Result<()>;
+
+    /// Settles the claim once the engine has built the stub the recording will be replayed from,
+    /// and **before** that stub is published (issue #910).
+    ///
+    /// Called instead of [`record`](Self::record) whenever a stub was generated — that is, when
+    /// `predicateGenerators`, `addWaitBehavior` or `addDecorateBehavior` is configured and
+    /// predicate generation succeeded. When no stub exists (none of those is configured, or
+    /// generation failed and recording a match-all stub would be wrong — issue #498) there is
+    /// nothing to publish and the engine calls [`record`](Self::record) as before.
+    ///
+    /// This ordering is the point: a store that publishes stubs to a shared or durable backend can
+    /// make "this signature is Recorded" strictly conditional on its own publication ack, instead
+    /// of committing it against a stub that does not exist yet.
+    ///
+    /// It also means the claim is held for the whole of predicate generation. That is negligible
+    /// for the ordinary generators, but a `predicateGenerators.inject` script runs under the
+    /// script timeout (5s by default), and a concurrent `proxyOnce` request arriving inside that
+    /// window sees [`ClaimOutcome::InFlight`] rather than [`ClaimOutcome::AlreadyRecorded`] — so it
+    /// proxies upstream instead of replaying. The signature is still recorded exactly once.
+    ///
+    /// The default delegates to [`record`](Self::record), so a store that does not publish is
+    /// unaffected.
+    ///
+    /// `Err` = backend unavailable, including "I could not publish the stub". As with
+    /// [`record`](Self::record) the caller then releases the claim, so the signature stays
+    /// retryable rather than wedging as Recorded-but-stub-less; the client still receives the
+    /// upstream response, because the upstream call succeeded and only recording failed.
+    fn complete(
+        &self,
+        port: u16,
+        sig: RequestSignature,
+        token: ClaimToken,
+        resp: RecordedResponse,
+        publication: &StubPublication<'_>,
+    ) -> Result<()> {
+        let _ = publication;
+        self.record(port, sig, token, resp)
+    }
+
+    /// Whether this store publishes generated stubs itself.
+    ///
+    /// `true` makes the engine skip its own in-process stub insertion entirely, leaving the store
+    /// as the only publisher — it must then honour the position carried by
+    /// [`StubPublication::placement`]. `false` (the default) keeps the engine's insertion, and the
+    /// stub handed to [`complete`](Self::complete) is informational.
+    ///
+    /// "Skip entirely" is unconditional, and that is the trade a publisher accepts: when no claim
+    /// was won — a concurrent `proxyOnce` loser, or [`try_claim`](Self::try_claim) reporting the
+    /// backend unavailable — there is no [`complete`](Self::complete) call *and* no local
+    /// insertion, so that request's stub is published nowhere. The engine will not quietly keep a
+    /// private copy the store's peers do not have.
+    fn publishes_stubs(&self) -> bool {
+        false
+    }
 
     /// Returns the recorded response for replay, if any.
     fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse>;
@@ -313,6 +409,14 @@ mod tests {
         RequestSignature::new("GET", path, None, &[])
     }
 
+    fn generated_stub() -> Stub {
+        serde_json::from_value(serde_json::json!({
+            "predicates": [{ "equals": { "path": "/test" } }],
+            "responses": [{ "is": { "statusCode": 200, "body": "recorded" } }],
+        }))
+        .expect("valid stub")
+    }
+
     fn resp(status: u16, body: &str) -> RecordedResponse {
         RecordedResponse {
             status,
@@ -515,6 +619,95 @@ mod tests {
             store.try_claim(1, &s).unwrap(),
             ClaimOutcome::Claimed(_)
         ));
+    }
+
+    /// Implements only the methods that existed before #910 — the shape every pre-#910 store has.
+    /// Its mere existence is the source-compatibility assertion; the tests below use it to prove
+    /// the new defaults behave as documented.
+    #[derive(Default)]
+    struct LegacyStore {
+        recorded: Mutex<Vec<(u16, RequestSignature, RecordedResponse)>>,
+    }
+
+    impl ProxyRecordingStore for LegacyStore {
+        fn try_claim(&self, _port: u16, _sig: &RequestSignature) -> Result<ClaimOutcome> {
+            Ok(ClaimOutcome::Claimed(ClaimToken::new(1)))
+        }
+        fn release_claim(&self, _port: u16, _sig: &RequestSignature, _token: ClaimToken) {}
+        fn record(
+            &self,
+            port: u16,
+            sig: RequestSignature,
+            _token: ClaimToken,
+            resp: RecordedResponse,
+        ) -> Result<()> {
+            self.recorded.lock().push((port, sig, resp));
+            Ok(())
+        }
+        fn lookup(&self, _port: u16, _sig: &RequestSignature) -> Option<RecordedResponse> {
+            None
+        }
+        fn clear(&self, _port: u16) {}
+    }
+
+    // AC2/AC5 (#910): a store written before `complete` existed still compiles, and the default
+    // `complete` delegates to its `record`. Driven through `dyn` so object safety is asserted too.
+    #[test]
+    fn default_complete_delegates_to_record() {
+        let store = LegacyStore::default();
+        let stub = generated_stub();
+        let publication = StubPublication {
+            stub: &stub,
+            placement: StubPlacement::BeforeProxy,
+            proxy_to: "http://upstream",
+        };
+
+        let dynamic: &dyn ProxyRecordingStore = &store;
+        assert!(
+            !dynamic.publishes_stubs(),
+            "a store publishes nothing unless it opts in"
+        );
+        dynamic
+            .complete(
+                7,
+                sig("/legacy"),
+                ClaimToken::new(1),
+                resp(200, "ok"),
+                &publication,
+            )
+            .expect("default complete delegates to record");
+
+        let recorded = store.recorded.lock();
+        assert_eq!(recorded.len(), 1, "the recording reached record()");
+        assert_eq!(recorded[0].0, 7, "port is passed through");
+        assert_eq!(recorded[0].2.body, b"ok");
+    }
+
+    // AC1/AC6 (#910): completing a claim through `complete` is recording — same visible result as
+    // `record`, so `LocalProxyStore` is unchanged by the new seam.
+    #[test]
+    fn local_complete_records_like_record() {
+        let store = LocalProxyStore::new(ProxyMode::ProxyOnce);
+        let s = sig("/complete");
+        let stub = generated_stub();
+        let publication = StubPublication {
+            stub: &stub,
+            placement: StubPlacement::BeforeProxy,
+            proxy_to: "http://upstream",
+        };
+
+        let t = claim_token(store.try_claim(1, &s).unwrap());
+        store
+            .complete(1, s.clone(), t, resp(200, "done"), &publication)
+            .unwrap();
+
+        assert_eq!(store.lookup(1, &s).unwrap().body, b"done");
+        assert_eq!(
+            store.try_claim(1, &s).unwrap(),
+            ClaimOutcome::AlreadyRecorded,
+            "complete settles the claim exactly as record does"
+        );
+        assert!(!store.publishes_stubs());
     }
 
     // The total-signatures cap drops new signatures once full (proxyOnce), as before.

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -150,6 +150,12 @@ pub trait ProxyRecordingStore: Send + Sync {
     /// Release a claim after a failed upstream call so the signature is retryable.
     fn release_claim(&self, port: u16, sig: &RequestSignature, token: ClaimToken);
     fn record(&self, /* port, sig, response, token */) -> Result<()>;
+    /// Settle the claim once the generated stub exists, before it is published.
+    /// Defaults to `record`, so implementing it is optional.
+    fn complete(&self, /* port, sig, token, response */
+                publication: &StubPublication<'_>) -> Result<()> { /* -> record */ }
+    /// `true` = this store publishes generated stubs itself; the engine then inserts none.
+    fn publishes_stubs(&self) -> bool { false }
     fn lookup(&self, port: u16, sig: &RequestSignature) -> Option<RecordedResponse>;
     fn clear(&self, port: u16);
 }
@@ -157,6 +163,59 @@ pub trait ProxyRecordingStore: Send + Sync {
 
 Its typed error is `ProxyStoreError` (`ProxyStoreError::Unavailable(String)`). Inject with
 `.with_proxy_store(Arc<dyn ProxyRecordingStore>)`.
+
+### Publishing stubs from the store
+
+`record` is called before the engine has generated the stub the recording will be replayed from,
+which is fine for an in-process store but not for one that must publish that stub somewhere durable
+or replicated: it would have to commit "this signature is Recorded" against a stub that does not
+exist yet, and a publication that then failed would leave the signature permanently recorded with
+nothing to replay.
+
+`complete` is the seam for that. It is called **instead of** `record` whenever a stub was generated
+(`predicateGenerators`, `addWaitBehavior` or `addDecorateBehavior` configured, and generation
+succeeded), and always **before** the stub is published — so a store can make its own commit
+conditional on its publication ack. Returning `Err` releases the claim, leaving the signature
+retryable; the client still receives the upstream response, because the upstream call succeeded and
+only recording failed. When no stub is generated — nothing configured to generate one, or predicate
+generation failed — there is nothing to publish and the engine calls `record` as before.
+
+`publishes_stubs() == true` additionally makes the engine skip its own in-process stub insertion, so
+the store is the sole publisher. It must then honour the position the engine resolved, which arrives
+alongside the stub:
+
+```rust
+pub struct StubPublication<'a> {
+    pub stub: &'a Stub,              // the generated stub, exactly as the engine would insert it
+    pub placement: StubPlacement,    // where it belongs relative to the proxy stub
+    pub proxy_to: &'a str,           // `proxy.to` of that proxy stub — the anchor
+}
+
+pub enum StubPlacement {
+    /// proxyOnce: insert BEFORE the proxy stub, so the recording matches first next time.
+    BeforeProxy,
+    /// proxyAlways: place AFTER the proxy stub (so the proxy keeps recording), merging responses
+    /// into an existing stub with structurally equal, non-empty predicates rather than appending
+    /// a duplicate.
+    AfterProxyMerging,
+}
+```
+
+Both additions are defaulted, so a store written against the pre-`complete` trait keeps compiling
+and behaving identically. `StubPublication` and `StubPlacement` are `#[non_exhaustive]` — match the
+placement with a `_` arm and treat an unknown one as unpublishable rather than guessing a position.
+
+Two consequences worth knowing before you set `publishes_stubs() == true`:
+
+- **Skipping is unconditional.** When no claim was won — a concurrent `proxyOnce` loser, or
+  `try_claim` reporting the backend unavailable — there is no `complete` call *and* no local
+  insertion, so that request's stub is published nowhere. The engine will not quietly keep a private
+  copy your store's peers do not have.
+- **The claim is held across predicate generation.** Negligible for the ordinary generators, but a
+  `predicateGenerators.inject` script runs under the script timeout (5s by default), and a
+  concurrent `proxyOnce` request arriving inside that window sees `InFlight` rather than
+  `AlreadyRecorded`, so it proxies upstream instead of replaying. The signature is still recorded
+  exactly once.
 
 ## `ImposterEventListener` — observe reconciliation
 


### PR DESCRIPTION
A ProxyRecordingStore can now settle a claim after the generated stub exists and own stub publication outright. The trait's record is called before predicate generation, which is invisible for the in-process LocalProxyStore but inverts the guarantee for an embedder whose store publishes recordings to a shared or durable backend.

Two defaulted additions close this: complete(..., &StubPublication) is called after generation and before publication, and publishes_stubs() makes the engine skip its own insertion so the store is the sole publisher. Both default to today's behaviour.

Docs: `docs/embedding/spi.md` gains a *Publishing stubs from the store* section and `CHANGELOG.md` an Unreleased→Added entry.

Closes #910
Milestone: none (standalone engine seam)