### PR TITLE
test(ci): cross-SDK conformance matrix + docs/sdk landing pages (SDK-M6)

### DIFF
--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -1,0 +1,223 @@
+name: SDK Matrix
+
+# Issue #462 (SDK-M6): prove the four released SDKs still work against the *latest* engine release.
+#
+# Each SDK's own CI pins an engine version and tests against that pin, so an engine change that
+# breaks a released SDK is green everywhere: green here (no SDK is built in this repo), and green
+# there (it is still testing the old engine). The break only surfaces when a user upgrades. This
+# gate closes that hole by replaying each SDK's conformance lane at its latest release tag against
+# the newest published engine.
+#
+# Lives outside ci.yml deliberately, same reasoning as demo-compose.yml/perf.yml: ci.yml has no
+# schedule and ignores pushes to master, and none of the three triggers below can be expressed
+# there.
+#
+# Scope, stated rather than implied: every lane runs on ubuntu-latest only, and only the embedded
+# transport is overridden to the latest engine. Platform coverage (macOS/Windows) and the spawn
+# lanes stay each SDK's own CI's job — this gate is about *version* drift, and running a lane whose
+# engine version the SDK resolves internally would just re-test the pin.
+
+on:
+  schedule:
+    # Daily at 05:23 UTC. Off the hour: shared runners are contended on the hour.
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+    inputs:
+      engine_version:
+        description: "Engine release tag to test against (default: latest published release)"
+        required: false
+        type: string
+  release:
+    # A fresh engine release is the event most likely to break an SDK, so prove it within minutes
+    # rather than waiting up to a day for the cron.
+    types: [published]
+
+concurrency:
+  group: sdk-matrix
+  # Never cancel: a cancelled run reports nothing, and there is no PR waiting on this.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write # the drift reporter opens/updates one tracking issue per SDK
+
+jobs:
+  engine:
+    name: Resolve engine release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.engine_version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION:-}" ]; then
+            version="$INPUT_VERSION"
+          elif [ -n "${RELEASE_TAG:-}" ]; then
+            version="$RELEASE_TAG"
+          else
+            version="$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName)"
+          fi
+          echo "Engine under test: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  sdk:
+    name: ${{ matrix.sdk.name }} @ latest release
+    needs: engine
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one drifting SDK must not hide the state of the other three
+      matrix:
+        sdk:
+          - { name: java, repo: achird-labs/rift-java }
+          - { name: scala, repo: achird-labs/rift-scala }
+          - { name: node, repo: achird-labs/rift-node }
+          - { name: go, repo: achird-labs/rift-go }
+    env:
+      ENGINE: ${{ needs.engine.outputs.version }}
+    steps:
+      # This repo, for scripts/sdk-matrix-report.sh. The SDK goes in sdk/ below.
+      - uses: actions/checkout@v7
+
+      - name: Resolve the SDK's latest release tag
+        id: sdk-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release view --repo ${{ matrix.sdk.repo }} --json tagName -q .tagName)"
+          echo "rift-${{ matrix.sdk.name }} latest release: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      # All four SDK repos are public, so the default token is enough for a cross-repo checkout —
+      # no dispatch-token secret is needed here, unlike release.yml's rift-node trigger (which
+      # needs actions:write on another repo, something GITHUB_TOKEN cannot have).
+      - name: Check out ${{ matrix.sdk.repo }} at ${{ steps.sdk-tag.outputs.tag }}
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ matrix.sdk.repo }}
+          ref: ${{ steps.sdk-tag.outputs.tag }}
+          path: sdk
+
+      # Asset naming is this repo's contract, so resolving it here — rather than letting each SDK
+      # fetch its pinned version — is exactly what makes the lane test the new engine.
+      - name: Download engine ${{ needs.engine.outputs.version }} assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p natives dist corpus
+          lib=librift_ffi-linux-x86_64.so
+          triple=x86_64-unknown-linux-gnu
+
+          gh release download "$ENGINE" --repo ${{ github.repository }} --dir dist \
+            --pattern "$lib" \
+            --pattern "rift-$ENGINE-$triple.tar.gz" \
+            --pattern "sdk-conformance-$ENGINE.tar.gz"
+
+          mv "dist/$lib" natives/
+          tar -xzf "dist/rift-$ENGINE-$triple.tar.gz" -C dist
+          tar -xzf "dist/sdk-conformance-$ENGINE.tar.gz" -C corpus
+
+          # Neither archive's internal layout is contractual, so locate rather than assume.
+          engine_bin="$(find dist -type f -name rift -perm -u+x | head -1)"
+          [ -n "$engine_bin" ] || { echo "::error::no rift binary in the release tarball"; exit 1; }
+          manifest="$(find corpus -type f -name manifest.json | head -1)"
+          [ -n "$manifest" ] || { echo "::error::no manifest.json in the corpus tarball"; exit 1; }
+
+          {
+            echo "RIFT_FFI_LIB=$PWD/natives/$lib"
+            echo "RIFT_BINARY=$PWD/$engine_bin"
+            # go wants the directory holding manifest.json; rift-java's Corpus.descend() wants the
+            # parent and resolves the single extracted sdk-conformance-* child itself.
+            echo "RIFT_CORPUS_DIR=$(dirname "$manifest")"
+            echo "RIFT_CORPUS_ROOT=$PWD/corpus"
+          } >> "$GITHUB_ENV"
+
+      - name: Set up JDK 22
+        if: matrix.sdk.name == 'java' || matrix.sdk.name == 'scala'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "22"
+          cache: ${{ matrix.sdk.name == 'java' && 'maven' || 'sbt' }}
+
+      - name: Set up sbt
+        if: matrix.sdk.name == 'scala'
+        uses: sbt/setup-sbt@v1
+
+      - name: Set up Node 22
+        if: matrix.sdk.name == 'node'
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Set up Go
+        if: matrix.sdk.name == 'go'
+        uses: actions/setup-go@v5
+        with:
+          # go-version-file, not a pinned version: gofmt and the toolchain must match what the SDK
+          # builds with, per rift-go's own CI note.
+          go-version-file: sdk/go.mod
+
+      # Each lane below is the SDK's own conformance invocation, with the engine inputs it already
+      # reads from the environment pointed at the release resolved above. Those env names come from
+      # each SDK's own CI, which is what makes the override work rather than being ignored — if a
+      # lane ever stops honouring one, this gate reports drift against the pinned engine instead of
+      # the new one, which the first `workflow_dispatch` run against a known-good release will show.
+      - name: java — replay the corpus over the embedded transport
+        if: matrix.sdk.name == 'java'
+        working-directory: sdk
+        env:
+          RIFT_IT: "1"
+          CONFORMANCE_TRANSPORT: EMBEDDED
+        run: ./mvnw -B -ntp -pl rift-java-conformance -am verify
+
+      - name: scala — full suite with the embedded lane required
+        if: matrix.sdk.name == 'scala'
+        working-directory: sdk
+        env:
+          # Names the lane this job requires, so a silently-unavailable engine is red, not a green
+          # skip (rift-scala issue #63). The corpus is vendored in that repo, so this proves the
+          # SDK's pinned corpus still replays on the newest engine.
+          RIFT_G3_REQUIRE: embedded
+        run: sbt test
+
+      - name: node — conformance + embedded integration tests
+        if: matrix.sdk.name == 'node'
+        working-directory: sdk
+        env:
+          RIFT_SKIP_BINARY_DOWNLOAD: "1"
+        run: |
+          npm ci
+          npm run build
+          npm run test:embedded
+
+      - name: go — embedded engine + corpus replay
+        if: matrix.sdk.name == 'go'
+        working-directory: sdk
+        run: |
+          set -euo pipefail
+          go test -count=1 ./riftembed/...
+          # A fixture may be skipped only when the manifest's `requires` names a capability this
+          # lane lacks, so a run that silently skipped everything would still report green.
+          go test -count=1 -v ./conformance/... 2>&1 | tee conformance.log
+          grep -q -- "--- PASS: TestServeAndReplay/embedded" conformance.log \
+            || { echo "::error::the embedded conformance lane did not run"; exit 1; }
+
+      # The whole point of a scheduled gate: there is no PR to turn red, so the failure has to
+      # become an issue. The reporter keeps one open issue per SDK and comments on it thereafter.
+      - name: Report drift
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/sdk-matrix-report.sh \
+            --sdk "${{ matrix.sdk.name }}" \
+            --tag "${{ steps.sdk-tag.outputs.tag }}" \
+            --engine "$ENGINE" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ effect-library-native â€” ZIO, Cats Effect 3 / FS2, or no effect system at all â
 four transports (embedded, connect, spawn, container):
 
 ```scala
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.0" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
 ```
 
 ```scala
@@ -335,6 +335,13 @@ Assertion counting runs through the engine's own predicate evaluator, so `xpath`
 nearest non-matching request with the clauses it failed. See the
 [rift-go docs](https://achird-labs.github.io/rift-go/).
 
+### All four SDKs
+
+Java, Scala, Node/TypeScript and Go are all officially supported, and all four replay the same
+conformance corpus so their DSLs stay in lockstep with the engine grammar. The
+[Language SDKs](https://achird-labs.github.io/rift/sdk/) section collects the install snippets,
+hello-worlds, transport matrix and version-compatibility table.
+
 ---
 
 ## Documentation
@@ -343,6 +350,7 @@ nearest non-matching request with the clauses it failed. See the
 - [Installation](https://achird-labs.github.io/rift/getting-started/) - Docker, binary, build from source
 - [Quick Start](https://achird-labs.github.io/rift/getting-started/quickstart) - Create your first imposter
 - [Node.js Integration](https://achird-labs.github.io/rift/getting-started/nodejs/) - npm package for Node.js
+- [Language SDKs](https://achird-labs.github.io/rift/sdk/) - Java, Scala, Node/TypeScript and Go, with the transport and version-compatibility matrices
 - [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
 - [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
 - [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -28,6 +28,7 @@ the source, the source wins — please file an issue.
 | Replace a storage backend (flow-state, request journal, proxy recording, response sequencing) | SPI traits on `ImposterManager` | [Extension Points (SPI)]({{ site.baseurl }}/embedding/spi/) |
 | Observe reconciliation events or decorate responses | `ImposterEventListener` / `ResponseDecorator` | [Extension Points (SPI)]({{ site.baseurl }}/embedding/spi/) |
 | Drive Rift from a non-Rust host (JVM, Node, Go, …) | The C-ABI (`rift-ffi`) | [FFI (C-ABI)]({{ site.baseurl }}/embedding/ffi/) |
+| Drive Rift from Java, Scala, Node/TypeScript or Go without writing an FFI bridge yourself | An official SDK | [Language SDKs]({{ site.baseurl }}/sdk/) |
 
 > **Runtime topology is yours to choose when embedding.** The `--runtime per-core` flag
 > ([Performance → Runtime Topology]({{ site.baseurl }}/performance/#runtime-topology-per-core-experimental))

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -135,6 +135,20 @@ so `CGO_ENABLED=0` keeps working and no C toolchain is needed. `rift.Spawn(ctx, 
 binary instead, and `rift.Connect(url, …)` targets any running admin endpoint — neither needs the
 native library. See the [rift-go documentation](https://achird-labs.github.io/rift-go/).
 
+### Scala 3
+
+```scala
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
+```
+
+There is a module per effect system — ZIO, Cats Effect 3 / FS2, or no effect system at all — over
+one shared typed model. See [rift-scala]({{ site.baseurl }}/sdk/scala/).
+
+### All four SDKs
+
+Install snippets, hello-worlds, the transport matrix and the version-compatibility table for Java,
+Scala, Node/TypeScript and Go live in [Language SDKs]({{ site.baseurl }}/sdk/).
+
 ---
 
 ## Verify Installation
@@ -235,9 +249,10 @@ Example `imposters.json`:
 
 - [Quick Start Tutorial]({{ site.baseurl }}/getting-started/quickstart/) - Detailed walkthrough
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
-- [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
-- [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
-- [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)
+- [Language SDKs]({{ site.baseurl }}/sdk/) - Java, Scala, Node/TypeScript and Go, with the transport and version-compatibility matrices
+- [Java / JVM SDK]({{ site.baseurl }}/sdk/java/) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Scala SDK]({{ site.baseurl }}/sdk/scala/) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
+- [Go SDK]({{ site.baseurl }}/sdk/go/) - rift-go for `testing.T`, embedded via purego (no cgo)
 - [Predicates Guide]({{ site.baseurl }}/mountebank/predicates/) - Request matching
 - [Responses Guide]({{ site.baseurl }}/mountebank/responses/) - Response configuration
 - [Migration Guide]({{ site.baseurl }}/getting-started/migration/) - Switching from Mountebank

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,12 @@ func TestUserLookup(t *testing.T) {
 See the [rift-go documentation](https://achird-labs.github.io/rift-go/) for the full feature
 surface.
 
+### All four SDKs
+
+Java, Scala, Node/TypeScript and Go are all officially supported and all replay the same
+conformance corpus. The [Language SDKs]({{ site.baseurl }}/sdk/) section has the install snippet and
+hello-world for each, plus the transport and version-compatibility matrices.
+
 ---
 
 ## Documentation
@@ -188,9 +194,10 @@ surface.
 - [Installation]({{ site.baseurl }}/getting-started/) - Docker, binary, and build from source
 - [Quick Start]({{ site.baseurl }}/getting-started/quickstart/) - Create your first imposter
 - [Node.js Integration]({{ site.baseurl }}/getting-started/nodejs/) - npm package for Node.js projects
-- [Java / JVM SDK](https://github.com/achird-labs/rift-java) - rift-java for JUnit 5, Spring, and Testcontainers
-- [Scala SDK](https://github.com/achird-labs/rift-scala) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
-- [Go SDK](https://github.com/achird-labs/rift-go) - rift-go for `testing.T`, embedded via purego (no cgo)
+- [Language SDKs]({{ site.baseurl }}/sdk/) - Java, Scala, Node/TypeScript and Go, with the transport and version-compatibility matrices
+- [Java / JVM SDK]({{ site.baseurl }}/sdk/java/) - rift-java for JUnit 5, Spring, and Testcontainers
+- [Scala SDK]({{ site.baseurl }}/sdk/scala/) - rift-scala for ZIO, Cats Effect, FS2, and zio-bdd
+- [Go SDK]({{ site.baseurl }}/sdk/go/) - rift-go for `testing.T`, embedded via purego (no cgo)
 - [Migration from Mountebank]({{ site.baseurl }}/getting-started/migration/) - Switch from Mountebank to Rift
 
 ### Concepts

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Go
+parent: Language SDKs
+nav_order: 4
+permalink: /sdk/go/
+---
+
+# rift-go
+
+The official Go SDK. Requires Go 1.24+, and the embedded engine loads through
+[purego](https://github.com/ebitengine/purego) rather than cgo — so `CGO_ENABLED=0` keeps working,
+no C toolchain is needed, and cross-compilation is unaffected.
+
+## Install
+
+```bash
+go get github.com/achird-labs/rift-go
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+```
+
+The second line downloads and SHA-256-verifies the native library for the embedded transport; the
+connect and spawn transports do not need it.
+
+## Hello world
+
+```go
+func TestUserLookup(t *testing.T) {
+	users := rifttest.Imposter(t, rift.NewImposter("users").
+		Stub(rift.OnGet("/api/users/1").
+			Return(rift.OKJSON(map[string]rift.JSON{"id": 1, "name": "Alice"}))))
+
+	callSUT(t, users.BaseURL())
+
+	rifttest.AssertReceived(t, users, rift.OnGet("/api/users/1"), rift.Once())
+}
+```
+
+`rifttest` owns the lifecycle: a shared engine, `t.Cleanup` teardown, and request assertions that
+report the nearest non-matching request when they fail.
+
+## Transports
+
+All three implement `rift.Client`, so a suite written against one runs against the others:
+
+```go
+// In-process. No binary, no port, no cleanup.
+eng, err := riftembed.Start(riftembed.Options{})
+
+// An engine already running somewhere.
+eng, err := rift.Connect("http://localhost:2525", rift.RemoteOptions{})
+
+// A binary this process manages. ctx bounds startup; Close stops it.
+eng, err := rift.Spawn(ctx, rift.SpawnOptions{})
+```
+
+## Further reading
+
+- [rift-go documentation](https://achird-labs.github.io/rift-go/) — package map, intercept, and the
+  `testing.T` helpers
+- [rift-go on GitHub](https://github.com/achird-labs/rift-go)

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: Language SDKs
+nav_order: 10.5
+has_children: true
+permalink: /sdk/
+---
+
+# Language SDKs
+
+Rift has four official SDKs. Each one wraps the same engine — the typed wire model, the three
+transports, and the natives distribution — behind an idiomatic DSL and test-framework glue, so you
+never hand-write Mountebank JSON or an FFI bridge.
+
+| SDK | Package | Latest | Docs |
+|---|---|---|---|
+| [Java / JVM]({{ site.baseurl }}/sdk/java/) | `io.github.achird-labs:rift-java-core` | `v0.2.2` | [rift-java](https://achird-labs.github.io/rift-java/) |
+| [Scala 3]({{ site.baseurl }}/sdk/scala/) | `io.github.achird-labs::rift-scala-*` | `v0.1.3` | [rift-scala](https://achird-labs.github.io/rift-scala/) |
+| [Node / TypeScript]({{ site.baseurl }}/sdk/node/) | `@rift-vs/rift` | `v0.15.0` | [rift-node](https://achird-labs.github.io/rift-node/) |
+| [Go]({{ site.baseurl }}/sdk/go/) | `github.com/achird-labs/rift-go` | `v0.1.0` | [rift-go](https://achird-labs.github.io/rift-go/) |
+
+---
+
+## Transports
+
+Every SDK offers these three ways to run the engine, and the full feature surface is available on
+each — the transport is a deployment choice, not a capability tier. Some SDKs add more on top
+(rift-java's Testcontainers module, rift-scala's `Rift.container()`); see each SDK's own docs.
+
+- **Embedded** — the engine runs in-process, loaded from a native library. No container, no port
+  juggling, no separate lifecycle. Fastest to start and the usual choice for unit tests.
+- **Connect** — the SDK talks to any already-running admin endpoint over HTTP. Use it against a
+  shared or containerised Rift.
+- **Spawn** — the SDK downloads and manages the engine binary as a child process. No native-library
+  loading, so it works on runtimes where the embedded path is unavailable.
+
+| SDK | Embedded | Connect | Spawn |
+|---|---|---|---|
+| Java | Panama FFM — JDK 22+ (`rift-java-embedded`), or JDK 21 with `rift-java-embedded-jdk21` | JDK 17+ | JDK 17+ |
+| Scala | via the rift-java bridge — JDK 22+ (JDK 21 via the jdk21 artifact) | JDK 21+ | JDK 21+ |
+| Node | [koffi](https://koffi.dev/) — Node 20+ | Node 20+ | Node 20+ |
+| Go | [purego](https://github.com/ebitengine/purego) — Go 1.24+, `CGO_ENABLED=0` keeps working | Go 1.24+ | Go 1.24+ |
+
+Only the embedded transport needs the platform `librift_ffi` library; connect and spawn do not.
+Getting it is a one-line step rather than something you manage by hand — rift-java and rift-scala
+bundle it in a natives artifact, rift-node puts it behind the `@rift-vs/rift-embedded` package, and
+rift-go ships a `rift-fetch` command that downloads and SHA-256-verifies it.
+
+---
+
+## Version compatibility
+
+| SDK | SDK version | Engine floor |
+|---|---|---|
+| rift-java | `v0.2.2` | `v0.16.0` |
+| rift-scala | `v0.1.3` | `v0.16.0` |
+| rift-node | `v0.15.0` | `v0.16.0` |
+| rift-go | `v0.1.0` | `v0.16.0` |
+
+**How this table stays honest.** Each SDK pins an engine version and has its own bump automation
+that opens a PR when a new engine release lands, so an SDK release is never more than one engine
+release behind for long. The table names each SDK's *floor* — the engine it is tested against —
+and a newer engine is expected to work. That expectation is not taken on trust: the
+[cross-SDK matrix](https://github.com/achird-labs/rift/blob/master/.github/workflows/sdk-matrix.yml)
+replays every SDK's conformance lane against the newest engine release daily and on every publish,
+so drift shows up as a tracking issue rather than as a user's broken build.
+
+---
+
+## Why the DSLs agree
+
+Every SDK replays the same [SDK conformance corpus]({{ site.baseurl }}/embedding/sdk-conformance/)
+in its own CI — a fixture the typed DSL cannot express is a red build. That is what keeps four
+independently-written DSLs in lockstep with one engine grammar, and with each other.

--- a/docs/sdk/java.md
+++ b/docs/sdk/java.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: Java / JVM
+parent: Language SDKs
+nav_order: 1
+permalink: /sdk/java/
+---
+
+# rift-java
+
+The official JVM SDK. Fluent typed DSL, all three transports, and JUnit 5, Spring and
+Testcontainers integrations.
+
+## Install
+
+```xml
+<dependency>
+  <groupId>io.github.achird-labs</groupId>
+  <artifactId>rift-java-core</artifactId>
+  <version>0.2.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+The [BOM](https://github.com/achird-labs/rift-java/blob/master/rift-java-bom/README.md) pins every
+module at once if you use more than one.
+
+For the embedded transport, add `rift-java-embedded` (JDK 22+ bytecode, stable Panama FFM) or
+`rift-java-embedded-jdk21` on JDK 21. Connect and spawn need neither and run on JDK 17+.
+
+## Hello world
+
+```java
+try (Rift rift = Rift.embedded()) {                  // or Rift.connect(uri) / Rift.spawn()
+    Imposter users = rift.create(
+        imposter("users").stub(onGet("/api/users/1").willReturn(okJson("{\"id\":1}"))));
+
+    // point your system under test at users.uri(), then assert:
+    users.verify(onGet("/api/users/1"), times(1));
+}
+```
+
+`Rift.embedded()` runs the engine in-process over Panama FFM — no separate binary and no container.
+`Rift.spawn()` manages a downloaded binary for you, and `Rift.connect(uri)` targets any running
+admin endpoint.
+
+## Further reading
+
+- [rift-java documentation](https://achird-labs.github.io/rift-java/) — the full feature surface,
+  JUnit 5 extension, Spring and Testcontainers integrations
+- [rift-java on GitHub](https://github.com/achird-labs/rift-java)

--- a/docs/sdk/node.md
+++ b/docs/sdk/node.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Node / TypeScript
+parent: Language SDKs
+nav_order: 3
+permalink: /sdk/node/
+---
+
+# rift-node
+
+The official Node.js / TypeScript SDK, published as `@rift-vs/rift`. ESM only, requires Node 20+,
+and the core package has zero runtime dependencies.
+
+## Install
+
+```bash
+npm install --save-dev @rift-vs/rift
+```
+
+`@rift-vs/rift` covers the connect and spawn transports. The in-process engine behind
+`rift.embedded()` lives in a second package — installing it is what opts your project into
+[koffi](https://koffi.dev/) as a dependency:
+
+```bash
+npm install --save-dev @rift-vs/rift-embedded
+```
+
+## Hello world
+
+```ts
+import { rift, imposter, onGet, onPost, okJson, created, status, times } from '@rift-vs/rift';
+
+await using engine = await rift.embedded(); // or rift.connect(url) / rift.spawn()
+
+const users = await engine.create(
+  imposter('users')
+    .record()
+    .stub(onGet('/api/users/1').willReturn(okJson({ id: 1, name: 'Alice' })))
+    .stub(onPost('/api/users').willReturn(created().latency(50), status(503)))); // cycling
+
+// point your system under test at users.url, then:
+await users.verify(onGet('/api/users/1'), times(1));
+```
+
+## Coming from Mountebank
+
+The Mountebank-compatible `create()` surface is permanent, not a transitional shim:
+
+```javascript
+import rift from '@rift-vs/rift';
+
+const server = await rift.create({ port: 2525 });
+// ... create imposters, run your tests ...
+await server.close();
+```
+
+Raw Mountebank imposter JSON round-trips through `fromJson()` and can be mixed with DSL-built
+imposters on the same engine, so the typed DSL can be adopted one stub at a time. See also the
+[Node.js integration guide]({{ site.baseurl }}/getting-started/nodejs/) on this site.
+
+## Further reading
+
+- [rift-node documentation](https://achird-labs.github.io/rift-node/) ·
+  [API reference](https://achird-labs.github.io/rift-node/reference/sdk-api/) ·
+  [migration guide](https://achird-labs.github.io/rift-node/mountebank/migration/)
+- [rift-node on GitHub](https://github.com/achird-labs/rift-node) ·
+  [`@rift-vs/rift` on npm](https://www.npmjs.com/package/@rift-vs/rift)

--- a/docs/sdk/scala.md
+++ b/docs/sdk/scala.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Scala 3
+parent: Language SDKs
+nav_order: 2
+permalink: /sdk/scala/
+---
+
+# rift-scala
+
+The official Scala 3 SDK. One typed model and DSL, with a thin module per effect system — pick the
+surface that matches your stack rather than adapting to someone else's.
+
+## Install
+
+```scala
+// ZIO 2
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
+
+// Cats Effect 3 (+ FS2)
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-cats" % "0.1.3" % Test
+
+// No effect system — Either-based, Using-friendly
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-pure" % "0.1.3" % Test
+```
+
+Requires JDK 21+. The embedded transport comes through the rift-java bridge, so it needs JDK 22+
+(or the `rift-java-embedded-jdk21` artifact on JDK 21); connect and spawn run on JDK 21+.
+
+Testkit and codec side-cars are separate modules — `rift-scala-zio-testkit`,
+`rift-scala-cats-testkit`, `rift-scala-fs2`, `rift-scala-zio-json`, `rift-scala-circe` — plus
+`rift-scala-zio-bdd`, a [zio-bdd](https://github.com/EtaCassiopeia/zio-bdd) `MockControl` adapter.
+
+## Hello world
+
+```scala
+import zio.*
+import zio.test.*
+
+import rift.dsl.*
+import rift.zio.Rift
+
+object PaymentsSpec extends ZIOSpecDefault:
+
+  def spec = suite("payments")(
+    test("records the lookup"):
+      for
+        users <- Rift.create(
+          imposter("users").record.stub(
+            get("/api/users/1").reply(ok.json("""{"id":1}"""))
+          )
+        )
+        _ <- callSut(users.uri) // point your SUT at users.uri
+        _ <- users.verify(get("/api/users/1"), 1)
+      yield assertCompletes
+  ).provideShared(Rift.embedded)
+```
+
+`Rift.embedded` needs no Docker and no separate binary. Swap it for `Rift.connect(uri)`,
+`Rift.spawn()` or `Rift.container()` without touching the test body.
+
+## Further reading
+
+- [rift-scala documentation](https://achird-labs.github.io/rift-scala/) — module map, ZIO / Cats
+  Effect / FS2 lifecycles, and the test-framework integrations
+- [rift-scala on GitHub](https://github.com/achird-labs/rift-scala)

--- a/scripts/sdk-matrix-report.sh
+++ b/scripts/sdk-matrix-report.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# SDK drift reporter (issue #462).
+#
+# `sdk-matrix.yml` runs each released SDK's conformance lane against the *latest* engine release.
+# When a lane goes red, that is engine↔SDK drift and someone has to look at it — but a scheduled
+# workflow has no PR to turn red, so the signal has to become an issue. Filing one per run would
+# bury the repo under a daily duplicate, so this keeps exactly one open tracking issue per SDK and
+# appends to it instead.
+#
+# Dedupe is by an HTML-comment marker in the issue body, matched against `gh issue list` (a direct
+# API listing) rather than `gh issue search`. The search index is eventually consistent: an issue
+# filed by this morning's run is not reliably searchable by this afternoon's, and every miss is a
+# duplicate — the one failure mode this script exists to prevent.
+#
+# Usage:
+#   scripts/sdk-matrix-report.sh --sdk java --tag v0.2.2 --engine v0.16.0 [--run-url URL]
+#   scripts/sdk-matrix-report.sh --self-test    # prove create-then-update never duplicates
+#
+set -euo pipefail
+
+# Indirection so --self-test can substitute a stub for the real CLI.
+GH="${GH:-gh}"
+REPO="${SDK_MATRIX_REPO:-achird-labs/rift}"
+
+marker_for() { printf '<!-- sdk-matrix-drift:%s -->' "$1"; }
+
+usage() {
+  sed -n '3,18p' "${BASH_SOURCE[0]}" >&2
+  exit 2
+}
+
+# Emits the number of the open tracking issue for this SDK, or nothing if there is none.
+# Returns non-zero if the listing could not be read at all — the caller must not treat that as
+# "no issue exists", since doing so files a fresh duplicate on every failed lookup. Checked
+# explicitly rather than left to `set -e`, which is suppressed whenever a caller wraps this in a
+# conditional.
+find_open_tracking_issue() {
+  local marker="$1" listing
+  if ! listing="$($GH issue list --repo "$REPO" --state open --label sdk --limit 100 --json number,body)"; then
+    printf 'error: could not list open issues in %s — refusing to file a possible duplicate\n' "$REPO" >&2
+    return 1
+  fi
+  printf '%s' "$listing" \
+    | jq -r --arg m "$marker" 'map(select(.body != null and (.body | contains($m)))) | .[0].number // empty'
+}
+
+report() {
+  local sdk="$1" tag="$2" engine="$3" run_url="$4"
+  local marker existing title body
+  marker="$(marker_for "$sdk")"
+  title="sdk-matrix: rift-${sdk} ${tag} is red against engine ${engine}"
+
+  if ! existing="$(find_open_tracking_issue "$marker")"; then
+    return 1
+  fi
+
+  if [ -n "$existing" ]; then
+    # Update, never duplicate. A comment keeps the history of which engine versions were red,
+    # which is what tells a triager whether this is a new break or a known one still unfixed.
+    $GH issue comment "$existing" --repo "$REPO" --body \
+      "Still red: rift-${sdk} \`${tag}\` against engine \`${engine}\`.${run_url:+ Run: ${run_url}}"
+    printf 'updated #%s\n' "$existing"
+    return 0
+  fi
+
+  # Written to a file rather than captured with `body="$(cat <<EOF …)"`: bash 3.2 — still what
+  # macOS ships, and what a maintainer runs --self-test under — mis-parses an apostrophe inside a
+  # heredoc nested in command substitution, and this body has several.
+  body="$(mktemp)"
+  cat >"$body" <<EOF
+${marker}
+
+The scheduled cross-SDK conformance matrix (\`.github/workflows/sdk-matrix.yml\`) found drift.
+
+| | |
+|---|---|
+| SDK | \`rift-${sdk}\` |
+| SDK release | \`${tag}\` |
+| Engine release | \`${engine}\` |
+${run_url:+| Run | ${run_url} |}
+
+The SDK's own conformance lane passes against the engine version it pins; this gate replays it
+against the newest engine release instead. Something in that path failed — the engine may have
+broken compatibility, the SDK may need a bump, or the release assets this lane downloads may be
+missing or renamed. The run log says which step went red.
+
+This issue is reused for every subsequent red run of this SDK — see the comments for the history.
+EOF
+
+  $GH issue create --repo "$REPO" --title "$title" --label sdk --label needs-triage --body-file "$body"
+  rm -f "$body"
+  printf 'created\n'
+}
+
+# --- self-test ---------------------------------------------------------------------------------
+# Runs the real code path twice against a stub `gh` and asserts exactly one issue was created and
+# the second run commented instead. A reporter that silently duplicates would still "work" in the
+# workflow, so this is the only place the dedupe is actually proven.
+self_test() {
+  local tmp status=0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  cat >"$tmp/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh: `issue list` replays whatever state/ holds; create/comment record the call.
+set -euo pipefail
+state="$SDK_MATRIX_STUB_STATE"
+case "$1 $2" in
+  "issue list")
+    cat "$state/issues.json"
+    ;;
+  "issue create")
+    body_file=""
+    while [ $# -gt 0 ]; do
+      case "$1" in --body-file) body_file="$2"; shift 2 ;; *) shift ;; esac
+    done
+    body="$(cat "$body_file")"
+    printf '%s\n' "$body" >"$state/created-body.txt"
+    printf 'create\n' >>"$state/calls"
+    # A created issue is immediately visible to the next `issue list`.
+    jq -n --arg b "$body" '[{number: 4242, body: $b}]' >"$state/issues.json"
+    ;;
+  "issue comment")
+    printf 'comment\n' >>"$state/calls"
+    ;;
+  *)
+    printf 'unexpected stub call: %s\n' "$*" >&2; exit 1 ;;
+esac
+STUB
+  chmod +x "$tmp/gh"
+
+  export SDK_MATRIX_STUB_STATE="$tmp"
+  printf '[]\n' >"$tmp/issues.json"
+  : >"$tmp/calls"
+
+  GH="$tmp/gh" report go v0.1.0 v0.16.0 "https://example.invalid/run/1" >/dev/null
+  GH="$tmp/gh" report go v0.1.0 v0.17.0 "https://example.invalid/run/2" >/dev/null
+
+  local creates comments
+  creates="$(grep -c '^create$' "$tmp/calls" || true)"
+  comments="$(grep -c '^comment$' "$tmp/calls" || true)"
+
+  if [ "$creates" != "1" ]; then
+    printf 'FAIL: expected exactly 1 issue creation, got %s\n' "$creates" >&2
+    status=1
+  fi
+  if [ "$comments" != "1" ]; then
+    printf 'FAIL: expected the second red run to comment once, got %s\n' "$comments" >&2
+    status=1
+  fi
+
+  # The issue has to name the SDK, its tag and the engine version — a tracking issue that does not
+  # is unactionable, and the marker is what makes the next run find it.
+  local created; created="$(cat "$tmp/created-body.txt")"
+  local needle
+  for needle in '<!-- sdk-matrix-drift:go -->' 'rift-go' 'v0.1.0' 'v0.16.0'; do
+    case "$created" in
+      *"$needle"*) ;;
+      *) printf 'FAIL: created issue body is missing %s\n' "$needle" >&2; status=1 ;;
+    esac
+  done
+
+  # An unrelated SDK's open issue must not be mistaken for this one's.
+  jq -n '[{number: 7, body: "<!-- sdk-matrix-drift:java -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  GH="$tmp/gh" report go v0.1.0 v0.16.0 "" >/dev/null
+  if [ "$(grep -c '^create$' "$tmp/calls" || true)" != "1" ]; then
+    printf 'FAIL: a different SDK'\''s tracking issue was matched as this one'\''s\n' >&2
+    status=1
+  fi
+
+  # Fail closed when the lookup itself fails. An unreadable issue list is indistinguishable from
+  # "no tracking issue exists", and guessing the wrong one of those files a duplicate every run —
+  # the exact failure this script exists to prevent. So it must abort, not create.
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$tmp/gh-broken"
+  chmod +x "$tmp/gh-broken"
+  : >"$tmp/calls"
+  if GH="$tmp/gh-broken" report go v0.1.0 v0.16.0 "" >/dev/null 2>&1; then
+    printf 'FAIL: a failing issue lookup was treated as "no open issue"\n' >&2
+    status=1
+  fi
+
+  if [ "$status" = "0" ]; then
+    printf 'self-test: OK — create once, then update; per-SDK markers do not collide\n'
+  fi
+  return "$status"
+}
+
+sdk="" tag="" engine="" run_url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test) self_test; exit $? ;;
+    --sdk)     sdk="${2:-}"; shift 2 ;;
+    --tag)     tag="${2:-}"; shift 2 ;;
+    --engine)  engine="${2:-}"; shift 2 ;;
+    --run-url) run_url="${2:-}"; shift 2 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; usage ;;
+  esac
+done
+
+[ -n "$sdk" ] && [ -n "$tag" ] && [ -n "$engine" ] || usage
+report "$sdk" "$tag" "$engine" "$run_url"


### PR DESCRIPTION
Adds the scheduled cross-SDK drift gate and the on-site SDK documentation that close out the
language-SDK program.

`sdk-matrix.yml` replays each of the four SDKs' own conformance lanes — at their latest release
tags — against the newest published engine, daily and on every release. `sdk-matrix-report.sh`
turns a red lane into exactly one open tracking issue per SDK, deduped by body marker and
fail-closed when the lookup itself errors.

`docs/sdk/` adds a landing page per SDK plus the transport and version-compatibility matrices;
Scala previously had no page in `docs/` at all.

Two notes on scope: the issue's §3 premise that the rift-go references were stale was incorrect
(they already described a released SDK), and `docs/_data/sync.yml` is deliberately **not** bumped —
this is an additive section, not the full reconciliation pass that marker asserts.

Closes #462

Milestone: SDK-M6 (closing this closes epic #458)
