### PR TITLE
fix(ci): export absolute corpus and binary paths to the SDK matrix lanes

### DIFF
--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -16,6 +16,11 @@ name: SDK Matrix
 # transport is overridden to the latest engine. Platform coverage (macOS/Windows) and the spawn
 # lanes stay each SDK's own CI's job — this gate is about *version* drift, and running a lane whose
 # engine version the SDK resolves internally would just re-test the pin.
+#
+# A consequence worth naming, since it is invisible in a green run: some SDK suites self-skip the
+# sub-suites this gate does not feed. rift-node's spawn replay block and rift-scala's G3 spawn lane
+# both skip here by design. What must never skip is the embedded replay — hence the explicit
+# assertion in the go lane below, which is what caught the corpus path bug on the first live run.
 
 on:
   schedule:
@@ -124,14 +129,27 @@ jobs:
           tar -xzf "dist/sdk-conformance-$ENGINE.tar.gz" -C corpus
 
           # Neither archive's internal layout is contractual, so locate rather than assume.
-          engine_bin="$(find dist -type f -name rift -perm -u+x | head -1)"
+          # Search from an absolute root so every path below is absolute by construction: these are
+          # exported to lanes that run with `working-directory: sdk`, where a relative path quietly
+          # resolves under the SDK checkout instead. A corpus that resolves to nowhere does not fail
+          # — the suite reports "corpus unavailable" and skips itself green.
+          engine_bin="$(find "$PWD/dist" -type f -name rift -perm -u+x | head -1)"
           [ -n "$engine_bin" ] || { echo "::error::no rift binary in the release tarball"; exit 1; }
-          manifest="$(find corpus -type f -name manifest.json | head -1)"
+          manifest="$(find "$PWD/corpus" -type f -name manifest.json | head -1)"
           [ -n "$manifest" ] || { echo "::error::no manifest.json in the corpus tarball"; exit 1; }
+
+          # Belt and braces: assert absoluteness rather than trusting the two `find` roots above to
+          # stay absolute through a future edit. This is the check that would have caught the bug.
+          for p in "$engine_bin" "$manifest"; do
+            case "$p" in
+              /*) ;;
+              *) echo "::error::expected an absolute path for the SDK lanes, got: $p"; exit 1 ;;
+            esac
+          done
 
           {
             echo "RIFT_FFI_LIB=$PWD/natives/$lib"
-            echo "RIFT_BINARY=$PWD/$engine_bin"
+            echo "RIFT_BINARY=$engine_bin"
             # go wants the directory holding manifest.json; rift-java's Corpus.descend() wants the
             # parent and resolves the single extracted sdk-conformance-* child itself.
             echo "RIFT_CORPUS_DIR=$(dirname "$manifest")"


### PR DESCRIPTION
The first live `sdk-matrix` run ([30827106971](https://github.com/achird-labs/rift/actions/runs/30827106971)) went red on the go lane. It was a bug in this workflow, not SDK drift.

`RIFT_CORPUS_DIR` was built from `find corpus …` — a relative root — while every other exported path got `$PWD`. The lanes run with `working-directory: sdk`, so it resolved under the SDK checkout and the corpus was never found.

Nothing failed at that point. rift-go's conformance suite reports `corpus unavailable` and skips itself, so the job printed `ok` / `PASS` having replayed zero fixtures. The only thing that turned it red was the explicit `the embedded conformance lane did not run` assertion — which is precisely the case that assertion was written for.

## Changes

- `find` from `"$PWD/dist"` / `"$PWD/corpus"`, so the exported paths are absolute by construction
- an explicit absoluteness guard on both, rather than trusting two `find` roots to stay absolute through a future edit — this is the check that would have caught the bug
- name the sub-suites that self-skip by design (rift-node's spawn replay, rift-scala's G3 spawn lane), since a green run makes them invisible

## Verification

Replayed the workflow's asset-resolution block against fake extraction dirs: the old form reproduces `corpus/sdk-conformance-v0.16.0` verbatim, the new form is absolute, and the guard rejects the old value. `actionlint` clean.

From the same live run, the other three lanes were genuinely green against `v0.16.0` — not vacuously so:

| Lane | Evidence |
|---|---|
| java | `CorpusReplayIT` — 15 tests, 6.5s (93 total) |
| scala | "G3 replay complete over the embedded transport" |
| node | embedded block: `replays basic-api.json` (131 ms), `error-testing.json` (84 ms) |

The drift reporter also worked end-to-end, filing #913 with the correct title, labels and dedupe marker.

Closes #913
