### PR TITLE
fix(release): publish rift-store-redis, and make the crates.io skip check actually work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,18 +395,42 @@ jobs:
             # Idempotent re-runs: skip ONLY if this exact version is already on crates.io. Any
             # real failure (bad manifest, missing owner, unpublished/unresolvable dep) still fails
             # the job loudly — it is not swallowed.
-            if curl -sf "https://crates.io/api/v1/crates/${crate}/${VERSION}" >/dev/null 2>&1; then
-              echo "${crate} ${VERSION} already on crates.io — skipping"
-              return 0
-            fi
+            #
+            # -A is not decoration: crates.io rejects a request with no User-Agent with 403, so
+            # `curl -sf` failed for every crate and this check always concluded "not published".
+            # That made the re-run it exists to enable impossible — the job would re-publish an
+            # already-published version and die on "crate version is already uploaded". Distinguish
+            # 404 (genuinely absent) from any other status rather than treating all failure as
+            # absence, so a rate-limit or an outage stops the job instead of driving a bad publish.
+            local status
+            status="$(curl -s -o /dev/null -w '%{http_code}' \
+              -A "rift-release/${VERSION} (+https://github.com/achird-labs/rift)" \
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
+            case "$status" in
+              200)
+                echo "${crate} ${VERSION} already on crates.io — skipping"
+                return 0
+                ;;
+              404)
+                ;;
+              *)
+                echo "::error::crates.io returned HTTP ${status} for ${crate} ${VERSION}; refusing to guess whether it is published"
+                return 1
+                ;;
+            esac
             echo "Publishing ${crate} ${VERSION}..."
             cargo publish -p "${crate}" --allow-dirty
             # Let crates.io index the new version before a dependent crate tries to resolve it.
             sleep 30
           }
+          # Dependency order — a crate must be on the index before anything that depends on it is
+          # packaged. rift-store-redis was extracted from rift-mock-core in #853 and never added
+          # here, so v0.17.0 published three crates and then died packaging rift-http-proxy with
+          # "no matching package named `rift-store-redis` found".
           publish_crate rift-lint
           publish_crate rift-types
           publish_crate rift-mock-core
+          publish_crate rift-store-redis
           publish_crate rift-http-proxy
 
   # =============================================================================


### PR DESCRIPTION
The `v0.17.0` release ([30831732894](https://github.com/achird-labs/rift/actions/runs/30831732894)) failed at **Publish to crates.io**. Everything else — all 7 target builds, the GitHub Release and its assets, Docker, Homebrew — succeeded. Two separate bugs, both latent until now.

## 1. `rift-store-redis` was never in the publish list

It was extracted into its own crate in #853 (shipped in this release). `rift-http-proxy` depends on it, so packaging failed:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `rift-store-redis` found
  location searched: crates.io index
  required by package `rift-http-proxy v0.17.0`
```

Added in dependency order, before its dependent.

## 2. The skip check could never return true

```sh
if curl -sf "https://crates.io/api/v1/crates/${crate}/${VERSION}"; then
```

No `User-Agent` — crates.io answers **403**, so `curl -sf` fails and the check concludes "not published" for *every* crate. The "idempotent re-runs" the comment promises were therefore impossible: a re-run would attempt to re-publish an already-published version and die on `crate version is already uploaded`. That is exactly the state we are in now, which is why this had to be fixed before the release could be completed.

It now sends a User-Agent and distinguishes `404` (genuinely absent → publish) from any other status (→ abort), so a rate-limit or outage stops the job rather than driving a publish decision off a failed request.

Verified against the live API:

| crate | HTTP | action |
|---|---|---|
| `rift-mock-core` 0.17.0 | 200 | skip |
| `rift-store-redis` 0.17.0 | 404 | publish |

## Current crates.io state for 0.17.0

Published: `rift-lint`, `rift-types`, `rift-mock-core`. Missing: `rift-store-redis`, `rift-http-proxy`. Completing it needs a re-run against `v0.17.0` **after** this merges — the fixed skip check makes that safe.

`actionlint`: 27 findings before and after, all pre-existing elsewhere in the file; this change adds none.
