### PR TITLE
docs(sdk): track the v0.17.0 engine release across all four SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ effect-library-native â€” ZIO, Cats Effect 3 / FS2, or no effect system at all â
 four transports (embedded, connect, spawn, container):
 
 ```scala
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.4" % Test
 ```
 
 ```scala
@@ -315,7 +315,7 @@ changes by depending on it.
 
 ```bash
 go get github.com/achird-labs/rift-go
-go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.17.0
 ```
 
 ```go

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -114,7 +114,7 @@ the native library once:
 
 ```bash
 go get github.com/achird-labs/rift-go
-go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.17.0
 ```
 
 Usage:
@@ -138,7 +138,7 @@ native library. See the [rift-go documentation](https://achird-labs.github.io/ri
 ### Scala 3
 
 ```scala
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.4" % Test
 ```
 
 There is a module per effect system — ZIO, Cats Effect 3 / FS2, or no effect system at all — over

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,7 +162,7 @@ working**: no C toolchain, and cross-compilation is unaffected.
 
 ```bash
 go get github.com/achird-labs/rift-go
-go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.17.0
 ```
 
 ```go

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -16,7 +16,7 @@ no C toolchain is needed, and cross-compilation is unaffected.
 
 ```bash
 go get github.com/achird-labs/rift-go
-go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.16.0
+go run github.com/achird-labs/rift-go/cmd/rift-fetch@latest -version v0.17.0
 ```
 
 The second line downloads and SHA-256-verifies the native library for the embedded transport; the

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -14,10 +14,10 @@ never hand-write Mountebank JSON or an FFI bridge.
 
 | SDK | Package | Latest | Docs |
 |---|---|---|---|
-| [Java / JVM]({{ site.baseurl }}/sdk/java/) | `io.github.achird-labs:rift-java-core` | `v0.2.2` | [rift-java](https://achird-labs.github.io/rift-java/) |
-| [Scala 3]({{ site.baseurl }}/sdk/scala/) | `io.github.achird-labs::rift-scala-*` | `v0.1.3` | [rift-scala](https://achird-labs.github.io/rift-scala/) |
-| [Node / TypeScript]({{ site.baseurl }}/sdk/node/) | `@rift-vs/rift` | `v0.15.0` | [rift-node](https://achird-labs.github.io/rift-node/) |
-| [Go]({{ site.baseurl }}/sdk/go/) | `github.com/achird-labs/rift-go` | `v0.1.0` | [rift-go](https://achird-labs.github.io/rift-go/) |
+| [Java / JVM]({{ site.baseurl }}/sdk/java/) | `io.github.achird-labs:rift-java-core` | `v0.2.3` | [rift-java](https://achird-labs.github.io/rift-java/) |
+| [Scala 3]({{ site.baseurl }}/sdk/scala/) | `io.github.achird-labs::rift-scala-*` | `v0.1.4` | [rift-scala](https://achird-labs.github.io/rift-scala/) |
+| [Node / TypeScript]({{ site.baseurl }}/sdk/node/) | `@rift-vs/rift` | `v0.15.1` | [rift-node](https://achird-labs.github.io/rift-node/) |
+| [Go]({{ site.baseurl }}/sdk/go/) | `github.com/achird-labs/rift-go` | `v0.2.0` | [rift-go](https://achird-labs.github.io/rift-go/) |
 
 ---
 
@@ -52,10 +52,10 @@ rift-go ships a `rift-fetch` command that downloads and SHA-256-verifies it.
 
 | SDK | SDK version | Engine floor |
 |---|---|---|
-| rift-java | `v0.2.2` | `v0.16.0` |
-| rift-scala | `v0.1.3` | `v0.16.0` |
-| rift-node | `v0.15.0` | `v0.16.0` |
-| rift-go | `v0.1.0` | `v0.16.0` |
+| rift-java | `v0.2.3` | `v0.17.0` |
+| rift-scala | `v0.1.4` | `v0.17.0` |
+| rift-node | `v0.15.1` | `v0.17.0` |
+| rift-go | `v0.2.0` | `v0.17.0` |
 
 **How this table stays honest.** Each SDK pins an engine version and has its own bump automation
 that opens a PR when a new engine release lands, so an SDK release is never more than one engine

--- a/docs/sdk/java.md
+++ b/docs/sdk/java.md
@@ -17,7 +17,7 @@ Testcontainers integrations.
 <dependency>
   <groupId>io.github.achird-labs</groupId>
   <artifactId>rift-java-core</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/docs/sdk/scala.md
+++ b/docs/sdk/scala.md
@@ -15,13 +15,13 @@ surface that matches your stack rather than adapting to someone else's.
 
 ```scala
 // ZIO 2
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.3" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-zio" % "0.1.4" % Test
 
 // Cats Effect 3 (+ FS2)
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-cats" % "0.1.3" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-cats" % "0.1.4" % Test
 
 // No effect system — Either-based, Using-friendly
-libraryDependencies += "io.github.achird-labs" %% "rift-scala-pure" % "0.1.3" % Test
+libraryDependencies += "io.github.achird-labs" %% "rift-scala-pure" % "0.1.4" % Test
 ```
 
 Requires JDK 21+. The embedded transport comes through the rift-java bridge, so it needs JDK 22+


### PR DESCRIPTION
Engine `v0.17.0` shipped and every SDK has re-released against it. The docs still advertised the previous set.

| SDK | was | now |
|---|---|---|
| rift-java | `v0.2.2` | **`v0.2.3`** |
| rift-scala | `v0.1.3` | **`v0.1.4`** |
| rift-node | `v0.15.0` | **`v0.15.1`** |
| rift-go | `v0.1.0` | **`v0.2.0`** |

All four verified live before this was opened — rift-java and rift-scala resolvable on Maven Central, `@rift-vs/rift@0.15.1` on npm as `latest`, rift-go tagged and released.

## Changes

- `docs/sdk/index.md` — the SDK table and the version-compatibility table, whose engine floor moves `v0.16.0` → `v0.17.0`
- the install snippets that quote a version: the Maven coordinate (`docs/sdk/java.md`), the three sbt coordinates (`docs/sdk/scala.md`), and the `rift-fetch -version` argument (`docs/sdk/go.md`) — that last one is not cosmetic, it selects the cdylib a reader ends up running
- the same `rift-fetch` and sbt lines duplicated in `README.md`, `docs/index.md` and `docs/getting-started/index.md`, updated together so a reader does not get a different pinned version depending on which page they landed on

`scripts/verify-docs-coverage.sh` passes. No structural or nav changes — version strings only.

## Context

Getting these four releases out surfaced four automation defects, filed separately: achird-labs/rift-java#185, achird-labs/rift-java#186, achird-labs/rift-go#15, achird-labs/rift-scala#143. Every SDK release today needed manual intervention, so this table will go stale again next release until those are fixed.
