### PR TITLE
feat(ci): close the sdk-matrix drift issue when a lane goes green again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
       - name: SDK conformance packager self-test
         run: ./scripts/gen-sdk-conformance.sh --self-test
 
+      # Issue #915: the sdk-matrix drift reporter's lifecycle (create once, comment while red,
+      # close on green, per-SDK marker isolation, fail-closed red path / fail-open green path)
+      # is only ever exercised by its self-test — the real workflow runs it against live issues.
+      - name: SDK matrix drift-reporter self-test
+        run: ./scripts/sdk-matrix-report.sh --self-test
+
       # Issue #344: a pinned cbindgen so the header regenerate-diff in the smoke test is
       # deterministic (cbindgen output varies across versions) and actually runs (the step
       # skips the diff when cbindgen is absent). Keep the version in sync with the header's.

--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -44,7 +44,7 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write # the drift reporter opens/updates one tracking issue per SDK
+  issues: write # the drift reporter opens/updates one tracking issue per SDK, and closes it on green
 
 jobs:
   engine:
@@ -228,13 +228,29 @@ jobs:
             || { echo "::error::the embedded conformance lane did not run"; exit 1; }
 
       # The whole point of a scheduled gate: there is no PR to turn red, so the failure has to
-      # become an issue. The reporter keeps one open issue per SDK and comments on it thereafter.
+      # become an issue. The reporter keeps one open issue per SDK, comments on it while the lane
+      # stays red, and the green half below closes it when the lane recovers.
       - name: Report drift
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/sdk-matrix-report.sh \
+            --sdk "${{ matrix.sdk.name }}" \
+            --tag "${{ steps.sdk-tag.outputs.tag }}" \
+            --engine "$ENGINE" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      # The green half (#915): a passing lane closes its SDK's open drift issue, so a transient
+      # red (infra flake, asset race) self-resolves instead of costing a human close — and an open
+      # drift issue always means live drift. The script fails open by design: bookkeeping errors
+      # must never turn a green conformance lane red.
+      - name: Close drift issue
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/sdk-matrix-report.sh --resolved \
             --sdk "${{ matrix.sdk.name }}" \
             --tag "${{ steps.sdk-tag.outputs.tag }}" \
             --engine "$ENGINE" \

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -63,7 +63,8 @@ release behind for long. The table names each SDK's *floor* — the engine it is
 and a newer engine is expected to work. That expectation is not taken on trust: the
 [cross-SDK matrix](https://github.com/achird-labs/rift/blob/master/.github/workflows/sdk-matrix.yml)
 replays every SDK's conformance lane against the newest engine release daily and on every publish,
-so drift shows up as a tracking issue rather than as a user's broken build.
+so drift shows up as a tracking issue rather than as a user's broken build — and the issue closes
+itself when the lane goes green again, so an open one always means live drift.
 
 ---
 

--- a/scripts/sdk-matrix-report.sh
+++ b/scripts/sdk-matrix-report.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 #
-# SDK drift reporter (issue #462).
+# SDK drift reporter (issue #462) and its close-on-green half (issue #915).
 #
 # `sdk-matrix.yml` runs each released SDK's conformance lane against the *latest* engine release.
 # When a lane goes red, that is engine↔SDK drift and someone has to look at it — but a scheduled
 # workflow has no PR to turn red, so the signal has to become an issue. Filing one per run would
 # bury the repo under a daily duplicate, so this keeps exactly one open tracking issue per SDK and
-# appends to it instead.
+# appends to it instead. When the lane passes again, `--resolved` closes that issue — without it
+# every transient red costs a human close, and a stale open issue is indistinguishable from live
+# drift (#915 sat open through two green runs).
 #
 # Dedupe is by an HTML-comment marker in the issue body, matched against `gh issue list` (a direct
 # API listing) rather than `gh issue search`. The search index is eventually consistent: an issue
@@ -15,7 +17,8 @@
 #
 # Usage:
 #   scripts/sdk-matrix-report.sh --sdk java --tag v0.2.2 --engine v0.16.0 [--run-url URL]
-#   scripts/sdk-matrix-report.sh --self-test    # prove create-then-update never duplicates
+#   scripts/sdk-matrix-report.sh --resolved --sdk java --tag v0.2.2 --engine v0.16.0 [--run-url URL]
+#   scripts/sdk-matrix-report.sh --self-test    # prove create/update/close never misbehaves
 #
 set -euo pipefail
 
@@ -26,7 +29,7 @@ REPO="${SDK_MATRIX_REPO:-achird-labs/rift}"
 marker_for() { printf '<!-- sdk-matrix-drift:%s -->' "$1"; }
 
 usage() {
-  sed -n '3,18p' "${BASH_SOURCE[0]}" >&2
+  sed -n '3,21p' "${BASH_SOURCE[0]}" >&2
   exit 2
 }
 
@@ -93,10 +96,46 @@ EOF
   printf 'created\n'
 }
 
+# The green half of the lifecycle (#915): a passing lane closes its SDK's open tracking issue.
+# The error handling is deliberately the mirror image of report()'s. The red path fails CLOSED
+# (an unreadable issue list aborts rather than filing a possible duplicate); this path fails
+# OPEN: any error here is warned about and swallowed, because issue bookkeeping must never turn
+# a green conformance lane red. Worst case the issue stays open until the next green run.
+resolve() {
+  local sdk="$1" tag="$2" engine="$3" run_url="$4"
+  local marker existing
+  marker="$(marker_for "$sdk")"
+
+  if ! existing="$(find_open_tracking_issue "$marker")"; then
+    printf 'warning: could not list open issues — leaving any rift-%s tracking issue open\n' "$sdk" >&2
+    return 0
+  fi
+
+  if [ -z "$existing" ]; then
+    printf 'no open tracking issue for rift-%s\n' "$sdk"
+    return 0
+  fi
+
+  # Comment before closing so the "why it closed" lands even if the close then fails — and each
+  # step gets its own warning, so a log reader debugs the right gh subcommand.
+  if ! $GH issue comment "$existing" --repo "$REPO" --body \
+    "Green again: rift-${sdk} \`${tag}\` passed against engine \`${engine}\`.${run_url:+ Run: ${run_url}}"; then
+    printf 'warning: could not comment on #%s — leaving it open\n' "$existing" >&2
+    return 0
+  fi
+  if ! $GH issue close "$existing" --repo "$REPO" --reason completed; then
+    printf 'warning: commented on #%s but could not close it — leaving it open\n' "$existing" >&2
+    return 0
+  fi
+  printf 'closed #%s\n' "$existing"
+}
+
 # --- self-test ---------------------------------------------------------------------------------
-# Runs the real code path twice against a stub `gh` and asserts exactly one issue was created and
-# the second run commented instead. A reporter that silently duplicates would still "work" in the
-# workflow, so this is the only place the dedupe is actually proven.
+# Runs the real code paths against a stub `gh`. The red half proves create-once-then-update (a
+# reporter that silently duplicates would still "work" in the workflow); the green half proves
+# close-on-green, marker isolation, and the polarity split — red fails closed, green fails open —
+# including through the real CLI dispatch the workflow steps invoke. This is the only place any
+# of that is actually proven.
 self_test() {
   local tmp status=0
   tmp="$(mktemp -d)"
@@ -123,7 +162,18 @@ case "$1 $2" in
     jq -n --arg b "$body" '[{number: 4242, body: $b}]' >"$state/issues.json"
     ;;
   "issue comment")
+    # Record the body too: the assertions must be able to tell "Still red" from "Green again".
+    body=""
+    while [ $# -gt 0 ]; do
+      case "$1" in --body) body="$2"; shift 2 ;; *) shift ;; esac
+    done
+    printf '%s\n' "$body" >>"$state/comment-bodies.txt"
     printf 'comment\n' >>"$state/calls"
+    ;;
+  "issue close")
+    printf 'close %s\n' "$3" >>"$state/calls"
+    # A closed issue disappears from the next open-issues listing.
+    printf '[]\n' >"$state/issues.json"
     ;;
   *)
     printf 'unexpected stub call: %s\n' "$*" >&2; exit 1 ;;
@@ -134,6 +184,7 @@ STUB
   export SDK_MATRIX_STUB_STATE="$tmp"
   printf '[]\n' >"$tmp/issues.json"
   : >"$tmp/calls"
+  : >"$tmp/comment-bodies.txt"
 
   GH="$tmp/gh" report go v0.1.0 v0.16.0 "https://example.invalid/run/1" >/dev/null
   GH="$tmp/gh" report go v0.1.0 v0.17.0 "https://example.invalid/run/2" >/dev/null
@@ -150,6 +201,10 @@ STUB
     printf 'FAIL: expected the second red run to comment once, got %s\n' "$comments" >&2
     status=1
   fi
+  case "$(cat "$tmp/comment-bodies.txt")" in
+    *"Still red"*) ;;
+    *) printf 'FAIL: the second red run comment is missing "Still red"\n' >&2; status=1 ;;
+  esac
 
   # The issue has to name the SDK, its tag and the engine version — a tracking issue that does not
   # is unactionable, and the marker is what makes the next run find it.
@@ -182,16 +237,122 @@ STUB
     status=1
   fi
 
+  # --- close-on-green (--resolved) — the other half of the lifecycle (#915) --------------------
+
+  # red → green: the open tracking issue gets exactly one "Green again" comment and one close.
+  jq -n '[{number: 4242, body: "<!-- sdk-matrix-drift:go -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  : >"$tmp/comment-bodies.txt"
+  GH="$tmp/gh" resolve go v0.1.0 v0.17.0 "https://example.invalid/run/3" >/dev/null
+  if [ "$(grep -c '^close 4242$' "$tmp/calls" || true)" != "1" ] \
+    || [ "$(grep -c '^comment$' "$tmp/calls" || true)" != "1" ]; then
+    printf 'FAIL: a green run over an open tracking issue must comment once and close once\n' >&2
+    status=1
+  fi
+  case "$(cat "$tmp/comment-bodies.txt")" in
+    *"Green again"*) ;;
+    *) printf 'FAIL: the closing comment is missing "Green again"\n' >&2; status=1 ;;
+  esac
+
+  # Green with no open tracking issue — the everyday case — must not comment on or close anything.
+  printf '[]\n' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  GH="$tmp/gh" resolve go v0.1.0 v0.17.0 "" >/dev/null
+  if [ -s "$tmp/calls" ]; then
+    printf 'FAIL: a green run with no tracking issue must not comment or close anything\n' >&2
+    status=1
+  fi
+
+  # Marker isolation on the green path, mirroring the red-path case above.
+  jq -n '[{number: 7, body: "<!-- sdk-matrix-drift:java -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  GH="$tmp/gh" resolve go v0.1.0 v0.17.0 "" >/dev/null
+  if [ -s "$tmp/calls" ]; then
+    printf 'FAIL: a different SDK'\''s tracking issue was closed by this SDK'\''s green run\n' >&2
+    status=1
+  fi
+
+  # Fail OPEN when the lookup fails in --resolved mode — the mirror image of the red path's
+  # fail-closed case: issue bookkeeping must never turn a green conformance lane red.
+  if ! GH="$tmp/gh-broken" resolve go v0.1.0 v0.17.0 "" >/dev/null 2>&1; then
+    printf 'FAIL: a failing issue lookup in --resolved mode must not fail the green lane\n' >&2
+    status=1
+  fi
+
+  # Comment-lands-then-close-fails split — the ordering guarantee resolve() documents. This stub
+  # forwards everything except `issue close` to the normal stub, so the comment is recorded.
+  cat >"$tmp/gh-close-fails" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2" = "issue close" ]; then exit 1; fi
+exec "$(dirname "$0")/gh" "$@"
+STUB
+  chmod +x "$tmp/gh-close-fails"
+  jq -n '[{number: 4242, body: "<!-- sdk-matrix-drift:go -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  : >"$tmp/comment-bodies.txt"
+  local green_out
+  if ! green_out="$(GH="$tmp/gh-close-fails" resolve go v0.1.0 v0.17.0 "" 2>&1)"; then
+    printf 'FAIL: a failing close must not fail the green lane\n' >&2
+    status=1
+  fi
+  if [ "$(grep -c '^comment$' "$tmp/calls" || true)" != "1" ]; then
+    printf 'FAIL: the "Green again" comment must land before the close is attempted\n' >&2
+    status=1
+  fi
+  case "$green_out" in
+    *"closed #"*) printf 'FAIL: resolve claimed "closed" though the close failed\n' >&2; status=1 ;;
+  esac
+  case "$green_out" in
+    *"could not close"*) ;;
+    *) printf 'FAIL: a failed close must be warned about, not silent\n' >&2; status=1 ;;
+  esac
+
+  # The workflow's exact CLI shape, through the real arg parser — the direct resolve() calls
+  # above bypass the dispatch the "Close drift issue" step depends on.
+  jq -n '[{number: 4242, body: "<!-- sdk-matrix-drift:go -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  if ! GH="$tmp/gh" bash "${BASH_SOURCE[0]}" --resolved --sdk go --tag v0.1.0 \
+    --engine v0.17.0 --run-url "https://example.invalid/run/4" >/dev/null; then
+    printf 'FAIL: the --resolved CLI invocation must exit 0\n' >&2
+    status=1
+  fi
+  if [ "$(grep -c '^close 4242$' "$tmp/calls" || true)" != "1" ]; then
+    printf 'FAIL: the --resolved CLI invocation did not close the tracking issue\n' >&2
+    status=1
+  fi
+
+  # An empty --tag is runtime data (a blank tagName from the SDK release lookup), not an
+  # authoring error: the green path must swallow it and still close, never exit 2 — while the
+  # red path must keep rejecting it loudly. This is the validation-polarity split at the
+  # dispatch layer, the one place resolve()'s own fail-open cannot reach.
+  jq -n '[{number: 4242, body: "<!-- sdk-matrix-drift:go -->"}]' >"$tmp/issues.json"
+  : >"$tmp/calls"
+  if ! GH="$tmp/gh" bash "${BASH_SOURCE[0]}" --resolved --sdk go --tag "" \
+    --engine v0.17.0 >/dev/null 2>&1; then
+    printf 'FAIL: an empty --tag must not redden the green lane\n' >&2
+    status=1
+  fi
+  if [ "$(grep -c '^close 4242$' "$tmp/calls" || true)" != "1" ]; then
+    printf 'FAIL: an empty --tag must still let the green run close the tracking issue\n' >&2
+    status=1
+  fi
+  if GH="$tmp/gh" bash "${BASH_SOURCE[0]}" --sdk go --tag "" --engine v0.17.0 >/dev/null 2>&1; then
+    printf 'FAIL: the red path must still reject a missing --tag loudly\n' >&2
+    status=1
+  fi
+
   if [ "$status" = "0" ]; then
-    printf 'self-test: OK — create once, then update; per-SDK markers do not collide\n'
+    printf 'self-test: OK — create once, then update, close on green; per-SDK markers do not collide\n'
   fi
   return "$status"
 }
 
-sdk="" tag="" engine="" run_url=""
+mode=report sdk="" tag="" engine="" run_url=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --self-test) self_test; exit $? ;;
+    --resolved) mode=resolve; shift ;;
     --sdk)     sdk="${2:-}"; shift 2 ;;
     --tag)     tag="${2:-}"; shift 2 ;;
     --engine)  engine="${2:-}"; shift 2 ;;
@@ -200,5 +361,25 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$sdk" ] && [ -n "$tag" ] && [ -n "$engine" ] || usage
+# Validation polarity follows the mode's failure polarity. The red path insists on all three
+# values — a malformed report is worth failing loudly over. The green path's fail-open contract
+# has to hold HERE too, before resolve() is ever reached: --tag arrives empty whenever the SDK's
+# release lookup yields a blank tagName, and an exit 2 from this line would redden a green lane.
+# Only --sdk is load-bearing for a close; an empty tag/engine merely blunts the comment text.
+# (A genuinely unknown flag still exits 2 above in either mode: that is a workflow-authoring
+# bug, best caught loudly on its first run — the self-test drives this exact CLI shape.)
+if [ "$mode" = report ]; then
+  [ -n "$sdk" ] && [ -n "$tag" ] && [ -n "$engine" ] || usage
+elif [ -z "$sdk" ]; then
+  printf 'warning: --resolved without --sdk — nothing to close\n' >&2
+  exit 0
+fi
+
+# Belt and braces on the same contract: even if resolve() ever leaks a non-zero status through
+# a path the self-test missed, the green lane stays green.
+if [ "$mode" = resolve ]; then
+  resolve "$sdk" "$tag" "$engine" "$run_url" \
+    || printf 'warning: close-on-green bookkeeping failed — leaving any tracking issue open\n' >&2
+  exit 0
+fi
 report "$sdk" "$tag" "$engine" "$run_url"


### PR DESCRIPTION
The sdk-matrix drift reporter implemented only half its lifecycle: create a tracking issue on the first red lane, comment on later reds — nothing closed it on green. This adds the close-on-green half: a `--resolved` reporter mode (fail-open by design: bookkeeping errors must never turn a green conformance lane red) plus an `if: success()` "Close drift issue" workflow step, with the whole lifecycle proven by the extended `--self-test`, now wired into ci.yml. One-line docs update in docs/sdk/index.md.

Closes #915
Milestone: none (standalone CI tooling)