### PR TITLE
docs: correct the install path and surface the full feature set for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 **High-performance Mountebank-compatible HTTP/HTTPS mock server written in Rust**
 
-[![Status](https://img.shields.io/badge/status-beta-blue)](https://github.com/achird-labs/rift)
+[![Status](https://img.shields.io/badge/status-stable-brightgreen)](https://github.com/achird-labs/rift/releases/latest)
+[![Release](https://img.shields.io/github/v/release/achird-labs/rift)](https://github.com/achird-labs/rift/releases/latest)
+[![crates.io](https://img.shields.io/crates/v/rift-http-proxy)](https://crates.io/crates/rift-http-proxy)
+[![Docker](https://img.shields.io/docker/v/zainalpour/rift-proxy?label=docker)](https://hub.docker.com/r/zainalpour/rift-proxy)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-nightly-orange)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.92%2B%20stable-orange)](https://www.rust-lang.org/)
 
 Rift is a high-performance, [Mountebank](https://www.mbtest.dev/)-compatible mock server that delivers **~20–150x faster throughput on typical workloads, and up to ~1,850x on large regex predicate sets** — the conservative laptop figures from the table below; the 16-vCPU server column is higher still. Use your existing Mountebank configurations and enjoy faster test execution.
 
@@ -127,11 +130,37 @@ data does *not* support: [docs/comparisons/microcks](docs/comparisons/microcks.m
 
 ### Full Feature Support
 
+Everything Mountebank does:
+
 - **Imposters** - HTTP/HTTPS mock servers
 - **Predicates** - equals, contains, matches, exists, jsonpath, xpath, and, or, not
 - **Responses** - Static, proxy, injection
 - **Behaviors** - wait, decorate, copy, lookup
 - **Proxy Mode** - Record and replay
+
+...and a good deal it doesn't:
+
+| | |
+|:--|:--|
+| [Fault Injection](docs/features/fault-injection.md) | Probabilistic latency, error, and TCP faults — chaos testing without a sidecar |
+| [Scripting](docs/features/scripting.md) | Rhai and JavaScript engines for dynamic responses, with a `script check`/`script run` CLI |
+| [Scenarios (FSM)](docs/features/scenarios.md) | Declarative state machines instead of hand-rolled stateful injection |
+| [Flow State](docs/features/flow-state.md) | Per-flow key/value store, in-memory or Redis-backed |
+| [Correlated Isolation](docs/features/spaces.md) | Per-flow stub and state partitioning, so parallel tests don't collide |
+| [Front Door](docs/features/front-door.md) | One listener routing to many imposters by host, path, header or method |
+| [Single-Port Gateway](docs/features/gateway.md) | Reach every imposter through the admin port |
+| [Intercept Proxy](docs/features/intercept-proxy.md) | TLS-MITM a hard-coded external HTTPS host — no mitmproxy needed |
+| [Stub Analysis](docs/features/stub-analysis.md) | Overlap and conflict detection before a stub silently shadows another |
+| [Debug Mode](docs/features/debug-mode.md) | `X-Rift-Debug` explains why a request matched, or didn't |
+| [Hot Reload](docs/features/hot-reload.md) | Re-read config without dropping the process |
+| [Metrics](docs/features/metrics.md) | Prometheus endpoint |
+| [Linting](docs/features/linting.md) | `rift-lint` validates configs in CI before they ever load |
+| [Terminal UI](docs/features/tui.md) | `rift-tui` for interactive imposter management |
+| [Embedding & FFI](docs/embedding/index.md) | Run the engine in-process from Rust, or any language over the C ABI |
+
+Four official SDKs — [Java](docs/sdk/java.md), [Scala](docs/sdk/scala.md),
+[Node/TypeScript](docs/sdk/node.md), [Go](docs/sdk/go.md) — wrap all of it behind a typed DSL, and
+all four replay the same conformance corpus. See [Language SDKs](docs/sdk/index.md).
 
 ---
 
@@ -196,11 +225,19 @@ cargo install rift-http-proxy
 Download pre-built binaries from [GitHub Releases](https://github.com/achird-labs/rift/releases):
 
 ```bash
-# Example for Linux x86_64
-curl -LO https://github.com/achird-labs/rift/releases/latest/download/rift-vX.X.X-x86_64-unknown-linux-gnu.tar.gz
-tar -xzf rift-vX.X.X-x86_64-unknown-linux-gnu.tar.gz
-sudo mv rift-vX.X.X-x86_64-unknown-linux-gnu/bin/* /usr/local/bin/
+# Example for Linux x86_64 — set VERSION to the release you want
+VERSION=v0.17.0
+TARGET=x86_64-unknown-linux-gnu
+
+curl -LO https://github.com/achird-labs/rift/releases/download/$VERSION/rift-$VERSION-$TARGET.tar.gz
+tar -xzf rift-$VERSION-$TARGET.tar.gz
+sudo mv rift-$VERSION-$TARGET/bin/* /usr/local/bin/
+
+rift --version
 ```
+
+Each archive unpacks to a `bin/` directory containing `rift` (the server), `rift-lint`, `rift-tui`,
+and `rift-verify`.
 
 Available platforms:
 - Linux: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`
@@ -529,4 +566,4 @@ Apache License 2.0 - see [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 
-- [Mountebank](http://www.mbtest.org/) - The original service virtualization tool that inspired Rift's API and configuration format
+- [Mountebank](https://www.mbtest.dev/) - The original service virtualization tool that inspired Rift's API and configuration format

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -42,7 +42,7 @@ search:
   button: false
 
 # Footer
-footer_content: "Copyright &copy; 2026 Rift Contributors. Distributed under the <a href=\"https://github.com/achird-labs/rift/blob/master/LICENSE\">Apache License 2.0</a>. Docs current as of <a href=\"https://github.com/achird-labs/rift/releases/tag/v0.13.0\">v0.13.0</a>."
+footer_content: "Copyright &copy; 2026 Rift Contributors. Distributed under the <a href=\"https://github.com/achird-labs/rift/blob/master/LICENSE\">Apache License 2.0</a>. Docs current as of <a href=\"https://github.com/achird-labs/rift/releases/tag/v0.17.0\">v0.17.0</a>."
 
 # Back to top link
 back_to_top: true

--- a/docs/_data/sync.yml
+++ b/docs/_data/sync.yml
@@ -5,7 +5,7 @@
 #        git log --oneline --merges <commit>..origin/master
 #   2. Update the affected pages.
 #   3. Bump this file AND the version in _config.yml footer_content in the same PR.
-release: v0.13.0
-commit: dcc927b92296848a0de3299540b16299b202fac3
-date: 2026-07-10
+release: v0.17.0
+commit: 4318cdb9069a25bf13cefc43a711ceb824d5d655
+date: 2026-08-04
 tracking_issue: 280

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -8,7 +8,7 @@ permalink: /concepts/
 
 # Concepts
 
-Rift is a high-performance mock server. It speaks the [Mountebank](http://www.mbtest.org/) API for
+Rift is a high-performance mock server. It speaks the [Mountebank](https://www.mbtest.dev/) API for
 compatibility, but it is a tool in its own right — with a stateful model (flow-state, scenarios,
 correlated isolation) that goes well beyond record/replay. This section explains the mental model
 once, conceptually, so the reference and feature pages make sense.

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -9,19 +9,24 @@ nav_order: 3
 
 Rift provides Mountebank-compatible CLI options for easy migration.
 
+> **The command is `rift`.** Docker, Homebrew, the release archives and the install script all put
+> the server on your `PATH` under that name. The one exception is `cargo install rift-http-proxy`,
+> which names the binary after the crate — substitute `rift-http-proxy` for `rift` in every example
+> below if you installed that way.
+
 ---
 
 ## Basic Usage
 
 ```bash
 # Start the server
-rift-http-proxy
+rift
 
 # With configuration file
-rift-http-proxy --configfile imposters.json
+rift --configfile imposters.json
 
 # With custom port
-rift-http-proxy --port 3525
+rift --port 3525
 ```
 
 
@@ -34,15 +39,15 @@ merged in the order given, and `POST /admin/reload` re-fetches all of them.
 
 ```bash
 # A local file (these three are identical)
-rift-http-proxy --configfile mocks.json
-rift-http-proxy --imposters file:mocks.json
-rift-http-proxy --imposters mocks.json
+rift --configfile mocks.json
+rift --imposters file:mocks.json
+rift --imposters mocks.json
 
 # A document served over HTTP
-rift-http-proxy --imposters https://config.example.com/imposters.json
+rift --imposters https://config.example.com/imposters.json
 
 # Several sources merged into one running set
-rift-http-proxy --imposters file:base.json,https://config.example.com/team-overrides.json
+rift --imposters file:base.json,https://config.example.com/team-overrides.json
 ```
 
 `--configfile <p>` is sugar for `--imposters file:<p>` and behaves identically; passing both is an
@@ -121,7 +126,7 @@ grow its own dialect of the config format.
 ## CLI Options
 
 ```bash
-rift-http-proxy [OPTIONS]
+rift [OPTIONS]
 
 Options:
       --port <PORT>                Admin API port [default: 2525]
@@ -211,7 +216,7 @@ wherever that CA is installed — and installing it is the whole point of the fe
 LAN-reachable host, set a credential:
 
 ```bash
-rift-http-proxy --intercept-port 8888 --intercept-auth ci:s3cr3t
+rift --intercept-port 8888 --intercept-auth ci:s3cr3t
 ```
 
 Every `CONNECT` must then carry `Proxy-Authorization: Basic <base64(user:pass)>`; anything else gets
@@ -250,13 +255,13 @@ counts as blank. Omit the flag entirely to run the admin API explicitly unauthen
 merely *contains* spaces is still a valid key and is compared exactly as given.
 
 ```bash
-rift-http-proxy --api-key s3cr3t
+rift --api-key s3cr3t
 curl -H "Authorization: s3cr3t" http://localhost:2525/imposters
 ```
 
 ### Unauthenticated admin plane on a public interface
 
-`--host` defaults to `0.0.0.0`, so a bare `rift-http-proxy` with no `--api-key` already serves the
+`--host` defaults to `0.0.0.0`, so a bare `rift` with no `--api-key` already serves the
 full admin API — which can create imposters and drive the TLS intercept proxy — on every interface
 with no authentication. Since 0.17.0 that posture is stated at startup instead of being silent:
 
@@ -274,9 +279,9 @@ and every keyless quickstart. Fleets that want fail-closed opt in:
 
 ```bash
 # Refuse to start unless the admin plane is authenticated or loopback-only
-rift-http-proxy --require-admin-auth              # errors: 0.0.0.0 with no key
-rift-http-proxy --require-admin-auth --api-key s3cr3t   # ok — authenticated
-rift-http-proxy --require-admin-auth --local-only       # ok — not reachable off-host
+rift --require-admin-auth                    # errors: 0.0.0.0 with no key
+rift --require-admin-auth --api-key s3cr3t   # ok — authenticated
+rift --require-admin-auth --local-only       # ok — not reachable off-host
 ```
 
 `--require-admin-auth` gates on *authentication*, not on the address: a real `--api-key` satisfies
@@ -296,7 +301,7 @@ self-signed certificate. Pass `--no-self-signed-tls` to turn a missing certifica
 error instead of silently self-signing.
 
 ```bash
-rift-http-proxy \
+rift \
   --default-tls-cert ./certs/server.pem \
   --default-tls-key ./certs/server-key.pem \
   --no-self-signed-tls
@@ -306,20 +311,20 @@ rift-http-proxy \
 
 ```bash
 # Start with custom port
-rift-http-proxy --port 3525
+rift --port 3525
 
 # Load configuration and enable injection
-rift-http-proxy --configfile imposters.json --allow-injection
+rift --configfile imposters.json --allow-injection
 
 # Debug logging
-rift-http-proxy --loglevel debug
+rift --loglevel debug
 
 # Restrict access
-rift-http-proxy --local-only
-rift-http-proxy --api-key s3cr3t --require-admin-auth
+rift --local-only
+rift --api-key s3cr3t --require-admin-auth
 
 # With persistent data directory
-rift-http-proxy --datadir ./mb-data
+rift --datadir ./mb-data
 ```
 
 ---
@@ -414,10 +419,10 @@ services:
 
 ```bash
 # Via CLI
-rift-http-proxy --loglevel debug
+rift --loglevel debug
 
 # Via environment
-RUST_LOG=debug rift-http-proxy
+RUST_LOG=debug rift
 ```
 
 | Level | Description |
@@ -432,13 +437,13 @@ RUST_LOG=debug rift-http-proxy
 
 ```bash
 # Debug only rift modules
-RUST_LOG=rift=debug rift-http-proxy
+RUST_LOG=rift=debug rift
 
 # Debug HTTP handling
-RUST_LOG=rift::http=debug rift-http-proxy
+RUST_LOG=rift::http=debug rift
 
 # Multiple modules
-RUST_LOG=rift=info,rift::proxy=debug rift-http-proxy
+RUST_LOG=rift=info,rift::proxy=debug rift
 ```
 
 ---
@@ -466,10 +471,10 @@ curl http://localhost:9090/metrics
 
 ```bash
 # Graceful shutdown
-kill -TERM $(pidof rift-http-proxy)
+kill -TERM $(pidof rift)
 
 # Force kill (not recommended)
-kill -9 $(pidof rift-http-proxy)
+kill -9 $(pidof rift)
 ```
 
 ---
@@ -494,8 +499,8 @@ Rift supports several subcommands for server management:
 Start the Rift server (default behavior when no subcommand is specified):
 
 ```bash
-rift-http-proxy start
-rift-http-proxy start --port 3525 --configfile imposters.json
+rift start
+rift start --port 3525 --configfile imposters.json
 ```
 
 ### stop
@@ -504,10 +509,10 @@ Stop a running Rift server using its PID file:
 
 ```bash
 # Stop server using default PID file (rift.pid)
-rift-http-proxy stop
+rift stop
 
 # Stop using custom PID file
-rift-http-proxy stop --pidfile /var/run/rift.pid
+rift stop --pidfile /var/run/rift.pid
 ```
 
 ### restart
@@ -515,7 +520,7 @@ rift-http-proxy stop --pidfile /var/run/rift.pid
 Restart a running Rift server:
 
 ```bash
-rift-http-proxy restart --pidfile /var/run/rift.pid
+rift restart --pidfile /var/run/rift.pid
 ```
 
 ### save
@@ -524,10 +529,10 @@ Save current imposters to a file for later replay:
 
 ```bash
 # Save imposters to file
-rift-http-proxy save --savefile recorded.json
+rift save --savefile recorded.json
 
 # Save with proxies removed (pure recorded responses)
-rift-http-proxy save --savefile mocks.json --remove-proxies
+rift save --savefile mocks.json --remove-proxies
 ```
 
 ### replay
@@ -535,7 +540,7 @@ rift-http-proxy save --savefile mocks.json --remove-proxies
 Replay saved imposters from a file:
 
 ```bash
-rift-http-proxy replay --configfile recorded.json
+rift replay --configfile recorded.json
 ```
 
 ### script
@@ -549,9 +554,9 @@ the intended hook, and (for a config) `state`-used-without-`flowState`. Exits no
 error — so a script whose entrypoint is misnamed fails here instead of at request time.
 
 ```bash
-rift-http-proxy script check scripts/fail-twice.rhai
-rift-http-proxy script check scripts/decorate.js --hook respond
-rift-http-proxy script check imposters.yaml            # every _rift.script in the config
+rift script check scripts/fail-twice.rhai
+rift script check scripts/decorate.js --hook respond
+rift script check imposters.yaml            # every _rift.script in the config
 ```
 
 | Flag | Description | Default |
@@ -563,8 +568,8 @@ printing the decision, the mutated flow state, captured `ctx.logger` output, and
 duration. No server runs.
 
 ```bash
-rift-http-proxy script run scripts/fail-twice.rhai --state attempts=2
-rift-http-proxy script run scripts/echo.js --request fixtures/get-resource.json --flow-id t1
+rift script run scripts/fail-twice.rhai --state attempts=2
+rift script run scripts/echo.js --request fixtures/get-resource.json --flow-id t1
 ```
 
 | Flag | Description | Default |
@@ -588,9 +593,9 @@ configuration. A bind-any host (`0.0.0.0`, `::`) is probed on loopback, since th
 bound to every interface answers.
 
 ```bash
-rift-http-proxy healthcheck                                        # probes http://127.0.0.1:2525/health
-MB_PORT=3000 rift-http-proxy healthcheck                           # follows MB_PORT
-rift-http-proxy healthcheck --url http://localhost:9090/metrics    # probe something else
+rift healthcheck                                        # probes http://127.0.0.1:2525/health
+MB_PORT=3000 rift healthcheck                           # follows MB_PORT
+rift healthcheck --url http://localhost:9090/metrics    # probe something else
 ```
 
 | Flag | Description | Default |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -135,7 +135,7 @@ docker run -e MB_PORT=2525 -e MB_ALLOW_INJECTION=true \
 ## Command Line Options
 
 ```bash
-rift-http-proxy [OPTIONS]
+rift [OPTIONS]
 
 Options:
       --port <PORT>          Admin API port [default: 2525]

--- a/docs/configuration/mountebank.md
+++ b/docs/configuration/mountebank.md
@@ -382,7 +382,7 @@ docker run -v $(pwd)/imposters.json:/imposters.json \
   zainalpour/rift-proxy:latest --configfile /imposters.json
 
 # Binary
-./rift-http-proxy --configfile imposters.json
+./rift --configfile imposters.json
 ```
 
 ### Via REST API

--- a/docs/configuration/native.md
+++ b/docs/configuration/native.md
@@ -133,7 +133,7 @@ Redis support requires building with the `redis-backend` feature:
 cargo build --release --features redis-backend
 
 # Run with Redis backend
-rift-http-proxy --configfile imposters.json
+rift --configfile imposters.json
 ```
 
 ---

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -9,7 +9,14 @@ permalink: /demo/
 
 Quick-start demos for Rift in different modes.
 
-> **Note**: These demos use a locally-built Docker image. Run `docker build -t rift-proxy:local -f crates/rift-http-proxy/Dockerfile .` from the project root first.
+> **Nothing to build.** These demos pull the published `zainalpour/rift-proxy:latest` image, so
+> `docker compose up -d` works from a fresh clone. To run one against your own working tree instead,
+> build and retag it first:
+>
+> ```bash
+> docker build -t rift-proxy:local -f crates/rift-http-proxy/Dockerfile .
+> docker tag rift-proxy:local zainalpour/rift-proxy:latest
+> ```
 
 ## Demo 1: Mountebank Mode (HTTP)
 

--- a/docs/demo/docker-compose-https.yml
+++ b/docs/demo/docker-compose-https.yml
@@ -1,9 +1,6 @@
 # Rift Demo - HTTPS/TLS Mode
 #
 # Prerequisites:
-#   1. Build the local image:
-#      docker build -t rift-proxy:local -f crates/rift-http-proxy/Dockerfile .
-#
 #   2. Generate certificates:
 #      ./generate-certs.sh
 #
@@ -18,7 +15,7 @@
 
 services:
   rift:
-    image: rift-proxy:local
+    image: zainalpour/rift-proxy:latest
     container_name: rift-https-demo
     ports:
       - "2525:2525"    # Admin API

--- a/docs/demo/docker-compose-rift-features.yml
+++ b/docs/demo/docker-compose-rift-features.yml
@@ -1,6 +1,6 @@
 services:
   rift:
-    image: rift-proxy:local
+    image: zainalpour/rift-proxy:latest
     ports:
       - "2525:2525"   # Admin API
       - "4547:4547"   # Fault Injection demo

--- a/docs/demo/docker-compose-scripting-engines.yml
+++ b/docs/demo/docker-compose-scripting-engines.yml
@@ -1,6 +1,6 @@
 services:
   rift:
-    image: rift-proxy:local
+    image: zainalpour/rift-proxy:latest
     ports:
       - "2525:2525"   # Admin API
       - "4560:4560"   # Scripting engines demo

--- a/docs/demo/docker-compose-scripting.yml
+++ b/docs/demo/docker-compose-scripting.yml
@@ -1,6 +1,6 @@
 services:
   rift:
-    image: rift-proxy:local
+    image: zainalpour/rift-proxy:latest
     ports:
       - "2525:2525"   # Admin API
       - "4550:4550"   # Scripting demo

--- a/docs/demo/docker-compose.yml
+++ b/docs/demo/docker-compose.yml
@@ -9,7 +9,7 @@
 
 services:
   rift:
-    image: rift-proxy:local
+    image: zainalpour/rift-proxy:latest
     container_name: rift-demo
     ports:
       - "2525:2525"    # Admin API

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -14,10 +14,7 @@ Deploy Rift using Docker for quick setup and consistent environments.
 ## Quick Start
 
 ```bash
-# Pull the image (from GitHub Container Registry)
-docker pull zainalpour/rift-proxy:latest
-
-# Or from Docker Hub
+# Pull the image from Docker Hub
 docker pull zainalpour/rift-proxy:latest
 
 # Run with default settings
@@ -373,9 +370,8 @@ docker compose down -v
 # Check logs
 docker logs rift
 
-# Verify config
-docker run --rm -v $(pwd)/imposters.json:/imposters.json \
-  zainalpour/rift-proxy:latest --validate /imposters.json
+# Verify config (rift-lint ships as its own image; the server image does not include it)
+docker run --rm -v $(pwd):/imposters zainalpour/rift-lint /imposters/imposters.json
 ```
 
 ### Port Already in Use

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -26,10 +26,21 @@ Rift provides advanced features for service virtualization and chaos engineering
 
 - **Fault Injection** - Probabilistic latency, error, and TCP fault injection
 - **Scripting** - Rhai and JavaScript engines for dynamic behavior
-- **Flow State** - Stateful scenarios with InMemory or Redis backends
+- **Scenarios (FSM)** - Stateful stubs as declarative state machines
+- **Flow State** - Per-flow key/value store with InMemory or Redis backends
+- **Correlated Isolation (Spaces)** - Per-flow stub and state partitioning
 - **Stub Analysis** - Overlap detection and conflict warnings
 - **Debug Mode** - Request matching diagnostics with `X-Rift-Debug` header
 - **Metrics** - Prometheus integration
+
+### Server-Level Capabilities
+
+- **Front Door** - One listener routing to many imposters by host, path, header or method
+- **Single-Port Gateway** - Reach every imposter through the admin port
+- **Intercept Proxy** - TLS-MITM a hard-coded external HTTPS host, no mitmproxy needed
+- **Hot Reload** - Re-read configuration without restarting the process
+- **Imposter Sources** - Load from a path or a URI, merging several sources
+- **Embedding** - Run the engine in-process from Rust, or any language over the C ABI
 
 ---
 
@@ -44,13 +55,22 @@ Rift provides advanced features for service virtualization and chaos engineering
 | JavaScript Injection | ✅ | — |
 | Probabilistic Faults | Via injection | ✅ `_rift.fault` |
 | Rhai/JS Scripting | — | ✅ `_rift.script` |
+| Scenarios (FSM) | Via injection | ✅ stub `scenarioName` |
 | Flow State | Via injection | ✅ `_rift.flowState` |
+| Correlated Isolation | — | ✅ stub `space` |
 | Stub Analysis | — | ✅ `_rift.warnings` |
 | Stub IDs | — | ✅ `id` field |
 | Debug Mode | — | ✅ `X-Rift-Debug` header |
 | Prometheus Metrics | ✅ | ✅ |
+| Front Door | — | ✅ `--front-door` |
+| Single-Port Gateway | — | ✅ via the admin port |
+| Intercept Proxy (TLS-MITM) | — | ✅ `--intercept-port` |
+| Hot Reload | — | ✅ `POST /admin/reload` |
 | Config Linting | — | ✅ `rift-lint` |
+| Stub Verification | — | ✅ `rift-verify` |
 | Terminal UI | — | ✅ `rift-tui` |
+| In-Process Embedding | — | ✅ Rust API + C ABI |
+| Official Typed SDKs | — | ✅ Java, Scala, Node, Go |
 
 ---
 

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -30,9 +30,9 @@ curl http://localhost:9090/metrics
 Change the port with `--metrics-port` or `RIFT_METRICS_PORT`:
 
 ```bash
-rift-http-proxy --metrics-port 8090
+rift --metrics-port 8090
 # or
-RIFT_METRICS_PORT=8090 rift-http-proxy
+RIFT_METRICS_PORT=8090 rift
 ```
 
 There is no environment variable to disable the metrics server; if you don't scrape it, it sits

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,30 +26,53 @@ docker pull zainalpour/rift-proxy:latest
 docker run -p 2525:2525 zainalpour/rift-proxy:latest
 ```
 
-### Download Binary
-
-Download pre-built binaries from the [releases page](https://github.com/achird-labs/rift/releases):
+### Homebrew (macOS/Linux)
 
 ```bash
-# Linux (x86_64)
-curl -L https://github.com/achird-labs/rift/releases/latest/download/rift-http-proxy-linux-x86_64 -o rift
-chmod +x rift
-./rift
-
-# macOS (Apple Silicon)
-curl -L https://github.com/achird-labs/rift/releases/latest/download/rift-http-proxy-darwin-aarch64 -o rift
-chmod +x rift
-./rift
-
-# macOS (Intel)
-curl -L https://github.com/achird-labs/rift/releases/latest/download/rift-http-proxy-darwin-x86_64 -o rift
-chmod +x rift
-./rift
+brew tap achird-labs/rift
+brew install rift
 ```
+
+This installs four binaries: `rift` (the server), `rift-lint`, `rift-tui`, and `rift-verify`.
+
+### Download Binary
+
+Release archives are published per platform on the
+[releases page](https://github.com/achird-labs/rift/releases), named
+`rift-vX.Y.Z-<target>.tar.gz` (`.zip` on Windows). Each unpacks to a `bin/` directory
+containing `rift`, `rift-lint`, `rift-tui`, and `rift-verify`.
+
+```bash
+# macOS (Apple Silicon) — substitute your platform triple from the list below
+VERSION=v0.17.0
+TARGET=aarch64-apple-darwin
+
+curl -LO https://github.com/achird-labs/rift/releases/download/$VERSION/rift-$VERSION-$TARGET.tar.gz
+tar -xzf rift-$VERSION-$TARGET.tar.gz
+sudo mv rift-$VERSION-$TARGET/bin/* /usr/local/bin/
+
+rift --version
+```
+
+Available platform triples:
+
+- Linux: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`
+- macOS: `x86_64-apple-darwin`, `aarch64-apple-darwin`
+- Windows: `x86_64-pc-windows-msvc`
+
+### Cargo (crates.io)
+
+```bash
+cargo install rift-http-proxy
+```
+
+Note that cargo names the installed binary after the crate — `rift-http-proxy`, not `rift`. Every
+other install method above puts it on your `PATH` as `rift`, which is the name used throughout
+these docs.
 
 ### Build from Source
 
-Requires Rust 1.70+:
+Requires Rust 1.92+ (see `rust-version` in `Cargo.toml`):
 
 ```bash
 git clone https://github.com/achird-labs/rift.git
@@ -69,12 +92,18 @@ npm install @rift-vs/rift
 Usage:
 
 ```javascript
-import rift from '@rift-vs/rift';
+import { rift, imposter, onGet, okJson, times } from '@rift-vs/rift';
 
-const server = await rift.create({ port: 2525 });
-// Create imposters, run tests...
-await server.close();
+await using engine = await rift.embedded(); // or rift.connect(url) / rift.spawn()
+
+const users = await engine.create(
+  imposter('users').stub(onGet('/api/users/1').willReturn(okJson({ id: 1, name: 'Alice' }))));
+
+await users.verify(onGet('/api/users/1'), times(1));
 ```
+
+The Mountebank-compatible `rift.create({ port })` API stays available as a permanent drop-in if you
+are migrating.
 
 See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) for complete documentation.
 
@@ -159,12 +188,12 @@ Once Rift is running, verify it's working:
 # Check the admin API
 curl http://localhost:2525/
 
-# Expected response:
+# Expected response (hrefs are absolute, built from the admin host and port):
 {
   "_links": {
-    "imposters": { "href": "/imposters" },
-    "config": { "href": "/config" },
-    "logs": { "href": "/logs" }
+    "config": { "href": "http://localhost:2525/config" },
+    "imposters": { "href": "http://localhost:2525/imposters" },
+    "logs": { "href": "http://localhost:2525/logs" }
   }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ permalink: /
 **High-performance Mountebank-compatible HTTP/HTTPS mock server written in Rust**
 {: .fs-6 .fw-300 }
 
-Rift is a drop-in replacement for [Mountebank](http://www.mbtest.org/) that provides **2-250x better performance** while maintaining full API compatibility. Use your existing Mountebank configurations and enjoy faster test execution.
+Rift is a drop-in replacement for [Mountebank](https://www.mbtest.dev/) that delivers **~20–150x faster throughput on typical workloads, and up to ~1,850x on large regex predicate sets** — while maintaining full API compatibility. Use your existing Mountebank configurations and enjoy faster test execution.
 
 [Get Started]({{ site.baseurl }}/getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/achird-labs/rift){: .btn .fs-5 .mb-4 .mb-md-0 }
@@ -56,6 +56,22 @@ Rift supports all major Mountebank features:
 - **Behaviors** - wait, decorate, copy, lookup
 - **Recording** - Proxy mode with response recording
 
+### And Then Some
+
+Compatibility is the floor, not the ceiling. Rift adds the things you would otherwise build by hand
+on top of a mock server:
+
+- **[Fault Injection]({{ site.baseurl }}/features/fault-injection/)** - probabilistic latency, error and TCP faults, declaratively
+- **[Scripting]({{ site.baseurl }}/features/scripting/)** - Rhai and JavaScript engines, with a `script check` / `script run` CLI
+- **[Scenarios]({{ site.baseurl }}/features/scenarios/)** and **[Flow State]({{ site.baseurl }}/features/flow-state/)** - declarative state machines and a per-flow key/value store
+- **[Correlated Isolation]({{ site.baseurl }}/features/spaces/)** - per-flow partitioning so parallel tests don't collide
+- **[Front Door]({{ site.baseurl }}/features/front-door/)** and **[Gateway]({{ site.baseurl }}/features/gateway/)** - route many imposters through one listener
+- **[Intercept Proxy]({{ site.baseurl }}/features/intercept-proxy/)** - TLS-MITM a hard-coded external host without mitmproxy
+- **[Stub Analysis]({{ site.baseurl }}/features/stub-analysis/)** and **[Debug Mode]({{ site.baseurl }}/features/debug-mode/)** - find shadowed stubs, and see why a request matched
+- **[Embedding & FFI]({{ site.baseurl }}/embedding/)** - run the engine in-process from Rust or any language over the C ABI
+
+The [Features]({{ site.baseurl }}/features/) section covers all of them.
+
 ---
 
 ## Quick Start
@@ -63,10 +79,7 @@ Rift supports all major Mountebank features:
 ### Using Docker (Recommended)
 
 ```bash
-# Pull the latest image (from GitHub Container Registry)
-docker pull zainalpour/rift-proxy:latest
-
-# Or from Docker Hub
+# Pull the latest image from Docker Hub
 docker pull zainalpour/rift-proxy:latest
 
 # Run Rift (Mountebank-compatible mode)
@@ -110,15 +123,19 @@ npm install @rift-vs/rift
 ```
 
 ```javascript
-import rift from '@rift-vs/rift';
+import { rift, imposter, onGet, okJson, times } from '@rift-vs/rift';
 
-// Start a Rift server (drop-in replacement for Mountebank)
-const server = await rift.create({ port: 2525 });
+await using engine = await rift.embedded(); // or rift.connect(url) / rift.spawn()
 
-// Create imposters, run your tests...
+const users = await engine.create(
+  imposter('users').stub(onGet('/api/users/1').willReturn(okJson({ id: 1, name: 'Alice' }))));
 
-await server.close();
+await fetch(`${users.url}/api/users/1`);
+await users.verify(onGet('/api/users/1'), times(1)); // throws with a diff on mismatch
 ```
+
+Migrating from Mountebank? The Mountebank-compatible `rift.create({ port })` API stays available as
+a permanent drop-in, so adopting the typed DSL above is incremental rather than a rewrite.
 
 See the [Node.js Integration Guide]({{ site.baseurl }}/getting-started/nodejs/) for complete documentation.
 
@@ -218,10 +235,22 @@ hello-world for each, plus the transport and version-compatibility matrices.
 - [CLI Reference]({{ site.baseurl }}/configuration/cli/) - Command-line options
 
 ### Features
+- [Features Overview]({{ site.baseurl }}/features/) - Every extension, with the Mountebank comparison table
 - [Fault Injection]({{ site.baseurl }}/features/fault-injection/) - Latency and error simulation
 - [Scripting]({{ site.baseurl }}/features/scripting/) - Rhai and JavaScript engines
+- [Scenarios (FSM)]({{ site.baseurl }}/features/scenarios/) - Stateful stubs as declarative state machines
+- [Correlated Isolation (Spaces)]({{ site.baseurl }}/features/spaces/) - Per-flow stub and state partitioning
+- [Flow State]({{ site.baseurl }}/features/flow-state/) - Per-flow key/value store
+- [Front Door]({{ site.baseurl }}/features/front-door/) - One listener routing to many imposters
+- [Single-Port Gateway]({{ site.baseurl }}/features/gateway/) - Reach every imposter through the admin port
+- [Intercept Proxy (TLS-MITM)]({{ site.baseurl }}/features/intercept-proxy/) - Mock a hard-coded external HTTPS host
+- [Hot Reload]({{ site.baseurl }}/features/hot-reload/) - Re-read config without restarting
+- [Stub Analysis]({{ site.baseurl }}/features/stub-analysis/) - Overlap detection and warnings
+- [Debug Mode]({{ site.baseurl }}/features/debug-mode/) - Why a request matched, or didn't
 - [TLS/HTTPS]({{ site.baseurl }}/features/tls/) - Secure connections
 - [Metrics]({{ site.baseurl }}/features/metrics/) - Prometheus integration
+- [Configuration Linting]({{ site.baseurl }}/features/linting/) - Validate configs before they load
+- [Terminal UI]({{ site.baseurl }}/features/tui/) - Interactive imposter management
 
 ### Deployment
 - [Docker]({{ site.baseurl }}/deployment/docker/) - Container deployment
@@ -243,19 +272,23 @@ hello-world for each, plus the transport and version-compatibility matrices.
 
 ## Project Status
 
-Rift is under active development. Current status:
+The HTTP/HTTPS surface is stable and actively developed. Current status:
 
-| Feature | Status |
-|:--------|:-------|
-| HTTP Imposters | Stable |
-| HTTPS Imposters | Stable |
-| All Predicates | Stable |
-| Static Responses | Stable |
-| Proxy Mode | Stable |
-| Behaviors (wait, decorate) | Stable |
-| Injection (JavaScript) | Stable |
-| TCP Protocol | Planned |
-| SMTP Protocol | Planned |
+| Area | Status |
+|:-----|:-------|
+| HTTP / HTTPS imposters | Stable |
+| All predicates, static responses, behaviors | Stable |
+| Proxy mode (record & replay) | Stable |
+| JavaScript injection | Stable |
+| Fault injection, scripting (Rhai / JS) | Stable |
+| Scenarios, flow state, correlated isolation | Stable |
+| Front door, single-port gateway | Stable |
+| Intercept proxy (TLS-MITM) | Stable |
+| Stub analysis, debug mode, hot reload | Stable |
+| Prometheus metrics, linting, terminal UI | Stable |
+| Embedding (Rust API, C ABI) and the four SDKs | Stable |
+| TCP protocol | Planned |
+| SMTP protocol | Planned |
 
 ---
 

--- a/docs/mountebank/index.md
+++ b/docs/mountebank/index.md
@@ -8,7 +8,7 @@ permalink: /mountebank/
 
 # Mountebank Compatibility
 
-Rift implements the [Mountebank](http://www.mbtest.org/) REST API and configuration format. This allows you to use Rift as a drop-in replacement for Mountebank with significantly better performance.
+Rift implements the [Mountebank](https://www.mbtest.dev/) REST API and configuration format. This allows you to use Rift as a drop-in replacement for Mountebank with significantly better performance.
 
 **Scope:** Rift imposters are **HTTP/HTTPS only**. Mountebank also supports `tcp` and `smtp`
 imposters, which Rift rejects — see the [migration guide]({{ site.baseurl }}/getting-started/migration/)

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -644,13 +644,13 @@ alternative topology (RFC-712) trades a little complexity for **materially lower
 
 ```bash
 # Default — one work-stealing runtime (unchanged behaviour)
-rift-http-proxy --runtime work-stealing
+rift --runtime work-stealing
 
 # Per-core: N single-threaded runtimes, N = physical cores
-rift-http-proxy --runtime per-core
+rift --runtime per-core
 
 # …or pin the worker count explicitly
-rift-http-proxy --runtime per-core=8
+rift --runtime per-core=8
 
 # Env-var equivalent (the CLI flag wins if both are set)
 RIFT_RUNTIME=per-core rift-http-proxy

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# Example Imposter Configurations
+
+Six ready-to-run configs, each a single self-contained Mountebank-format file. They are checked by
+`rift-lint` in CI, so they parse and load.
+
+| File | Port | What it shows |
+|:-----|:-----|:--------------|
+| [`basic-api.json`](basic-api.json) | 4545 | The smallest useful config — a health check and CRUD over `/api/users`. Start here. |
+| [`task-management-api.json`](task-management-api.json) | 4545 | A fuller REST surface: regex path predicates, path parameters, and per-resource responses. |
+| [`authentication-api.json`](authentication-api.json) | 4547 | Login / logout / token validation, using `scenarioName` so a session advances through states. |
+| [`feature-flags-api.json`](feature-flags-api.json) | 4546 | Flag lookup with a catch-all regex for unknown keys. |
+| [`error-testing.json`](error-testing.json) | 4545 | Every error status your client should handle — 400, 401, 403, 404, 429, 500, 502, 503. |
+| [`latency-testing.json`](latency-testing.json) | 4545 | Fixed and random delays plus a timeout endpoint, for exercising client retry and timeout logic. |
+
+Several use port 4545, so run one at a time unless you edit the ports.
+
+## Running one
+
+```bash
+# With a locally installed binary
+rift --configfile examples/basic-api.json
+
+# With Docker
+docker run -p 2525:2525 -p 4545:4545 \
+  -v "$(pwd)/examples:/examples" \
+  zainalpour/rift-proxy:latest --configfile /examples/basic-api.json
+```
+
+Then drive it:
+
+```bash
+curl http://localhost:4545/health
+curl http://localhost:4545/api/users
+```
+
+## Validating before you load
+
+```bash
+rift-lint examples/
+```
+
+## Where to go next
+
+These cover the Mountebank-compatible surface. For Rift's own features — fault injection, scripting,
+scenarios, flow state, the front door, the TLS intercept proxy — see the runnable `docker-compose`
+demos in [`../docs/demo/`](../docs/demo/), each of which comes up in one command, and the
+[Features documentation](https://achird-labs.github.io/rift/features/).


### PR DESCRIPTION
Pre-launch audit of every user-facing doc, demo and example against the v0.17.0 engine. The docs sync marker and the site footer both still read v0.13.0 — four releases behind — and several of the first commands a new user copy-pastes did not work.

## Broken, now fixed

- **Binary download URLs 404'd.** `getting-started` named a `rift-http-proxy-<os>-<arch>` asset that has never been published; releases ship `rift-vX.Y.Z-<target>.tar.gz`. Old URLs verified 404, new ones 200.
- **The documented command name doesn't exist.** ~50 CLI examples invoked `rift-http-proxy`. Docker (`ENTRYPOINT /usr/local/bin/rift`), Homebrew (`bin.install "bin/rift"`), the release tarballs and `install.sh` all install it as `rift`. Only `cargo install` produces the crate name — now called out explicitly in the CLI reference. Crate/path/cargo references left intact.
- **`--validate` is not a flag.** `docker.md` recommended it for config checking; replaced with the `zainalpour/rift-lint` image (`WORKDIR /imposters`, `ENTRYPOINT rift-lint`).
- **Duplicate registry block.** The landing page and `docker.md` offered "pull from GitHub Container Registry" followed by an identical Docker Hub line. There is no GHCR image.
- **Rust badge said `nightly`.** CI uses `dtolnay/rust-toolchain@stable` throughout; MSRV is 1.92. Getting-started also claimed "Rust 1.70+" and omitted Homebrew and cargo.
- **Stale markers.** `_config.yml` footer and `_data/sync.yml` bumped v0.13.0 → v0.17.0. Landing page claimed "2-250x", contradicting its own table (24x–1,857x).

## Undersell

The README and landing page described only Mountebank parity — front door, intercept proxy, scenarios, spaces, flow state, gateway, hot reload, stub analysis, debug mode, embedding and the four SDKs were invisible to anyone evaluating Rift. The status table listed seven rows, all basics; the features nav linked 4 of 17 pages. All expanded, with config keys checked against the feature docs (`scenarioName` and stub-level `space`, not the `_rift.*` keys a first draft guessed). Node snippets switched from the legacy `rift.create({port})` to the typed DSL, keeping the drop-in note. Status badge is now `stable`.

## Demos and examples

All six `docker-compose` demos now run off the published image instead of requiring `docker build -t rift-proxy:local` first, so `docker compose up -d` works from a fresh clone. `verify-demo-compose.sh` compares image IDs and CI already retags the build under test, so the gate still proves demos exercise the working tree. Added `examples/README.md` — the README links `examples/` and it rendered as a bare file listing.

## Verification

- `verify-docs-coverage.sh` — 44 flags, 34 env vars, 7 subcommands
- `verify-docs-examples.sh` — every documented config loads and serves
- `verify-demo-compose.sh` — 6/6 stacks boot healthy, run against the pulled published image
- `verify-feature-propagation.sh` — pass
- `rift-lint examples/` — clean

## Follow-up, not in this PR

`release.yml` bumps `Cargo.toml` but touches no docs, so the `v0.17.0` strings in README, getting-started, `_config.yml` and `sync.yml` will drift at the next release. Worth automating before the campaign drives traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)