### PR TITLE
chore(errors): remove the deprecated top-level backendUnavailable keys (0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ record.
 
 ## [Unreleased]
 
+### Removed
+
+- **The deprecated top-level `error` / `feature` / `detail` keys on backend-error responses**
+  (issue #801). Deprecated in 0.16.0 and retained through 0.17.0, the pre-envelope duplicates are
+  now gone: the Mountebank `errors` envelope is the only shape this door serves. Branch on
+  `errors[0].type == "backend unavailable"`; `errors[0].feature` / `errors[0].detail` carry the
+  same information the top-level keys did.
+
 ## [0.17.0] - 2026-08-03
 
 ### Added
@@ -577,7 +585,8 @@ record.
 
   **Deprecation:** the **top-level** `error`/`feature`/`detail` keys are unchanged and still
   served, so nothing breaks — but they are deprecated and will be **removed in 0.17.0** (#801).
-  Read `errors[0]` instead.
+  Read `errors[0]` instead. *(Correction, 2026-08-04: the removal missed the 0.17.0 train and
+  ships in 0.18.0 — see the `Removed` entry above.)*
 
 
 ## [0.15.0] - 2026-07-21

--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1456,8 +1456,13 @@ mod requests_filter_tests {
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
-        assert_eq!(json["error"], "backendUnavailable");
-        // Issue #800: the admin plane serves the envelope on this door as well.
+        // Issue #801: the admin plane serves only the envelope on this door.
+        assert!(
+            json.get("error").is_none()
+                && json.get("feature").is_none()
+                && json.get("detail").is_none(),
+            "top-level legacy keys were removed in 0.18.0 (#801), got: {json}"
+        );
         assert_eq!(json["errors"][0]["code"], "503");
         assert_eq!(json["errors"][0]["type"], "backend unavailable");
         let _ = manager.delete_imposter(19742).await;

--- a/crates/rift-http-proxy/tests/backend_decorate.rs
+++ b/crates/rift-http-proxy/tests/backend_decorate.rs
@@ -108,8 +108,8 @@ async fn data_plane_scenario_gate_returns_structured_503() {
         .expect("request");
     assert_eq!(resp.status(), 503);
     let body: serde_json::Value = resp.json().await.expect("json");
-    assert_eq!(body["error"], "backendUnavailable");
-    assert_eq!(body["feature"], "flowState");
+    assert_eq!(body["errors"][0]["type"], "backend unavailable");
+    assert_eq!(body["errors"][0]["feature"], "flowState");
 
     manager.delete_all().await;
 }
@@ -134,7 +134,7 @@ async fn flow_state_admin_endpoint_returns_structured_503() {
         "backend failure must be a structured 503"
     );
     let body: serde_json::Value = resp.json().await.expect("json");
-    assert_eq!(body["error"], "backendUnavailable");
+    assert_eq!(body["errors"][0]["type"], "backend unavailable");
 
     manager.delete_all().await;
 }
@@ -154,7 +154,7 @@ async fn scenario_list_maps_backend_error_to_503() {
         .expect("request");
     assert_eq!(resp.status(), 503);
     let body: serde_json::Value = resp.json().await.expect("json");
-    assert_eq!(body["error"], "backendUnavailable");
+    assert_eq!(body["errors"][0]["type"], "backend unavailable");
 
     manager.delete_all().await;
 }
@@ -219,7 +219,7 @@ async fn transition_write_failure_returns_structured_503() {
         .expect("request");
     assert_eq!(resp.status(), 503, "a lost transition must fail loudly");
     let body: serde_json::Value = resp.json().await.expect("json");
-    assert_eq!(body["error"], "backendUnavailable");
+    assert_eq!(body["errors"][0]["type"], "backend unavailable");
 
     manager.delete_all().await;
 }
@@ -284,7 +284,7 @@ async fn gateway_503_is_decorated_with_admin_phase() {
         "gateway responses are decorated"
     );
     let body: serde_json::Value = resp.json().await.expect("json");
-    assert_eq!(body["error"], "backendUnavailable");
+    assert_eq!(body["errors"][0]["type"], "backend unavailable");
 
     let calls = recorder.calls.lock().clone();
     let call = calls

--- a/crates/rift-mock-core/src/extensions/decorate.rs
+++ b/crates/rift-mock-core/src/extensions/decorate.rs
@@ -74,17 +74,15 @@ pub trait ResponseDecorator: Send + Sync {
 /// Map a backend/handler error to its response: [`BackendUnavailable`] anywhere in the
 /// chain → `503`; anything else → `500`. Never a silent fallback.
 ///
-/// Serves **two shapes in one body** (issue #800). This door predates the #611/#797 envelope
-/// sweeps and was the last one still serving only its own `{"error":"backendUnavailable",…}`
-/// shape, so a client that followed #797's guidance and switched to reading `errors[0].type` got
-/// nothing here. It now carries the Mountebank envelope *as well*:
+/// Serves the Mountebank envelope only. This door predates the #611/#797 envelope sweeps and
+/// served its own `{"error":"backendUnavailable",…}` shape through 0.15.0; #800 added the
+/// envelope alongside those keys, and #801 removed them in 0.18.0 after the deprecation window
+/// (deprecated 0.16.0, retained through 0.17.0, no consumer left parsing them — confirmed via
+/// rift-enterprise#90).
 ///
-/// - `errors[0]` — the envelope, with the `type` slug new consumers branch on. `feature`/`detail`
-///   ride inside the error object rather than being flattened into `message`, because naming
-///   *which* backend failed is this door's whole purpose.
-/// - top-level `error`/`feature`/`detail` — the legacy 0.15.0 keys, **frozen**. Deprecated in
-///   0.16.0, removed in 0.17.0 by issue #801. They stay because `rift-cluster` parses
-///   them today; dropping them here would break the cluster mid-bump.
+/// `errors[0]` carries the `type` slug consumers branch on; `feature`/`detail` ride inside the
+/// error object rather than being flattened into `message`, because naming *which* backend
+/// failed is this door's whole purpose.
 pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
     let (status, body) = match err.downcast_ref::<BackendUnavailable>() {
         Some(b) => (
@@ -97,9 +95,6 @@ pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
                     "feature": b.feature,
                     "detail": b.detail,
                 }],
-                "error": "backendUnavailable",
-                "feature": b.feature,
-                "detail": b.detail,
             }),
         ),
         None => (
@@ -108,12 +103,10 @@ pub fn backend_error_response(err: &anyhow::Error) -> Response<Full<Bytes>> {
                 "errors": [{
                     "code": StatusCode::INTERNAL_SERVER_ERROR.as_str(),
                     "type": crate::response::ErrorKind::InternalError.slug(),
+                    // "{err:#}" keeps the whole context chain — the outermost message alone
+                    // rarely says why ("Redis GET failed" without the refused connection).
                     "message": format!("{err:#}"),
                 }],
-                "error": "internalError",
-                // "{err:#}" keeps the whole context chain — the outermost message alone
-                // rarely says why ("Redis GET failed" without the refused connection).
-                "detail": format!("{err:#}"),
             }),
         ),
     };
@@ -174,12 +167,14 @@ mod tests {
         assert_eq!(resp.status(), hyper::StatusCode::SERVICE_UNAVAILABLE);
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
-        // Legacy top-level keys (issue #800 AC2): byte-identical to 0.15.0. Deprecated in 0.16.0
-        // and removed in 0.17.0 — these three assertions are what the removal issue deletes, and
-        // until then they are what stops the deprecation window closing by accident.
-        assert_eq!(json["error"], "backendUnavailable");
-        assert_eq!(json["feature"], "flowState");
-        assert_eq!(json["detail"], "redis connection refused");
+        // Issue #801: the deprecation window is closed — the legacy 0.15.0 top-level keys are
+        // gone, and these assertions are what stops them creeping back.
+        assert!(
+            json.get("error").is_none()
+                && json.get("feature").is_none()
+                && json.get("detail").is_none(),
+            "top-level legacy keys were removed in 0.18.0 (#801), got: {json}"
+        );
 
         // AC1: the door now also serves the Mountebank envelope with the #797 `type` slug.
         assert_eq!(
@@ -191,11 +186,11 @@ mod tests {
             "a dedicated slug — generic `unavailable` would not distinguish a backend outage \
              from any other 503, which is the whole reason this door exists"
         );
-        assert!(
-            json["errors"][0]["message"]
-                .as_str()
-                .is_some_and(|m| !m.is_empty()),
-            "message must be non-empty, got: {json}"
+        // The exact join both docs promise — coverage previously carried by the deleted
+        // dual-shape tripwire test, and independent of the legacy keys' existence.
+        assert_eq!(
+            json["errors"][0]["message"], "flowState: redis connection refused",
+            "message is the `feature: detail` join the docs show verbatim"
         );
         // AC3: the structured split stays machine-readable inside the envelope — `feature` names
         // WHICH backend failed, which is the door's entire value and must not be flattened away.
@@ -209,8 +204,11 @@ mod tests {
         assert_eq!(resp.status(), hyper::StatusCode::INTERNAL_SERVER_ERROR);
         let bytes = resp.into_body().collect().await.expect("body").to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
-        // Legacy key, frozen (AC2).
-        assert_eq!(json["error"], "internalError");
+        // Issue #801: no legacy keys on the 500 branch either.
+        assert!(
+            json.get("error").is_none() && json.get("detail").is_none(),
+            "top-level legacy keys were removed in 0.18.0 (#801), got: {json}"
+        );
         // AC1: envelope on this branch too — a generic internal error is exactly what it is.
         assert_eq!(json["errors"][0]["code"], "500");
         assert_eq!(json["errors"][0]["type"], "internal error");
@@ -225,28 +223,6 @@ mod tests {
             json["errors"][0]["feature"].is_null() && json["errors"][0]["detail"].is_null(),
             "the non-backend branch has neither `feature` nor `detail` inside the envelope, \
              got: {json}"
-        );
-    }
-
-    // Drift tripwire, not an independent equivalence proof: both shapes are populated from the
-    // same `b.feature`/`b.detail` in one `json!` literal, so this passes trivially today. Its job
-    // is to fail the moment someone edits one shape and not the other — e.g. a fix applied only to
-    // the legacy keys — which is how the two would silently start describing different failures.
-    #[tokio::test]
-    async fn legacy_and_envelope_shapes_agree_on_the_same_error() {
-        let err = anyhow::Error::new(BackendUnavailable {
-            feature: "proxyStore",
-            detail: "connection reset".to_string(),
-        });
-        let resp = backend_error_response(&err);
-        let bytes = resp.into_body().collect().await.expect("body").to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
-        assert_eq!(json["feature"], json["errors"][0]["feature"]);
-        assert_eq!(json["detail"], json["errors"][0]["detail"]);
-        let msg = json["errors"][0]["message"].as_str().expect("message");
-        assert!(
-            msg.contains("proxyStore") && msg.contains("connection reset"),
-            "message must carry both halves of the legacy split, got: {msg}"
         );
     }
 

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -3538,8 +3538,8 @@ mod tests {
                 .expect("request");
             assert_eq!(resp.status(), 503, "sequencer outage is a structured 503");
             let body: serde_json::Value = resp.json().await.expect("json");
-            assert_eq!(body["error"], "backendUnavailable");
-            assert_eq!(body["feature"], "sequencer");
+            assert_eq!(body["errors"][0]["type"], "backend unavailable");
+            assert_eq!(body["errors"][0]["feature"], "sequencer");
 
             manager.delete_all().await;
         }

--- a/crates/rift-mock-core/src/imposter/tests.rs
+++ b/crates/rift-mock-core/src/imposter/tests.rs
@@ -3849,10 +3849,14 @@ mod backend_errors {
             "decorator header must land on the wire"
         );
         let body: serde_json::Value = resp.json().await.expect("json");
-        assert_eq!(body["error"], "backendUnavailable");
-        assert_eq!(body["feature"], "flowState");
-        // Issue #800: a real request over the wire must carry the envelope too, not just the
-        // legacy keys — the unit tests exercise the mapper, this proves it survives serialization.
+        // Issue #801: over the wire the envelope is the only shape — the removed legacy
+        // top-level keys must not survive serialization either.
+        assert!(
+            body.get("error").is_none()
+                && body.get("feature").is_none()
+                && body.get("detail").is_none(),
+            "top-level legacy keys were removed in 0.18.0 (#801), got: {body}"
+        );
         assert_eq!(body["errors"][0]["code"], "503");
         assert_eq!(body["errors"][0]["type"], "backend unavailable");
         assert_eq!(body["errors"][0]["feature"], "flowState");

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -759,9 +759,8 @@ port alike — carries three fields:
 { "errors": [ { "code": "...", "type": "...", "message": "..." } ] }
 ```
 
-**One door carries extra keys.** A backend outage (an unavailable flow-store or proxy store, and any
-matcher failure that is not an injection error) serves the envelope *plus* a legacy shape it
-predates:
+**One door carries extra fields.** A backend outage (an unavailable flow-store or proxy store, and
+any matcher failure that is not an injection error) enriches the envelope's error object:
 
 ```json
 {
@@ -771,18 +770,14 @@ predates:
     "message": "flowState: redis connection refused",
     "feature": "flowState",
     "detail": "redis connection refused"
-  }],
-  "error": "backendUnavailable",
-  "feature": "flowState",
-  "detail": "redis connection refused"
+  }]
 }
 ```
 
-`feature` names *which* backend failed and `detail` gives the underlying cause; both are available
-inside `errors[0]`, so nothing needs the legacy keys.
+`feature` names *which* backend failed and `detail` gives the underlying cause.
 
-> **Deprecated:** the **top-level** `error`, `feature` and `detail` keys are retained unchanged for
-> backward compatibility and will be **removed in 0.17.0**. Read `errors[0]` instead.
+> **Removed in 0.18.0:** this door used to duplicate `error`/`feature`/`detail` as **top-level**
+> keys (the pre-0.16.0 shape, deprecated in 0.16.0, #801). They are gone; read `errors[0]`.
 
 | Field | Read it? | What it is |
 |:------|:---------|:-----------|

--- a/docs/embedding/spi.md
+++ b/docs/embedding/spi.md
@@ -499,15 +499,12 @@ failed:
     "message": "flowState: redis connection refused",
     "feature": "flowState",
     "detail": "redis connection refused"
-  }],
-  "error": "backendUnavailable",
-  "feature": "flowState",
-  "detail": "redis connection refused"
+  }]
 }
 ```
 
-> **Deprecated:** the **top-level** `error`/`feature`/`detail` keys are retained for backward
-> compatibility and will be **removed in 0.17.0** (#801). Read `errors[0]` instead.
+> **Removed in 0.18.0:** the **top-level** `error`/`feature`/`detail` duplicates (deprecated in
+> 0.16.0, #801) are gone; `errors[0]` is the only shape.
 
 Per-request operational metadata travels through a tokio task-local annotation scope:
 `annotate(key: &'static str, value: String)` records a `(key, value)` that a `ResponseDecorator` later


### PR DESCRIPTION
Closes the deprecation window #800 opened: the top-level `error`/`feature`/`detail` keys on backend-error responses are removed; the Mountebank `errors` envelope is the only shape. Deprecated in 0.16.0, retained through 0.17.0, removed for 0.18.0 — all five gate boxes on the issue are ticked, and achird-labs/rift-enterprise#90 confirmed no consumer parses the keys. Docs (`docs/api/index.md`, `docs/embedding/spi.md`) and CHANGELOG updated, including a correction note on the 0.16.0 entry's stale "removed in 0.17.0" promise. Test coverage converted to absence assertions, with the deleted dual-shape tripwire's unique message-content check preserved in the surviving 503 test.

Closes #801
Milestone: none (standalone compatibility chore)