### PR TITLE
build(ci): stop docs install snippets from silently rotting each release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,18 @@ jobs:
           ./scripts/verify-feature-propagation.sh --self-test
           ./scripts/verify-feature-propagation.sh
 
+      # An install snippet names a release version, because a release asset URL and
+      # `rift-fetch -version` have no "latest" spelling — so every one of them rots the moment a
+      # release lands. Nothing caught that: the docs shipped an asset name that never existed and
+      # the site footer sat four releases behind. release.yml now bumps docs/_data/rift.yml and
+      # runs `--fix`; this gate catches the other direction, a hand-edited or newly-added snippet
+      # left at a stale version. Hermetic — no GitHub API call, so it cannot flake.
+      # --self-test first proves the checker isn't a no-op.
+      - name: Verify install snippets name the current release
+        run: |
+          ./scripts/verify-docs-version.sh --self-test
+          ./scripts/verify-docs-version.sh
+
   docs-links:
     name: Docs Links
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,87 @@ env:
 
 jobs:
   # =============================================================================
+  # Refuse to release with stale install docs
+  # =============================================================================
+  # Every install snippet in README.md and docs/ names a release version literally, because a
+  # release asset URL and `rift-fetch -version` have no "latest" spelling. That made them rot
+  # silently on each release: the docs shipped an asset name that had never existed, and the site
+  # footer sat four releases behind (v0.13.0 against a v0.17.0 engine) for three weeks.
+  #
+  # Rather than open a follow-up PR nobody merges — and which GITHUB_TOKEN could not get CI to run
+  # on anyway — this makes the bump part of cutting a release: it is a one-command edit
+  # (`scripts/verify-docs-version.sh --set vX.Y.Z`) that belongs in the release-prep PR alongside
+  # the CHANGELOG, and CI already gates that the snippets match this file on that PR.
+  #
+  # Fail-closed and FIRST, so a stale docs tree stops the release in ~15s instead of after seven
+  # target builds. `build` needs this job.
+  docs-version:
+    name: Docs version matches the tag
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Assert docs/_data/rift.yml names this release
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.VERSION }}"
+          DECLARED="$(sed -n 's/^latest_release:[[:space:]]*\(v[0-9][0-9.]*\).*/\1/p' docs/_data/rift.yml | head -1)"
+
+          if [ -z "$DECLARED" ]; then
+            echo "::error::docs/_data/rift.yml has no 'latest_release: vX.Y.Z' key"
+            exit 1
+          fi
+
+          if [ "$DECLARED" != "$TAG" ]; then
+            echo "::error::docs/_data/rift.yml declares ${DECLARED}, but this release is ${TAG}."
+            echo "::error::The install snippets in README.md and docs/ would 404 for ${TAG}."
+            echo "::error::Fix on the release-prep branch, then re-tag:"
+            echo "::error::  scripts/verify-docs-version.sh --set ${TAG}"
+            exit 1
+          fi
+
+          # Belt and braces: the declared value is right, but prove the snippets actually match it,
+          # in case someone edited a snippet without running the script.
+          ./scripts/verify-docs-version.sh
+
+          echo "docs install snippets name ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+
+      # Not a gate — a nudge, surfaced at the one moment someone is looking. sync.yml records the
+      # revision a human last reconciled the docs against, so automation must never bump it (that
+      # would assert a review that never happened). But letting it drift unnoticed is exactly how
+      # the docs fell four releases behind, so say so in the release summary.
+      - name: Report docs-reconciliation staleness
+        continue-on-error: true
+        run: |
+          MARKER="$(sed -n 's/^release:[[:space:]]*\(v[0-9][0-9.]*\).*/\1/p' docs/_data/sync.yml | head -1)"
+          TAG="${{ steps.version.outputs.VERSION }}"
+          if [ -n "$MARKER" ] && [ "$MARKER" != "$TAG" ]; then
+            {
+              echo ""
+              echo "> **Docs reconciliation is behind.** \`docs/_data/sync.yml\` was last reconciled"
+              echo "> at \`${MARKER}\`; this release is \`${TAG}\`. Install snippets are current"
+              echo "> (gated above), but prose describing behaviour may not be. Consider a docs pass:"
+              echo "> \`git log --oneline \$(sed -n 's/^commit: //p' docs/_data/sync.yml)..HEAD\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # =============================================================================
   # Build binaries for all platforms
   # =============================================================================
   build:
     name: Build ${{ matrix.target }}
+    needs: docs-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/docs/_data/rift.yml
+++ b/docs/_data/rift.yml
@@ -1,0 +1,11 @@
+# The newest published engine release.
+#
+# Every *install snippet* in README.md and docs/ must name this exact version, because those
+# commands only work if the version resolves to a real release asset. `scripts/verify-docs-version.sh`
+# gates that agreement in CI and can rewrite the snippets (`--fix`); the release workflow bumps this
+# value and opens the follow-up PR, so the snippets track releases without anyone remembering to.
+#
+# This is NOT the same thing as `sync.yml`'s `release:`. That one records the last revision a human
+# actually reconciled the docs against, and is deliberately left alone by automation — bumping it
+# mechanically would assert a docs review that never happened.
+latest_release: v0.17.0

--- a/docs/_data/sync.yml
+++ b/docs/_data/sync.yml
@@ -1,8 +1,19 @@
 # Docs sync marker — the code revision these docs were last reconciled against.
 #
+# HUMAN-MAINTAINED, DELIBERATELY. Automation must never bump this: it is a claim that someone read
+# the prose against the code, and moving it mechanically would assert a review that never happened.
+# That is also why it is NOT the file the install snippets track — see `rift.yml`, which names the
+# newest release and IS machine-maintained. Conflating the two is what let this marker sit at
+# v0.13.0 against a v0.17.0 engine for three weeks.
+#
+# `release.yml` cannot fail on this (a docs pass is judgement, not a gate), so it prints a
+# staleness nudge in the release summary instead — visible at the one moment someone is looking.
+#
 # Starting a docs-update pass (see issue #280):
 #   1. Enumerate user-facing changes since the marker:
-#        git log --oneline --merges <commit>..origin/master
+#        git log --oneline <commit>..origin/master
+#      (use --merges only if the branch history is merge-based; this repo squash-merges, so
+#      --merges returned 3 commits where the real answer was 50)
 #   2. Update the affected pages.
 #   3. Bump this file AND the version in _config.yml footer_content in the same PR.
 release: v0.17.0

--- a/scripts/verify-docs-version.sh
+++ b/scripts/verify-docs-version.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# Docs install-snippet version gate.
+#
+# The install commands in README.md and docs/ embed a release version, because a release asset URL
+# and `rift-fetch -version` both name one — there is no "latest" spelling that works. So every one
+# of them silently rots the moment a release lands, and nothing noticed: the docs shipped a
+# `rift-http-proxy-linux-x86_64` asset name that had never existed, and the site footer sat four
+# releases behind (v0.13.0 while the engine was v0.17.0) for three weeks.
+#
+# `release.yml` bumps `docs/_data/rift.yml` and runs this with `--fix`, so the snippets follow
+# releases on their own. This gate exists for the other direction: a hand-edited snippet, or a new
+# one added at a version that has since moved on, fails CI instead of shipping a command that 404s.
+#
+# DISCOVERY, NOT A FILE LIST. Snippets are found by their two unambiguous shapes (below), never
+# enumerated — a list would go stale exactly when someone adds the snippet nobody remembered to
+# register. The shapes are narrow enough that prose cannot match:
+#
+#   VERSION=vX.Y.Z                                  shell variable in a download snippet
+#   rift-fetch@latest -version vX.Y.Z               the rift-go native-library fetch
+#
+# DELIBERATELY NOT COVERED — these are versions that must NOT track the newest release:
+#
+#   docs/embedding/ffi.md   "As of v0.11.3 (#429)"  historical statements about when behaviour
+#                           "(v0.11.2, #425/#426)"  changed; rewriting them would falsify history
+#   docs/sdk/index.md       SDK versions + engine   each SDK's own floor, maintained by that SDK's
+#                           floor columns           bump automation; a floor is what it is TESTED
+#                                                   against, not the newest engine
+#   docs/_config.yml        "Docs current as of"    a human-reconciliation claim (see sync.yml)
+#   docs/_data/sync.yml     release:/commit:/date:  ditto — automation must never assert a review
+#
+# The gate is HERMETIC: it compares the snippets against the declared value in docs/_data/rift.yml
+# and never calls the GitHub API, so it cannot flake on a network blip or fork-PR token. Keeping
+# that value honest is the release workflow's job, not this script's.
+#
+# Usage:
+#   scripts/verify-docs-version.sh              # check (exit 1 on any mismatch)
+#   scripts/verify-docs-version.sh --fix        # rewrite every snippet to the declared version
+#   scripts/verify-docs-version.sh --set vX.Y.Z # set the declared version, then --fix
+#   scripts/verify-docs-version.sh --self-test  # prove the checker flags a planted drift
+#
+set -euo pipefail
+
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Overridable so the self-test can point the checks at a scratch copy of the tree.
+ROOT="${ROOT:-$repo_root}"
+VERSION_FILE="${VERSION_FILE:-$ROOT/docs/_data/rift.yml}"
+
+log()  { echo "[docs-version] $*"; }
+fail() { echo "[FAIL] $*" >&2; }
+
+# --- the declared version ---------------------------------------------------
+
+read_declared() {
+  local v
+  # Deliberately not `yq`: this must run on a bare runner. The key is a plain scalar.
+  v="$(sed -n 's/^latest_release:[[:space:]]*\(v[0-9][0-9.]*\).*/\1/p' "$VERSION_FILE" | head -1)"
+  if [ -z "$v" ]; then
+    fail "no 'latest_release: vX.Y.Z' in $VERSION_FILE"
+    return 1
+  fi
+  printf '%s' "$v"
+}
+
+write_declared() {
+  local new="$1" tmp
+  tmp="$(mktemp)"
+  sed "s/^latest_release:[[:space:]]*v[0-9][0-9.]*.*/latest_release: ${new}/" "$VERSION_FILE" >"$tmp"
+  mv "$tmp" "$VERSION_FILE"
+}
+
+# --- snippet discovery ------------------------------------------------------
+
+# Files that may carry install snippets. README.md is included because it is the first thing a
+# visitor copy-pastes and is NOT part of the Jekyll site, so it cannot interpolate a data value —
+# the literal has to be kept in step by this script.
+snippet_files() {
+  { echo "$ROOT/README.md"
+    find "$ROOT/docs" -name '*.md' -type f
+  } | sort -u
+}
+
+# Emit "file:line:found-version" for every install snippet whose version != the declared one.
+# The two patterns are anchored tightly so prose like "since v0.11.2" can never match.
+drifted() {
+  local want="$1" f
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    grep -nE "(^|[[:space:]])VERSION=v[0-9]+\.[0-9]+\.[0-9]+|rift-fetch@latest -version v[0-9]+\.[0-9]+\.[0-9]+" "$f" 2>/dev/null \
+      | grep -vF "$want" \
+      | while IFS= read -r hit; do
+          printf '%s:%s\n' "${f#"$ROOT"/}" "$hit"
+        done
+  done < <(snippet_files)
+}
+
+fix_files() {
+  local want="$1" f tmp n=0
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    tmp="$(mktemp)"
+    sed -E "s/(^|[[:space:]])VERSION=v[0-9]+\.[0-9]+\.[0-9]+/\1VERSION=${want}/g; \
+            s/(rift-fetch@latest -version )v[0-9]+\.[0-9]+\.[0-9]+/\1${want}/g" "$f" >"$tmp"
+    if ! cmp -s "$f" "$tmp"; then
+      mv "$tmp" "$f"
+      log "updated ${f#"$ROOT"/}"
+      n=$((n + 1))
+    else
+      rm -f "$tmp"
+    fi
+  done < <(snippet_files)
+  log "$n file(s) rewritten to $want"
+}
+
+check() {
+  local want out
+  want="$(read_declared)"
+  out="$(drifted "$want" || true)"
+  if [ -n "$out" ]; then
+    fail "install snippet(s) disagree with docs/_data/rift.yml (latest_release: $want):"
+    echo "$out" | sed 's/^/  /' >&2
+    echo >&2
+    echo "Fix with: scripts/verify-docs-version.sh --fix" >&2
+    return 1
+  fi
+  log "OK: every install snippet names $want"
+}
+
+# --- self-test --------------------------------------------------------------
+#
+# Proves the checker actually flags drift rather than passing vacuously — the same failure mode
+# that let the stale docs ship. Runs against a throwaway copy so the working tree is untouched.
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  mkdir -p "$tmp/docs/_data"
+  cp "$VERSION_FILE" "$tmp/docs/_data/rift.yml"
+  printf 'VERSION=v9.9.9\n' >"$tmp/README.md"
+
+  # 1. planted drift must FAIL
+  if ROOT="$tmp" VERSION_FILE="$tmp/docs/_data/rift.yml" "$SELF" >/dev/null 2>&1; then
+    echo "verify-docs-version --self-test: FAILED — checker passed a planted drift." >&2
+    return 1
+  fi
+
+  # 2. --fix must repair it, and the repaired tree must PASS
+  ROOT="$tmp" VERSION_FILE="$tmp/docs/_data/rift.yml" "$SELF" --fix >/dev/null 2>&1
+  if ! ROOT="$tmp" VERSION_FILE="$tmp/docs/_data/rift.yml" "$SELF" >/dev/null 2>&1; then
+    echo "verify-docs-version --self-test: FAILED — checker rejected a correctly-synced tree." >&2
+    return 1
+  fi
+
+  # 3. a historical reference must NOT be rewritten (the ffi.md failure mode)
+  printf 'As of v0.11.3 (#429), passing both caCertPath and caKeyPath\n' >"$tmp/docs/history.md"
+  ROOT="$tmp" VERSION_FILE="$tmp/docs/_data/rift.yml" "$SELF" --fix >/dev/null 2>&1
+  if ! grep -q 'v0.11.3' "$tmp/docs/history.md"; then
+    echo "verify-docs-version --self-test: FAILED — rewrote a historical version reference." >&2
+    return 1
+  fi
+
+  echo "verify-docs-version --self-test: OK — flags drift, repairs it, leaves history alone."
+}
+
+# --- main -------------------------------------------------------------------
+
+case "${1:---check}" in
+  --check) check ;;
+  --fix)   fix_files "$(read_declared)"; check ;;
+  --set)
+    [ $# -ge 2 ] || { echo "usage: $0 --set vX.Y.Z" >&2; exit 64; }
+    case "$2" in
+      v[0-9]*.[0-9]*.[0-9]*) ;;
+      *) echo "$0: --set expects a vX.Y.Z tag, got '$2'" >&2; exit 64 ;;
+    esac
+    write_declared "$2"
+    log "declared version set to $2"
+    fix_files "$2"
+    check
+    ;;
+  --self-test) self_test ;;
+  -h | --help) echo "usage: $0 [--check | --fix | --set vX.Y.Z | --self-test]" >&2; exit 64 ;;
+  *) echo "$0: unknown option '$1'" >&2; exit 64 ;;
+esac


### PR DESCRIPTION
Follow-up to #921, which fixed the stale docs but left the cause in place: `release.yml` bumps `Cargo.toml` and touches no docs, so the version strings go stale again at the next release.

## Why they rot

Every install command names a release version **literally** — a release asset URL and `rift-fetch -version` have no "latest" spelling. Six such sites across four files. Nothing checked any of them, which is how the docs advertised a `rift-http-proxy-linux-x86_64` asset that has never been published, and how the site footer sat at `v0.13.0` against a `v0.17.0` engine for three weeks.

## Two mechanisms, because two things were conflated

The previous design treated "what version do the install commands name" and "when did a human last read the docs against the code" as one value. They are not, and automating the second would be a lie.

| File | Meaning | Maintained by |
|---|---|---|
| `docs/_data/rift.yml` (new) | the newest release; install snippets must match it or they 404 | **machine** — gated in CI, set by `--set vX.Y.Z` |
| `docs/_data/sync.yml` | the revision a human last reconciled the docs against | **human** — automation must never bump it |

Bumping `sync.yml` mechanically would assert a docs review that never happened, so `release.yml` prints a staleness nudge in the job summary instead of moving it. Both files now carry comments saying so, since conflating them is precisely what let the marker rot.

## `scripts/verify-docs-version.sh`

`--check` (default) / `--fix` / `--set vX.Y.Z` / `--self-test`, matching the convention of the other `verify-*` gates.

- **Hermetic.** Compares snippets against the declared value; never calls the GitHub API, so it cannot flake on a network blip or a fork-PR token. Keeping the declared value honest is the release workflow's job.
- **Discovery, not a file list.** Snippets are found by their two unambiguous shapes (`VERSION=vX.Y.Z`, `rift-fetch@latest -version vX.Y.Z`). A hardcoded list would go stale exactly when someone adds the snippet nobody remembered to register.
- **History is left alone.** The patterns are narrow enough that prose cannot match, so `ffi.md`'s "as of v0.11.3 (#429)", the sample FFI manifest, and each SDK's independently-maintained engine floor in `sdk/index.md` are untouched. The self-test asserts this directly rather than assuming it.

## Release guard

A new `docs-version` job runs **first** and gates `build`: if `rift.yml` disagrees with the tag being released, the release stops in ~15s instead of after seven target builds, with an error naming the exact fix command.

A follow-up bump PR was the alternative and a worse one — `GITHUB_TOKEN` cannot trigger CI on a PR it opens, so it would have sat unchecked, and master's ruleset admits no bot as a bypass actor, so nothing could merge it either. Making the bump part of the release-prep PR (where the CHANGELOG already goes) is one command and is gated both directions.

## Verification

- `--self-test` — flags planted drift, repairs it via `--fix`, and leaves a historical version reference intact
- round-trip `--set` on the real tree — rewrites all 6 sites across 4 files, restores byte-identically (`git diff` empty)
- release guard — blocks a mismatched tag, passes a matching one
- workflow YAML parses; job graph is `docs-version` → `build` → everything else
- `shellcheck` clean (SC2001 style excluded: the `sed` indent is clearer than a parameter expansion)
- existing gates still green: docs-coverage, feature-propagation, docs-version

🤖 Generated with [Claude Code](https://claude.com/claude-code)