### PR TITLE
fix(sources): dispatch on a bare `scheme:` URI instead of always reading it as a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--imposters` now dispatches on a bare `scheme:` URI instead of always reading it as a file
+  path.** `SourceRef::scheme` split on `://` and otherwise returned `file`, through two
+  byte-identical `None` arms — the second of which made the first dead code, and with it the
+  shorter `s3:key` / `registry:svc` spelling that a registered provider should answer. The
+  fallback is restored behind an [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1)
+  scheme grammar with a length-greater-than-one rule, so a Windows drive-letter path
+  (`C:\mocks.json`) stays a path rather than becoming a scheme named `C`. **Behaviour change:** a
+  path whose leading segment is scheme-shaped (`weird:path.json`) is now taken as a scheme and
+  fails at startup naming the known schemes, where it was previously opened as a literal filename;
+  spell it `file:weird:path.json` to keep the old reading. See
+  [Imposter Sources](docs/configuration/cli.md#how-a-scheme-is-recognised).
+
 ### Removed
 
 - **The deprecated top-level `error` / `feature` / `detail` keys on backend-error responses**

--- a/crates/rift-http-proxy/src/sources.rs
+++ b/crates/rift-http-proxy/src/sources.rs
@@ -49,11 +49,17 @@ impl SourceRef {
     /// A bare path is `file`, so `--imposters mocks.json` works like `--configfile mocks.json`.
     /// The `://` form is checked before the bare `scheme:` form so that a compound scheme such as
     /// `git+https://…` (a cluster provider) resolves to `git+https` rather than to `git`.
+    ///
+    /// The bare `scheme:` form dispatches too — `s3:key` is scheme `s3`, not a file named
+    /// `s3:key` — but only when what precedes the colon is actually scheme-shaped; see
+    /// [`is_scheme`]. Anything else is a path, and paths are `file`.
     pub fn scheme(&self) -> &str {
         match self.uri.split_once("://") {
             Some((scheme, _)) => scheme,
-            None if self.uri.starts_with("file:") => "file",
-            None => "file",
+            None => match self.uri.split_once(':') {
+                Some((scheme, _)) if is_scheme(scheme) => scheme,
+                _ => "file",
+            },
         }
     }
 
@@ -62,6 +68,21 @@ impl SourceRef {
     pub fn target(&self) -> &str {
         self.uri.strip_prefix("file:").unwrap_or(&self.uri)
     }
+}
+
+/// Is `s` shaped like a URI scheme, for the purpose of reading `scheme:rest` as a scheme rather
+/// than as a path that happens to contain a colon?
+///
+/// RFC 3986 §3.1 — `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` — with one deliberate deviation:
+/// the length must exceed 1, so a Windows drive-letter path (`C:\mocks.json`) stays a `file:`
+/// path instead of dispatching to a scheme named `C` that no provider will ever be registered
+/// for. Single-letter schemes are RFC-legal; none exist here, and keeping drive letters working
+/// is worth more than reserving them.
+fn is_scheme(s: &str) -> bool {
+    s.len() > 1
+        && s.as_bytes()[0].is_ascii_alphabetic()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
 }
 
 /// What a source knows about the version it just served, used to skip redundant work.
@@ -488,6 +509,67 @@ mod tests {
             "git+https"
         );
         assert_eq!(SourceRef::new("s3://bucket/key").scheme(), "s3");
+    }
+
+    #[test]
+    fn bare_colon_form_dispatches_on_its_scheme() {
+        // The `scheme:rest` spelling is not sugar for a filename — it dispatches, so a cluster
+        // provider registered for `s3` is reached by `s3:key` as well as by `s3://bucket/key`.
+        assert_eq!(SourceRef::new("s3:bucket/key").scheme(), "s3");
+        assert_eq!(SourceRef::new("registry:svc-a,svc-b").scheme(), "registry");
+        assert_eq!(SourceRef::new("git+https:h/r#main:p").scheme(), "git+https");
+        // Digits, `+`, `-` and `.` are all scheme characters; the first byte must be a letter.
+        assert_eq!(SourceRef::new("s3v2:key").scheme(), "s3v2");
+        assert_eq!(SourceRef::new("my-source:key").scheme(), "my-source");
+        assert_eq!(SourceRef::new("my.source:key").scheme(), "my.source");
+    }
+
+    #[test]
+    fn a_path_that_merely_contains_a_colon_is_still_a_file() {
+        // A Windows drive letter is the case this guard exists for: `C` is scheme-shaped by RFC
+        // 3986 but one byte long, so it stays a path and `target()` hands it over verbatim.
+        for uri in ["C:\\mocks.json", "C:/mocks.json", "c:\\mocks.json"] {
+            assert_eq!(SourceRef::new(uri).scheme(), "file", "{uri}");
+            assert_eq!(SourceRef::new(uri).target(), uri, "{uri}");
+        }
+        // A leading non-letter is not a scheme, however colon-laden the rest is.
+        assert_eq!(SourceRef::new("./a:b.json").scheme(), "file");
+        assert_eq!(SourceRef::new("/tmp/a:b.json").scheme(), "file");
+        assert_eq!(SourceRef::new("../a:b.json").scheme(), "file");
+        assert_eq!(SourceRef::new("2024:notes.json").scheme(), "file");
+        // An underscore is not in the RFC 3986 scheme set, so this stays a path.
+        assert_eq!(SourceRef::new("my_source:key").scheme(), "file");
+        // An empty scheme is not a scheme.
+        assert_eq!(SourceRef::new(":mocks.json").scheme(), "file");
+        // No colon at all, the ordinary case.
+        assert_eq!(SourceRef::new("mocks.json").scheme(), "file");
+    }
+
+    #[test]
+    fn a_scheme_shaped_prefix_wins_even_when_it_was_meant_as_a_path() {
+        // The guard is a grammar, not a mind-reader: a path whose leading segment happens to be
+        // scheme-shaped now dispatches on it. Both of these fail *loudly* at startup — the
+        // registry lookup in `SourceSet::fetch_all` names the scheme and lists the known ones —
+        // rather than being opened as a literal filename. `file:` is the escape hatch.
+        assert_eq!(SourceRef::new("weird:path.json").scheme(), "weird");
+        // A Unix filename may legally end in a colon; such a path must be spelled `file:`.
+        assert_eq!(SourceRef::new("mocks.json:").scheme(), "mocks.json");
+        assert_eq!(SourceRef::new("file:mocks.json:").scheme(), "file");
+        assert_eq!(SourceRef::new("file:mocks.json:").target(), "mocks.json:");
+    }
+
+    #[test]
+    fn file_prefix_survives_the_grammar_guard() {
+        // `file:` used to be recognised by its own arm. It is now just a scheme that satisfies
+        // the grammar — same answer, and `target()` still strips exactly that prefix.
+        assert_eq!(SourceRef::new("file:mocks.json").scheme(), "file");
+        assert_eq!(SourceRef::new("file:mocks.json").target(), "mocks.json");
+        assert_eq!(SourceRef::new("file:/abs/mocks.json").scheme(), "file");
+        assert_eq!(SourceRef::new("file:C:\\mocks.json").scheme(), "file");
+        assert_eq!(
+            SourceRef::new("file:C:\\mocks.json").target(),
+            "C:\\mocks.json"
+        );
     }
 
     #[test]

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -60,6 +60,35 @@ error. `RIFT_IMPOSTERS` is the environment-variable spelling.
 | `file:` | `file:<path>`, or a bare path | none — always re-read |
 | `http:` / `https:` | a full URL | the response `ETag` |
 
+Embedders register their own schemes (this is how the Rift Cluster `git+https:`, `s3:` and
+`registry:` providers attach), so the table above is the built-in set, not the whole set.
+
+### How a scheme is recognised
+
+Both `scheme://rest` and the shorter `scheme:rest` dispatch on their scheme, so `s3://bucket/key`
+and `s3:bucket/key` reach the same provider. The `://` form is checked first, so a compound scheme
+such as `git+https://…` resolves to `git+https` rather than to `git`.
+
+A URI without `://` is read as `scheme:rest` only when what precedes the first colon is actually
+scheme-shaped — [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1)
+(`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`) **and longer than one character**. Everything else
+is a path, and paths are `file:`:
+
+```bash
+rift --imposters s3:bucket/key       # scheme `s3`
+rift --imposters C:\mocks.json       # a path — a drive letter is one character, so not a scheme
+rift --imposters ./a:b.json          # a path — does not start with a letter
+rift --imposters my_source:key       # a path — `_` is not an RFC 3986 scheme character
+```
+
+The one-character rule is a deliberate deviation from the RFC: single-letter schemes are legal
+there, but keeping Windows drive-letter paths working is worth more than reserving them.
+
+A path whose leading segment *is* scheme-shaped (`weird:path.json`, or a Unix filename ending in a
+colon) is taken as a scheme and fails at startup with `no imposter source is registered for the
+'weird:' scheme`, listing the schemes that are. Spell such a path `file:weird:path.json` — the
+`file:` prefix is stripped verbatim and the rest is opened as-is.
+
 ### Merging
 
 Every source contributes its imposters to one set. A port declared by **two** sources is a


### PR DESCRIPTION
## What

`SourceRef::scheme` splits on `://` and otherwise returns `file`, through two byte-identical `None` arms:

```rust
None if self.uri.starts_with("file:") => "file",
None => "file",
```

The guarded arm is dead code, and what it guards is the giveaway: a **bare-colon fallback was intended and lost**. So the shorter `s3:key` / `registry:svc` spelling silently becomes a request to open a file of that literal name instead of reaching the provider registered for the scheme.

## Why the naive fix is wrong

`None => self.uri.split_once(':')` also fires on a Windows drive letter. `C:\mocks.json` rides today's always-`file` behaviour; under a naive restoration it would dispatch to a scheme named `C` that nothing will ever register. That is presumably how the fallback got lost in the first place.

So the fallback returns behind an [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) scheme grammar — `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` — plus a **length > 1** rule. Single-letter schemes are RFC-legal and are sacrificed deliberately: drive letters are real, single-letter schemes are not.

The `://` arm is unchanged and still checked first, so `git+https://…` keeps resolving to `git+https` rather than `git`. `file:` no longer needs an arm of its own — it just satisfies the grammar — and `target()` is untouched, so a drive-letter path still reaches `FileSource` verbatim.

## Behaviour table

| input | before | after | |
|---|---|---|---|
| `file:data.json` | `file` | `file` | unchanged |
| `data.json` | `file` | `file` | bare path |
| `C:\mocks.json`, `C:/mocks.json` | `file` | `file` | length-1 fails the guard |
| `./a:b.json`, `2024:notes.json` | `file` | `file` | first byte is not ALPHA |
| `my_source:key` | `file` | `file` | `_` is not a scheme character |
| `s3:key`, `registry:a,b` | `file` | `s3`, `registry` | **the restored fallback** |
| `git+https://h/r#main:p` | `git+https` | `git+https` | `://` arm, checked first |
| `https://host/x` | `https` | `https` | unchanged |
| `weird:path.json` | `file` | `weird` | **behaviour change — see below** |
| `mocks.json:` | `file` | `mocks.json` | **behaviour change — see below** |

## The behaviour change, stated plainly

A path whose **leading segment is itself scheme-shaped** is now read as a scheme. Two shapes hit this: a genuinely odd spelling like `weird:path.json`, and a Unix filename that legally ends in a colon (`mocks.json:`).

Both now fail **at startup**, through the registry lookup that already exists in `SourceSet::fetch_all` — it names the scheme and lists the schemes that are registered. Previously they were opened as a literal filename.

This is a loud failure replacing a quiet misreading, and it is recoverable without a code change: `file:weird:path.json` restores the old reading, because `target()` strips exactly the `file:` prefix and hands over the rest verbatim. A test pins that escape hatch.

## Tests

Extends the existing `scheme_detection_covers_bare_paths_and_compound_schemes` with three new cases covering the whole table:

- `bare_colon_form_dispatches_on_its_scheme` — the restored behaviour, including compound and digit/`+`/`-`/`.` schemes
- `a_path_that_merely_contains_a_colon_is_still_a_file` — drive letters (asserting `target()` too), leading non-letters, `_`, the empty scheme
- `a_scheme_shaped_prefix_wins_even_when_it_was_meant_as_a_path` — the behaviour change and the `file:` escape hatch

Local: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo test -p rift-http-proxy --all-features --lib --test imposter_sources` → 354 + 17 passed.

## Docs

`docs/configuration/cli.md` gains a **How a scheme is recognised** section (both spellings, the grammar, the drive-letter deviation, the `file:` escape hatch), and the built-in scheme table now says embedders register their own. CHANGELOG entry under `[Unreleased] / Fixed` carries the behaviour-change note.

## Provenance

Filed downstream as achird-labs/rift-cluster#310, found while implementing achird-labs/rift-cluster#301. Non-urgent there — Rift Cluster refuses the ambiguous spelling at admission regardless of how this routes — but it matters for correctness and for Rift users not behind that admission filter.
