### PR TITLE
fix(admin): refuse a space-stub body that is not a stub

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/scenarios.rs
@@ -232,6 +232,76 @@ pub async fn handle_delete_flow_state(
 
 // ── Correlated-isolation "space" endpoints (issue #223) ─────────────────────────
 
+/// Every field name a `Stub` recognises, in the JSON spelling a client sends (issue #336).
+///
+/// Kept beside the check that uses it rather than derived from `StubRaw`: `StubRaw` is private to
+/// `rift-mock-core` and its `rename_all = "camelCase"` means the Rust identifiers are not the wire
+/// names anyway. The cost is that a new stub field must be added here too — which is why the
+/// message this list produces names the fields, so a client hitting it can see immediately whether
+/// the list is stale rather than being told only that their body was rejected.
+const STUB_FIELD_NAMES: [&str; 12] = [
+    "scenarioName",
+    "requiredScenarioState",
+    "newScenarioState",
+    "space",
+    "id",
+    "routePattern",
+    "predicates",
+    "rules",
+    "responses",
+    "recordedFrom",
+    "delayRange",
+    "_verify",
+];
+
+/// Refuse a body that is not shaped like a stub (issue #336).
+///
+/// `Stub` deserializes through `StubRaw`, where every field is `#[serde(default)]` and unknown keys
+/// are discarded — so **any** JSON object deserializes, and an object with only unrecognised keys
+/// deserializes to the vacuous stub: no id, no predicates, no responses. That stub is the worst one
+/// the engine can hold. No predicates means it matches everything in its space, shadowing the stubs
+/// that were meant to answer; no responses means it serves a default nobody authored; and no id
+/// means the console cannot address it to delete it. Recovery is tearing down the whole space.
+///
+/// The trap is reachable by an ordinary typo because the two sibling routes disagree about their
+/// envelope: `POST /imposters/:port/stubs` takes `{"stub": {…}}`, this route takes the bare stub.
+/// Posting the documented shape of the former here yields exactly the vacuous stub above — the
+/// `stub` key is unrecognised and every field it carried is discarded.
+///
+/// The rule is deliberately about **shape, not emptiness**: it asks the raw JSON whether any
+/// recognised field name is present, before serde erases the distinction. After deserialization
+/// `{}` and an explicit `{"predicates": []}` are indistinguishable, so a post-hoc emptiness check
+/// would also reject the legitimate, explicitly-authored space-wide default. This does not change
+/// what a legal `Stub` is; it only refuses bodies that are not stubs at all.
+///
+/// Scoped to this route on purpose. The space surface is a Rift extension (issue #223), not a
+/// Mountebank-parity one, so tightening it breaks no compatibility contract — the imposter-level
+/// routes keep `additionalProperties: true` and the bare-`{}`-inside-the-envelope allowance exactly
+/// as upstream Mountebank has them.
+fn reject_if_not_a_stub(payload: &serde_json::Value) -> Option<Response<Full<Bytes>>> {
+    let object = payload.as_object()?;
+    if object
+        .keys()
+        .any(|key| STUB_FIELD_NAMES.contains(&key.as_str()))
+    {
+        return None;
+    }
+    // Name the actual mistake when we can recognise it. A caller who sent the imposter-level
+    // envelope has made a specific, common error, and "no recognised stub field present" would
+    // leave them re-reading their stub for a fault that is not in it.
+    let message = if object.contains_key("stub") {
+        "this route takes the stub object directly — the `{\"stub\": …}` envelope belongs to \
+         POST /imposters/{port}/stubs"
+            .to_string()
+    } else {
+        format!(
+            "body is not a stub: no recognised stub field present (expected at least one of {})",
+            STUB_FIELD_NAMES.join(", ")
+        )
+    };
+    Some(error_response(StatusCode::BAD_REQUEST, &message))
+}
+
 /// POST /imposters/:port/spaces/:flowId/stubs — register a stub scoped to that space.
 pub async fn handle_add_space_stub(
     port: u16,
@@ -245,6 +315,10 @@ pub async fn handle_add_space_stub(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    // Before serde, which cannot tell "not a stub" from "an empty stub" (issue #336).
+    if let Some(rejection) = reject_if_not_a_stub(&payload) {
+        return rejection;
+    }
     let mut stub: Stub = match serde_json::from_value(payload) {
         Ok(s) => s,
         Err(e) => return error_response(StatusCode::BAD_REQUEST, &format!("Invalid stub: {e}")),

--- a/crates/rift-http-proxy/tests/admin_api_integration.rs
+++ b/crates/rift-http-proxy/tests/admin_api_integration.rs
@@ -487,6 +487,87 @@ async fn space_teardown_resets_scenario_state_and_leaves_others() {
     let _ = manager.delete_imposter(19774).await;
 }
 
+/// Issue #336: a body that is not a stub must be refused, not turned into a catch-all.
+///
+/// Before this, `Stub`'s every-field-`default` deserialization meant *any* JSON object was a valid
+/// stub, so a typo produced `201` and installed the worst stub the engine can hold: no predicates
+/// (matches everything in the space, shadowing the stubs meant to answer), no responses (serves a
+/// default nobody wrote), and no id (the console cannot address it to delete it). Recovery was
+/// tearing down the whole space.
+///
+/// The `{"stub": …}` case is called out separately because it is how the bug is actually reached:
+/// the sibling route `POST /imposters/:port/stubs` requires that envelope and this one does not, so
+/// posting the documented shape of one at the other is an ordinary mistake with a catastrophic
+/// outcome. It gets an error that names the mistake rather than one that sends the operator
+/// re-reading a stub that was never at fault.
+#[tokio::test]
+async fn a_space_stub_body_that_is_not_a_stub_is_refused() {
+    let manager = std::sync::Arc::new(ImposterManager::new());
+    let config = serde_json::from_value(correlated_config(19782, serde_json::json!([]))).unwrap();
+    manager.create_imposter(config).await.expect("create");
+
+    let admin_addr = "127.0.0.1:12601".parse().unwrap();
+    let server = rift_http_proxy::admin_api::AdminApiServer::new(admin_addr, manager.clone(), None);
+    tokio::spawn(server.run());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let c = reqwest::Client::new();
+    let admin = "http://127.0.0.1:12601";
+    let post = |body: &'static str| {
+        c.post(format!("{admin}/imposters/19782/spaces/alpha/stubs"))
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+    };
+
+    // The exact body from the report.
+    let r = post(r#"{"complete":"nonsense","zzz":123}"#).await.unwrap();
+    assert_eq!(r.status(), 400, "a non-stub body must not be accepted");
+    let text = r.text().await.unwrap();
+    assert!(
+        text.contains("not a stub") && text.contains("predicates"),
+        "the refusal must say what was expected: {text}"
+    );
+
+    // The envelope mistake, named.
+    let r = post(r#"{"stub":{"predicates":[],"responses":[]}}"#)
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 400);
+    let text = r.text().await.unwrap();
+    assert!(
+        text.contains("envelope") && text.contains("/imposters/{port}/stubs"),
+        "the envelope mistake must be named, not reported as a generic shape error: {text}"
+    );
+
+    // And nothing was installed by either attempt — the harm was never the status code, it was the
+    // stub left behind.
+    let listed = c
+        .get(format!("{admin}/imposters/19782/spaces/alpha/stubs"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let listed: serde_json::Value = serde_json::from_str(&listed).unwrap();
+    assert_eq!(
+        listed["stubs"].as_array().map(Vec::len),
+        Some(0),
+        "a refused body must leave no stub behind: {listed}"
+    );
+
+    // The rule is about shape, not emptiness: an explicitly authored space-wide default still
+    // works. Rejecting this would break a legitimate use and change what a legal stub is.
+    let r = post(r#"{"predicates":[],"responses":[{"is":{"statusCode":204}}]}"#)
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        201,
+        "an explicit empty-predicate stub is legal Mountebank semantics and must still be accepted"
+    );
+}
+
 #[tokio::test]
 async fn space_stub_registration_and_inspection_endpoints() {
     let manager = std::sync::Arc::new(ImposterManager::new());


### PR DESCRIPTION
## What

`POST /imposters/:port/spaces/:flowId/stubs` accepted a body that is not a stub, answered `201`, and appended an empty stub:

```
$ curl -X POST .../imposters/7004/spaces/qa-flow/stubs -d '{"complete":"nonsense","zzz":123}'
HTTP 201
{"space":"qa-flow","stubs":[{"predicates":[],"responses":[],"space":"qa-flow"}]}
```

## Why it matters more than a validation nit

The stub it creates is the worst one the engine can hold — no predicates (matches everything in the space, shadowing the stubs that were supposed to answer), no responses (serves a default nobody authored), no id (the console has no by-id address for it, so it cannot be deleted). Recovery is tearing down the whole space.

It is reached by an ordinary typo, because the two sibling routes disagree about their envelope: `POST /imposters/:port/stubs` requires `{"stub": {…}}`, this route takes the bare stub. Posting the documented shape of the former at the latter is exactly the failing case.

## The rule

Before serde, reject any JSON object carrying none of the recognised stub field names. Two messages: one naming the envelope mistake when the body has a `stub` key, one listing the accepted fields otherwise.

Deliberately about **shape, not emptiness** — after deserialization `{}` and an explicit `{"predicates": []}` are indistinguishable, so a post-hoc emptiness check would also refuse a legitimate, explicitly-authored space-wide default. This does not change what a legal `Stub` is.

Scoped to this route: the space surface is a Rift extension (#223), not a Mountebank-parity one, so the imposter-level routes keep `additionalProperties: true` and the bare-`{}`-inside-the-envelope allowance exactly as upstream Mountebank has them.

## Tests

`a_space_stub_body_that_is_not_a_stub_is_refused` covers the reported body, the envelope mistake, that **no stub is left behind** by either attempt (the harm was never the status code), and that an explicit empty-predicate stub is still accepted. Verified by mutation: bypassing the new check fails exactly this test.

## Note

`origin_announces_connection_close_on_a_200` / `_304` in `tests/imposter_sources.rs` fail on this machine — confirmed pre-existing by stashing this change and re-running on clean `master` (2deb419). Unrelated to this diff, which touches only the space-stub handler.

Reported downstream as achird-labs/rift-cluster#336.