### PR TITLE
intercept: ServeStub.body is Option<String> while stub is.body accepts any JSON value — object serve bodies rejected with an opaque untagged-enum error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ record.
 
 ## [Unreleased]
 
+### Added
+
+- **An intercept `serve` rule's `body` now accepts any JSON value**, not just a string (issue
+  #933). `body` was `Option<String>` while the imposter stub path's `is.body` has always taken any
+  value, so an object body — legal Mountebank semantics — was refused by serde, and because rules
+  parse through an untagged enum the caller saw only `data did not match any variant of untagged
+  enum RuleOrRules` with no hint that `body` was at fault. A non-string body is rendered once, at
+  rule-insert time, with compact `serde_json::to_string` (the same render-once shape as `is.body`,
+  issue #479), so the intercept request path never re-serializes it. Strictly widening: a string
+  body is still served byte-identically, `null`/absent still means an empty body, and
+  `GET /intercept/rules` gives the body back in its original JSON shape. See
+  [Intercept proxy](docs/features/intercept-proxy.md#serve-an-inline-stub).
+
 ### Fixed
 
 - **`--imposters` now dispatches on a bare `scheme:` URI instead of always reading it as a file

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -399,11 +399,7 @@ mod tests {
             .add(InterceptRule {
                 host: None,
                 predicates: vec![],
-                action: InterceptAction::Serve(ServeStub {
-                    status_code: 200,
-                    headers: Default::default(),
-                    body: None,
-                }),
+                action: InterceptAction::Serve(ServeStub::new(200, Default::default(), None)),
             })
             .unwrap();
 
@@ -444,6 +440,44 @@ mod tests {
         assert_eq!(state.rules.len(), 1, "a rejected body must not add a rule");
     }
 
+    // Issue #933 at the door it actually failed on. A non-string `serve` body used to be refused
+    // here, and because rules parse through the untagged `RuleOrRules` the caller got only "data
+    // did not match any variant of untagged enum RuleOrRules" — no mention of `body`. The single
+    // and batch shapes are both asserted because the untagged enum tries them in order, so a
+    // regression could plausibly break one and not the other.
+    #[test]
+    fn add_rules_from_bytes_accepts_non_string_serve_bodies() {
+        let state = test_state();
+        let one = br#"{"host":"cdn.example.com","action":{"serve":{"statusCode":200,"body":{"featureX":"ON"}}}}"#;
+        assert_eq!(
+            add_rules_from_bytes(one, &state, true).status(),
+            StatusCode::CREATED,
+            "an object serve body is accepted, not rejected by the untagged enum"
+        );
+
+        let many = br#"[{"action":{"serve":{"body":[1,2,3]}}},{"action":{"serve":{"body":42}}}]"#;
+        assert_eq!(
+            add_rules_from_bytes(many, &state, true).status(),
+            StatusCode::CREATED,
+            "array and number bodies are accepted in the batch shape too"
+        );
+
+        let served: Vec<String> = state
+            .rules
+            .list()
+            .iter()
+            .map(|rule| match &rule.action {
+                InterceptAction::Serve(stub) => stub.body_str().to_string(),
+                other => panic!("expected a serve action, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            served,
+            vec![r#"{"featureX":"ON"}"#, "[1,2,3]", "42"],
+            "each stored rule carries the compact rendering the listener will serve"
+        );
+    }
+
     // Issue #554: once the store is at MAX_RULES, POST /intercept/rules is rejected with 429 for
     // both the single-rule and the batch shape, and stores nothing.
     #[test]
@@ -453,11 +487,7 @@ mod tests {
         let filler = InterceptRule {
             host: None,
             predicates: vec![],
-            action: InterceptAction::Serve(ServeStub {
-                status_code: 200,
-                headers: Default::default(),
-                body: None,
-            }),
+            action: InterceptAction::Serve(ServeStub::new(200, Default::default(), None)),
         };
         state
             .rules

--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -308,7 +308,7 @@ async fn write_stub_response<S>(stream: &mut S, stub: &ServeStub) -> anyhow::Res
 where
     S: AsyncWrite + Unpin,
 {
-    let body = stub.body.clone().unwrap_or_default();
+    let body = stub.body_str();
     let mut head = format!(
         "HTTP/1.1 {} {}\r\n",
         stub.status_code,
@@ -617,6 +617,87 @@ mod tests {
     /// takes it and the "dead" upstream answers (issue #859).
     const CLOSED_PORT: u16 = 1;
 
+    // ===== Issue #933: a `serve` stub with a non-string JSON body, on the wire =====
+
+    async fn rendered_stub_response(stub: &ServeStub) -> String {
+        let mut out: Vec<u8> = Vec::new();
+        write_stub_response(&mut out, stub)
+            .await
+            .expect("writing to a Vec cannot fail");
+        String::from_utf8(out).expect("the test stubs are all valid UTF-8")
+    }
+
+    // AC1 at the wire level: the object body is serialized compactly into the response body, and
+    // `content-length` counts the rendered bytes.
+    #[tokio::test]
+    async fn write_stub_response_serves_object_body_as_compact_json() {
+        let stub = ServeStub::new(
+            200,
+            HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            Some(serde_json::json!({ "featureX": "ON" })),
+        );
+        let response = rendered_stub_response(&stub).await;
+        let (head, body) = response
+            .split_once("\r\n\r\n")
+            .expect("a well-formed response has a head/body separator");
+        assert_eq!(body, r#"{"featureX":"ON"}"#);
+        assert!(
+            head.contains(&format!("content-length: {}", body.len())),
+            "content-length counts the rendered body: {head}"
+        );
+        assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
+    }
+
+    // `content-length` is a *byte* count — a multi-byte body must not report its character count.
+    #[tokio::test]
+    async fn write_stub_response_object_body_content_length_is_bytes() {
+        let stub = ServeStub::new(
+            200,
+            HashMap::new(),
+            Some(serde_json::json!({ "msg": "héllo→" })),
+        );
+        let response = rendered_stub_response(&stub).await;
+        let (head, body) = response
+            .split_once("\r\n\r\n")
+            .expect("well-formed response");
+        let byte_len = body.len();
+        assert!(
+            body.chars().count() < byte_len,
+            "the body is multi-byte, so a character count would differ from the byte count"
+        );
+        assert!(
+            head.contains(&format!("content-length: {byte_len}")),
+            "content-length is the byte length: {head}"
+        );
+    }
+
+    // AC3/AC4 at the wire level: the pre-#933 behaviour for string and absent bodies is unchanged.
+    #[tokio::test]
+    async fn write_stub_response_string_and_absent_bodies_are_unchanged() {
+        let string_body = ServeStub::new(
+            200,
+            HashMap::new(),
+            Some(serde_json::json!(r#"{"featureX":"ON"}"#)),
+        );
+        let response = rendered_stub_response(&string_body).await;
+        let (_, body) = response
+            .split_once("\r\n\r\n")
+            .expect("well-formed response");
+        assert_eq!(
+            body, r#"{"featureX":"ON"}"#,
+            "a string body reaches the wire byte-identically to before the widening"
+        );
+
+        let absent = ServeStub::new(404, HashMap::new(), None);
+        let response = rendered_stub_response(&absent).await;
+        assert!(response.starts_with("HTTP/1.1 404 Not Found\r\n"));
+        assert!(response.contains("content-length: 0\r\n"));
+        assert!(
+            response.ends_with("\r\n\r\n"),
+            "no body follows the head: {response:?}"
+        );
+    }
+
     // Issue #522: a panicked accept loop must not be swallowed by `shutdown`/`stop` — its
     // `JoinError` is logged rather than discarded.
     #[tokio::test]
@@ -691,11 +772,11 @@ mod tests {
                 .expect("valid predicate JSON")
         };
         let serve = |marker: &str| {
-            InterceptAction::Serve(ServeStub {
-                status_code: 200,
-                headers: HashMap::new(),
-                body: Some(marker.to_string()),
-            })
+            InterceptAction::Serve(ServeStub::new(
+                200,
+                HashMap::new(),
+                Some(serde_json::Value::String(marker.to_string())),
+            ))
         };
 
         let rules = InterceptRules::new();
@@ -725,8 +806,8 @@ mod tests {
         );
         match action {
             Some(InterceptAction::Serve(stub)) => assert_eq!(
-                stub.body.as_deref(),
-                Some("base64"),
+                stub.body_str(),
+                "base64",
                 "the base64-keyed rule matches; the lossy-keyed rule does not"
             ),
             other => panic!("expected the base64-keyed serve rule to match, got {other:?}"),
@@ -998,11 +1079,11 @@ mod tests {
             .add(InterceptRule {
                 host: Some("cdn.example.com".to_string()),
                 predicates: vec![],
-                action: InterceptAction::Serve(ServeStub {
-                    status_code: 418,
-                    headers: HashMap::from([("x-rift".to_string(), "1".to_string())]),
-                    body: Some("brewed".to_string()),
-                }),
+                action: InterceptAction::Serve(ServeStub::new(
+                    418,
+                    HashMap::from([("x-rift".to_string(), "1".to_string())]),
+                    Some(serde_json::json!("brewed")),
+                )),
             })
             .unwrap();
         let (listener, ca_pem) = start_listener(rules).await;
@@ -1043,11 +1124,11 @@ mod tests {
                     serde_json::from_value(serde_json::json!({ "equals": { "body": b64 } }))
                         .expect("valid predicate JSON"),
                 ],
-                action: InterceptAction::Serve(ServeStub {
-                    status_code: 418,
-                    headers: HashMap::new(),
-                    body: Some("matched-binary".to_string()),
-                }),
+                action: InterceptAction::Serve(ServeStub::new(
+                    418,
+                    HashMap::new(),
+                    Some(serde_json::json!("matched-binary")),
+                )),
             })
             .unwrap();
         let (listener, ca_pem) = start_listener(rules).await;

--- a/crates/rift-http-proxy/src/intercept_control.rs
+++ b/crates/rift-http-proxy/src/intercept_control.rs
@@ -655,11 +655,11 @@ mod tests {
             host: Some(host.to_string()),
             predicates: vec![],
             action: crate::intercept_rules::InterceptAction::Serve(
-                crate::intercept_rules::ServeStub {
-                    status_code: 200,
-                    headers: Default::default(),
-                    body: Some("seeded".to_string()),
-                },
+                crate::intercept_rules::ServeStub::new(
+                    200,
+                    Default::default(),
+                    Some(serde_json::json!("seeded")),
+                ),
             ),
         }
     }

--- a/crates/rift-http-proxy/src/intercept_rules.rs
+++ b/crates/rift-http-proxy/src/intercept_rules.rs
@@ -38,15 +38,89 @@ pub enum InterceptAction {
 }
 
 /// An inline stub response for a [`InterceptAction::Serve`] rule.
+///
+/// Build one with [`ServeStub::new`]: `body` and its pre-rendered form must stay in step, so
+/// neither is publicly writable and there is no struct-literal form outside this module.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", from = "ServeStubRaw")]
 pub struct ServeStub {
     #[serde(default = "default_status")]
     pub status_code: u16,
     #[serde(default)]
     pub headers: HashMap<String, String>,
+    /// Issue #933: any JSON value, matching `is.body` on the imposter stub path. A string body is
+    /// served verbatim; any other value is pre-rendered into `rendered_body`. Read it through
+    /// [`Self::body`]; writing it directly would strand the rendering.
     #[serde(default)]
-    pub body: Option<String>,
+    body: Option<serde_json::Value>,
+    /// Issue #933: compact JSON rendering of a non-string [`Self::body`], computed ONCE at
+    /// rule-insert time so the intercept request path never re-serializes it — the same
+    /// render-once shape as `StubResponse::Is::rendered_body` (issue #479). `None` for a string
+    /// body (served as-is) or no body at all. A derived cache, not part of the wire format.
+    #[serde(skip)]
+    rendered_body: Option<Arc<str>>,
+}
+
+impl ServeStub {
+    pub fn new(
+        status_code: u16,
+        headers: HashMap<String, String>,
+        body: Option<serde_json::Value>,
+    ) -> Self {
+        // Only a non-string body needs rendering; a string body is served as-is. `Display` on a
+        // `Value` *is* its compact serialization and is total, so there is no failure to swallow
+        // here — unlike `to_string(&T)`, which would hand back a `Result` we could only default.
+        let rendered_body = body
+            .as_ref()
+            .filter(|b| !b.is_string())
+            .map(|b| Arc::from(b.to_string().as_str()));
+        Self {
+            status_code,
+            headers,
+            body,
+            rendered_body,
+        }
+    }
+
+    /// The body as posted, in its original JSON shape — this is what `GET /intercept/rules`
+    /// lists. Use [`Self::body_str`] for the bytes to put on the wire.
+    #[must_use]
+    pub fn body(&self) -> Option<&serde_json::Value> {
+        self.body.as_ref()
+    }
+
+    /// The response body to serve: a string body verbatim, a non-string body's pre-rendered
+    /// compact JSON, or empty when there is no body. Never serializes — the rendering happened at
+    /// construction.
+    #[must_use]
+    pub fn body_str(&self) -> &str {
+        match (&self.rendered_body, &self.body) {
+            (Some(rendered), _) => rendered,
+            (None, Some(serde_json::Value::String(s))) => s,
+            (None, _) => "",
+        }
+    }
+}
+
+/// Deserialization shim for [`ServeStub`]: the derive would default the `#[serde(skip)]`
+/// `rendered_body` to `None`, silently pushing the rendering back onto the request path. Routing
+/// deserialization through [`ServeStub::new`] is what keeps the render-once guarantee true for
+/// rules that arrive over the admin API (which is all of them).
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ServeStubRaw {
+    #[serde(default = "default_status")]
+    status_code: u16,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    body: Option<serde_json::Value>,
+}
+
+impl From<ServeStubRaw> for ServeStub {
+    fn from(raw: ServeStubRaw) -> Self {
+        ServeStub::new(raw.status_code, raw.headers, raw.body)
+    }
 }
 
 fn default_status() -> u16 {
@@ -196,6 +270,195 @@ mod tests {
         serde_json::from_value(value).expect("valid predicate JSON")
     }
 
+    // ===== Issue #933: `serve` bodies accept any JSON value, like `is.body` on the stub path =====
+
+    /// Deserialize a whole rule rather than a bare `ServeStub`, so a rule-level serde change
+    /// cannot pass this gate while breaking real input. The admin API's untagged `RuleOrRules`
+    /// wrapper — the layer that turned this issue's failure into an opaque error — is private to
+    /// `admin_api::handlers::intercept` and is covered by a test there.
+    fn serve_stub_from_action(action: serde_json::Value) -> ServeStub {
+        let rule: InterceptRule =
+            serde_json::from_value(serde_json::json!({ "action": { "serve": action } }))
+                .expect("a serve rule with any JSON body deserializes");
+        match rule.action {
+            InterceptAction::Serve(stub) => stub,
+            other => panic!("expected a serve action, got {other:?}"),
+        }
+    }
+
+    fn serve_stub_with_body(body: serde_json::Value) -> ServeStub {
+        serve_stub_from_action(serde_json::json!({ "statusCode": 200, "body": body }))
+    }
+
+    // AC1: the shape the issue reports — an object body — deserializes and serves the compact
+    // rendering, not a serde error.
+    #[test]
+    fn serve_stub_object_body_renders_compact_json() {
+        let stub = serve_stub_with_body(serde_json::json!({ "featureX": "ON", "n": 1 }));
+        assert_eq!(
+            stub.body_str(),
+            r#"{"featureX":"ON","n":1}"#,
+            "an object body renders as compact JSON, matching the stub path's `is.body`"
+        );
+        assert_eq!(stub.status_code, 200);
+    }
+
+    // AC2: every non-string JSON value renders, not just objects.
+    #[test]
+    fn serve_stub_non_string_body_variants_render() {
+        for (body, expected) in [
+            (serde_json::json!([1, 2, 3]), "[1,2,3]"),
+            (serde_json::json!(42), "42"),
+            (serde_json::json!(true), "true"),
+            (
+                serde_json::json!({ "a": { "b": [1, null] } }),
+                r#"{"a":{"b":[1,null]}}"#,
+            ),
+        ] {
+            assert_eq!(
+                serve_stub_with_body(body.clone()).body_str(),
+                expected,
+                "body {body} renders compactly"
+            );
+        }
+    }
+
+    // AC3: the widening is strictly additive — a string body is still served verbatim, never
+    // re-quoted or re-escaped. This is the wire-compatibility guarantee the issue promises.
+    #[test]
+    fn serve_stub_string_body_is_served_verbatim() {
+        let stub = serve_stub_with_body(serde_json::json!(r#"{"featureX":"ON"}"#));
+        assert_eq!(
+            stub.body_str(),
+            r#"{"featureX":"ON"}"#,
+            "a string body is served as-is; widening must not add a layer of JSON quoting"
+        );
+        assert_eq!(
+            serve_stub_with_body(serde_json::json!("hi")).body_str(),
+            "hi"
+        );
+    }
+
+    // AC4: absent and explicit-null bodies keep today's empty-body behaviour.
+    #[test]
+    fn serve_stub_absent_and_null_body_are_empty() {
+        let absent = serve_stub_from_action(serde_json::json!({ "statusCode": 204 }));
+        assert_eq!(absent.body(), None, "an omitted body stays absent");
+        assert_eq!(absent.body_str(), "");
+        assert_eq!(absent.status_code, 204);
+
+        let null = serve_stub_with_body(serde_json::Value::Null);
+        assert_eq!(
+            null.body(),
+            None,
+            "an explicit null body deserializes to None exactly as it did when body was a String"
+        );
+        assert_eq!(null.body_str(), "");
+    }
+
+    // `body()` reports the body as posted, which is a different question from `body_str()`'s "what
+    // goes on the wire" — for a non-string body the two deliberately disagree, and an embedder
+    // inspecting a rule wants the former.
+    #[test]
+    fn serve_stub_body_reports_the_posted_json_not_the_rendering() {
+        let stub = serve_stub_with_body(serde_json::json!({ "featureX": "ON" }));
+        assert_eq!(
+            stub.body(),
+            Some(&serde_json::json!({ "featureX": "ON" })),
+            "the posted JSON value is preserved, not replaced by its rendering"
+        );
+        assert_eq!(stub.body_str(), r#"{"featureX":"ON"}"#);
+
+        let string_body = serve_stub_with_body(serde_json::json!("hi"));
+        assert_eq!(string_body.body(), Some(&serde_json::json!("hi")));
+        assert_eq!(
+            string_body.body_str(),
+            "hi",
+            "for a string body the two agree apart from JSON quoting"
+        );
+    }
+
+    // AC5: the non-string rendering happens ONCE, at rule-insert time, and is *not* recomputed per
+    // request. Pointer equality across calls proves the value is a stored cache rather than a fresh
+    // serialization — and doing it on a *deserialized* stub proves the cache survives the serde
+    // path (a `#[serde(skip)]` field that defaults to `None` would silently reintroduce hot-path
+    // serialization).
+    #[test]
+    fn serve_stub_renders_body_once_at_construction() {
+        let stub = serve_stub_with_body(serde_json::json!({ "featureX": "ON" }));
+        let first = stub.body_str();
+        let second = stub.body_str();
+        assert_eq!(first, second);
+        assert!(
+            std::ptr::eq(first.as_ptr(), second.as_ptr()),
+            "the rendered body is cached at construction, not re-serialized per request"
+        );
+
+        // The cache must also survive the clone `match_request` hands to the request path.
+        let cloned = stub.clone();
+        assert_eq!(cloned.body_str(), r#"{"featureX":"ON"}"#);
+    }
+
+    // AC6: `GET /intercept/rules` must give back what was posted — an object body round-trips as an
+    // object, not as its rendered string.
+    //
+    // Asserted as *whole-value* equality, not just on `body`: `#[serde(from = "ServeStubRaw")]`
+    // makes `ServeStub`'s own deserialize attributes dead, so the field list now lives in two
+    // places with nothing coupling them. A field added to one and forgotten in the other would be
+    // silently dropped from every inbound rule; only a full round-trip catches that.
+    #[test]
+    fn serve_stub_round_trips_object_body() {
+        let posted = serde_json::json!({
+            "host": "cdn.example.com",
+            "predicates": [],
+            "action": { "serve": {
+                "statusCode": 503,
+                "headers": { "content-type": "application/json" },
+                "body": { "featureX": "ON" }
+            }}
+        });
+        let rule: InterceptRule =
+            serde_json::from_value(posted.clone()).expect("object serve body is accepted");
+        let listed = serde_json::to_value(&rule).expect("a rule serializes");
+        assert_eq!(
+            listed, posted,
+            "a listed rule is byte-for-byte what was posted — every field survives the \
+             ServeStubRaw shim, and the render-once cache never leaks onto the wire"
+        );
+    }
+
+    // The rendered body must reach the request path through the store, which is what
+    // `match_request` clones out.
+    #[test]
+    fn object_serve_body_survives_the_rule_store() {
+        let rules = InterceptRules::new();
+        rules
+            .add(InterceptRule {
+                host: None,
+                predicates: vec![predicate_path_equals("/config.json")],
+                action: InterceptAction::Serve(ServeStub::new(
+                    200,
+                    HashMap::new(),
+                    Some(serde_json::json!({ "featureX": "ON" })),
+                )),
+            })
+            .unwrap();
+
+        match rules.match_request(
+            "any.example.com",
+            "GET",
+            "/config.json",
+            None,
+            &HashMap::new(),
+            None,
+        ) {
+            Some(InterceptAction::Serve(stub)) => {
+                assert_eq!(stub.body_str(), r#"{"featureX":"ON"}"#)
+            }
+            other => panic!("expected the serve rule to match, got {other:?}"),
+        }
+    }
+
     #[test]
     fn rules_crud_roundtrip() {
         let rules = InterceptRules::new();
@@ -205,11 +468,11 @@ mod tests {
         let rule = InterceptRule {
             host: Some("cdn.example.com".to_string()),
             predicates: vec![],
-            action: InterceptAction::Serve(ServeStub {
-                status_code: 200,
-                headers: HashMap::new(),
-                body: Some("hi".to_string()),
-            }),
+            action: InterceptAction::Serve(ServeStub::new(
+                200,
+                HashMap::new(),
+                Some(serde_json::json!("hi")),
+            )),
         };
         rules.add(rule.clone()).unwrap();
         assert_eq!(rules.len(), 1);

--- a/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
+++ b/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
@@ -34,11 +34,11 @@ async fn intercepts_external_config_cdn_without_mitmproxy() {
         .add(InterceptRule {
             host: Some("cdn.example.com".to_string()),
             predicates: vec![path_predicate],
-            action: InterceptAction::Serve(ServeStub {
-                status_code: 200,
+            action: InterceptAction::Serve(ServeStub::new(
+                200,
                 headers,
-                body: Some(r#"{"featureX":"ON"}"#.to_string()),
-            }),
+                Some(serde_json::json!({ "featureX": "ON" })),
+            )),
         })
         .unwrap();
 

--- a/crates/rift-http-proxy/tests/intercept_configfile.rs
+++ b/crates/rift-http-proxy/tests/intercept_configfile.rs
@@ -71,7 +71,12 @@ async fn configfile_intercept_block_serves_without_any_admin_call() {
                       "predicates": [{ "equals": { "path": "/datafiles/key-a.json" } }],
                       "action": { "serve": { "statusCode": 200,
                                              "headers": { "content-type": "application/json" },
-                                             "body": "{\"featureX\":\"ON\"}" } } }
+                                             "body": "{\"featureX\":\"ON\"}" } } },
+                    { "host": "cdn.example.com",
+                      "predicates": [{ "equals": { "path": "/datafiles/key-b.json" } }],
+                      "action": { "serve": { "statusCode": 200,
+                                             "headers": { "content-type": "application/json" },
+                                             "body": { "featureX": "ON" } } } }
                 ]
             }
         }"#,
@@ -97,6 +102,18 @@ async fn configfile_intercept_block_serves_without_any_admin_call() {
         .send()
         .await
         .expect("the SUT's hard-coded HTTPS call is intercepted");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
+
+    // Issue #933: a `serve` body declared as a JSON *object* survives the whole boot path — parsed
+    // out of the config file, seeded into the rule store before `bind`, and rendered compactly on
+    // the wire. The two rules above differ only in how the same body is written, so this also pins
+    // that the object form is byte-identical to the escaped-string form it replaces.
+    let resp = sut_client(intercept, &ca_pem)
+        .get("https://cdn.example.com/datafiles/key-b.json")
+        .send()
+        .await
+        .expect("an object serve body declared in the config file is intercepted");
     assert_eq!(resp.status(), 200);
     assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
 

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -281,10 +281,21 @@ curl -X POST http://localhost:2525/intercept/rules -d '{
   "action": { "serve": {
     "statusCode": 200,
     "headers": { "content-type": "application/json" },
-    "body": "{\"featureX\":\"ON\"}"
+    "body": { "featureX": "ON" }
   }}
 }'
 ```
+
+`body` takes **any JSON value**, exactly like `is.body` on an imposter stub. A string is served
+verbatim — byte for byte, no re-quoting — so the equivalent `"body": "{\"featureX\":\"ON\"}"`
+above puts the same bytes on the wire. Any other value (object, array, number, boolean) is
+rendered as **compact JSON**, once when the rule is stored rather than on each intercepted
+request. Omitting `body`, or sending `null`, serves an empty body with `content-length: 0`.
+Note that `body` does not set `content-type` for you: an object body still needs
+`"content-type": "application/json"` in `headers` if the SUT checks it.
+
+`GET /intercept/rules` returns the body in the shape you posted — an object stays an object, not
+its rendered string.
 
 ### Forward to one of your imposters
 


### PR DESCRIPTION
Widens an intercept `serve` rule's `body` from `Option<String>` to any JSON value, matching `is.body` on the imposter stub path. An object body — legal Mountebank semantics — used to fail with an opaque `data did not match any variant of untagged enum RuleOrRules`.

A non-string body is rendered once, at rule-insert time, into a private `Arc<str>` cache (the same render-once shape as #479), so the intercept request path never re-serializes it. Strictly widening: string bodies stay byte-identical, `null`/absent still serves an empty body, and `GET /intercept/rules` returns the body in its posted JSON shape.

Docs: `docs/features/intercept-proxy.md` (Serve an inline stub) + CHANGELOG.

Out of scope, per the issue's own "can be split out if preferred": `statusCode` as a string and multi-value `headers`. Both need `rift-mock-core`'s `pub(crate)` deserialize helpers to cross a crate boundary; filed separately.

Closes #933
Milestone: none (standalone compatibility issue)