### PR TITLE
intercept: ServeStub.status_code and headers reject valid Mountebank forms — parity gap deferred from #933

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ record.
 
 ### Added
 
+- **An intercept `serve` rule now accepts a numeric-string `statusCode` and multi-value `headers`**
+  (issue #936), completing the parity #933 started for `body`. `"statusCode": "418"` and
+  `"set-cookie": ["a=1", "b=2"]` are the forms Mountebank accepts and the imposter stub path has
+  always handled; on the intercept path they were refused, and because rules parse through an
+  untagged enum the caller saw only `data did not match any variant`. Non-string scalar header
+  values (`"x-retry": 3`) coerce to strings, matching what recorders emit. Each value of a
+  multi-value header becomes its own line on the wire — never comma-joined, which is what
+  `set-cookie` requires — and the CR/LF response-splitting guard applies per value.
+  The helpers behind this moved from `rift-mock-core`'s crate-private module into the shared
+  `rift-types::wire`, so the two paths cannot drift apart again; no crate gained a dependency.
+  Strictly widening: previously-valid rules deserialize identically and
+  `GET /intercept/rules` still lists a single-value header as a plain string and a status as a
+  number. See [Intercept proxy](docs/features/intercept-proxy.md#serve-an-inline-stub).
+
 - **An intercept `serve` rule's `body` now accepts any JSON value**, not just a string (issue
   #933). `body` was `Option<String>` while the imposter stub path's `is.body` has always taken any
   value, so an object body — legal Mountebank semantics — was refused by serde, and because rules

--- a/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/intercept.rs
@@ -478,6 +478,56 @@ mod tests {
         );
     }
 
+    // Issue #936 / AC1 at the door it fails on. Both shapes are asserted because the untagged
+    // `RuleOrRules` tries them in order, so a regression could break one and not the other.
+    #[test]
+    fn add_rules_from_bytes_accepts_string_status_code_and_multi_value_headers() {
+        let state = test_state();
+        let one =
+            br#"{"action":{"serve":{"statusCode":"418","headers":{"set-cookie":["a=1","b=2"]}}}}"#;
+        assert_eq!(
+            add_rules_from_bytes(one, &state, true).status(),
+            StatusCode::CREATED,
+            "a numeric-string statusCode and a multi-value header are accepted, not refused by \
+             the untagged enum"
+        );
+
+        let many = br#"[{"action":{"serve":{"statusCode":"503"}}},{"action":{"serve":{"headers":{"x-retry":3}}}}]"#;
+        assert_eq!(
+            add_rules_from_bytes(many, &state, true).status(),
+            StatusCode::CREATED,
+            "the batch shape accepts them too"
+        );
+
+        let stored: Vec<(u16, Option<Vec<String>>)> = state
+            .rules
+            .list()
+            .iter()
+            .map(|rule| match &rule.action {
+                InterceptAction::Serve(stub) => {
+                    (stub.status_code, stub.headers.get("set-cookie").cloned())
+                }
+                other => panic!("expected a serve action, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            stored,
+            vec![
+                (418, Some(vec!["a=1".to_string(), "b=2".to_string()])),
+                (503, None),
+                (200, None),
+            ],
+            "each rule is stored with its parsed status and headers"
+        );
+
+        // Junk must still be refused at this door rather than silently defaulting to 200.
+        let bad = br#"{"action":{"serve":{"statusCode":"not-a-number"}}}"#;
+        assert_eq!(
+            add_rules_from_bytes(bad, &state, true).status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
     // Issue #554: once the store is at MAX_RULES, POST /intercept/rules is rejected with 429 for
     // both the single-rule and the batch shape, and stores nothing.
     #[test]

--- a/crates/rift-http-proxy/src/intercept.rs
+++ b/crates/rift-http-proxy/src/intercept.rs
@@ -314,16 +314,26 @@ where
         stub.status_code,
         reason_phrase(stub.status_code)
     );
-    for (name, value) in &stub.headers {
+    for (name, values) in &stub.headers {
         if is_hop_by_hop(name) {
             continue;
         }
-        // Guard against header/response splitting via CR/LF in admin-supplied stub headers.
-        if name.contains(['\r', '\n']) || value.contains(['\r', '\n']) {
-            tracing::warn!(header = %name, "skipping intercept stub header containing CR/LF");
+        // Guard against header/response splitting via CR/LF in admin-supplied stub headers. The
+        // name is checked once — a poisoned name disqualifies every one of its values — while the
+        // value check is per value, so one bad value does not take its clean siblings with it.
+        if name.contains(['\r', '\n']) {
+            tracing::warn!(header = %name, "skipping intercept stub header name containing CR/LF");
             continue;
         }
-        head.push_str(&format!("{name}: {value}\r\n"));
+        // One line per value (issue #936); comma-joining would be wrong for `set-cookie`, which is
+        // the header multi-value support exists for.
+        for value in values {
+            if value.contains(['\r', '\n']) {
+                tracing::warn!(header = %name, "skipping intercept stub header value containing CR/LF");
+                continue;
+            }
+            head.push_str(&format!("{name}: {value}\r\n"));
+        }
     }
     head.push_str(&format!("content-length: {}\r\n", body.len()));
     head.push_str("connection: close\r\n\r\n");
@@ -627,13 +637,83 @@ mod tests {
         String::from_utf8(out).expect("the test stubs are all valid UTF-8")
     }
 
+    // Issue #936 / AC3: a header with several values becomes several header lines. Collapsing them
+    // into one comma-joined line is wrong for `set-cookie`, which is the header that motivates
+    // multi-value support at all.
+    #[tokio::test]
+    async fn write_stub_response_emits_one_line_per_header_value() {
+        let stub = ServeStub::new(
+            200,
+            HashMap::from([
+                (
+                    "set-cookie".to_string(),
+                    vec!["a=1".to_string(), "b=2".to_string()],
+                ),
+                (
+                    "content-type".to_string(),
+                    vec!["application/json".to_string()],
+                ),
+            ]),
+            None,
+        );
+        let response = rendered_stub_response(&stub).await;
+        let (head, _) = response
+            .split_once("\r\n\r\n")
+            .expect("well-formed response");
+        let lines: Vec<&str> = head.lines().collect();
+
+        assert!(
+            lines.contains(&"set-cookie: a=1") && lines.contains(&"set-cookie: b=2"),
+            "each value gets its own line: {head}"
+        );
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|l| l.starts_with("set-cookie:"))
+                .count(),
+            2,
+            "two values, two lines — never comma-joined: {head}"
+        );
+        assert!(lines.contains(&"content-type: application/json"));
+    }
+
+    // The CR/LF response-splitting guard has to apply per value, not per header name — otherwise
+    // widening to multi-value would quietly reopen the injection hole it closed.
+    #[tokio::test]
+    async fn write_stub_response_skips_only_the_injecting_header_value() {
+        let stub = ServeStub::new(
+            200,
+            HashMap::from([(
+                "x-multi".to_string(),
+                vec![
+                    "clean".to_string(),
+                    "bad\r\nx-injected: yes".to_string(),
+                    "also-clean".to_string(),
+                ],
+            )]),
+            None,
+        );
+        let response = rendered_stub_response(&stub).await;
+        assert!(
+            !response.to_ascii_lowercase().contains("x-injected"),
+            "the CR/LF-bearing value is dropped: {response}"
+        );
+        assert!(
+            response.contains("x-multi: clean") && response.contains("x-multi: also-clean"),
+            "its clean siblings still go out: {response}"
+        );
+    }
+
     // AC1 at the wire level: the object body is serialized compactly into the response body, and
     // `content-length` counts the rendered bytes.
     #[tokio::test]
     async fn write_stub_response_serves_object_body_as_compact_json() {
         let stub = ServeStub::new(
             200,
-            HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            HashMap::from([(
+                "content-type".to_string(),
+                vec!["application/json".to_string()],
+            )]),
             Some(serde_json::json!({ "featureX": "ON" })),
         );
         let response = rendered_stub_response(&stub).await;
@@ -1081,7 +1161,7 @@ mod tests {
                 predicates: vec![],
                 action: InterceptAction::Serve(ServeStub::new(
                     418,
-                    HashMap::from([("x-rift".to_string(), "1".to_string())]),
+                    HashMap::from([("x-rift".to_string(), vec!["1".to_string()])]),
                     Some(serde_json::json!("brewed")),
                 )),
             })

--- a/crates/rift-http-proxy/src/intercept_rules.rs
+++ b/crates/rift-http-proxy/src/intercept_rules.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, RwLock};
 use rift_mock_core::imposter::stub_matches;
 use rift_mock_core::proxy::intercept_ca::CertificateAuthority;
 use rift_types::Predicate;
+use rift_types::wire::{deserialize_optional_status_code, multi_value_headers};
 
 /// A single intercept rule: an optional host filter plus predicates (AND-ed together), and the
 /// action to take when both match.
@@ -44,10 +45,15 @@ pub enum InterceptAction {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", from = "ServeStubRaw")]
 pub struct ServeStub {
-    #[serde(default = "default_status")]
+    // No field-level `default`s here: `#[serde(from = "ServeStubRaw")]` means the derived
+    // `Deserialize` never reads them, so the parsing and defaulting rules live on the shim below
+    // and nowhere else. Only the `serialize_with` half is live.
     pub status_code: u16,
-    #[serde(default)]
-    pub headers: HashMap<String, String>,
+    /// Issue #936: one or many values per name, matching `is.headers` on the imposter stub path.
+    /// Serialized back through the shared helper, so a single value lists as a bare string and
+    /// only a genuinely multi-value header becomes an array.
+    #[serde(serialize_with = "multi_value_headers::serialize")]
+    pub headers: HashMap<String, Vec<String>>,
     /// Issue #933: any JSON value, matching `is.body` on the imposter stub path. A string body is
     /// served verbatim; any other value is pre-rendered into `rendered_body`. Read it through
     /// [`Self::body`]; writing it directly would strand the rendering.
@@ -64,7 +70,7 @@ pub struct ServeStub {
 impl ServeStub {
     pub fn new(
         status_code: u16,
-        headers: HashMap<String, String>,
+        headers: HashMap<String, Vec<String>>,
         body: Option<serde_json::Value>,
     ) -> Self {
         // Only a non-string body needs rendering; a string body is served as-is. `Display` on a
@@ -109,17 +115,27 @@ impl ServeStub {
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ServeStubRaw {
-    #[serde(default = "default_status")]
-    status_code: u16,
-    #[serde(default)]
-    headers: HashMap<String, String>,
+    /// Issue #936: `Option` rather than a serde default, because the number-or-string parser runs
+    /// only when the field is present — the 200 default is applied in `From` below. Same shape as
+    /// `StubResponseRaw::status_code` on the imposter path, which also means an explicit
+    /// `"statusCode": null` now reads as absent (200) where it used to be an error; that is the
+    /// imposter path's own rule, and it widens what is accepted without changing any rule that
+    /// was already valid.
+    #[serde(default, deserialize_with = "deserialize_optional_status_code")]
+    status_code: Option<u16>,
+    #[serde(default, deserialize_with = "multi_value_headers::deserialize")]
+    headers: HashMap<String, Vec<String>>,
     #[serde(default)]
     body: Option<serde_json::Value>,
 }
 
 impl From<ServeStubRaw> for ServeStub {
     fn from(raw: ServeStubRaw) -> Self {
-        ServeStub::new(raw.status_code, raw.headers, raw.body)
+        ServeStub::new(
+            raw.status_code.unwrap_or_else(default_status),
+            raw.headers,
+            raw.body,
+        )
     }
 }
 
@@ -397,6 +413,115 @@ mod tests {
         // The cache must also survive the clone `match_request` hands to the request path.
         let cloned = stub.clone();
         assert_eq!(cloned.body_str(), r#"{"featureX":"ON"}"#);
+    }
+
+    // ===== Issue #936: statusCode and headers accept the same forms as the imposter stub path ====
+
+    // AC2: a numeric-string `statusCode` is accepted (the form Mountebank takes and `is.statusCode`
+    // already handles); a number still works; genuine junk is still refused rather than defaulted.
+    #[test]
+    fn serve_stub_status_code_takes_number_or_numeric_string() {
+        assert_eq!(
+            serve_stub_from_action(serde_json::json!({ "statusCode": 418 })).status_code,
+            418
+        );
+        assert_eq!(
+            serve_stub_from_action(serde_json::json!({ "statusCode": "418" })).status_code,
+            418,
+            "the string form is what this issue adds"
+        );
+        assert_eq!(
+            serve_stub_from_action(serde_json::json!({})).status_code,
+            200,
+            "an absent statusCode still defaults to 200"
+        );
+        // The one accept-set change beyond the string form: an explicit null used to be an error
+        // and now reads as absent, because the shared parser treats it that way for the imposter
+        // path too. Strictly widening — no previously-valid rule changed meaning — but pinned
+        // here so it stays a decision rather than a surprise.
+        assert_eq!(
+            serve_stub_from_action(serde_json::json!({ "statusCode": null })).status_code,
+            200,
+            "an explicit null statusCode reads as absent, matching `is.statusCode`"
+        );
+
+        for junk in [
+            serde_json::json!("abc"),
+            serde_json::json!(true),
+            // One past `u16::MAX` in both spellings — the out-of-range boundary, not just an
+            // obviously-silly number.
+            serde_json::json!("65536"),
+            serde_json::json!(65536),
+        ] {
+            let rule = serde_json::from_value::<InterceptRule>(serde_json::json!({
+                "action": { "serve": { "statusCode": junk } }
+            }));
+            assert!(
+                rule.is_err(),
+                "statusCode {junk} must be refused, not coerced or defaulted"
+            );
+        }
+    }
+
+    // AC5: #754 parity — Mountebank recorders emit non-string scalar header values and coerce them
+    // to strings. Sharing the stub path's helper means the intercept path inherits that, and this
+    // pins it deliberately rather than leaving it an accident of the shared module.
+    #[test]
+    fn serve_stub_coerces_scalar_header_values() {
+        let stub = serve_stub_from_action(serde_json::json!({
+            "headers": { "X-Retry": 3, "X-Flag": true, "X-Ratio": 1.5 }
+        }));
+        assert_eq!(stub.headers["X-Retry"], vec!["3".to_string()]);
+        assert_eq!(stub.headers["X-Flag"], vec!["true".to_string()]);
+        assert_eq!(stub.headers["X-Ratio"], vec!["1.5".to_string()]);
+    }
+
+    // AC3 (parse half) + AC4/AC6: multi-value headers survive the wire, a single value still
+    // round-trips as a bare string rather than a one-element array, and the whole rule is
+    // byte-identical through the `ServeStubRaw` shim — which is what catches the shim drifting
+    // out of step with `ServeStub` as fields are added.
+    #[test]
+    fn serve_stub_round_trips_multi_value_headers_and_string_status() {
+        let stub = serve_stub_from_action(serde_json::json!({
+            "headers": { "set-cookie": ["a=1", "b=2"] }
+        }));
+        assert_eq!(
+            stub.headers["set-cookie"],
+            vec!["a=1".to_string(), "b=2".to_string()]
+        );
+
+        let posted = serde_json::json!({
+            "host": "cdn.example.com",
+            "predicates": [],
+            "action": { "serve": {
+                "statusCode": 503,
+                "headers": { "content-type": "application/json", "set-cookie": ["a=1", "b=2"] },
+                "body": { "featureX": "ON" }
+            }}
+        });
+        let rule: InterceptRule =
+            serde_json::from_value(posted.clone()).expect("the widened forms are accepted");
+        assert_eq!(
+            serde_json::to_value(&rule).expect("a rule serializes"),
+            posted,
+            "a listed rule is byte-for-byte what was posted: the number status stays a number, \
+             the single-value header stays a bare string, and the multi-value one stays an array"
+        );
+    }
+
+    // A string `statusCode` is normalised to the number form on the way out — the rule is stored
+    // as `u16`, so listing it back as `"418"` would be inventing a shape the store does not hold.
+    #[test]
+    fn serve_stub_lists_a_string_status_code_back_as_a_number() {
+        let rule: InterceptRule = serde_json::from_value(serde_json::json!({
+            "action": { "serve": { "statusCode": "418" } }
+        }))
+        .expect("string status accepted");
+        let listed = serde_json::to_value(&rule).expect("a rule serializes");
+        assert_eq!(
+            listed["action"]["serve"]["statusCode"],
+            serde_json::json!(418)
+        );
     }
 
     // AC6: `GET /intercept/rules` must give back what was posted — an object body round-trips as an

--- a/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
+++ b/crates/rift-http-proxy/tests/intercept_config_cdn_example.rs
@@ -29,7 +29,10 @@ async fn intercepts_external_config_cdn_without_mitmproxy() {
         serde_json::from_value(serde_json::json!({ "equals": { "path": "/config.json" } }))
             .expect("valid predicate");
     let mut headers = HashMap::new();
-    headers.insert("content-type".to_string(), "application/json".to_string());
+    headers.insert(
+        "content-type".to_string(),
+        vec!["application/json".to_string()],
+    );
     rules
         .add(InterceptRule {
             host: Some("cdn.example.com".to_string()),

--- a/crates/rift-http-proxy/tests/intercept_configfile.rs
+++ b/crates/rift-http-proxy/tests/intercept_configfile.rs
@@ -76,6 +76,12 @@ async fn configfile_intercept_block_serves_without_any_admin_call() {
                       "predicates": [{ "equals": { "path": "/datafiles/key-b.json" } }],
                       "action": { "serve": { "statusCode": 200,
                                              "headers": { "content-type": "application/json" },
+                                             "body": { "featureX": "ON" } } } },
+                    { "host": "cdn.example.com",
+                      "predicates": [{ "equals": { "path": "/datafiles/key-c.json" } }],
+                      "action": { "serve": { "statusCode": "418",
+                                             "headers": { "content-type": "application/json",
+                                                          "set-cookie": ["a=1", "b=2"] },
                                              "body": { "featureX": "ON" } } } }
                 ]
             }
@@ -115,6 +121,29 @@ async fn configfile_intercept_block_serves_without_any_admin_call() {
         .await
         .expect("an object serve body declared in the config file is intercepted");
     assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
+
+    // Issue #936: a numeric-string `statusCode` and a multi-value header declared in the config
+    // file survive the same boot path. The config door is the one #933's note calls out as
+    // ungated by `verify-docs-coverage.sh`, so it gets its own assertion rather than riding on
+    // the admin-API tests.
+    let resp = sut_client(intercept, &ca_pem)
+        .get("https://cdn.example.com/datafiles/key-c.json")
+        .send()
+        .await
+        .expect("a string statusCode and multi-value headers from the config file are intercepted");
+    assert_eq!(resp.status(), 418, "the string \"418\" parsed as a status");
+    let cookies: Vec<&str> = resp
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .map(|v| v.to_str().expect("ascii cookie"))
+        .collect();
+    assert_eq!(
+        cookies,
+        vec!["a=1", "b=2"],
+        "both values arrive as separate header lines"
+    );
     assert_eq!(resp.text().await.unwrap(), r#"{"featureX":"ON"}"#);
 
     server.shutdown().await;

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -5,74 +5,13 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Serde for multi-value headers (issue #238). Accepts the Mountebank-style `"k": "v"` *and*
-/// `"k": ["v1", "v2"]` on the wire; serializes a single value back as a plain string and multiple
-/// values as an array, so existing single-value consumers are unaffected.
-pub(crate) mod multi_value_headers {
-    use serde::Deserialize;
-    use serde::de::Deserializer;
-    use serde::ser::{SerializeMap, Serializer};
-    use std::collections::HashMap;
-
-    pub fn serialize<S: Serializer>(
-        headers: &HashMap<String, Vec<String>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(headers.len()))?;
-        for (key, values) in headers {
-            match values.as_slice() {
-                [] => continue, // a key with no values would emit no header line; omit it
-                [single] => map.serialize_entry(key, single)?,
-                many => map.serialize_entry(key, many)?,
-            }
-        }
-        map.end()
-    }
-
-    /// A single header value on the wire. Mountebank tolerates non-string scalars — its recorders
-    /// routinely emit `"Content-Length": 124` (a JSON number) and `"X-Flag": true` — and coerces
-    /// them to their string form. Rift matches that so real recorded imposters load unchanged
-    /// (issue #754); previously a numeric/bool value failed both `OneOrMany` variants and rejected
-    /// the whole imposter with a 400.
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Scalar {
-        Str(String),
-        Num(serde_json::Number),
-        Bool(bool),
-    }
-
-    impl Scalar {
-        fn into_string(self) -> String {
-            match self {
-                Scalar::Str(s) => s,
-                Scalar::Num(n) => n.to_string(),
-                Scalar::Bool(b) => b.to_string(),
-            }
-        }
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<HashMap<String, Vec<String>>, D::Error> {
-        // Order matters for `#[serde(untagged)]`: a scalar can never match `Many` and an array can
-        // never match `One`, so either order is sound — `One` first keeps the common case first.
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum OneOrMany {
-            One(Scalar),
-            Many(Vec<Scalar>),
-        }
-        let raw = HashMap::<String, OneOrMany>::deserialize(deserializer)?;
-        Ok(raw
-            .into_iter()
-            .map(|(k, v)| match v {
-                OneOrMany::One(s) => (k, vec![s.into_string()]),
-                OneOrMany::Many(v) => (k, v.into_iter().map(Scalar::into_string).collect()),
-            })
-            .collect())
-    }
-}
+// Issue #936: the Mountebank wire-shape tolerance helpers moved to `rift-types::wire` so the
+// intercept rule schema can share them — the imposter path and the intercept path parse the
+// same JSON and must agree about what it means. Re-exported here so every
+// `#[serde(with = "multi_value_headers")]` attribute path in this file resolves unchanged.
+pub(crate) use rift_types::wire::{
+    deserialize_optional_status_code, deserialize_status_code, multi_value_headers,
+};
 
 // ============================================================================
 // Recorded Request Types
@@ -690,43 +629,6 @@ where
 
 pub(crate) fn default_status_code() -> u16 {
     200
-}
-
-/// Parse a JSON `statusCode` value that may be a number or a (numeric) string.
-fn parse_status_code_value<E: serde::de::Error>(value: serde_json::Value) -> Result<u16, E> {
-    match value {
-        serde_json::Value::Number(n) => n
-            .as_u64()
-            .and_then(|n| u16::try_from(n).ok())
-            .ok_or_else(|| E::custom("invalid status code number")),
-        serde_json::Value::String(s) => s
-            .parse::<u16>()
-            .map_err(|_| E::custom(format!("invalid status code string: {s}"))),
-        _ => Err(E::custom("statusCode must be a number or string")),
-    }
-}
-
-/// Deserialize statusCode from either a number or a string
-pub(crate) fn deserialize_status_code<'de, D>(deserializer: D) -> Result<u16, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    parse_status_code_value(serde_json::Value::deserialize(deserializer)?)
-}
-
-/// Deserialize an optional top-level `statusCode` (flat response form, issue #304), reusing the
-/// number-or-string parsing. Only invoked when the field is present; a `null` is treated as
-/// absent (`None`) so a stray null on a non-flat response stays accepted as before.
-pub(crate) fn deserialize_optional_status_code<'de, D>(
-    deserializer: D,
-) -> Result<Option<u16>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    match serde_json::Value::deserialize(deserializer)? {
-        serde_json::Value::Null => Ok(None),
-        value => parse_status_code_value(value).map(Some),
-    }
 }
 
 impl From<StubResponseRaw> for StubResponse {

--- a/crates/rift-types/src/lib.rs
+++ b/crates/rift-types/src/lib.rs
@@ -1,8 +1,11 @@
 //! Shared core types for the Rift workspace.
 //!
 //! Pure, serde-friendly data types with no behaviour, so they can be depended on by
-//! `rift-http-proxy`, `rift-lint`, and `rift-tui` without circular dependencies.
+//! `rift-http-proxy`, `rift-lint`, and `rift-tui` without circular dependencies. The one
+//! exception is [`wire`], which carries the shared serde rules for how those types are spelled on
+//! the wire — it lives here for the same reason the types do: so no two crates can disagree.
 
 pub mod predicate;
+pub mod wire;
 
 pub use predicate::{Predicate, PredicateOperation, PredicateParameters, PredicateSelector};

--- a/crates/rift-types/src/wire.rs
+++ b/crates/rift-types/src/wire.rs
@@ -1,0 +1,265 @@
+//! Mountebank wire-shape tolerance, shared across crates (issue #936).
+//!
+//! Mountebank accepts several spellings of the same value — a status code as a number *or* a
+//! numeric string, a header as one value *or* an array, a header value as any JSON scalar. Those
+//! rules are a property of the wire format, not of any one subsystem, so they live here rather
+//! than inside the imposter types: the imposter stub path and the intercept rule schema both
+//! parse the same JSON and must agree about what it means. They previously lived in
+//! `rift-mock-core` as `pub(crate)`, which is exactly why the intercept path drifted (issue #933
+//! for `body`, this issue for `statusCode`/`headers`).
+
+/// Serde for multi-value headers (issue #238). Accepts the Mountebank-style `"k": "v"` *and*
+/// `"k": ["v1", "v2"]` on the wire; serializes a single value back as a plain string and multiple
+/// values as an array, so existing single-value consumers are unaffected.
+pub mod multi_value_headers {
+    use serde::Deserialize;
+    use serde::de::Deserializer;
+    use serde::ser::{SerializeMap, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        headers: &HashMap<String, Vec<String>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(headers.len()))?;
+        for (key, values) in headers {
+            match values.as_slice() {
+                [] => continue, // a key with no values would emit no header line; omit it
+                [single] => map.serialize_entry(key, single)?,
+                many => map.serialize_entry(key, many)?,
+            }
+        }
+        map.end()
+    }
+
+    /// A single header value on the wire. Mountebank tolerates non-string scalars — its recorders
+    /// routinely emit `"Content-Length": 124` (a JSON number) and `"X-Flag": true` — and coerces
+    /// them to their string form. Rift matches that so real recorded imposters load unchanged
+    /// (issue #754); previously a numeric/bool value failed both `OneOrMany` variants and rejected
+    /// the whole imposter with a 400.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Scalar {
+        Str(String),
+        Num(serde_json::Number),
+        Bool(bool),
+    }
+
+    impl Scalar {
+        fn into_string(self) -> String {
+            match self {
+                Scalar::Str(s) => s,
+                Scalar::Num(n) => n.to_string(),
+                Scalar::Bool(b) => b.to_string(),
+            }
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<String, Vec<String>>, D::Error> {
+        // Order matters for `#[serde(untagged)]`: a scalar can never match `Many` and an array can
+        // never match `One`, so either order is sound — `One` first keeps the common case first.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany {
+            One(Scalar),
+            Many(Vec<Scalar>),
+        }
+        let raw = HashMap::<String, OneOrMany>::deserialize(deserializer)?;
+        Ok(raw
+            .into_iter()
+            .map(|(k, v)| match v {
+                OneOrMany::One(s) => (k, vec![s.into_string()]),
+                OneOrMany::Many(v) => (k, v.into_iter().map(Scalar::into_string).collect()),
+            })
+            .collect())
+    }
+}
+
+use serde::Deserialize;
+
+/// Parse a JSON `statusCode` value that may be a number or a (numeric) string.
+fn parse_status_code_value<E: serde::de::Error>(value: serde_json::Value) -> Result<u16, E> {
+    match value {
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .and_then(|n| u16::try_from(n).ok())
+            .ok_or_else(|| E::custom("invalid status code number")),
+        serde_json::Value::String(s) => s
+            .parse::<u16>()
+            .map_err(|_| E::custom(format!("invalid status code string: {s}"))),
+        _ => Err(E::custom("statusCode must be a number or string")),
+    }
+}
+
+/// Deserialize statusCode from either a number or a string
+pub fn deserialize_status_code<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    parse_status_code_value(serde_json::Value::deserialize(deserializer)?)
+}
+
+/// Deserialize an optional top-level `statusCode` (flat response form, issue #304), reusing the
+/// number-or-string parsing. Only invoked when the field is present; a `null` is treated as
+/// absent (`None`) so a stray null on a non-flat response stays accepted as before.
+pub fn deserialize_optional_status_code<'de, D>(deserializer: D) -> Result<Option<u16>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::Null => Ok(None),
+        value => parse_status_code_value(value).map(Some),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+    use std::collections::HashMap;
+
+    /// Exercises the helpers through serde attributes, the only way they are ever reached — a
+    /// direct call would not prove the `#[serde(with = ...)]` wiring still resolves.
+    #[derive(Deserialize)]
+    struct HeadersIn {
+        #[serde(default, deserialize_with = "multi_value_headers::deserialize")]
+        headers: HashMap<String, Vec<String>>,
+    }
+
+    #[derive(Serialize)]
+    struct HeadersOut {
+        #[serde(serialize_with = "multi_value_headers::serialize")]
+        headers: HashMap<String, Vec<String>>,
+    }
+
+    #[derive(Deserialize)]
+    struct StatusIn {
+        #[serde(deserialize_with = "deserialize_status_code")]
+        status: u16,
+    }
+
+    #[derive(Deserialize)]
+    struct OptionalStatusIn {
+        #[serde(default, deserialize_with = "deserialize_optional_status_code")]
+        status: Option<u16>,
+    }
+
+    #[test]
+    fn headers_accept_a_bare_string_or_an_array() {
+        let one: HeadersIn = serde_json::from_str(r#"{"headers":{"X-One":"v"}}"#).unwrap();
+        assert_eq!(one.headers["X-One"], vec!["v".to_string()]);
+
+        let many: HeadersIn =
+            serde_json::from_str(r#"{"headers":{"Set-Cookie":["a","b"]}}"#).unwrap();
+        assert_eq!(
+            many.headers["Set-Cookie"],
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    // Issue #754: recorded imposters carry non-string scalars; they coerce rather than 400.
+    #[test]
+    fn headers_coerce_numeric_and_bool_scalars() {
+        let r: HeadersIn = serde_json::from_str(
+            r#"{"headers":{"Content-Length":124,"X-Flag":true,"X-Ratio":1.5,"X-Multi":[200,"x",false]}}"#,
+        )
+        .expect("numeric/bool header values must be accepted (mb parity)");
+        assert_eq!(r.headers["Content-Length"], vec!["124".to_string()]);
+        assert_eq!(r.headers["X-Flag"], vec!["true".to_string()]);
+        assert_eq!(r.headers["X-Ratio"], vec!["1.5".to_string()]);
+        assert_eq!(
+            r.headers["X-Multi"],
+            vec!["200".to_string(), "x".to_string(), "false".to_string()]
+        );
+    }
+
+    #[test]
+    fn headers_serialize_single_as_string_many_as_array_and_omit_empty() {
+        let out = HeadersOut {
+            headers: HashMap::from([
+                ("X-One".to_string(), vec!["v".to_string()]),
+                (
+                    "Set-Cookie".to_string(),
+                    vec!["a".to_string(), "b".to_string()],
+                ),
+                ("X-Empty".to_string(), vec![]),
+            ]),
+        };
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["headers"]["X-One"], serde_json::json!("v"));
+        assert_eq!(v["headers"]["Set-Cookie"], serde_json::json!(["a", "b"]));
+        assert!(
+            v["headers"].get("X-Empty").is_none(),
+            "a key with no values emits no header line, so it is omitted"
+        );
+    }
+
+    #[test]
+    fn status_code_accepts_a_number_or_a_numeric_string() {
+        assert_eq!(
+            serde_json::from_str::<StatusIn>(r#"{"status":404}"#)
+                .unwrap()
+                .status,
+            404
+        );
+        assert_eq!(
+            serde_json::from_str::<StatusIn>(r#"{"status":"404"}"#)
+                .unwrap()
+                .status,
+            404
+        );
+    }
+
+    #[test]
+    fn status_code_rejects_junk_rather_than_defaulting() {
+        for junk in [
+            r#"{"status":"abc"}"#,
+            r#"{"status":true}"#,
+            // One past `u16::MAX`, in both spellings — the boundary the two parse paths
+            // (`str::parse::<u16>` and `u16::try_from(u64)`) have to agree on.
+            r#"{"status":65536}"#,
+            r#"{"status":"65536"}"#,
+            r#"{"status":-1}"#,
+            // A non-integer number: `Number::as_u64` yields `None` rather than truncating.
+            r#"{"status":200.5}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<StatusIn>(junk).is_err(),
+                "{junk} must be an error, not a silent default"
+            );
+        }
+
+        // …and the boundary itself is still accepted, so the rejections above are landing on the
+        // right side of it.
+        assert_eq!(
+            serde_json::from_str::<StatusIn>(r#"{"status":65535}"#)
+                .unwrap()
+                .status,
+            65535
+        );
+    }
+
+    #[test]
+    fn optional_status_code_treats_null_and_absent_as_none() {
+        assert_eq!(
+            serde_json::from_str::<OptionalStatusIn>(r#"{}"#)
+                .unwrap()
+                .status,
+            None
+        );
+        assert_eq!(
+            serde_json::from_str::<OptionalStatusIn>(r#"{"status":null}"#)
+                .unwrap()
+                .status,
+            None
+        );
+        assert_eq!(
+            serde_json::from_str::<OptionalStatusIn>(r#"{"status":"201"}"#)
+                .unwrap()
+                .status,
+            Some(201)
+        );
+    }
+}

--- a/docs/features/intercept-proxy.md
+++ b/docs/features/intercept-proxy.md
@@ -294,8 +294,28 @@ request. Omitting `body`, or sending `null`, serves an empty body with `content-
 Note that `body` does not set `content-type` for you: an object body still needs
 `"content-type": "application/json"` in `headers` if the SUT checks it.
 
+`statusCode` takes a number **or** a numeric string (`"418"`), and `headers` takes one value or
+many per name — the same forms an imposter stub's `is.statusCode` / `is.headers` accept:
+
+```bash
+curl -X POST http://localhost:2525/intercept/rules -d '{
+  "host": "cdn.example.com",
+  "action": { "serve": {
+    "statusCode": "418",
+    "headers": { "set-cookie": ["a=1", "b=2"], "content-type": "application/json" },
+    "body": { "featureX": "ON" }
+  }}
+}'
+```
+
+Each value of a multi-value header becomes its own header line on the intercepted response — they
+are never comma-joined, which is what `set-cookie` requires. A non-string scalar header value
+(`"x-retry": 3`) is coerced to its string form, matching what Mountebank recorders emit.
+
 `GET /intercept/rules` returns the body in the shape you posted — an object stays an object, not
-its rendered string.
+its rendered string. A single-value header lists back as a plain string rather than a one-element
+array, and a `statusCode` given as a string lists back as a number, since that is what the rule
+store holds.
 
 ### Forward to one of your imposters
 


### PR DESCRIPTION
Completes the intercept/imposter parity #933 started for `body`: a `serve` rule now takes `"statusCode": "418"` and `"headers": {"set-cookie": ["a=1", "b=2"]}`, the forms Mountebank accepts and `is.statusCode` / `is.headers` already handled.

**Why a crate move.** The tolerance helpers were `pub(crate)` in `rift-mock-core`, which is precisely why the intercept path could drift from the imposter path. They now live in a shared `rift-types::wire` — the same home and reason as `Predicate` in #36 — re-exported into mock-core via `pub(crate) use` so every `#[serde(with = "...")]` path there resolves unchanged. Both crates already depended on `rift-types`, so the crate graph is unchanged.

The moved code is behaviour-preserving: diffed against `HEAD`, `multi_value_headers` is byte-identical and the status parsers differ only by the intended `pub(crate)`→`pub` and one rustfmt reflow.

**On the wire.** Each value of a multi-value header gets its own header line (never comma-joined — `set-cookie` requires this), and the CR/LF response-splitting guard applies per value, so a poisoned value is dropped without its clean siblings.

**Compatibility — strictly widening.** Previously-valid rules deserialize identically; `GET /intercept/rules` still lists a single-value header as a plain string and a status as a number. One accept-set change beyond the string form: `"statusCode": null` now reads as absent (200) where it was an error, which is the imposter path's own rule — pinned by a test rather than left implicit.

Covers all 9 acceptance criteria from the issue's triage comment, including the `--configfile` boot path (the door `verify-docs-coverage.sh` does not gate). Docs: `docs/features/intercept-proxy.md` + CHANGELOG.

Note: mock-core's three `multi_value_headers_*` tests were kept in place rather than moved as the triage plan said — they are written against `IsResponse`, and keeping them means the literal pre-move suite now exercises the moved code through the re-export. Net coverage went up.

Closes #936
Milestone: none (agent-found finding, triaged 2026-08-05)