### PR TITLE
feat(journal): record the status and time a request was answered with

### DIFF
--- a/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
+++ b/crates/rift-http-proxy/src/admin_api/handlers/imposters.rs
@@ -1136,6 +1136,9 @@ mod requests_filter_tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 
@@ -1908,6 +1911,9 @@ mod verify_tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 
@@ -2099,6 +2105,9 @@ mod replace_all_tests {
                 body: None,
                 timestamp: "2026-01-01T00:00:00Z".to_string(),
                 match_outcome: None,
+                status: None,
+                latency_ms: None,
+                node: None,
             });
 
         let body = serde_json::json!({"imposters": [cfg]}).to_string();

--- a/crates/rift-http-proxy/src/admin_api/request_filter.rs
+++ b/crates/rift-http-proxy/src/admin_api/request_filter.rs
@@ -167,6 +167,9 @@ mod tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 

--- a/crates/rift-http-proxy/tests/admin_sse.rs
+++ b/crates/rift-http-proxy/tests/admin_sse.rs
@@ -235,20 +235,32 @@ async fn request_event_matches_saved_requests() {
             .await
             .expect("saved json");
     let mut entry = saved[0].clone();
-    let outcome = entry
+    let object = entry
         .as_object_mut()
-        .expect("savedRequests entry is an object")
-        .remove("matchOutcome");
+        .expect("savedRequests entry is an object");
+    let outcome = object.remove("matchOutcome");
+    // Issue #364: `status` and `latencyMs` are attached after the response exists, exactly as
+    // `matchOutcome` is attached after the match — so they belong to the same category and are
+    // stripped for the same reason. The SSE push is a record-time copy by design.
+    let status = object.remove("status");
+    let latency = object.remove("latencyMs");
     assert!(
         outcome.is_some(),
         "the journal entry carries a match outcome: {}",
         saved[0]
     );
     assert!(
-        v["request"].get("matchOutcome").is_none(),
-        "the pushed copy predates the match, so it cannot carry an outcome: {}",
-        v["request"]
+        status.is_some() && latency.is_some(),
+        "the journal entry carries a response outcome (#364): {}",
+        saved[0]
     );
+    for annotation in ["matchOutcome", "status", "latencyMs"] {
+        assert!(
+            v["request"].get(annotation).is_none(),
+            "the pushed copy predates the response, so it cannot carry {annotation}: {}",
+            v["request"]
+        );
+    }
     assert_eq!(
         v["request"], entry,
         "SSE request JSON must equal the savedRequests entry"

--- a/crates/rift-mock-core/src/imposter/core/mod.rs
+++ b/crates/rift-mock-core/src/imposter/core/mod.rs
@@ -1490,6 +1490,9 @@ mod tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         };
 
         use crate::imposter::journal::MAX_RECORDED_REQUESTS;
@@ -1530,6 +1533,9 @@ mod tests {
                 body: None,
                 timestamp: "2026-01-01T00:00:00Z".to_string(),
                 match_outcome: None,
+                status: None,
+                latency_ms: None,
+                node: None,
             }
         };
         imposter.record_request(req("A"));

--- a/crates/rift-mock-core/src/imposter/core/recording.rs
+++ b/crates/rift-mock-core/src/imposter/core/recording.rs
@@ -57,6 +57,17 @@ impl Imposter {
             .attach_match(self.journal_port(), index, outcome);
     }
 
+    /// Attach the response status and elapsed time to the entry [`record_request`](Self::record_request)
+    /// returned `index` for, once the response has been produced (issue #364).
+    ///
+    /// Infallible on the same terms as [`attach_match_outcome`](Self::attach_match_outcome), and
+    /// for the same reason: a journal annotation that could fail a request would trade a real
+    /// response for a diagnostic.
+    pub fn attach_response_outcome(&self, index: u64, status: u16, latency_ms: u64) {
+        self.journal
+            .attach_response(self.journal_port(), index, status, latency_ms);
+    }
+
     /// Read recorded requests with the backend's completeness flag intact, so embedders
     /// can observe a degraded read programmatically (issue #314).
     pub fn read_recorded_requests(&self) -> JournalRead {

--- a/crates/rift-mock-core/src/imposter/core/verify.rs
+++ b/crates/rift-mock-core/src/imposter/core/verify.rs
@@ -320,6 +320,9 @@ mod tests {
             body: body.map(str::to_string),
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/events.rs
+++ b/crates/rift-mock-core/src/imposter/events.rs
@@ -179,6 +179,9 @@ mod tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/handler.rs
+++ b/crates/rift-mock-core/src/imposter/handler.rs
@@ -41,7 +41,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{debug, trace, warn};
 
 /// Maximum allowed request body size (10 MB)
@@ -331,11 +331,34 @@ pub async fn handle_imposter_request(
     let allow_cors = imposter.config.allow_cors;
     // Capture the method before `req` is consumed so we can record the request metric (issue #269).
     let method = req.method().to_string();
-    let mut response = handle_request_inner(req, imposter, client_addr).await?;
+    /*
+     * Issue #364. The journal entry is written inside `handle_request_inner`, before matching and
+     * long before a response exists, so the status and the elapsed time can only be attached from
+     * out here — where the finished response is, and where the clock started.
+     *
+     * The index travels out through an out-parameter rather than the return type because `inner`
+     * returns from eight places. Widening its return would touch every one of them to carry a
+     * value only this caller reads, and each extra site is a chance to drop it.
+     */
+    let started = Instant::now();
+    let mut journal_index = None;
+    let mut response =
+        handle_request_inner(req, Arc::clone(&imposter), client_addr, &mut journal_index).await?;
     // Record `rift_requests_total` once per request the imposter serves (issue #269). The imposter
     // serve path recorded no Prometheus metrics before; the recording proxy engine
     // (`proxy/handler.rs`) is a disjoint path, so there is no double-count.
     crate::extensions::record_request(&method, response.status().as_u16());
+    if let Some(index) = journal_index {
+        // Measured before CORS injection below, which is a header edit this node performs after
+        // the imposter has finished — counting it would report the engine as slower than it was.
+        imposter.attach_response_outcome(
+            index,
+            response.status().as_u16(),
+            // Saturating rather than `as`: a request parked long enough to overflow `u64`
+            // milliseconds is not reachable, but a silent wrap would report it as instant.
+            u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        );
+    }
     if allow_cors {
         inject_cors_headers(response.headers_mut());
     }
@@ -381,10 +404,14 @@ fn sanitize_header_value(value: &str) -> String {
     sanitized
 }
 
+/// `journal_index` is an out-parameter: the index of the entry this request was recorded under, so
+/// the caller can attach the status and elapsed time once the response exists (issue #364). Left
+/// `None` when nothing was recorded — recording off, or a backend with no stable indices.
 async fn handle_request_inner(
     req: Request<Incoming>,
     imposter: Arc<Imposter>,
     client_addr: SocketAddr,
+    journal_index: &mut Option<u64>,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     // Check if enabled
     if !imposter.is_enabled() {
@@ -508,7 +535,7 @@ async fn handle_request_inner(
     // request's match outcome can be attached to that exact entry once matching has finished;
     // `None` means there is no entry to annotate — recording is off, or the backend has no stable
     // indices.
-    let journal_index = if imposter.config.record_requests {
+    *journal_index = if imposter.config.record_requests {
         let recorded = RecordedRequest {
             request_from: client_addr.to_string(),
             method: method.clone(),
@@ -522,6 +549,12 @@ async fn handle_request_inner(
             timestamp: chrono::Utc::now().to_rfc3339(),
             // Filled in after the match, via `attach_match_outcome` below.
             match_outcome: None,
+            // Filled in after the response exists, by `attach_response_outcome` in the caller.
+            status: None,
+            latency_ms: None,
+            // Never set here: this engine is one node and has no name for itself. A clustered
+            // journal stamps it in its own `record` (issue #364).
+            node: None,
         };
         imposter.record_request(recorded)
     } else {
@@ -659,7 +692,7 @@ async fn handle_request_inner(
     // Attach once, from the FINAL match state — after any rescue, and never on the paths that
     // returned above (the debug branch and a matcher error), where absence of an outcome is the
     // honest report that none was reached.
-    if let (Some(index), Some(trace)) = (journal_index, trace) {
+    if let (Some(index), Some(trace)) = (*journal_index, trace) {
         let winner = matched.as_ref().map(|(state, i)| (&state.stub, *i));
         imposter.attach_match_outcome(index, trace.into_outcome(winner));
     }

--- a/crates/rift-mock-core/src/imposter/journal.rs
+++ b/crates/rift-mock-core/src/imposter/journal.rs
@@ -145,6 +145,20 @@ pub trait RequestJournal: Send + Sync {
     fn attach_match(&self, port: u16, index: u64, outcome: MatchOutcome) {
         let _ = (port, index, outcome);
     }
+
+    /// Attach the response status and the time taken to the entry `index` names (issue #364).
+    ///
+    /// A second write for the same reason [`attach_match`](Self::attach_match) is one: the entry is
+    /// journalled before the request is matched, let alone answered, so neither the status nor the
+    /// duration exists yet when `record` runs.
+    ///
+    /// Defaults to a no-op, and is infallible, on exactly the terms `attach_match` sets out — a
+    /// backend without stable indices cannot address the entry, and an entry evicted between the
+    /// record and the response is not an error. A diagnostic annotation must never be able to fail
+    /// a request.
+    fn attach_response(&self, port: u16, index: u64, status: u16, latency_ms: u64) {
+        let _ = (port, index, status, latency_ms);
+    }
 }
 
 #[derive(Default)]
@@ -314,6 +328,17 @@ impl RequestJournal for LocalJournal {
             entries[position].2.match_outcome = Some(outcome);
         }
     }
+
+    fn attach_response(&self, port: u16, index: u64, status: u16, latency_ms: u64) {
+        let slot = self.slot(port);
+        let mut entries = slot.entries.write();
+        // Same exactness as `attach_match`: indices are assigned under this write lock, so the
+        // deque is in strictly ascending index order and the search is precise, not heuristic.
+        if let Ok(position) = entries.binary_search_by(|(entry, _, _)| entry.cmp(&index)) {
+            entries[position].2.status = Some(status);
+            entries[position].2.latency_ms = Some(latency_ms);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -332,7 +357,90 @@ mod tests {
             body: None,
             timestamp: "t".into(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
+    }
+
+    /// Issue #364: the status and elapsed time land on the entry the index names, and only that one.
+    #[test]
+    fn attach_response_annotates_exactly_the_indexed_entry() {
+        let j = LocalJournal::default();
+        let first = j.record_indexed(1, "f", req("/a")).expect("indexed");
+        let second = j.record_indexed(1, "f", req("/b")).expect("indexed");
+
+        j.attach_response(1, second, 503, 42);
+
+        let entries = j.read(1).entries;
+        let a = entries
+            .iter()
+            .find(|r| r.path == "/a")
+            .expect("/a retained");
+        let b = entries
+            .iter()
+            .find(|r| r.path == "/b")
+            .expect("/b retained");
+        assert_eq!((b.status, b.latency_ms), (Some(503), Some(42)));
+        // The neighbour is untouched — absent, not defaulted to a zero that would read as
+        // "answered instantly with no status".
+        assert_eq!((a.status, a.latency_ms), (None, None));
+        assert_ne!(first, second);
+    }
+
+    /// Issue #364. Attaching to an entry that no longer exists is a no-op, never a panic: a
+    /// diagnostic annotation must not be able to fail the request it describes.
+    #[test]
+    fn attach_response_to_a_missing_entry_is_a_no_op() {
+        let j = LocalJournal::default();
+        let index = j.record_indexed(1, "f", req("/a")).expect("indexed");
+        j.clear(1).expect("clear");
+
+        j.attach_response(1, index, 200, 1);
+        j.attach_response(1, index + 9_999, 200, 1);
+
+        assert!(j.read(1).entries.is_empty());
+    }
+
+    /// Issue #364. A journal with no stable indices cannot address an entry, so the trait default
+    /// is a no-op — the backend simply never carries outcomes, and nothing else about it changes.
+    #[test]
+    fn a_backend_without_indices_ignores_the_attach() {
+        struct NoIndices(RwLock<Vec<RecordedRequest>>);
+        impl RequestJournal for NoIndices {
+            fn note_request(&self, _port: u16) {}
+            fn record(&self, _port: u16, _flow_id: &str, req: RecordedRequest) {
+                self.0.write().push(req);
+            }
+            fn read(&self, _port: u16) -> JournalRead {
+                JournalRead {
+                    entries: self.0.read().clone(),
+                    complete: true,
+                }
+            }
+            fn clear(&self, _port: u16) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn retain(&self, _port: u16, _keep: &dyn Fn(&RecordedRequest) -> bool) {}
+            fn clear_flow(&self, _port: u16, _flow_id: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn count(&self, _port: u16) -> u64 {
+                0
+            }
+        }
+
+        let j = NoIndices(RwLock::new(Vec::new()));
+        assert_eq!(
+            j.record_indexed(1, "f", req("/a")),
+            None,
+            "no stable indices"
+        );
+        j.attach_response(1, 0, 500, 7);
+
+        let entries = j.read(1).entries;
+        assert_eq!(entries.len(), 1);
+        assert_eq!((entries[0].status, entries[0].latency_ms), (None, None));
     }
 
     // AC1: the 10k cap evicts oldest-first, exactly like the embedded Vec did.

--- a/crates/rift-mock-core/src/imposter/manager.rs
+++ b/crates/rift-mock-core/src/imposter/manager.rs
@@ -2398,6 +2398,9 @@ mod tests {
             body: None,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         }
     }
 

--- a/crates/rift-mock-core/src/imposter/types.rs
+++ b/crates/rift-mock-core/src/imposter/types.rs
@@ -46,6 +46,39 @@ pub struct RecordedRequest {
     /// never "did not match".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_outcome: Option<MatchOutcome>,
+    /// The status that went back, and how long the imposter took to produce it (issue #364).
+    ///
+    /// Attached after the response exists, like [`Self::match_outcome`] and for the same reason:
+    /// the entry is journalled *before* matching, so neither is knowable at record time. They are
+    /// two fields rather than one because the console renders them as two columns, and one being
+    /// present without the other is not a state that can occur — both are attached together or
+    /// neither is.
+    ///
+    /// Absent means **not recorded**, never zero. A `0` here would read as "instant" and a
+    /// missing status as "no response"; both are claims this engine cannot make about a request
+    /// whose outcome it did not observe — the `X-Rift-Debug` path returns early, and a request
+    /// journalled before an error never reaches the attach.
+    ///
+    /// A present `latency_ms` of `0` is an ordinary reading, not a missing one: a stub answered
+    /// from memory usually takes well under a millisecond. The resolution is chosen for the
+    /// question the column exists to answer — *is this mock the slow thing?* — where the
+    /// interesting values are `behaviors.wait` delays and proxied upstreams, both far above 1 ms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    /// Which node served this request, when something clustered is embedding this engine.
+    ///
+    /// **Never set by this crate.** Single-node Rift has exactly one node and no name for it, so
+    /// the field exists here only because the journal entry is this crate's type: a
+    /// [`RequestJournal`](crate::imposter::RequestJournal) implementation that spans nodes stamps
+    /// it in its own `record`, where the node's identity is actually known.
+    ///
+    /// A `String`, not a numeric id: node identity is an identifier and never a magnitude, and an
+    /// embedder whose ids exceed 2^53 would otherwise have them silently rounded by any JavaScript
+    /// reading the journal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node: Option<String>,
 }
 
 /// Cap on the candidates named in [`MatchOutcome::tried`]; the rest are counted in
@@ -2106,6 +2139,69 @@ mod tests {
         assert_eq!(object.probability(), 0.25);
     }
 
+    /// Issue #364: recordings persist, so a journal written before these fields existed must still
+    /// read back — and must read back as *absent*, not as a zero status served instantly.
+    #[test]
+    fn a_recording_from_before_the_outcome_fields_still_deserializes() {
+        let before: RecordedRequest = serde_json::from_value(json!({
+            "requestFrom": "127.0.0.1:1234",
+            "method": "GET",
+            "path": "/x",
+            "query": {},
+            "headers": {},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }))
+        .expect("a pre-#364 recording still deserializes");
+
+        assert_eq!(before.status, None);
+        assert_eq!(before.latency_ms, None);
+        assert_eq!(before.node, None);
+    }
+
+    /// Issue #364, the other half of the compatibility contract: an entry carrying no outcome
+    /// serializes byte-identically to the pre-#364 shape, so nothing that reads existing
+    /// recordings sees three new keys appear. Same discipline as `_mode` below.
+    #[test]
+    fn an_unannotated_recording_omits_the_outcome_fields() {
+        let req = RecordedRequest {
+            request_from: "127.0.0.1:1234".to_string(),
+            method: "GET".to_string(),
+            path: "/x".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body: None,
+            mode: ResponseMode::Text,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
+        };
+        let value = serde_json::to_value(&req).expect("serializes");
+        let object = value.as_object().expect("an object");
+        // `latencyMs`, not `latency_ms`: this struct is `rename_all = "camelCase"`, so these are
+        // the names a client actually sees — and asserting the snake_case spelling would pass
+        // vacuously while proving nothing.
+        assert!(!object.contains_key("status"), "absent, not null: {value}");
+        assert!(
+            !object.contains_key("latencyMs"),
+            "absent, not null: {value}"
+        );
+        assert!(!object.contains_key("node"), "absent, not null: {value}");
+
+        // And when they are set, they are plain fields the console can read.
+        let annotated = RecordedRequest {
+            status: Some(503),
+            latency_ms: Some(42),
+            node: Some("rift-2".to_string()),
+            ..req
+        };
+        let value = serde_json::to_value(&annotated).expect("serializes");
+        assert_eq!(value["status"], 503);
+        assert_eq!(value["latencyMs"], 42);
+        assert_eq!(value["node"], "rift-2");
+    }
+
     // Issue #636: a text-bodied `RecordedRequest` must serialize byte-identically to the
     // pre-#636 shape — no `_mode` key at all — so existing recordings and all-text traffic are
     // unaffected by this change.
@@ -2121,6 +2217,9 @@ mod tests {
             mode: ResponseMode::Text,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         };
         let value = serde_json::to_value(&req).expect("serializes");
         assert!(
@@ -2144,6 +2243,9 @@ mod tests {
             mode: ResponseMode::Binary,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         };
         let value = serde_json::to_value(&req).expect("serializes");
         assert_eq!(value["_mode"], "binary");
@@ -2166,6 +2268,9 @@ mod tests {
             mode: ResponseMode::Text,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             match_outcome: None,
+            status: None,
+            latency_ms: None,
+            node: None,
         };
         assert_eq!(
             serde_json::to_string(&req).expect("serializes"),


### PR DESCRIPTION
A journal entry says when a request arrived, what it asked for and which stub answered it. It does not say **what went back** or **how long it took** — so the one column an operator scans when a mock is suspected of being the slow thing cannot be rendered, and neither can the status.

`RecordedRequest` gains `status`, `latencyMs` and `node`.

## Attached after the fact, like the match outcome

The entry is journalled before matching and long before a response exists — which is exactly why `matchOutcome` is already a second write via `attach_match`. Status and duration have the same shape, so they follow the same pattern: **`RequestJournal::attach_response`** beside `attach_match`, defaulting to a no-op on the same terms — a backend without stable indices cannot address the entry, and an entry evicted between the record and the response is not an error. A diagnostic annotation must never be able to fail the request it describes.

That default also means **this is not a breaking change for embedders**: a journal implementation that ignores it keeps compiling and keeps working, simply without outcomes.

The index reaches the caller through an out-parameter rather than a widened return type — `handle_request_inner` returns from eight places, and threading a value only its caller reads through all of them is eight chances to drop it.

Latency is measured **before** CORS header injection, which happens after the imposter has finished; counting it would report the engine as slower than it was.

## `node` is carried, never set

Single-node Rift has one node and no name for it, so nothing in this crate assigns it. The field exists because the journal entry is this crate's type: an embedder whose journal spans nodes stamps it in its own `record`, where the node's identity is actually known.

A `String` rather than a numeric id — node identity is an identifier, never a magnitude, and ids above 2^53 would otherwise be silently rounded by any JavaScript reading the journal.

## Absence means not recorded

All three are `Option`, absent on the wire. Two compatibility properties are tested directly:

- an entry written **before** these fields existed still deserializes, and reads back absent;
- an entry with no outcome serializes **byte-identically** to what it did before — no new keys appear for anything reading existing recordings.

Absence is load-bearing beyond compatibility. The `X-Rift-Debug` path returns early, and a request journalled before an error never reaches the attach, so "not recorded" is a real state. A `0` latency would read as *instant* and a missing status as *no response* — neither is a claim this engine can make about a request whose outcome it did not observe.

A **present** `latencyMs` of `0` is ordinary, though: a stub answered from memory is well under a millisecond. The resolution is chosen for the question the column exists to answer — *is this mock the slow thing?* — where the interesting values are `behaviors.wait` delays and proxied upstreams, both far above 1 ms.

## The SSE copy still predates the outcome

`request_event_matches_saved_requests` already stripped `matchOutcome` before comparing the pushed copy against the stored one, because the SSE push happens at record time. `status` and `latencyMs` are the same category and are stripped for the same reason — the assertion is generalised over all three rather than special-cased per field.

Worth stating plainly for consumers: **the SSE stream carries no outcome.** A live tail sees the request as recorded; the status and duration are visible on the `savedRequests` read. Changing that would mean moving the publish after the attach, which would alter the existing `matchOutcome` contract too — out of scope here.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | **exit 0** |
| `cargo test -p rift-mock-core -p rift-http-proxy` | **30 suites, 1463 passed, 0 failed** |

New tests: `attach_response_annotates_exactly_the_indexed_entry` (and leaves its neighbour absent, not zeroed), `attach_response_to_a_missing_entry_is_a_no_op`, `a_backend_without_indices_ignores_the_attach`, `a_recording_from_before_the_outcome_fields_still_deserializes`, `an_unannotated_recording_omits_the_outcome_fields`.

## Downstream

This is the upstream half of achird-labs/rift-cluster#364. The clustered side will implement `attach_response` in its own journal and stamp `node` in its `record`, then surface all three as columns in its console.

Closes #364
