### PR TITLE
test: http_source_enforces_its_timeout discards error, can pass for wrong reason

### DIFF
--- a/crates/rift-http-proxy/tests/imposter_sources.rs
+++ b/crates/rift-http-proxy/tests/imposter_sources.rs
@@ -715,7 +715,24 @@ async fn http_source_enforces_its_timeout() {
         "the timeout must fire well before the origin answers; took {:?}",
         started.elapsed()
     );
-    let _ = err;
+    // The elapsed check alone proves only that the fetch failed *fast* — a refused connection or a
+    // reset origin satisfies it just as well as the timeout under test, which is what discarding
+    // the error with `let _ = err;` let through (issue #950).
+    //
+    // Asked of the error structurally rather than by message: `{err:#}` could tell the two apart,
+    // since `TimedOut` renders as "operation timed out" in the chain, but that would pin reqwest's
+    // wording where what matters is its classification. `is_timeout` walks the chain for the marker
+    // whichever phase planted it — connect, headers or body. The chain reaches us at all only
+    // because issue #951 stopped the wrap from severing it, which is why the two failures below
+    // are separate assertions: they are separate regressions.
+    let transport = err
+        .chain()
+        .find_map(|c| c.downcast_ref::<reqwest::Error>())
+        .expect("the transport error must survive as a link in the chain (issue #951)");
+    assert!(
+        transport.is_timeout(),
+        "the fetch must have failed on the timeout, not some other transport error: {err:#}"
+    );
 }
 
 /// Behaviour pin, not a proof of our own line: mutation testing showed reqwest refuses a


### PR DESCRIPTION
`http_source_enforces_its_timeout` ended with `let _ = err;`, so the only thing it checked about the failure was that it arrived inside two seconds. A refused connection, a reset, or a dead origin thread all clear that bar and would have been reported as the timeout working.

The distinction cannot be drawn from the message: reqwest classes a timeout and a reset alike as `Kind::Request`, and both render as `error sending request for url (...)`. Only the `TimedOut` marker in the source chain separates them — which is why this had to wait for #951 to stop the wrap severing that chain.

The error is now walked for a `reqwest::Error` and asked `is_timeout()` — its classification rather than its wording, and true whichever phase planted the marker. Losing the link and losing the timeout are asserted separately because they are separate regressions.

Verified falsifiable: pointed at an immediately-refused connection the assertion fails, where the discarded-error version passed.

Replaces #955, which was opened as a stacked PR on #951's branch. #951 squash-merged, which moved the merge base, so #955 permanently displayed #951's five files as its own. Same commit, rebuilt on master so the diff is the one file it actually changes.

No milestone.

Closes #950