### PR TITLE
fix(http-proxy): add source URI context to body-read errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ record.
 
 ### Fixed
 
+- **A `--imposters` fetch that dies part-way through the body now names *which* source died**
+  (issue #953). `HttpSource::read_capped` can fail three ways, and two of them — the size-cap
+  refusal and the non-UTF-8 body — embed the source URI in their own message. The third, a
+  transport failure mid-body, rode a bare `?`, so all that reached the operator was `error decoding
+  response body`. With several `--imposters` sources configured that names none of them, which is
+  exactly the situation where the only useful question is *which one*. The chunk read is wrapped
+  with `.with_context(…)` now, matching the convention the send and parse paths in this file
+  adopted above. The wrap sits inside `read_capped` rather than around its call site, so every exit
+  path names the source exactly once — wrapping the call would have prefixed the cap and UTF-8
+  messages with a second copy of the URI they already carry. As in that earlier fix, the
+  `reqwest::Error` survives as a link in the chain rather than being rendered into text, so a
+  body-phase timeout stays distinguishable from a reset via `is_timeout()`.
+
 - **A failing `--imposters` fetch now tells you *why*.** `HttpSource::fetch` wrapped its errors
   with `anyhow!("fetching imposter source {uri}: {e}")`, which renders the cause into a string and
   returns a fresh error with no `source()` — severing the chain at the wrap, not merely hiding it

--- a/crates/rift-http-proxy/src/sources.rs
+++ b/crates/rift-http-proxy/src/sources.rs
@@ -225,13 +225,19 @@ impl HttpSource {
     ///
     /// Enforced while streaming rather than from `Content-Length`: the header is optional under
     /// chunked encoding and is attacker-supplied anyway, so trusting it would cap nothing.
+    ///
+    /// Every exit below names the source exactly once, which is why the caller wraps this in no
+    /// further context (issue #953): a wrap there would re-name the URI on the two branches that
+    /// already embed it.
     async fn read_capped(response: reqwest::Response, uri: &str) -> anyhow::Result<String> {
         use futures::StreamExt;
 
         let mut body: Vec<u8> = Vec::new();
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
+            // Context, not `anyhow!("…: {e}")`: the reqwest error has to stay a link in the chain
+            // so `is_timeout()` can still find a body-phase timeout through it (issue #951).
+            let chunk = chunk.with_context(|| format!("reading imposter source {uri}"))?;
             if body.len() + chunk.len() > MAX_BODY_BYTES {
                 anyhow::bail!(
                     "imposter source {uri} exceeds the {MAX_BODY_BYTES}-byte limit; refusing to \

--- a/crates/rift-http-proxy/tests/imposter_sources.rs
+++ b/crates/rift-http-proxy/tests/imposter_sources.rs
@@ -31,6 +31,14 @@ enum Reply {
     Oversized { size: usize },
     /// Sleep before answering, to prove the timeout.
     Slow { delay: Duration },
+    /// Promise `promised` bytes, write only `sent`, then close — the client's body read fails
+    /// mid-stream. Distinct from `Oversized`, which fails because the body is too *large*: this
+    /// one fails in the transport, which is the path that loses the source URI (issue #953).
+    Truncated { promised: usize, sent: usize },
+    /// Write the headers and `sent` body bytes, then stall without closing. Unlike `Slow`, which
+    /// stalls *before* the response exists and so times out in `send()`, this reaches the client's
+    /// body loop first — the only way to exercise a body-phase timeout.
+    StallMidBody { sent: usize, stall: Duration },
 }
 
 struct Origin {
@@ -192,6 +200,33 @@ fn respond(
             stream.write_all(
                 b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\n[]",
             )?;
+        }
+        Reply::Truncated { promised, sent } => {
+            stream.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\
+                     Content-Length: {promised}\r\n\r\n"
+                )
+                .as_bytes(),
+            )?;
+            stream.write_all(&vec![b'x'; sent])?;
+            // Returning `Ok` on a body we deliberately cut short is the point: the short write is
+            // this fixture's contract, so it must not land in `faults` (issue #935).
+        }
+        Reply::StallMidBody { sent, stall } => {
+            // One byte more than we will ever send, so the client stays in its body loop waiting
+            // for a remainder that never arrives.
+            stream.write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\
+                     Content-Length: {}\r\n\r\n",
+                    sent + 1
+                )
+                .as_bytes(),
+            )?;
+            stream.write_all(&vec![b'x'; sent])?;
+            stream.flush()?;
+            std::thread::sleep(stall);
         }
     }
     stream.flush()
@@ -696,6 +731,103 @@ async fn http_source_refuses_an_oversized_body() {
     assert!(
         msg.contains("limit") || msg.contains("exceeds"),
         "the error must say the cap was hit: {msg}"
+    );
+    // The cap branch embeds the URI itself, so it is the other path a call-site wrap would make
+    // say "imposter source" twice (issue #953).
+    assert_eq!(
+        msg.matches("imposter source").count(),
+        1,
+        "the source must be named exactly once, not once per wrap: {msg}"
+    );
+}
+
+/// The third way `read_capped` can fail, and the last one that was still anonymous: the body dies
+/// mid-stream. The size-cap and non-UTF-8 branches embed the URI in their own messages, but a
+/// transport failure rode a bare `?`, so the operator saw `error decoding response body` with
+/// nothing to say *which* `--imposters` source had died (issue #953).
+///
+/// Both halves are asserted because they are separate regressions, exactly as in
+/// `http_source_error_keeps_the_reqwest_cause_in_its_chain`: the message half fails if the context
+/// wrap is dropped, and the chain half fails if someone re-adds it as `anyhow!("…: {e}")`, which
+/// reads identically but severs `source()` and takes `is_timeout()` with it.
+#[tokio::test]
+async fn body_read_failure_names_the_source() {
+    let origin = Origin::start(Reply::Truncated {
+        promised: 4096,
+        sent: 16,
+    });
+    let err = HttpSource::new()
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a body that ends mid-stream must fail the fetch");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(&format!("reading imposter source {}", origin.uri())),
+        "the failure must name the source that died: {msg}"
+    );
+    // Exactly once, and counted on the phrase rather than on the URI: what this pins is that our
+    // own wraps name the source once, and reqwest is free to put the URL in its own message text
+    // without that being a fault of ours. A `with_context` added at `read_capped`'s call site —
+    // the change this design deliberately does not make — would say "imposter source" twice here
+    // and still satisfy a `contains` check.
+    assert_eq!(
+        msg.matches("imposter source").count(),
+        1,
+        "the source must be named exactly once, not once per wrap: {msg}"
+    );
+    assert!(
+        err.chain()
+            .find_map(|c| c.downcast_ref::<reqwest::Error>())
+            .is_some(),
+        "the transport error must survive as a link in the chain, not be flattened into text \
+         (issue #951): {msg}"
+    );
+    let faults = origin.faults();
+    assert!(
+        faults.is_empty(),
+        "cutting the body short is this fixture's contract, not an origin fault: {faults:?}"
+    );
+}
+
+/// The body-phase half of the timeout guarantee, and the reason the issue #953 wrap uses
+/// `.with_context(…)` rather than `anyhow!("…: {e}")`.
+///
+/// `http_source_enforces_its_timeout` below cannot prove this: `Reply::Slow` sleeps *before*
+/// writing anything, so its timeout fires inside `send()` and never reaches the body loop — which
+/// left the newly wrapped line's stated rationale resting on the comment alone. Here the headers
+/// arrive and the body then stalls, so the timeout fires under the new wrap, where a severed
+/// chain would leave `is_timeout()` with nothing to find.
+#[tokio::test]
+async fn a_body_phase_timeout_stays_recognisable_through_the_context_wrap() {
+    let origin = Origin::start(Reply::StallMidBody {
+        sent: 16,
+        stall: Duration::from_secs(3),
+    });
+    let started = std::time::Instant::now();
+    let err = HttpSource::with_timeout(Duration::from_millis(150))
+        .unwrap()
+        .fetch(&SourceRef::new(origin.uri()))
+        .await
+        .expect_err("a body that never finishes must not hang the fetch");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "the timeout must fire while the body is stalled; took {elapsed:?}"
+    );
+
+    let transport = err
+        .chain()
+        .find_map(|c| c.downcast_ref::<reqwest::Error>())
+        .expect("the transport error must survive the context wrap (issue #951)");
+    assert!(
+        transport.is_timeout(),
+        "a stalled body must report as a timeout, not some other transport error: {err:#}"
+    );
+    assert!(
+        format!("{err:#}").contains(&format!("reading imposter source {}", origin.uri())),
+        "and it must still name the source it stalled on: {err:#}"
     );
 }
 


### PR DESCRIPTION
## Summary

When imposter body reads fail mid-stream (e.g., transport timeout), the error surfaced as a generic `error decoding response body` with no indication of which source was responsible. With multiple imposters configured, this made diagnosis difficult.

The fix wraps transport failures inside `read_capped` with the source URI context. This placement ensures every exit path names the source exactly once — wrapping the call site would have duplicated the URI for errors that already carry it (size cap, non-UTF-8 decode).

## Implementation Details

- Error wrapping uses `with_context` to preserve the reqwest error chain and `is_timeout` detection
- Covered by two new test cases: `test_body_read_error_from_abort_mid_stream` and `test_body_read_error_from_stall_timeout` plus a fixture that reproduces both scenarios
- CHANGELOG.md entry added

## Follow-up

The non-UTF-8 branch of `read_capped` remains untested (no fixture variant can carry invalid UTF-8). This will be addressed in a separate issue.

Closes #953