### PR TITLE
feat(front-door): a seam that observes route dispatches

### DIFF
--- a/crates/rift-http-proxy/src/front_door/listener.rs
+++ b/crates/rift-http-proxy/src/front_door/listener.rs
@@ -10,6 +10,7 @@
 //! bodies have nothing in common; the accept-loop plumbing around them is what is common, and it
 //! is small enough that a shared abstraction would cost more to read than the duplication does.
 
+use crate::front_door::observer::RouteObserver;
 use crate::front_door::route_table::{CompiledRoutes, Route};
 use crate::imposter::ImposterManager;
 use crate::response::{ErrorKind, error_response_typed};
@@ -40,10 +41,31 @@ const NO_ROUTE_HEADER: &str = "x-rift-front-door";
 /// the bound address and can be shut down gracefully. `routes` is read fresh on every request via
 /// [`ArcSwap::load_full`], so an admin-API route-table update takes effect for the next request
 /// with no listener restart.
+///
+/// No [`RouteObserver`] — a single-node Rift has no route-hits column to feed and pays nothing
+/// for one. Embedders that need dispatches observed (a clustered admin plane's HITS counter,
+/// issue #368) call [`bind_front_door_with_observer`] instead; this is additive so existing
+/// callers of `bind_front_door` — this signature is `pub use`d from `front_door/mod.rs`, so
+/// external embedders depend on it — are unaffected.
 pub async fn bind_front_door(
     addr: SocketAddr,
     manager: Arc<ImposterManager>,
     routes: Arc<ArcSwap<CompiledRoutes>>,
+) -> anyhow::Result<RunningFrontDoor> {
+    bind_front_door_with_observer(addr, manager, routes, None).await
+}
+
+/// [`bind_front_door`] plus a [`RouteObserver`] notified once per request a route claims.
+///
+/// `observer` is `Option` rather than requiring a no-op implementation so the hot path costs
+/// nothing when nobody is watching: `None` is a single pointer-sized check per request, no
+/// allocation, no lock — the same shape as `RequestJournal`'s not existing at all in a build that
+/// never installs one.
+pub async fn bind_front_door_with_observer(
+    addr: SocketAddr,
+    manager: Arc<ImposterManager>,
+    routes: Arc<ArcSwap<CompiledRoutes>>,
+    observer: Option<Arc<dyn RouteObserver>>,
 ) -> anyhow::Result<RunningFrontDoor> {
     let listener = TcpListener::bind(addr).await?;
     let local_addr = listener.local_addr()?;
@@ -53,8 +75,15 @@ pub async fn bind_front_door(
     let tracker = TaskTracker::new();
     let (loop_cancel, loop_tracker) = (cancel.clone(), tracker.clone());
     let task = tokio::spawn(async move {
-        let result =
-            front_door_accept_loop(listener, manager, routes, loop_cancel, loop_tracker).await;
+        let result = front_door_accept_loop(
+            listener,
+            manager,
+            routes,
+            observer,
+            loop_cancel,
+            loop_tracker,
+        )
+        .await;
         // Preserve the metrics-listener precedent: an accept-loop failure is logged here because
         // nothing else joins this task by default.
         if let Err(ref e) = result {
@@ -133,6 +162,7 @@ async fn front_door_accept_loop(
     listener: TcpListener,
     manager: Arc<ImposterManager>,
     routes: Arc<ArcSwap<CompiledRoutes>>,
+    observer: Option<Arc<dyn RouteObserver>>,
     cancel: CancellationToken,
     tracker: TaskTracker,
 ) -> anyhow::Result<()> {
@@ -242,6 +272,9 @@ async fn front_door_accept_loop(
         let conn_cancel = cancel.clone();
         let manager = Arc::clone(&manager);
         let routes = Arc::clone(&routes);
+        // `Option<Arc<_>>::clone` is a null check plus (when `Some`) one refcount bump — no
+        // allocation either way, so a `None` observer costs the same as not having this field.
+        let observer = observer.clone();
 
         tracker.spawn(async move {
             // Held for the connection's lifetime; released back to the semaphore when this task
@@ -250,7 +283,8 @@ async fn front_door_accept_loop(
             let service = service_fn(move |req: Request<Incoming>| {
                 let manager = Arc::clone(&manager);
                 let routes = Arc::clone(&routes);
-                async move { handle_front_door_request(req, manager, routes).await }
+                let observer = observer.clone();
+                async move { handle_front_door_request(req, manager, routes, observer).await }
             });
 
             // Both builders yield a Connection with the same drive/graceful-shutdown shape;
@@ -305,6 +339,7 @@ async fn handle_front_door_request(
     req: Request<Incoming>,
     manager: Arc<ImposterManager>,
     routes: Arc<ArcSwap<CompiledRoutes>>,
+    observer: Option<Arc<dyn RouteObserver>>,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
     let host = request_host(&req);
 
@@ -322,7 +357,7 @@ async fn handle_front_door_request(
         .cloned();
 
     if let Some(route) = matched {
-        return Ok(dispatch_matched_route(route, req, &manager).await);
+        return Ok(dispatch_matched_route(route, req, &manager, observer.as_deref()).await);
     }
 
     // No route claimed it: the single-port gateway's own `/__rift/:port/<path>` addressing still
@@ -353,7 +388,18 @@ async fn dispatch_matched_route(
     route: Route,
     mut req: Request<Incoming>,
     manager: &ImposterManager,
+    observer: Option<&dyn RouteObserver>,
 ) -> Response<Full<Bytes>> {
+    // Fired unconditionally, before anything else in this function can fail or short-circuit:
+    // the route has claimed this request the moment we are here, and that is true whether the
+    // target imposter answers, answers 404 because it is gone, or a rewrite below fails with a
+    // 500. "This route is taking traffic" does not depend on how the traffic came out — a route
+    // that only ever 404s is exactly what a HITS column exists to reveal, so the miss must count
+    // too.
+    if let Some(observer) = observer {
+        observer.note_dispatch(&route.id);
+    }
+
     let target = route.target;
 
     if target.strip_prefix

--- a/crates/rift-http-proxy/src/front_door/mod.rs
+++ b/crates/rift-http-proxy/src/front_door/mod.rs
@@ -16,9 +16,11 @@
 //! from the client side and have completely different fixes.
 
 pub mod listener;
+pub mod observer;
 pub mod route_table;
 
-pub use listener::{RunningFrontDoor, bind_front_door};
+pub use listener::{RunningFrontDoor, bind_front_door, bind_front_door_with_observer};
+pub use observer::RouteObserver;
 pub use route_table::{
     CompiledRoutes, HeaderMatch, Route, RouteMatch, RouteTable, RouteTableError, RouteTarget,
 };

--- a/crates/rift-http-proxy/src/front_door/observer.rs
+++ b/crates/rift-http-proxy/src/front_door/observer.rs
@@ -1,0 +1,24 @@
+//! Observes route dispatches on the front door (issue #368): the seam a clustered embedder hangs
+//! a per-route hit counter on, so an operator's route table can show a HITS column — the column
+//! that answers "which of these routes is doing anything", where a zero means the route is wrong
+//! or dead.
+//!
+//! This trait lives beside [`crate::front_door::route_table`], not in `rift-mock-core`, because a
+//! *route* is an http-proxy concept. `rift-mock-core` knows imposters and ports, never routes, and
+//! putting a route-shaped trait there would be the first thread pulling that boundary apart.
+//!
+//! The shape mirrors [`rift_mock_core::imposter::journal::RequestJournal`]: an upstream trait an
+//! embedder implements, whose method the engine calls on every request. That trait's
+//! `note_request(port)` backs a per-imposter request count the same way this one backs a
+//! per-route dispatch count — same seam, one level up the addressing.
+
+/// Notified once per request a route claims, whatever happens to that request past that point.
+pub trait RouteObserver: Send + Sync {
+    /// Called once per request that a route claimed, with that route's `id`.
+    ///
+    /// Takes the id rather than the whole [`Route`](crate::front_door::route_table::Route)
+    /// because the observer's job is to count, not to re-decide anything — handing it the whole
+    /// route (its match rules, its target) would invite it to act on them. An id is all a
+    /// counter keyed by route needs.
+    fn note_dispatch(&self, route_id: &str);
+}

--- a/crates/rift-http-proxy/tests/front_door.rs
+++ b/crates/rift-http-proxy/tests/front_door.rs
@@ -2,10 +2,11 @@
 
 use arc_swap::ArcSwap;
 use rift_http_proxy::front_door::{
-    CompiledRoutes, RouteMatch, RouteTable, RouteTarget, bind_front_door,
+    CompiledRoutes, RouteMatch, RouteObserver, RouteTable, RouteTarget, bind_front_door,
+    bind_front_door_with_observer,
 };
 use rift_http_proxy::imposter::ImposterManager;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// A route with everything defaulted except what the test cares about.
 fn route(
@@ -71,6 +72,52 @@ async fn start_front_door(
         .expect("bind front door");
     let base = format!("http://{}", running.local_addr());
     (running, base)
+}
+
+/// A [`RouteObserver`] that records every id it is told about, in call order — including
+/// duplicates, since the whole point is to count dispatches, not to de-dupe them.
+#[derive(Default)]
+struct RecordingObserver {
+    seen: Mutex<Vec<String>>,
+}
+
+impl RecordingObserver {
+    fn seen(&self) -> Vec<String> {
+        self.seen.lock().expect("recording observer mutex").clone()
+    }
+}
+
+impl RouteObserver for RecordingObserver {
+    fn note_dispatch(&self, route_id: &str) {
+        self.seen
+            .lock()
+            .expect("recording observer mutex")
+            .push(route_id.to_owned());
+    }
+}
+
+/// Like [`start_front_door`], but wired to a [`RecordingObserver`] so a test can assert exactly
+/// which routes were observed as dispatched.
+async fn start_front_door_with_observer(
+    manager: Arc<ImposterManager>,
+    table: RouteTable,
+) -> (
+    rift_http_proxy::front_door::RunningFrontDoor,
+    String,
+    Arc<RecordingObserver>,
+) {
+    let compiled = Arc::new(ArcSwap::new(Arc::new(CompiledRoutes::new(&table))));
+    let observer = Arc::new(RecordingObserver::default());
+    let running = bind_front_door_with_observer(
+        "127.0.0.1:0".parse().unwrap(),
+        manager,
+        compiled,
+        Some(observer.clone() as Arc<dyn RouteObserver>),
+    )
+    .await
+    .expect("bind front door with observer");
+    let base = format!("http://{}", running.local_addr());
+    (running, base, observer)
 }
 
 #[tokio::test]
@@ -278,6 +325,150 @@ async fn gateway_addressing_still_works_through_the_front_door_with_an_empty_tab
         .unwrap();
     assert_eq!(resp.status(), 200);
     assert_eq!(resp.text().await.unwrap(), "gatewayed");
+
+    running.shutdown().await;
+}
+
+// --- RouteObserver (issue #368) ---------------------------------------------------------------
+
+#[tokio::test]
+async fn a_matched_dispatch_is_observed_exactly_once_with_its_route_id() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19910, "/", "from-a").await;
+
+    let table = RouteTable {
+        routes: vec![route("a", host_match("a.test"), 19910, false)],
+    };
+    let (running, base, observer) = start_front_door_with_observer(manager.clone(), table).await;
+
+    let resp = reqwest::Client::new()
+        .get(&base)
+        .header(reqwest::header::HOST, "a.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(observer.seen(), vec!["a".to_owned()]);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn two_requests_to_the_same_route_produce_two_observations() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19911, "/", "from-a").await;
+
+    let table = RouteTable {
+        routes: vec![route("a", host_match("a.test"), 19911, false)],
+    };
+    let (running, base, observer) = start_front_door_with_observer(manager.clone(), table).await;
+    let client = reqwest::Client::new();
+
+    for _ in 0..2 {
+        let resp = client
+            .get(&base)
+            .header(reqwest::header::HOST, "a.test")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    // Two dispatches to the same route are two observations, not one — the observer counts,
+    // it does not de-dupe.
+    assert_eq!(observer.seen(), vec!["a".to_owned(), "a".to_owned()]);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn requests_to_different_routes_are_attributed_to_the_right_id() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19912, "/", "from-a").await;
+    exact_path_imposter(&manager, 19913, "/", "from-b").await;
+
+    let table = RouteTable {
+        routes: vec![
+            route("a", host_match("a.test"), 19912, false),
+            route("b", host_match("b.test"), 19913, false),
+        ],
+    };
+    let (running, base, observer) = start_front_door_with_observer(manager.clone(), table).await;
+    let client = reqwest::Client::new();
+
+    client
+        .get(&base)
+        .header(reqwest::header::HOST, "b.test")
+        .send()
+        .await
+        .unwrap();
+    client
+        .get(&base)
+        .header(reqwest::header::HOST, "a.test")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(observer.seen(), vec!["b".to_owned(), "a".to_owned()]);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_route_whose_imposter_is_gone_is_still_observed() {
+    let manager = Arc::new(ImposterManager::new());
+    // No imposter is ever created on 19914 — the route matches, its target does not exist, and
+    // the response is a 404. The route still claimed the request: this is the case a HITS column
+    // exists to reveal (a route that only ever 404s), so it must be observed exactly like a
+    // healthy dispatch.
+    let table = RouteTable {
+        routes: vec![route("dead", host_match("dead.test"), 19914, false)],
+    };
+    let (running, base, observer) = start_front_door_with_observer(manager.clone(), table).await;
+
+    let resp = reqwest::Client::new()
+        .get(&base)
+        .header(reqwest::header::HOST, "dead.test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    assert_eq!(observer.seen(), vec!["dead".to_owned()]);
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn gateway_addressing_is_not_observed() {
+    let manager = Arc::new(ImposterManager::new());
+    exact_path_imposter(&manager, 19915, "/y", "gatewayed").await;
+
+    // Empty route table: nothing can claim this request via the route table, so it falls through
+    // to the single-port gateway's own `/__rift/:port` addressing — which never claimed a route
+    // and must not be observed.
+    let (running, base, observer) =
+        start_front_door_with_observer(manager.clone(), RouteTable::default()).await;
+
+    let resp = reqwest::get(format!("{base}/__rift/19915/y"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(observer.seen().is_empty());
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn an_unmatched_request_is_not_observed() {
+    let manager = Arc::new(ImposterManager::new());
+    let table = RouteTable {
+        routes: vec![route("only", host_match("only.test"), 19916, false)],
+    };
+    let (running, base, observer) = start_front_door_with_observer(manager.clone(), table).await;
+
+    let resp = reqwest::get(format!("{base}/nope")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+    assert!(observer.seen().is_empty());
 
     running.shutdown().await;
 }


### PR DESCRIPTION
## What

Adds `RouteObserver`, a seam that notifies an embedder once per request a front-door route claims.

Upstream gets the **seam only** — no counter, no storage, no admin surface. Those belong to whoever installs it.

## Why

Nothing observes a front-door dispatch today, so a per-route hit count cannot exist at all — not here and not in an embedder. The clustered enterprise layer wants one so an operator's route table can show a `HITS` column: the column that answers *which of these routes is doing anything*, where a zero means the route is either wrong or dead, and both are worth seeing.

## Shape, and why this one

Mirrors `RequestJournal` (`rift-mock-core/src/imposter/journal.rs`) — an upstream trait an embedder implements, whose method the engine calls per request. Same seam, one level up the addressing: `note_request(port)` backs a per-imposter count, `note_dispatch(route_id)` backs a per-route one.

Three decisions worth stating:

- **The trait lives beside the route table, not in `rift-mock-core`.** A route is an http-proxy concept; mock-core knows imposters and ports and never routes. Putting a route-shaped trait there would be the first thread pulling that boundary apart.
- **`bind_front_door` keeps its signature.** It is `pub use`d, so changing it would break every external embedder for a feature none of them asked for. It now delegates to `bind_front_door_with_observer`, and passing `None` is what it always effectively did.
- **It takes the route's `id`, not the `Route`.** The observer's job is to count, not to re-decide anything — handing it the match rules and the target would invite it to act on them.

## The behaviour most likely to be got wrong

The notification fires for **every** request a route claims, including one whose target imposter is gone and answers `404`. "This route is taking traffic" does not depend on how the traffic came out, and a route that only ever 404s is precisely what a HITS column exists to reveal.

It does **not** fire for the `/__rift/:port` gateway fallback or the no-route `404` — neither claimed a route.

## Cost when unused

An `Option` check on the hot path. A single-node Rift pays nothing for a counter only a cluster needs.

## Tests

Six new tests in `crates/rift-http-proxy/tests/front_door.rs`, over a recording observer:

- a matched dispatch is observed exactly once, with that route's id
- two requests to one route produce two observations (it counts; it does not de-dupe)
- requests matching different routes are attributed to the right id
- **a route whose imposter is gone is still observed** — the case above
- the `/__rift/:port` gateway path is not observed
- an unmatched request is not observed

The eight pre-existing `front_door.rs` tests are untouched and still exercise `bind_front_door` without an observer.

## Verification

`cargo fmt --check` clean; `cargo clippy -p rift-http-proxy --all-targets -- -D warnings` zero warnings; `cargo test -p rift-http-proxy` all green, including all 14 tests in `front_door.rs`.
