### PR TITLE
feat(flow-state): let a FlowStore enumerate its flows, when it can

### DIFF
--- a/crates/rift-mock-core/src/backends/inmemory.rs
+++ b/crates/rift-mock-core/src/backends/inmemory.rs
@@ -251,6 +251,37 @@ impl FlowStore for InMemoryFlowStore {
         Ok(())
     }
 
+    /// Every flow id currently holding at least one live (non-expired) key (issue #374). Reads
+    /// only — matches `get`/`exists`'s lazy-expiry rule (an expired entry is treated as absent on
+    /// read, actual removal happens on write via `remove_if_expired`/the amortized sweeper) rather
+    /// than inventing a second expiry rule here. A flow whose only keys have all expired is not
+    /// listed, exactly as `exists` would report `false` for each of them.
+    fn flow_ids(&self) -> Result<Option<Vec<String>>> {
+        let data = self.data.read();
+        let ids = data
+            .iter()
+            .filter(|(_, flow)| flow.values().any(|(_, expiry)| !Self::is_expired(expiry)))
+            .map(|(flow_id, _)| flow_id.clone())
+            .collect();
+        Ok(Some(ids))
+    }
+
+    /// Count of live (non-expired) keys under `flow_id` (issue #374) — `Some(0)` both for an empty
+    /// flow and for one that was never created, matching `exists`'s "absent looks like expired"
+    /// treatment rather than distinguishing the two.
+    fn entry_count(&self, flow_id: &str) -> Result<Option<usize>> {
+        let data = self.data.read();
+        let count = data
+            .get(flow_id)
+            .map(|flow| {
+                flow.values()
+                    .filter(|(_, expiry)| !Self::is_expired(expiry))
+                    .count()
+            })
+            .unwrap_or(0);
+        Ok(Some(count))
+    }
+
     /// Atomic under the single write lock (issue #311): compare and write happen with no
     /// interleaving window, unlike the trait's get-then-set default.
     fn compare_and_set(
@@ -856,5 +887,112 @@ mod tests {
         assert_eq!(store.stored_flow_count(), 1);
         // Clearing an absent flow is an idempotent no-op success.
         assert!(store.clear_flow("no-such-flow").is_ok());
+    }
+
+    // ===== flow_ids / entry_count (issue #374) =====
+
+    // An empty store can still enumerate — it just has nothing to report. `Some(vec![])`, not
+    // `None`: the store CAN answer, distinct from a backend that cannot enumerate at all.
+    #[test]
+    fn flow_ids_on_empty_store_is_some_empty() {
+        let store = InMemoryFlowStore::new(300);
+        assert_eq!(store.flow_ids().unwrap(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn flow_ids_lists_each_flow_exactly_once() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("flow1", "a", json!(1)).unwrap();
+        store.set("flow1", "b", json!(2)).unwrap();
+        store.set("flow2", "a", json!(1)).unwrap();
+
+        let mut ids = store
+            .flow_ids()
+            .unwrap()
+            .expect("in-memory store enumerates");
+        ids.sort();
+        assert_eq!(ids, vec!["flow1".to_string(), "flow2".to_string()]);
+    }
+
+    #[test]
+    fn clear_flow_removes_the_id_from_flow_ids() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("keep", "k", json!(1)).unwrap();
+        store.set("drop", "k", json!(1)).unwrap();
+
+        store.clear_flow("drop").unwrap();
+
+        let ids = store
+            .flow_ids()
+            .unwrap()
+            .expect("in-memory store enumerates");
+        assert_eq!(ids, vec!["keep".to_string()]);
+    }
+
+    #[test]
+    fn entry_count_counts_only_the_target_flows_keys() {
+        let store = InMemoryFlowStore::new(300);
+        store.set("f1", "a", json!(1)).unwrap();
+        store.set("f1", "b", json!(2)).unwrap();
+        store.set("f2", "x", json!(1)).unwrap();
+
+        assert_eq!(store.entry_count("f1").unwrap(), Some(2));
+        assert_eq!(store.entry_count("f2").unwrap(), Some(1));
+    }
+
+    // `Some(0)`, not `None`: the store can answer, and the answer is "no keys".
+    #[test]
+    fn entry_count_for_absent_flow_is_some_zero() {
+        let store = InMemoryFlowStore::new(300);
+        assert_eq!(store.entry_count("no-such-flow").unwrap(), Some(0));
+    }
+
+    #[test]
+    fn expired_flow_is_absent_from_flow_ids_and_entry_count() {
+        let store = InMemoryFlowStore::new(1); // 1s TTL
+        store.set("f", "k", json!("v")).unwrap();
+
+        // Live: appears in both.
+        assert_eq!(store.flow_ids().unwrap(), Some(vec!["f".to_string()]));
+        assert_eq!(store.entry_count("f").unwrap(), Some(1));
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Expired: gone from both, matching get/exists's lazy-expiry rule.
+        assert_eq!(store.flow_ids().unwrap(), Some(Vec::new()));
+        assert_eq!(store.entry_count("f").unwrap(), Some(0));
+    }
+
+    // A minimal third-party-style store that overrides nothing beyond the required methods must
+    // still compile and get `None` from both — proving the trait defaults are what an embedder
+    // gets without opting in.
+    #[test]
+    fn default_flow_ids_and_entry_count_are_none() {
+        use std::sync::Mutex;
+        struct Bare(Mutex<()>);
+        impl FlowStore for Bare {
+            fn get(&self, _: &str, _: &str) -> Result<Option<Value>> {
+                let _g = self.0.lock();
+                Ok(None)
+            }
+            fn set(&self, _: &str, _: &str, _: Value) -> Result<()> {
+                Ok(())
+            }
+            fn exists(&self, _: &str, _: &str) -> Result<bool> {
+                Ok(false)
+            }
+            fn delete(&self, _: &str, _: &str) -> Result<()> {
+                Ok(())
+            }
+            fn increment(&self, _: &str, _: &str) -> Result<i64> {
+                Ok(1)
+            }
+            fn set_ttl(&self, _: &str, _: i64) -> Result<()> {
+                Ok(())
+            }
+        }
+        let store = Bare(Mutex::new(()));
+        assert_eq!(store.flow_ids().unwrap(), None);
+        assert_eq!(store.entry_count("f").unwrap(), None);
     }
 }

--- a/crates/rift-mock-core/src/extensions/flow_state.rs
+++ b/crates/rift-mock-core/src/extensions/flow_state.rs
@@ -112,6 +112,42 @@ pub trait FlowStore: Send + Sync {
             Ok(CasOutcome::Conflict(current))
         }
     }
+
+    /// List every flow id this store currently holds live (non-expired) state for (issue #374).
+    ///
+    /// A flow's "space" is created implicitly by whatever flow id a request happened to carry —
+    /// there is no explicit registration step — so today the only way to learn which spaces exist
+    /// is to read the request log and infer it from `_rift.flowState`-touching requests. This is
+    /// the enumeration primitive an "Active spaces" admin view needs instead.
+    ///
+    /// Defaulted, not required: `FlowStore` is implemented by the built-in backends *and* by any
+    /// embedder through [`FlowStoreProvider`] — which exists precisely so embedders can plug their
+    /// own store in. A required method would break every external implementor at compile time. The
+    /// trait already establishes this pattern: `increment_by`, `set_key_ttl` and `clear_flow` all
+    /// ship defaults for exactly this reason.
+    ///
+    /// Returns `Option`, not a bare `Vec`, for a reason that matters: `None` means "this store
+    /// cannot enumerate", while `Some(vec![])` means "it can, and there are none right now".
+    /// Collapsing those two into one empty-list answer would make an admin surface render "no
+    /// spaces exist" as fact when the truth is "this backend cannot tell you" — a wrong-but-quiet
+    /// answer that is worse than an honest "unsupported". The default is `Ok(None)`: an
+    /// unenumerable store by construction, since it has no data to walk.
+    fn flow_ids(&self) -> Result<Option<Vec<String>>> {
+        Ok(None)
+    }
+
+    /// Count the live (non-expired) keys currently stored under `flow_id` (issue #374) — the
+    /// per-space size an "Active spaces" table would show next to each id from [`Self::flow_ids`].
+    ///
+    /// Same reasoning as `flow_ids` on both counts: defaulted (not required) so third-party
+    /// `FlowStore` impls keep compiling, and `Option`-typed so "this store cannot answer" (`None`)
+    /// stays distinguishable from "the flow has zero live keys, or does not exist" (`Some(0)`) —
+    /// again, collapsing the two would let an admin screen quietly lie about a backend it cannot
+    /// actually inspect.
+    fn entry_count(&self, flow_id: &str) -> Result<Option<usize>> {
+        let _ = flow_id;
+        Ok(None)
+    }
 }
 
 /// Embedder hook for supplying a custom [`FlowStore`] per imposter (issue #312), e.g.

--- a/crates/rift-store-redis/src/lib.rs
+++ b/crates/rift-store-redis/src/lib.rs
@@ -166,6 +166,12 @@ fn backend_err(op: &'static str, err: impl std::fmt::Display) -> anyhow::Error {
     })
 }
 
+// `flow_ids`/`entry_count` (issue #374) are deliberately left at the trait's `Ok(None)` defaults
+// and NOT implemented here. Enumerating them for real would mean a `KEYS`/`SCAN` walk over
+// however much of Redis this key prefix shares — and an unbounded keyspace walk triggered by an
+// admin screen loading is an operational hazard this crate should not hand out by default. `None`
+// is the honest answer, "this backend will not enumerate", and the `Option` in the trait's
+// signature exists precisely so that answer is representable instead of forcing a lie.
 impl FlowStore for RedisFlowStore {
     fn get(&self, flow_id: &str, key: &str) -> Result<Option<Value>> {
         let key_str = self.make_key(flow_id, key);


### PR DESCRIPTION
## What

Adds two defaulted methods to `FlowStore`:

```rust
fn flow_ids(&self) -> Result<Option<Vec<String>>> { Ok(None) }
fn entry_count(&self, flow_id: &str) -> Result<Option<usize>> { Ok(None) }
```

Implemented for the in-memory backend. Deliberately **not** implemented for Redis — see below.

## Why

A flow's space is created implicitly by whatever flow id a request happened to carry, so "which spaces exist" is a question nobody can ask. An operator can read a space they can already name (`GET /imposters/{port}/spaces/{flowId}`), and discovers the rest by reading the request log and inferring.

`FlowStore` today offers `get`, `set`, `exists`, `delete`, `is_blocking`, `increment`, `increment_by`, `set_ttl`, `set_key_ttl`, `clear_flow`. Nothing lists, so an embedder wanting to render an "Active spaces" table has no way to get one.

## Two decisions worth stating

**Defaulted, not required.** `FlowStoreProvider` exists precisely so an embedder can plug in its own store. A required method would break every external implementor at compile time for a feature they did not ask for. `increment_by`, `set_key_ttl` and `clear_flow` already establish defaults as the way this trait grows.

**`Option`, not a bare `Vec`/`usize`.** `None` means *this store cannot enumerate*; `Some(vec![])` means *it can, and there are none*. Collapsing those would let an admin screen render "no spaces exist" as a fact when the truth is "this backend cannot tell you" — wrong and quiet at the same time. The `Option` is what makes "will not answer" a representable answer rather than a lie.

## Redis is left defaulted on purpose

Implementing these for Redis would mean a `KEYS`/`SCAN` walk over however much of the keyspace this prefix shares. An unbounded keyspace walk triggered by an admin screen *loading* is an operational hazard, not a feature, so this crate should not hand it out by default. The impl block records that reasoning inline so the omission reads as a decision rather than an oversight.

An embedder that knows its Redis is dedicated and small can still override.

## Expiry

The in-memory implementation honours expiry the way `get` and `exists` already do — an expired flow is not listed, and expired keys do not contribute to `entry_count`. It follows the existing lazy-expiry behaviour rather than introducing a second rule.

## Tests

Eight new tests against the in-memory backend:

- an empty store returns `Some(vec![])`, not `None`
- a flow appears after a `set`, and exactly once even with several keys under it
- `clear_flow` removes the id from `flow_ids()`
- `entry_count` counts one flow's keys and is unaffected by another flow's
- `entry_count` for a flow that never existed is `Some(0)`, not `None`
- an expired flow is neither listed nor counted
- a minimal test double that overrides nothing returns `None` from both — proving what an external embedder actually gets from the defaults

## Verification

`cargo fmt --check` clean; `cargo clippy -p rift-mock-core -p rift-store-redis --all-targets -- -D warnings` exit 0; `cargo test -p rift-mock-core` 9 suites, 0 failed; `cargo build -p rift-store-redis` succeeds unchanged, confirming the defaults keep an existing implementor compiling.
